### PR TITLE
Minor changes to installation docs

### DIFF
--- a/docs/getting_started_for_linux.md
+++ b/docs/getting_started_for_linux.md
@@ -14,7 +14,16 @@ They may work on other operating systems too.
 For the full list of requirements to install, review [REQUIREMENTS.md](https://github.com/catalyst-cooperative/pudl/blob/master/REQUIREMENTS.md) in the PUDL GitHub repository.
 
 ### 2. Setting up the PUDL repository
-1. [Clone](https://help.github.com/articles/cloning-a-repository/) the PUDL repository. (This may require installing Git if you don't already have it.)
+1. [Clone](https://help.github.com/articles/cloning-a-repository/) the PUDL repository.
+
+#### Option A: Github Desktop
+
+1. If you don’t have a GitHub account, you’ll need to create one at [github.com](https://github.com). Since the database is a public repository, you’ll want to select a free public account (the option reads “Unlimited public repositories for free.”).
+2. Once you’ve created an account and confirmed your email address, you’ll want to download and install the GitHub desktop client at [desktop.github.com](https://desktop.github.com/).
+3. Use your new account credentials to log into the GitHub desktop client and select the option to clone a repository. Then, enter the URL `https://github.com/catalyst-cooperative/pudl`.
+4. Once you've cloned the repository you can use the `Repository -> Show In Finder` option in the desktop Github app to obtain the location of the repository directory so that you find it using Terminal.
+
+#### Option B: Command line
 ```sh
 git clone git@github.com:catalyst-cooperative/pudl.git
 ```
@@ -30,6 +39,7 @@ conda config --add channels conda-forge
 # Or to install in a new environment called 'pudl'
 conda create -n pudl --file=docs/requirements_conda.txt
 ```
+If you get an error `No such file or directory: docs/requirements_conda.txt`, make sure you're in the `pudl` repository downloaded in step 2.
 More on conda environments [here](https://conda.io/docs/user-guide/tasks/manage-environments.html).
 
 
@@ -89,6 +99,7 @@ Now we’re ready to download the data that we’ll use to populate the database
 python update_datastore.py
 ```
 This will bring data from the web into the `pudl/data/eia`, `pudl/data/eia`, and `pudl/data/eia` directories.
+If the download fails (e.g. the FTP server times out), this command can be run repeatedly until all the files are downloaded.
 4.  Once the datasets are downloaded and unzipped by `update_datastore.py`, begin the initialization script with
 ```sh
 python init_pudl.py

--- a/docs/getting_started_mac.md
+++ b/docs/getting_started_mac.md
@@ -12,7 +12,24 @@
 For the full list of requirements to install, review [REQUIREMENTS.md](https://github.com/catalyst-cooperative/pudl/blob/master/REQUIREMENTS.md) in the PUDL GitHub repository.
 
 
-### 2. Installing Anaconda and Python packages
+
+### 2. Setting up the PUDL repository
+1. [Clone](https://help.github.com/articles/cloning-a-repository/) the PUDL repository.
+
+#### Option A: Github Desktop
+
+  1. If you don’t have a GitHub account, you’ll need to create one at [github.com](https://github.com). Since the database is a public repository, you’ll want to select a free public account (the option reads “Unlimited public repositories for free.”).
+  2. Once you’ve created an account and confirmed your email address, you’ll want to download and install the GitHub desktop client at [desktop.github.com](https://desktop.github.com/).
+  3. Use your new account credentials to log into the GitHub desktop client and select the option to clone a repository. Then, enter the URL `https://github.com/catalyst-cooperative/pudl`.
+  4. Once you've cloned the repository you can use the `Repository -> Show In Finder` option in the desktop Github app to obtain the location of the repository directory so that you find it using Terminal.
+
+#### Option B: Command line
+(This may require installing Git if you don't already have it.)
+```sh
+git clone git@github.com:catalyst-cooperative/pudl.git
+```
+
+### 3. Installing Anaconda and Python packages
 1. Anaconda is a package manager, environment manager and Python distribution that contains many of the packages we’ll need to get the PUDL database up and running. Please select the Python 3.6 version on this [page](https://www.anaconda.com/download/#linux). You can follow a step by step guide to completing the installation on the Graphical Installer [here](https://docs.continuum.io/anaconda/install/mac-os#macos-graphical-install).
     - If you prefer a more minimal install, [miniconda](https://conda.io/miniconda.html) is also acceptable.
 2. Set up conda to use [conda-forge](https://conda-forge.org/), and install the required packages. In a terminal window type:
@@ -23,8 +40,8 @@ conda config --add channels conda-forge
 # Or to install in a new environment called 'pudl'
 conda create -n pudl --file=docs/requirements_conda.txt
 ```
+If you get an error `No such file or directory: docs/requirements_conda.txt`, make sure you're in the `pudl` repository downloaded in step 2.
 More on conda environments [here](https://conda.io/docs/user-guide/tasks/manage-environments.html).
-
 
 3. One of the required Python packages are not included in conda-forge so we’ll install it separately using pip. In your terminal window, run the following command to install the `postgres-copy` package.
 ```sh
@@ -32,33 +49,19 @@ pip install sqlalchemy-postgres-copy==0.5.0
 ```
 
 
-### 3. Setting up PostgreSQL
+### 4. Setting up PostgreSQL
 
 1. Now that we have all the required packages installed, we can install the PostgreSQL database. It’s most straightforward to set up through Postgres.app, which is available [here](http://postgresapp.com/).
 2. After installing PostgreSQL, open the application. Then we’ll set up command line access to PostgreSQL. In your terminal window, run `sudo mkdir -p /etc/paths.d &&
 echo /Applications/Postgres.app/Contents/Versions/latest/bin | sudo tee /etc/paths.d/postgresapp`. Then close the Terminal window and open a new one for changes to take effect. In your new terminal window, run `which psql` and press enter to verify that the changes took effect.
 3. We can now set up our PostgreSQL databases. In your terminal window, run `psql` to bring up the PostgreSQL prompt.
-  1. Run `CREATE USER catalyst with CREATEDB` to create the catalyst superuser.
+  1. Run `CREATE USER catalyst with CREATEDB;` to create the catalyst superuser.
   2. Run `CREATE DATABASE ferc1;` to create the database that will receive data from FERC form 1.
   3. Run `CREATE DATABASE pudl;` to create the PUDL database.
   4. Run `CREATE DATABASE pudl_test;` to create the PUDL test database.
   5. Run `CREATE DATABASE ferc1_test;` to create the FERC Form 1 test database.
   6. Run `\q` to exit the PostgreSQL prompt.
 
-4. Create a file in your home directory called [`.pgpass`](https://www.postgresql.org/docs/current/static/libpq-pgpass.html) and add a login line for the `catalyst` user.
-```sh
-touch ~/.pgpass
-chmod 0600 ~/.pgpass
-echo "127.0.0.1:*:*:catalyst:should_there_be_a_password_here?" >> ~/.pgpass
-```
-
-
-### 4. Setting up the PUDL repository
-
-  1. If you don’t have a GitHub account, you’ll need to create one at [github.com](https://github.com). Since the database is a public repository, you’ll want to select a free public account (the option reads “Unlimited public repositories for free.”).
-  2. Once you’ve created an account and confirmed your email address, you’ll want to download and install the GitHub desktop client at [desktop.github.com](https://desktop.github.com/).
-  3. Use your new account credentials to log into the GitHub desktop client and select the option to clone a repository. Then, enter the URL `https://github.com/catalyst-cooperative/pudl`.
-  4. Once you've cloned the repository you can use the `Repository -> Show In Finder` option in the desktop Github app to obtain the location of the repository directory so that you find it using Terminal.
 
 
 ### 5. Initializing the database
@@ -72,6 +75,7 @@ Now we’re ready to download the data that we’ll use to populate the database
 python update_datastore.py
 ```
 This will bring data from the web into the `pudl/data/eia`, `pudl/data/eia`, and `pudl/data/eia` directories.
+If the download fails (e.g. the FTP server times out), this command can be run repeatedly until all the files are downloaded.
 4.  Once the datasets are downloaded and unzipped by `update_datastore.py`, begin the initialization script with
 ```sh
 python init_pudl.py

--- a/docs/getting_started_pc.md
+++ b/docs/getting_started_pc.md
@@ -10,11 +10,20 @@
 For the full list of requirements to install, review [REQUIREMENTS.md](https://github.com/catalyst-cooperative/pudl/blob/master/REQUIREMENTS.md) in the PUDL GitHub repository.
 
 ### 2. Setting up the PUDL repository
-1. [Clone](https://help.github.com/articles/cloning-a-repository/) the PUDL repository. (This may require installing Git if you don't already have it.)
+1. [Clone](https://help.github.com/articles/cloning-a-repository/) the PUDL repository.
+
+#### Option A: Github Desktop
+
+1. If you don’t have a GitHub account, you’ll need to create one at [github.com](https://github.com). Since the database is a public repository, you’ll want to select a free public account (the option reads “Unlimited public repositories for free.”).
+2. Once you’ve created an account and confirmed your email address, you’ll want to download and install the GitHub desktop client at [desktop.github.com](https://desktop.github.com/).
+3. Use your new account credentials to log into the GitHub desktop client and select the option to clone a repository. Then, enter the URL `https://github.com/catalyst-cooperative/pudl`.
+4. Once you've cloned the repository you can use the `Repository -> Show In Finder` option in the desktop Github app to obtain the location of the repository directory so that you find it using Terminal.
+
+#### Option B: Command line
+(This may require [installing](https://gitforwindows.org/) Git if you don't already have it.)
 ```sh
 git clone git@github.com:catalyst-cooperative/pudl.git
 ```
-
 
 ### 3. Installing Anaconda and Python packages
 1. Anaconda is a package manager, environment manager and Python distribution that contains many of the packages we’ll need to get the PUDL database up and running. Please select the Python 3.6 version on this [page](https://www.anaconda.com/download/#windows). You can follow a step by step guide to completing the installation on the Graphical Installer [here](https://docs.anaconda.com/anaconda/install/windows).
@@ -27,6 +36,7 @@ conda config --add channels conda-forge
 # Or to install in a new environment called 'pudl'
 conda create -n pudl --file=docs/requirements_conda.txt
 ```
+If you get an error `No such file or directory: docs/requirements_conda.txt`, make sure you're in the `pudl` repository downloaded in step 2.
 More on conda environments [here](https://conda.io/docs/user-guide/tasks/manage-environments.html).
 
 3. One of the required Python packages are not included in conda-forge so we’ll install it separately using pip. In your terminal window, run the following command to install the `postgres-copy` package.
@@ -76,6 +86,7 @@ Now we’re ready to download the data that we’ll use to populate the database
 python update_datastore.py
 ```
 This will bring data from the web into the `pudl\data\eia`, `pudl\data\eia`, and `pudl\data\eia` directories.
+If the download fails (e.g. the FTP server times out), this command can be run repeatedly until all the files are downloaded.
 4.  Once the datasets are downloaded and unzipped by `update_datastore.py`, begin the initialization script with
 ```sh
 python init_pudl.py

--- a/docs/requirements_conda.txt
+++ b/docs/requirements_conda.txt
@@ -13,3 +13,4 @@ pytz==2017.2
 six==1.10.0
 SQLAlchemy==1.1.13
 xlrd==1.0.0
+matplotlib=2.2.2


### PR DESCRIPTION
- Add options for clone to mac instructions (`git clone` or Github
  Desktop)
- Fix order of instructions: need to clone repo before installing Python
  packages
- Fix missing `;` in Mac postgres commands
- Remove `.pgpass` from Mac postgres; the default config doesn't need it