### PR TITLE
Update URL for EIA form 923

### DIFF
--- a/pudl/constants.py
+++ b/pudl/constants.py
@@ -3037,7 +3037,7 @@ pudl_tables = {
 base_data_urls = {
     'eia860': 'https://www.eia.gov/electricity/data/eia860/xls',
     'eia861': 'https://www.eia.gov/electricity/data/eia861/zip',
-    'eia923': 'https://www.eia.gov/electricity/data/eia923/xls',
+    'eia923': 'https://www.eia.gov/electricity/data/eia923/archive/xls',
     'epacems': 'ftp://ftp.epa.gov/dmdnload/emissions/hourly/monthly',
     'ferc1': 'ftp://eforms1.ferc.gov/f1allyears',
     'mshaprod': 'https://arlweb.msha.gov/OpenGovernmentData/DataSets',


### PR DESCRIPTION
It looks like the EIA has changed their base URL from `https://www.eia.gov/electricity/data/eia923/archive/xls` to `https://www.eia.gov/electricity/data/eia923/xls` for all years before 2017.

Probably don't merge this yet. The URL is wrong for the not-yet-finalized 2017 data. How do you want to handle that? 