### PR TITLE
Setup and postgres changes

### DIFF
--- a/docs/getting_started_for_linux.md
+++ b/docs/getting_started_for_linux.md
@@ -1,16 +1,20 @@
 
-## Here’s a step-by-step guide to getting the PUDL database up and running on Windows:
+## Here’s a step-by-step guide to getting the PUDL database up and running on Linux:
+
+The directions below were written for Ubuntu 17.10.
+They may work on other operating systems too.
 
 ### 0. Short Version
 - Install conda and python dependencies
 - Create postgres user and databases
 - Run PUDL setup scripts to download data and load into postgres
 
+
 ### 1. Reviewing requirements
 For the full list of requirements to install, review [REQUIREMENTS.md](https://github.com/catalyst-cooperative/pudl/blob/master/REQUIREMENTS.md) in the PUDL GitHub repository.
 
 ### 2. Installing Anaconda and Python packages
-1. Anaconda is a package manager, environment manager and Python distribution that contains many of the packages we’ll need to get the PUDL database up and running. Please select the Python 3.6 version on this [page](https://www.anaconda.com/download/#windows). You can follow a step by step guide to completing the installation on the Graphical Installer [here](https://docs.anaconda.com/anaconda/install/windows).
+1. Anaconda is a package manager, environment manager and Python distribution that contains many of the packages we’ll need to get the PUDL database up and running. Please select the Python 3.6 version on this [page](https://www.anaconda.com/download/#linux). You can follow a step by step guide to completing the installation on the Graphical Installer [here](https://docs.anaconda.com/anaconda/install/linux).
     - If you prefer a more minimal install, [miniconda](https://conda.io/miniconda.html) is also acceptable.
 2. Set up conda to use [conda-forge](https://conda-forge.org/), and install the required packages. In a terminal window type:
 ```sh
@@ -22,6 +26,7 @@ conda create -n pudl --file=docs/requirements_conda.txt
 ```
 More on conda environments [here](https://conda.io/docs/user-guide/tasks/manage-environments.html).
 
+
 3. One of the required Python packages are not included in conda-forge so we’ll install it separately using pip. In your terminal window, run the following command to install the `postgres-copy` package.
 ```sh
 pip install sqlalchemy-postgres-copy==0.5.0
@@ -29,31 +34,43 @@ pip install sqlalchemy-postgres-copy==0.5.0
 
 ### 3. Setting up PostgreSQL
 
+These instructions borrow from [Ubuntu's PostgreSQL instructions](https://help.ubuntu.com/community/PostgreSQL).
 
-1. [Download](https://www.postgresql.org/download/windows/) the Postgres installer.
-The EnterpriseDB version is fine; you don't need the extras included in BigSQL.
-Install the latest PostgreSQL version (currently 10.2) for Windows (32- or 64-bit).
-
-2. The installer requires you to set a password for the `postgres` user.
-Remember this.
-In the installation, do install you should install PostgreSQL server and pgAdmin 4.
-The installer offers other things, like Stack Builder, that aren't necessary.
-
-3. We can now set up our PostgreSQL databases. Open the pgAdmin 4 program.
-
-
-4. In pgAdmin 4, log into the `postgres` account.
-5. Right click "Login/Group Roles" and add a new user called `catalyst`. Set a password for the `catalyst` user.
-    - Grant the catalyst users permissions to login and create databases.
-6. Next, right-click on "databases" and open up the create database menu.
-Create the `ferc1` database with `catalyst` as the owner. This database will receive data from FERC form 1.
-7. Repeat #6 to create databases called `pudl`, `ferc1_test`, and `pudl_test`.
-8. In Windows Explorer, go to `%APPDATA%\postgresql`. If the file `pgpass.conf` exists, open it. If not, create it.
-On a new line in `pgpass.conf`, add the following, substituting in the password you set for the `catalyst` user.
+1. You probably already have postgres installed. On a command line, make sure `which psql` gives some result.
+If it doesn't:
+```sh
+sudo apt install postgresql
 ```
-127.0.0.1:*:*:catalyst:the_password_you_picked
+
+2. Ubuntu has a user called `postgres` that can access the postgresql configuration. Use this user to make a new `catalyst` user with privileges to create databases and login.
+```sh
+sudo -u postgres createuser --createdb --login --pwprompt catalyst
 ```
-The line above says "whenever you try to connect to the local machine over IPv4 with the username `catalyst`, use the password ______".
+The system will ask for a password. Pick something without a colon (`:`) or  and remember it until the next step.
+
+3. Create a file in your home directory called [`.pgpass`](https://www.postgresql.org/docs/current/static/libpq-pgpass.html) and add a login line for the catalyst user.
+```sh
+touch ~/.pgpass
+chmod 0600 ~/.pgpass
+echo "127.0.0.1:*:*:catalyst:the_password_you_picked" >> ~/.pgpass
+```
+
+4. Now we need to make a few databases to store the data.
+Start by logging in as the catalyst user.
+```sh
+psql -U catalyst -d postgres -h 127.0.0.1
+```
+If you have login issues, you can delete the `catalyst`  user with the command `sudo -s dropuser catalyst`. The redo step 2.
+Once logged in, create these databases:
+```sql
+CREATE DATABASE ferc1;
+CREATE DATABASE pudl;
+-- The test databases are only necessary if you're going to run py.test
+CREATE DATABASE ferc1_test;
+CREATE DATABASE pudl_test;
+-- exit with \q
+```
+
 
 
 ### 4. Setting up the PUDL repository
@@ -68,12 +85,12 @@ git clone git@github.com:catalyst-cooperative/pudl.git
 Now we’re ready to download the data that we’ll use to populate the database.
 
 1. In your Terminal window, use `cd` to navigate to the directory containing the clone of the PUDL repository.
-2. Within the PUDL repository, use `cd` to navigate to the `pudl\scripts` directory.
-3. In the `pudl\scripts` directory, there’s a file called `update_datastore.py`. Run this with
+2. Within the PUDL repository, use `cd` to navigate to the `pudl/scripts` directory.
+3. In the `pudl/scripts` directory, there’s a file called `update_datastore.py`. Run this with
 ```sh
 python update_datastore.py
 ```
-This will bring data from the web into the `pudl\data\eia`, `pudl\data\eia`, and `pudl\data\eia` directories.
+This will bring data from the web into the `pudl/data/eia`, `pudl/data/eia`, and `pudl/data/eia` directories.
 4.  Once the datasets are downloaded and unzipped by `update_datastore.py`, begin the initialization script with
 ```sh
 python init_pudl.py
@@ -84,5 +101,5 @@ If you want to just do a small subset of the data to test whether the setup is w
 
 ### 7. Playing with the data
 
-In your Terminal window use cd to navigate to the `pudl\docs\notebooks\tutorials directory`. Then run `jupyter notebook pudl_intro.ipynb` to fire up the introductory notebook. There you’ll find more information on how to begin to play with the data.
+In your Terminal window use cd to navigate to the `pudl/docs/notebooks/tutorials directory`. Then run `jupyter notebook pudl_intro.ipynb` to fire up the introductory notebook. There you’ll find more information on how to begin to play with the data.
 (If you installed miniconda in step 2, you may have to `conda install jupyter`.)

--- a/docs/getting_started_mac.md
+++ b/docs/getting_started_mac.md
@@ -1,34 +1,86 @@
 ## Here’s a step-by-step guide to getting the PUDL database up and running on Mac OS X:
+
+
+### 0. Short Version
+- Install conda and python dependencies
+- Create postgres user and databases
+- Run PUDL setup scripts to download data and load into postgres
+
+
+
 ### 1. Reviewing requirements
 For the full list of requirements to install, review [REQUIREMENTS.md](https://github.com/catalyst-cooperative/pudl/blob/master/REQUIREMENTS.md) in the PUDL GitHub repository.
-### 2. Installing Anaconda and Python packages
-1. Anaconda is a package manager, environment manager and Python distribution that contains many of the packages we’ll need to get the PUDL database up and running. Please select the Python 3.6 Graphical Installer version on this [page](https://www.continuum.io/downloads). You can follow a step by step guide to completing the installation on the Graphical Installer [here](https://docs.continuum.io/anaconda/install/mac-os#macos-graphical-install).
-2. Two of the required Python packages are not included in Anaconda so we’ll install those separately using pip. In your terminal window, run `pip install dbfread` to install the dbfread package. Next, run `pip install -U sqlalchemy-postgres-copy` to install the postgres-copy package.
 
-### 3. Setting up PostgresQL
+
+### 2. Installing Anaconda and Python packages
+1. Anaconda is a package manager, environment manager and Python distribution that contains many of the packages we’ll need to get the PUDL database up and running. Please select the Python 3.6 version on this [page](https://www.anaconda.com/download/#linux). You can follow a step by step guide to completing the installation on the Graphical Installer [here](https://docs.continuum.io/anaconda/install/mac-os#macos-graphical-install).
+    - If you prefer a more minimal install, [miniconda](https://conda.io/miniconda.html) is also acceptable.
+2. Set up conda to use [conda-forge](https://conda-forge.org/), and install the required packages. In a terminal window type:
+```sh
+conda config --add channels conda-forge
+# To install in the default conda environment:
+#conda install --file=docs/requirements_conda.txt
+# Or to install in a new environment called 'pudl'
+conda create -n pudl --file=docs/requirements_conda.txt
+```
+More on conda environments [here](https://conda.io/docs/user-guide/tasks/manage-environments.html).
+
+
+3. One of the required Python packages are not included in conda-forge so we’ll install it separately using pip. In your terminal window, run the following command to install the `postgres-copy` package.
+```sh
+pip install sqlalchemy-postgres-copy==0.5.0
+```
+
+
+### 3. Setting up PostgreSQL
+
 1. Now that we have all the required packages installed, we can install the PostgreSQL database. It’s most straightforward to set up through Postgres.app, which is available [here](http://postgresapp.com/).
 2. After installing PostgreSQL, open the application. Then we’ll set up command line access to PostgreSQL. In your terminal window, run `sudo mkdir -p /etc/paths.d &&
 echo /Applications/Postgres.app/Contents/Versions/latest/bin | sudo tee /etc/paths.d/postgresapp`. Then close the Terminal window and open a new one for changes to take effect. In your new terminal window, run `which psql` and press enter to verify that the changes took effect.
 3. We can now set up our PostgreSQL databases. In your terminal window, run `psql` to bring up the PostgreSQL prompt.
-  1. Run `CREATE USER catalyst with SUPERUSER CREATEDB` to create the catalyst superuser.
+  1. Run `CREATE USER catalyst with CREATEDB` to create the catalyst superuser.
   2. Run `CREATE DATABASE ferc1;` to create the database that will receive data from FERC form 1.
   3. Run `CREATE DATABASE pudl;` to create the PUDL database.
   4. Run `CREATE DATABASE pudl_test;` to create the PUDL test database.
   5. Run `CREATE DATABASE ferc1_test;` to create the FERC Form 1 test database.
   6. Run `\q` to exit the PostgreSQL prompt.
+
+4. Create a file in your home directory called [`.pgpass`](https://www.postgresql.org/docs/current/static/libpq-pgpass.html) and add a login line for the `catalyst` user.
+```sh
+touch ~/.pgpass
+chmod 0600 ~/.pgpass
+echo "127.0.0.1:*:*:catalyst:should_there_be_a_password_here?" >> ~/.pgpass
+```
+
+
 ### 4. Setting up the PUDL repository
+
   1. If you don’t have a GitHub account, you’ll need to create one at [github.com](https://github.com). Since the database is a public repository, you’ll want to select a free public account (the option reads “Unlimited public repositories for free.”).
   2. Once you’ve created an account and confirmed your email address, you’ll want to download and install the GitHub desktop client at [desktop.github.com](https://desktop.github.com/).
   3. Use your new account credentials to log into the GitHub desktop client and select the option to clone a repository. Then, enter the URL `https://github.com/catalyst-cooperative/pudl`.
   4. Once you've cloned the repository you can use the `Repository -> Show In Finder` option in the desktop Github app to obtain the location of the repository directory so that you find it using Terminal.
-### 5. Downloading data from FERC and EIA
+
+
+### 5. Initializing the database
+
 Now we’re ready to download the data that we’ll use to populate the database.
-  1. In your Terminal window, use `cd` to navigate to the directory containing the clone of the PUDL repository.
-  2. Within the PUDL respository, use `cd` to navigate to the `pudl/data` directory.
-  3. In the `pudl/data` directory, there’s a file called `get-all-data.sh`. Run `bash get-all-data.sh` to run the script, which will bring data from the web into the `pudl/data/eia`, `pudl/data/eia`, and `pudl/data/eia` directories.
-### 6. Initializing the database
-Let’s initialize the database! In your Terminal window use `cd` to navigate to the `pudl/scripts` directory. Run `python init_pudl.py` to begin the initialization script.
-This script will load all of the data that is currently working - years 2004-2016 for FERC Form 1, 2009-2016 for EIA923, and 2011-2015 for EIA860. The whole process will likely take about 20 minutes, and the database will take up about 2GB of space once it's done.
+
+1. In your Terminal window, use `cd` to navigate to the directory containing the clone of the PUDL repository.
+2. Within the PUDL repository, use `cd` to navigate to the `pudl/scripts` directory.
+3. In the `pudl/scripts` directory, there’s a file called `update_datastore.py`. Run this with
+```sh
+python update_datastore.py
+```
+This will bring data from the web into the `pudl/data/eia`, `pudl/data/eia`, and `pudl/data/eia` directories.
+4.  Once the datasets are downloaded and unzipped by `update_datastore.py`, begin the initialization script with
+```sh
+python init_pudl.py
+```
+This script will load all of the data that is currently working (see [README.md](https://github.com/catalyst-cooperative/pudl/#project-status) for details.)
+5. This process will take tens of minutes to download the data and about 20 minutes to run the initialization script. The unzipped data folder will be about 8GB and the postgres database will take up about 1GB.
 If you want to just do a small subset of the data to test whether the setup is working, check out the help message on the script by calling python `init_pudl.py -h`.
-### 7. Playing with the data
+
+### 6. Playing with the data
+
 In your Terminal window use cd to navigate to the `pudl/docs/notebooks/tutorials directory`. Then run `jupyter notebook pudl_intro.ipynb` to fire up the introductory notebook. There you’ll find more information on how to begin to play with the data.
+(If you installed miniconda in step 2, you may have to `conda install jupyter`.)

--- a/docs/requirements_conda.txt
+++ b/docs/requirements_conda.txt
@@ -4,7 +4,6 @@ numpy==1.13.3
 networkx==2.1
 packaging==16.8
 pandas==0.22.0
-pipdeptree==0.10.1
 psycopg2==2.7.1
 py==1.4.34
 pyparsing==2.2.0

--- a/pudl/settings.py
+++ b/pudl/settings.py
@@ -18,39 +18,34 @@ TEST_DIR = os.path.join(PUDL_DIR, 'test')
 DOCS_DIR = os.path.join(PUDL_DIR, 'docs')
 
 # These DB connection dictionaries are used by sqlalchemy.URL()
-
+# (Using 127.0.0.1, the numeric equivalent of localhost, to make postgres use
+# the `.pgpass` file without fussing around in the config.)
+# sqlalchemy.URL will make a URL missing post (therefore using the default),
+# and missing a password (which will make the system look for .pgpass)
 DB_FERC1 = {
     'drivername': 'postgresql',
-    'host': 'localhost',
-    'port': '5432',
+    'host': '127.0.0.1',
     'username': 'catalyst',
-    'password': '',
     'database': 'ferc1'
 }
 
 DB_PUDL = {
     'drivername': 'postgresql',
-    'host': 'localhost',
-    'port': '5432',
+    'host': '127.0.0.1',
     'username': 'catalyst',
-    'password': '',
     'database': 'pudl'
 }
 
 DB_FERC1_TEST = {
     'drivername': 'postgresql',
-    'host': 'localhost',
-    'port': '5432',
+    'host': '127.0.0.1',
     'username': 'catalyst',
-    'password': '',
     'database': 'ferc1_test'
 }
 
 DB_PUDL_TEST = {
     'drivername': 'postgresql',
-    'host': 'localhost',
-    'port': '5432',
+    'host': '127.0.0.1',
     'username': 'catalyst',
-    'password': '',
     'database': 'pudl_test'
 }


### PR DESCRIPTION
Let me know what you think!

Changes:
- Rely on the user having a `.pgpass` file for the `catalyst` postgres user
- Changes in `settings.py`:
  - Connect with IPv4 (127.0.0.1) instead of local unix socket
  - Don't supply a password (will use .pgpass instead)
- Add and edit documentation for these changes
  - Note that windows and linux don't require `catalyst` to be a postgres superuser. It would be nice if these changes meant os x didn't either, but I'm not at all certain.

I've tested these changes in linux, but not windows or os x. If these look okay, could you please test them on a mac before merging?  This will require creating a .pgpass file with a line like `127.0.0.1:*:*:catalyst:`

Sorry for all the configuration PRs. I promise I'll look at EIA 860 stuff once I actually have things installed.