### PR TITLE
Python formatting changes: remove parentheses

### DIFF
--- a/pudl/analysis.py
+++ b/pudl/analysis.py
@@ -45,7 +45,7 @@ def is_annual(df_year, year_col='report_date'):
     else:
         assert False, "Zero dates found!"
 
-    return(True)
+    return True
 
 
 def merge_on_date_year(df_date, df_year, on=[], how='inner',
@@ -121,7 +121,7 @@ def merge_on_date_year(df_date, df_year, on=[], how='inner',
     merged = pd.merge(df_date, df_year[cols_to_use], how=how, on=full_on)
     merged = merged.drop(['year_temp'], axis=1)
 
-    return(merged)
+    return merged
 
 
 def simple_select(table_name, pudl_engine):
@@ -162,7 +162,7 @@ def simple_select(table_name, pudl_engine):
     else:
         table = table
 
-    return(table)
+    return table
 
 
 def simple_ferc1_plant_ids(pudl_engine):
@@ -171,7 +171,7 @@ def simple_ferc1_plant_ids(pudl_engine):
                                   pudl_engine)
     ferc1_simple_plant_ids = ferc1_plant_ids.drop_duplicates('plant_id_pudl',
                                                              keep=False)
-    return(ferc1_simple_plant_ids)
+    return ferc1_simple_plant_ids
 
 
 def simple_eia_plant_ids(pudl_engine):
@@ -180,7 +180,7 @@ def simple_eia_plant_ids(pudl_engine):
                                 pudl_engine)
     eia_simple_plant_ids = eia_plant_ids.drop_duplicates('plant_id_pudl',
                                                          keep=False)
-    return(eia_simple_plant_ids)
+    return eia_simple_plant_ids
 
 
 def simple_pudl_plant_ids(pudl_engine):
@@ -189,7 +189,7 @@ def simple_pudl_plant_ids(pudl_engine):
     eia_simple = simple_eia_plant_ids(pudl_engine)
     pudl_simple = np.intersect1d(ferc1_simple['plant_id_pudl'],
                                  eia_simple['plant_id_pudl'])
-    return(pudl_simple)
+    return pudl_simple
 
 
 def ferc_eia_shared_plant_ids(pudl_engine):
@@ -200,21 +200,21 @@ def ferc_eia_shared_plant_ids(pudl_engine):
                                 pudl_engine)
     shared_plant_ids = np.intersect1d(ferc_plant_ids['plant_id_pudl'],
                                       eia_plant_ids['plant_id_pudl'])
-    return(shared_plant_ids)
+    return shared_plant_ids
 
 
 def ferc_pudl_plant_ids(pudl_engine):
     """Generate a list of PUDL plant IDs that correspond to FERC plants."""
     ferc_plant_ids = pd.read_sql('''SELECT plant_id_pudl FROM plants_ferc''',
                                  pudl_engine)
-    return(ferc_plant_ids)
+    return ferc_plant_ids
 
 
 def eia_pudl_plant_ids(pudl_engine):
     """Generate a list of PUDL plant IDs that correspond to EIA plants."""
     eia_plant_ids = pd.read_sql('''SELECT plant_id_pudl FROM plants_eia''',
                                 pudl_engine)
-    return(eia_plant_ids)
+    return eia_plant_ids
 
 
 def yearly_sum_eia(df, sum_by, columns=['plant_id_eia', 'generator_id']):
@@ -245,7 +245,7 @@ def yearly_sum_eia(df, sum_by, columns=['plant_id_eia', 'generator_id']):
     """
     df['report_year'] = pd.to_datetime(df['report_date']).dt.year
     gb = df.groupby(by=columns)
-    return(gb.agg({sum_by: np.sum}))
+    return gb.agg({sum_by: np.sum})
 
 
 def eia_operator_plants(operator_id, pudl_engine):
@@ -264,7 +264,7 @@ def eia_operator_plants(operator_id, pudl_engine):
                                plant_id_pudl.
                                in_(pudl_plant_ids))]
     session.close_all()
-    return(eia923_plant_ids)
+    return eia923_plant_ids
 
 
 def consolidate_ferc1_expns(steam_df, min_capfac=0.6, min_corr=0.5):
@@ -314,7 +314,7 @@ def consolidate_ferc1_expns(steam_df, min_capfac=0.6, min_corr=0.5):
     # - non-production expenses
     steam_df['expns_total_nonproduction'] = steam_df[npx].copy().sum(axis=1)
 
-    return(steam_df)
+    return steam_df
 
 
 def ferc1_expns_corr(steam_df, min_capfac=0.6):
@@ -369,7 +369,7 @@ def ferc1_expns_corr(steam_df, min_capfac=0.6):
         expns_plants = steam_df[expns][steam_df[expns] != 0]
         expns_corr[expns] = np.corrcoef(mwh_plants, expns_plants)[0, 1]
 
-    return(expns_corr)
+    return expns_corr
 
 
 def ferc_expenses(pudl_engine, pudl_plant_ids=[], require_eia=True,
@@ -425,7 +425,7 @@ def ferc_expenses(pudl_engine, pudl_plant_ids=[], require_eia=True,
             steam_df.plant_id_pudl.isin(eia_pudl.plant_id_pudl)]
 
     # Pass back both the expense correlations, and the plant data.
-    return(expns_corrs, steam_df)
+    return expns_corrs, steam_df
 
 
 def fuel_ferc1_by_pudl(pudl_plant_ids, pudl_engine,
@@ -451,7 +451,7 @@ def fuel_ferc1_by_pudl(pudl_plant_ids, pudl_engine,
     # Calculate the total fuel heat content for the plant by fuel
     fuel_df = fuel_df[fuel_df.plant_id_pudl.isin(pudl_plant_ids)]
 
-    if (fuels == 'all'):
+    if fuels == 'all':
         cols_to_gb = ['plant_id_pudl', 'report_year']
     else:
         # Limit to records that pertain to our fuels of interest.
@@ -462,7 +462,7 @@ def fuel_ferc1_by_pudl(pudl_plant_ids, pudl_engine,
     fuel_df = fuel_df.groupby(cols_to_gb)[cols].sum()
     fuel_df = fuel_df.reset_index()
 
-    return(fuel_df)
+    return fuel_df
 
 
 def steam_ferc1_by_pudl(pudl_plant_ids, pudl_engine,
@@ -481,7 +481,7 @@ def steam_ferc1_by_pudl(pudl_plant_ids, pudl_engine,
     steam_df = steam_df.groupby(['plant_id_pudl', 'report_year'])[cols].sum()
     steam_df = steam_df.reset_index()
 
-    return(steam_df)
+    return steam_df
 
 
 def frc_by_pudl(pudl_plant_ids, pudl_engine,
@@ -514,7 +514,7 @@ def frc_by_pudl(pudl_plant_ids, pudl_engine,
     cols_to_keep = cols_to_keep + cols
     cols_to_gb = [pd.Grouper(freq='A'), 'plant_id_pudl']
 
-    if (fuels != 'all'):
+    if fuels != 'all':
         frc_df = frc_df[frc_df.fuel.isin(fuels)]
         cols_to_keep = cols_to_keep + ['fuel', ]
         cols_to_gb = cols_to_gb + ['fuel', ]
@@ -537,7 +537,7 @@ def frc_by_pudl(pudl_plant_ids, pudl_engine,
     frc_totals_df = frc_totals_df.drop('report_date', axis=1)
     frc_totals_df = frc_totals_df.dropna()
 
-    return(frc_totals_df)
+    return frc_totals_df
 
 
 def gen_fuel_by_pudl(pudl_plant_ids, pudl_engine,
@@ -576,7 +576,7 @@ def gen_fuel_by_pudl(pudl_plant_ids, pudl_engine,
     cols_to_keep = cols_to_keep + cols
     cols_to_gb = [pd.Grouper(freq='A'), 'plant_id_pudl']
 
-    if (fuels != 'all'):
+    if fuels != 'all':
         gf_df = gf_df[gf_df.fuel.isin(fuels)]
         cols_to_keep = cols_to_keep + ['fuel', ]
         cols_to_gb = cols_to_gb + ['fuel', ]
@@ -598,7 +598,7 @@ def gen_fuel_by_pudl(pudl_plant_ids, pudl_engine,
     gf_totals_df = gf_totals_df.drop('report_date', axis=1)
     gf_totals_df = gf_totals_df.dropna()
 
-    return(gf_totals_df)
+    return gf_totals_df
 
 
 def generator_proportion_eia923(g, id_col='plant_id_eia'):
@@ -644,7 +644,7 @@ def generator_proportion_eia923(g, id_col='plant_id_eia'):
         ['net_generation_mwh_x', 'net_generation_mwh_y'], axis=1)
     g_gens_proportion.reset_index(inplace=True)
 
-    return(g_gens_proportion)
+    return g_gens_proportion
 
 
 def capacity_proportion_eia923(g, id_col='plant_id_eia',
@@ -684,7 +684,7 @@ def capacity_proportion_eia923(g, id_col='plant_id_eia',
         columns={'nameplate_capacity_mw_x': 'nameplate_capacity_gen_mw',
                  'nameplate_capacity_mw_y': 'nameplate_capacity_plant_mw'})
 
-    return(g_capacity_proportion)
+    return g_capacity_proportion
 
 
 def values_by_generator_eia923(table_eia923, column_name, g):
@@ -728,7 +728,7 @@ def values_by_generator_eia923(table_eia923, column_name, g):
     # drop the unneccessary columns
     g_generator = g_generator.drop(
         ['proportion_of_generation', column_name_by_plant], axis=1)
-    return(g_generator)
+    return g_generator
 
 
 def primary_fuel_ferc1(fuel_df, fuel_thresh=0.5):
@@ -765,7 +765,7 @@ def primary_fuel_ferc1(fuel_df, fuel_thresh=0.5):
     mask = plants_by_heat >= fuel_thresh
     plants_by_heat = plants_by_heat.where(mask)
     plants_by_heat['primary_fuel'] = plants_by_heat.idxmax(axis=1)
-    return(plants_by_heat[['primary_fuel', ]].reset_index())
+    return plants_by_heat[['primary_fuel', ]].reset_index()
 
 
 def plant_fuel_proportions_ferc1(fuel_df):
@@ -800,7 +800,7 @@ def plant_fuel_proportions_ferc1(fuel_df):
                       inplace=True)
     del heat_pivot.columns.name
 
-    return(heat_pivot)
+    return heat_pivot
 
 
 def plant_fuel_proportions_frc_eia923(frc_df, id_col='plant_id_eia'):
@@ -850,7 +850,7 @@ def plant_fuel_proportions_frc_eia923(frc_df, id_col='plant_id_eia'):
     heat_pivot = heat_pivot.reset_index()
     del heat_pivot.columns.name
 
-    return(heat_pivot)
+    return heat_pivot
 
 
 def primary_fuel_frc_eia923(frc_df, id_col='plant_id_eia', fuel_thresh=0.5):
@@ -868,7 +868,7 @@ def primary_fuel_frc_eia923(frc_df, id_col='plant_id_eia', fuel_thresh=0.5):
     mask = frc_by_heat >= fuel_thresh
     frc_by_heat = frc_by_heat.where(mask)
     frc_by_heat['primary_fuel'] = frc_by_heat.idxmax(axis=1)
-    return(frc_by_heat[['primary_fuel', ]].reset_index())
+    return frc_by_heat[['primary_fuel', ]].reset_index()
 
 
 def plant_fuel_proportions_gf_eia923(gf_df):
@@ -920,7 +920,7 @@ def plant_fuel_proportions_gf_eia923(gf_df):
     heat_pivot = heat_pivot.reset_index()
     del heat_pivot.columns.name
 
-    return(heat_pivot)
+    return heat_pivot
 
 
 def primary_fuel_gf_eia923(gf_df, id_col='plant_id_eia', fuel_thresh=0.5):
@@ -938,7 +938,7 @@ def primary_fuel_gf_eia923(gf_df, id_col='plant_id_eia', fuel_thresh=0.5):
     mask = gf_by_heat >= fuel_thresh
     gf_by_heat = gf_by_heat.where(mask)
     gf_by_heat['primary_fuel'] = gf_by_heat.idxmax(axis=1)
-    return(gf_by_heat[['primary_fuel', ]].reset_index())
+    return gf_by_heat[['primary_fuel', ]].reset_index()
 
 
 def fercplants(plant_tables=['f1_steam',
@@ -1047,7 +1047,7 @@ def fercplants(plant_tables=['f1_steam',
 
     # If we're only trying to get the NEW plants, then we need to see which
     # ones we've already got in the PUDL DB, and look at what's different.
-    if(new):
+    if new:
         ferc1_plants_all = ferc1_plants_all.set_index(
             ['respondent_id', 'plant_name'])
 
@@ -1071,4 +1071,4 @@ def fercplants(plant_tables=['f1_steam',
     else:
         ferc1_plants = ferc1_plants_all
 
-    return(ferc1_plants)
+    return ferc1_plants

--- a/pudl/datastore.py
+++ b/pudl/datastore.py
@@ -50,36 +50,36 @@ def source_url(source, year):
 
     base_url = pc.base_data_urls[source]
 
-    if (source == 'eia860'):
+    if source == 'eia860':
         download_url = '{}/eia860{}.zip'.format(base_url, year)
-    elif (source == 'eia861'):
-        if (year < 2012):
+    elif source == 'eia861':
+        if year < 2012:
             # Before 2012 they used 2 digit years. Y2K12 FTW!
             download_url = '{}/f861{}.zip'.format(base_url, str(year)[2:])
         else:
             download_url = '{}/f861{}.zip'.format(base_url, year)
-    elif (source == 'eia923'):
-        if(year < 2008):
+    elif source == 'eia923':
+        if year < 2008:
             prefix = 'f906920_'
         else:
             prefix = 'f923_'
         download_url = '{}/{}{}.zip'.format(base_url, prefix, year)
-    elif (source == 'ferc1'):
+    elif source == 'ferc1':
         download_url = '{}/f1_{}.zip'.format(base_url, year)
-    elif (source == 'mshamines'):
+    elif source == 'mshamines':
         download_url = '{}/Mines.zip'.format(base_url)
-    elif (source == 'mshaops'):
+    elif source == 'mshaops':
         download_url = '{}/ControllerOperatorHistory.zip'.format(base_url)
-    elif (source == 'mshaprod'):
+    elif source == 'mshaprod':
         download_url = '{}/MinesProdQuarterly.zip'.format(base_url)
-    # elif (source == 'epacems'):
+    # elif source == 'epacems':
     # We have not yet implemented downloading of EPA CEMS data.
     else:
         # we should never ever get here because of the assert statement.
         assert False, \
             "Bad data source '{}' requested.".format(source)
 
-    return(download_url)
+    return download_url
 
 
 def path(source, year=0, file=True, datadir=settings.DATA_DIR):
@@ -121,45 +121,45 @@ def path(source, year=0, file=True, datadir=settings.DATA_DIR):
         assert year in pc.data_years[source], \
             "Invalid year {} specified for datastore path.".format(year)
 
-    if(file):
+    if file:
         assert year != 0, \
             "Non-zero year required to generate full datastore file path."
 
-    if (source == 'eia860'):
+    if source == 'eia860':
         dstore_path = os.path.join(datadir, 'eia', 'form860')
-        if(year != 0):
+        if year != 0:
             dstore_path = os.path.join(dstore_path, 'eia860{}'.format(year))
-    elif (source == 'eia861'):
+    elif source == 'eia861':
         dstore_path = os.path.join(datadir, 'eia', 'form861')
-        if(year != 0):
+        if year != 0:
             dstore_path = os.path.join(dstore_path, 'eia861{}'.format(year))
-    elif (source == 'eia923'):
+    elif source == 'eia923':
         dstore_path = os.path.join(datadir, 'eia', 'form923')
-        if(year != 0):
-            if(year < 2008):
+        if year != 0:
+            if year < 2008:
                 prefix = 'f906920_'
             else:
                 prefix = 'f923_'
             dstore_path = os.path.join(dstore_path,
                                        '{}{}'.format(prefix, year))
-    elif (source == 'ferc1'):
+    elif source == 'ferc1':
         dstore_path = os.path.join(datadir, 'ferc', 'form1')
-        if(year != 0):
+        if year != 0:
             dstore_path = os.path.join(dstore_path, 'f1_{}'.format(year))
-    elif (source == 'mshamines' and file):
+    elif source == 'mshamines' and file:
         dstore_path = os.path.join(datadir, 'msha')
-        if(year != 0):
+        if year != 0:
             dstore_path = os.path.join(dstore_path, 'Mines.zip')
-    elif (source == 'mshaops'):
+    elif source == 'mshaops':
         dstore_path = os.path.join(datadir, 'msha')
-        if(year != 0 and file):
+        if year != 0 and file:
             dstore_path = os.path.join(dstore_path,
                                        'ControllerOperatorHistory.zip')
-    elif (source == 'mshaprod' and file):
+    elif source == 'mshaprod' and file:
         dstore_path = os.path.join(datadir, 'msha')
-        if(year != 0):
+        if year != 0:
             dstore_path = os.path.join(dstore_path, 'MinesProdQuarterly.zip')
-    # elif (source == 'epacems'):
+    # elif source == 'epacems':
     # We have not yet implemented downloading of EPA CEMS data.
     else:
         # we should never ever get here because of the assert statement.
@@ -169,13 +169,13 @@ def path(source, year=0, file=True, datadir=settings.DATA_DIR):
     # Current naming convention requires the name of the directory to which
     # an original data source is downloaded to be the same as the basename
     # of the file itself...
-    if(file):
+    if file:
         if source not in ['mshamines', 'mshaops', 'mshaprod']:
             dstore_path = \
                 os.path.join(dstore_path,
                              '{}.zip'.format(os.path.basename(dstore_path)))
 
-    return(dstore_path)
+    return dstore_path
 
 
 def download(source, year, datadir=settings.DATA_DIR, verbose=True):
@@ -218,13 +218,13 @@ def download(source, year, datadir=settings.DATA_DIR, verbose=True):
 
     tmp_file = os.path.join(tmp_dir, os.path.basename(path(source, year)))
 
-    if(verbose):
+    if verbose:
         print("""Downloading {} data for {}...
     {}""".format(source, year, src_url))
 
     outfile, msg = urllib.request.urlretrieve(src_url, filename=tmp_file)
 
-    return(outfile)
+    return outfile
 
 
 def organize(source, year, unzip=True,
@@ -287,7 +287,7 @@ def organize(source, year, unzip=True,
     # However, when we integrate the CEMS data, we may need to store it
     # in its zipped form -- since unzipped it is ~100GB, and it's extremely
     # compressible.
-    if(unzip):
+    if unzip:
         # Unzip the downloaded file in its new home:
         zip_ref = zipfile.ZipFile(destfile, 'r')
         zip_ref.extractall(destdir)
@@ -295,7 +295,7 @@ def organize(source, year, unzip=True,
         # Most of the data sources can just be unzipped in place and be done
         # with it, but FERC Form 1 requires some special attention:
         # data source we're working with:
-        if(source == 'ferc1'):
+        if source == 'ferc1':
             topdirs = [os.path.join(destdir, td)
                        for td in ['UPLOADERS', 'FORMSADMIN']]
             for td in topdirs:

--- a/pudl/extract/eia860.py
+++ b/pudl/extract/eia860.py
@@ -174,7 +174,7 @@ def get_eia860_page(page, eia860_xlsx,
         newdata.columns = newdata.columns.str.replace(' ', '_')
 
         # boiler_generator_assn tab is missing a YEAR column. Add it!
-        if page == 'boiler_generator_assn', 'utilty':
+        if 'report_year' not in newdata.columns:
             newdata['report_year'] = yr
 
         newdata = newdata.rename(columns=column_map)

--- a/pudl/extract/eia860.py
+++ b/pudl/extract/eia860.py
@@ -44,7 +44,7 @@ def get_eia860_file(yr, file):
         path to EIA 860 spreadsheets corresponding to a given year.
     """
     assert(yr > 2010), "EIA860 file selection only works for 2010 & later."
-    return(glob.glob(os.path.join(datadir(yr), file))[0])
+    return glob.glob(os.path.join(datadir(yr), file))[0]
 
 
 def get_eia860_xlsx(years, filename):
@@ -68,7 +68,7 @@ def get_eia860_xlsx(years, filename):
     for yr in years:
         print("    {}...".format(yr))
         eia860_xlsx[yr] = pd.ExcelFile(get_eia860_file(yr, pattern))
-    return(eia860_xlsx)
+    return eia860_xlsx
 
 
 def get_eia860_column_map(page, year):
@@ -129,7 +129,7 @@ def get_eia860_column_map(page, year):
     for k, v in d.items():
         column_map[v] = k
 
-    return((sheet_name, skiprows, column_map))
+    return (sheet_name, skiprows, column_map)
 
 
 def get_eia860_page(page, eia860_xlsx,
@@ -174,13 +174,13 @@ def get_eia860_page(page, eia860_xlsx,
         newdata.columns = newdata.columns.str.replace(' ', '_')
 
         # boiler_generator_assn tab is missing a YEAR column. Add it!
-        if(page == 'boiler_generator_assn', 'utilty'):
+        if page == 'boiler_generator_assn', 'utilty':
             newdata['report_year'] = yr
 
         newdata = newdata.rename(columns=column_map)
 
         df = df.append(newdata)
-    return(df)
+    return df
 
 
 def create_dfs_eia860(files=pc.files_eia860,
@@ -210,7 +210,7 @@ def create_dfs_eia860(files=pc.files_eia860,
             eia860_dfs[page] = get_eia860_page(page, eia860_xlsx,
                                                years=eia860_years,
                                                verbose=verbose)
-    return(eia860_dfs)
+    return eia860_dfs
 
 
 def get_eia860_plants(years, eia860_xlsx):
@@ -242,6 +242,6 @@ def get_eia860_plants(years, eia860_xlsx):
                                'eia_sector', 'naics_code',
                                'reporting_frequency', 'nameplate_capacity_mw',
                                'report_year'])
-    if (len(recent_years) > 0):
+    if len(recent_years) > 0:
         pf = get_eia860_page('boiler_generator_assn_eia860', eia860_xlsx,
                              years=recent_years)

--- a/pudl/extract/eia923.py
+++ b/pudl/extract/eia923.py
@@ -31,10 +31,10 @@ def datadir(year, basedir=settings.EIA923_DATA_DIR):
     """
     # These are the only years we've got...
     assert year in pc.data_years['eia923']
-    if(year < 2008):
-        return(os.path.join(basedir, 'f906920_{}'.format(year)))
+    if year < 2008:
+        return os.path.join(basedir, 'f906920_{}'.format(year))
     else:
-        return(os.path.join(basedir, 'f923_{}'.format(year)))
+        return os.path.join(basedir, 'f923_{}'.format(year))
 
 
 def get_eia923_file(yr, basedir=settings.EIA923_DATA_DIR):
@@ -54,7 +54,7 @@ def get_eia923_file(yr, basedir=settings.EIA923_DATA_DIR):
     # There can only be one!
     assert len(eia923_filematch) == 1, \
         'Multiple matching EIA923 spreadsheets found for {}'.format(yr)
-    return(eia923_filematch[0])
+    return eia923_filematch[0]
 
 
 def get_eia923_column_map(page, year):
@@ -113,7 +113,7 @@ def get_eia923_column_map(page, year):
     for k, v in d.items():
         column_map[v] = k
 
-    return((sheet_name, skiprows, column_map))
+    return (sheet_name, skiprows, column_map)
 
 
 def get_eia923_page(page, eia923_xlsx,
@@ -164,22 +164,22 @@ def get_eia923_page(page, eia923_xlsx,
         newdata.drop(to_drop, axis=1, inplace=True)
 
         # stocks tab is missing a YEAR column for some reason. Add it!
-        if(page == 'stocks'):
+        if page == 'stocks':
             newdata['report_year'] = yr
 
         newdata = newdata.rename(columns=column_map)
-        if(page == 'stocks'):
+        if page == 'stocks':
             newdata = newdata.rename(columns={
                 'unnamed_0': 'census_division_and_state'})
 
         # Drop the fields with plant_id_eia 99999 or 999999.
         # These are state index
-        if(page != 'stocks'):
+        if page != 'stocks':
             newdata = newdata[~newdata.plant_id_eia.isin([99999, 999999])]
 
         df = df.append(newdata)
 
-    return(df)
+    return df
 
 
 def get_eia923_xlsx(years):
@@ -200,7 +200,7 @@ def get_eia923_xlsx(years):
     for yr in years:
         print("    {}...".format(yr))
         eia923_xlsx[yr] = pd.ExcelFile(get_eia923_file(yr))
-    return(eia923_xlsx)
+    return eia923_xlsx
 
 
 def get_eia923_plants(years, eia923_xlsx):
@@ -232,7 +232,7 @@ def get_eia923_plants(years, eia923_xlsx):
                                'eia_sector', 'naics_code',
                                'reporting_frequency', 'nameplate_capacity_mw',
                                'report_year'])
-    if (len(recent_years) > 0):
+    if len(recent_years) > 0:
         pf = get_eia923_page('plant_frame', eia923_xlsx, years=recent_years)
         pf_mw = pd.DataFrame(columns=['plant_id_eia', 'nameplate_capacity_mw',
                                       'report_year'])
@@ -290,7 +290,7 @@ def get_eia923_plants(years, eia923_xlsx):
                 plant_info_compiled.columns.str.replace('_x$', '')
     plant_info_compiled = plant_info_compiled.drop_duplicates('plant_id_eia')
     plant_info_compiled = plant_info_compiled.drop(['report_year'], axis=1)
-    return(plant_info_compiled)
+    return plant_info_compiled
 
 
 def yearly_to_monthly_eia923(df, md):
@@ -339,4 +339,4 @@ def yearly_to_monthly_eia923(df, md):
     # data frame we started with -- all of which should be independent of the
     # month, and apply across all 12 of the monthly records created from each
     # of the # initial annual records.
-    return(yearly.merge(monthly, left_index=True, right_index=True))
+    return yearly.merge(monthly, left_index=True, right_index=True)

--- a/pudl/extract/ferc1.py
+++ b/pudl/extract/ferc1.py
@@ -22,7 +22,7 @@ def connect_db(testing=False):
 
     Returns sqlalchemy engine instance.
     """
-    if(testing):
+    if testing:
         return sa.create_engine(sa.engine.url.URL(**settings.DB_FERC1_TEST))
     else:
         return sa.create_engine(sa.engine.url.URL(**settings.DB_FERC1))
@@ -147,7 +147,7 @@ def extract_dbc_tables(year, minstring=4, basedir=settings.FERC1_DATA_DIR):
         for sn, ln in zip(tf_doubledict[k].keys(), tf_doubledict[k].values()):
             assert(ln[:8] == sn.lower()[:8])
 
-    return(tf_doubledict)
+    return tf_doubledict
 
 
 def define_db(refyear, ferc1_tables, ferc1_meta,
@@ -200,21 +200,21 @@ def define_db(refyear, ferc1_tables, ferc1_meta,
             col_type = pc.dbf_typemap[field.type]
 
             # String/VarChar is the only type that really NEEDS a length
-            if(col_type == sa.String):
+            if col_type == sa.String:
                 col_type = col_type(length=field.length)
 
             # This eliminates the "footnote" fields which all mirror database
             # fields, but end with _f. We have not yet integrated the footnotes
             # into the rest of the DB, and so why clutter it up?
-            if(not re.match('(.*_f$)', col_name)):
+            if not re.match('(.*_f$)', col_name):
                 ferc1_sql.append_column(sa.Column(col_name, col_type))
 
         # Append primary key constraints to the table:
-        if (table_name == 'f1_respondent_id'):
+        if table_name == 'f1_respondent_id':
             ferc1_sql.append_constraint(
                 sa.PrimaryKeyConstraint('respondent_id'))
 
-        if (table_name in pc.ferc1_data_tables):
+        if table_name in pc.ferc1_data_tables:
             # All the "real" data tables use the same 5 fields as a composite
             # primary key: [ respondent_id, report_year, report_prd,
             # row_number, spplmnt_num ]
@@ -308,7 +308,7 @@ def init_db(ferc1_tables=pc.ferc1_default_tables,
             # need to avoid collisions in the f1_respondent_id table, which
             # does not have a year field... F1_1 is the DBF file that stores
             # this table:
-            if(dbf == 'F1_1'):
+            if dbf == 'F1_1':
                 sql_stmt = sql_stmt.on_conflict_do_nothing()
 
             # insert the new records!
@@ -341,7 +341,7 @@ def fuel(ferc1_raw_dfs,
 
     ferc1_raw_dfs[pudl_table] = fuel_ferc1_df
 
-    return(ferc1_raw_dfs)
+    return ferc1_raw_dfs
 
 
 def plants_steam(ferc1_raw_dfs,
@@ -361,7 +361,7 @@ def plants_steam(ferc1_raw_dfs,
     # populate the unlatered dictionary of dataframes
     ferc1_raw_dfs[pudl_table] = ferc1_steam_df
 
-    return(ferc1_raw_dfs)
+    return ferc1_raw_dfs
 
 
 def plants_small(ferc1_raw_dfs,
@@ -398,7 +398,7 @@ def plants_small(ferc1_raw_dfs,
     # populate the unlatered dictionary of dataframes
     ferc1_raw_dfs[pudl_table] = ferc1_small_df
 
-    return(ferc1_raw_dfs)
+    return ferc1_raw_dfs
 
 
 def plants_hydro(ferc1_raw_dfs,
@@ -416,7 +416,7 @@ def plants_hydro(ferc1_raw_dfs,
 
     ferc1_raw_dfs[pudl_table] = ferc1_hydro_df
 
-    return(ferc1_raw_dfs)
+    return ferc1_raw_dfs
 
 
 def plants_pumped_storage(ferc1_raw_dfs,
@@ -438,7 +438,7 @@ def plants_pumped_storage(ferc1_raw_dfs,
 
     ferc1_raw_dfs[pudl_table] = ferc1_pumped_storage_df
 
-    return(ferc1_raw_dfs)
+    return ferc1_raw_dfs
 
 
 def plant_in_service(ferc1_raw_dfs,
@@ -459,7 +459,7 @@ def plant_in_service(ferc1_raw_dfs,
 
     ferc1_raw_dfs[pudl_table] = ferc1_pis_df
 
-    return(ferc1_raw_dfs)
+    return ferc1_raw_dfs
 
 
 def purchased_power(ferc1_raw_dfs,
@@ -475,7 +475,7 @@ def purchased_power(ferc1_raw_dfs,
 
     ferc1_raw_dfs[pudl_table] = ferc1_purchased_pwr_df
 
-    return(ferc1_raw_dfs)
+    return ferc1_raw_dfs
 
 
 def accumulated_depreciation(ferc1_raw_dfs,
@@ -491,4 +491,4 @@ def accumulated_depreciation(ferc1_raw_dfs,
 
     ferc1_raw_dfs[pudl_table] = ferc1_apd_df
 
-    return(ferc1_raw_dfs)
+    return ferc1_raw_dfs

--- a/pudl/init.py
+++ b/pudl/init.py
@@ -54,7 +54,7 @@ import pudl.constants as pc
 
 def connect_db(testing=False):
     """Connect to the PUDL database using global settings from settings.py."""
-    if(testing):
+    if testing:
         return sa.create_engine(sa.engine.url.URL(**settings.DB_PUDL_TEST))
     else:
         return sa.create_engine(sa.engine.url.URL(**settings.DB_PUDL))
@@ -409,7 +409,7 @@ def extract_eia860(eia860_years=pc.working_years['eia860'],
         pudl.extract.eia860.create_dfs_eia860(files=pc.files_eia860,
                                               eia860_years=eia860_years,
                                               verbose=verbose)
-    return(eia860_raw_dfs)
+    return eia860_raw_dfs
 
 
 def extract_eia923(eia923_years=pc.working_years['eia923'],
@@ -422,7 +422,7 @@ def extract_eia923(eia923_years=pc.working_years['eia923'],
     # Create DataFrames
     eia923_raw_dfs = {}
     for page in pc.tab_map_eia923.columns:
-        if (page != 'plant_frame'):
+        if page != 'plant_frame':
             eia923_raw_dfs[page] = pudl.extract.eia923.\
                 get_eia923_page(page, eia923_xlsx,
                                 years=eia923_years,
@@ -431,7 +431,7 @@ def extract_eia923(eia923_years=pc.working_years['eia923'],
             #    eia923_years, eia923_xlsx)
         # else:
 
-    return(eia923_raw_dfs)
+    return eia923_raw_dfs
 
 
 def transform_eia923(eia923_raw_dfs,
@@ -457,14 +457,14 @@ def transform_eia923(eia923_raw_dfs,
         if table in eia923_tables:
             if verbose:
                 print("    {}...".format(table))
-            if (table == 'fuel_receipts_costs_eia923'):
+            if table == 'fuel_receipts_costs_eia923':
                 eia923_transform_functions[table](eia923_raw_dfs,
                                                   eia923_transformed_dfs,
                                                   pudl_engine)
             else:
                 eia923_transform_functions[table](eia923_raw_dfs,
                                                   eia923_transformed_dfs)
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs
 
 
 def extract_ferc1(ferc1_tables=pc.ferc1_pudl_tables,
@@ -511,7 +511,7 @@ def extract_ferc1(ferc1_tables=pc.ferc1_pudl_tables,
                                            pudl_table=table,
                                            ferc1_years=ferc1_years)
 
-    return(ferc1_raw_dfs)
+    return ferc1_raw_dfs
 
 
 def transform_ferc1(ferc1_raw_dfs,
@@ -543,7 +543,7 @@ def transform_ferc1(ferc1_raw_dfs,
             ferc1_transform_functions[table](ferc1_raw_dfs,
                                              ferc1_transformed_dfs)
 
-    return(ferc1_transformed_dfs)
+    return ferc1_transformed_dfs
 
 
 def init_db(ferc1_tables=pc.ferc1_pudl_tables,

--- a/pudl/mcoe.py
+++ b/pudl/mcoe.py
@@ -77,7 +77,7 @@ def heat_rate_by_unit(pudl_out, verbose=False):
     hr_by_unit['heat_rate_mmbtu_mwh'] = \
         hr_by_unit.total_heat_content_mmbtu / hr_by_unit.net_generation_mwh
 
-    return(hr_by_unit)
+    return hr_by_unit
 
 
 def heat_rate_by_gen(pudl_out, verbose=False):
@@ -111,7 +111,7 @@ def heat_rate_by_gen(pudl_out, verbose=False):
                                 'fuel_type_pudl', 'fuel_type_count']],
         on=['plant_id_eia', 'generator_id']
     )
-    return(hr_by_gen)
+    return hr_by_gen
 
 
 def fuel_cost(pudl_out, verbose=False):
@@ -230,7 +230,7 @@ def fuel_cost(pudl_out, verbose=False):
     out_df = pd.merge(out_df.drop_duplicates(), fuel_cost,
                       on=['report_date', 'plant_id_eia', 'generator_id'])
 
-    return(out_df)
+    return out_df
 
 
 def capacity_factor(pudl_out, min_cap_fact=0, max_cap_fact=1.5, verbose=False):
@@ -297,7 +297,7 @@ def capacity_factor(pudl_out, min_cap_fact=0, max_cap_fact=1.5, verbose=False):
     # drop the hours column, cause we don't need it anymore
     capacity_factor.drop(['hours'], axis=1, inplace=True)
 
-    return(capacity_factor)
+    return capacity_factor
 
 
 def mcoe(pudl_out,
@@ -397,4 +397,4 @@ def mcoe(pudl_out,
     if max_cap_fact is not None:
         mcoe_out = mcoe_out[mcoe_out.capacity_factor <= max_cap_fact]
 
-    return(mcoe_out)
+    return mcoe_out

--- a/pudl/outputs.py
+++ b/pudl/outputs.py
@@ -101,18 +101,18 @@ class PudlOutput(object):
                 plants_utils_eia(start_date=self.start_date,
                                  end_date=self.end_date,
                                  testing=self.testing)
-        return(self._dfs['pu_eia'])
+        return self._dfs['pu_eia']
 
     def pu_eia(self, update=False):
-        return(self.plants_utilities_eia(update=update))
+        return self.plants_utilities_eia(update=update)
 
     def plants_utilities_ferc1(self, update=False):
         if update or self._dfs['pu_ferc1'] is None:
             self._dfs['pu_ferc1'] = plants_utils_ferc1(testing=self.testing)
-        return(self._dfs['pu_ferc1'])
+        return self._dfs['pu_ferc1']
 
     def pu_ferc1(self, update=False):
-        return(self.plants_utilities_ferc1(update=update))
+        return self.plants_utilities_ferc1(update=update)
 
     def utilities_eia860(self, update=False):
         if update or self._dfs['utils_eia860'] is None:
@@ -120,10 +120,10 @@ class PudlOutput(object):
                 utilities_eia860(start_date=self.start_date,
                                  end_date=self.end_date,
                                  testing=self.testing)
-        return(self._dfs['utils_eia860'])
+        return self._dfs['utils_eia860']
 
     def utils_eia860(self, update=False):
-        return(self.utilities_eia860(update=update))
+        return self.utilities_eia860(update=update)
 
     def boiler_generator_assn_eia860(self, update=False):
         if update or self._dfs['bga_eia860'] is None:
@@ -131,10 +131,10 @@ class PudlOutput(object):
                 boiler_generator_assn_eia860(start_date=self.start_date,
                                              end_date=self.end_date,
                                              testing=self.testing)
-        return(self._dfs['bga_eia860'])
+        return self._dfs['bga_eia860']
 
     def bga_eia860(self, update=False):
-        return(self.boiler_generator_assn_eia860(update=update))
+        return self.boiler_generator_assn_eia860(update=update)
 
     def plants_eia860(self, update=False):
         if update or self._dfs['plants_eia860'] is None:
@@ -142,7 +142,7 @@ class PudlOutput(object):
                 plants_eia860(start_date=self.start_date,
                               end_date=self.end_date,
                               testing=self.testing)
-        return(self._dfs['plants_eia860'])
+        return self._dfs['plants_eia860']
 
     def generators_eia860(self, update=False):
         if update or self._dfs['gens_eia860'] is None:
@@ -150,10 +150,10 @@ class PudlOutput(object):
                 generators_eia860(start_date=self.start_date,
                                   end_date=self.end_date,
                                   testing=self.testing)
-        return(self._dfs['gens_eia860'])
+        return self._dfs['gens_eia860']
 
     def gens_eia860(self, update=False):
-        return(self.generators_eia860(update=update))
+        return self.generators_eia860(update=update)
 
     def ownership_eia860(self, update=False):
         if update or self._dfs['own_eia860'] is None:
@@ -161,10 +161,10 @@ class PudlOutput(object):
                 ownership_eia860(start_date=self.start_date,
                                  end_date=self.end_date,
                                  testing=self.testing)
-        return(self._dfs['own_eia860'])
+        return self._dfs['own_eia860']
 
     def own_eia860(self, update=False):
-        return(self.ownership_eia860(update=update))
+        return self.ownership_eia860(update=update)
 
     def generation_fuel_eia923(self, update=False):
         if update or self._dfs['gf_eia923'] is None:
@@ -173,10 +173,10 @@ class PudlOutput(object):
                                        start_date=self.start_date,
                                        end_date=self.end_date,
                                        testing=self.testing)
-        return(self._dfs['gf_eia923'])
+        return self._dfs['gf_eia923']
 
     def gf_eia923(self, update=False):
-        return(self.generation_fuel_eia923(update=update))
+        return self.generation_fuel_eia923(update=update)
 
     def fuel_receipts_costs_eia923(self, update=False):
         if update or self._dfs['frc_eia923'] is None:
@@ -185,10 +185,10 @@ class PudlOutput(object):
                                            start_date=self.start_date,
                                            end_date=self.end_date,
                                            testing=self.testing)
-        return(self._dfs['frc_eia923'])
+        return self._dfs['frc_eia923']
 
     def frc_eia923(self, update=False):
-        return(self.fuel_receipts_costs_eia923(update=update))
+        return self.fuel_receipts_costs_eia923(update=update)
 
     def boiler_fuel_eia923(self, update=False):
         if update or self._dfs['bf_eia923'] is None:
@@ -197,10 +197,10 @@ class PudlOutput(object):
                                    start_date=self.start_date,
                                    end_date=self.end_date,
                                    testing=self.testing)
-        return(self._dfs['bf_eia923'])
+        return self._dfs['bf_eia923']
 
     def bf_eia923(self, update=False):
-        return(self.boiler_fuel_eia923(update=update))
+        return self.boiler_fuel_eia923(update=update)
 
     def generation_eia923(self, update=False):
         if update or self._dfs['gen_eia923'] is None:
@@ -209,21 +209,21 @@ class PudlOutput(object):
                                   start_date=self.start_date,
                                   end_date=self.end_date,
                                   testing=self.testing)
-        return(self._dfs['gen_eia923'])
+        return self._dfs['gen_eia923']
 
     def gen_eia923(self, update=False):
-        return(self.generation_eia923(update=update))
+        return self.generation_eia923(update=update)
 
     def plants_steam_ferc1(self, update=False):
         if update or self._dfs['plants_steam_ferc1'] is None:
             self._dfs['plants_steam_ferc1'] = \
                 plants_steam_ferc1(testing=self.testing)
-        return(self._dfs['plants_steam_ferc1'])
+        return self._dfs['plants_steam_ferc1']
 
     def fuel_ferc1(self, update=False):
         if update or self._dfs['fuel_ferc1'] is None:
             self._dfs['fuel_ferc1'] = fuel_ferc1(testing=self.testing)
-        return(self._dfs['fuel_ferc1'])
+        return self._dfs['fuel_ferc1']
 
     def boiler_generator_assn_eia(self, update=False, verbose=False):
         if update or self._dfs['bga'] is None:
@@ -231,32 +231,32 @@ class PudlOutput(object):
                 boiler_generator_assn_eia(start_date=self.start_date,
                                           end_date=self.end_date,
                                           testing=self.testing)
-        return(self._dfs['bga'])
+        return self._dfs['bga']
 
     def bga(self, update=False, verbose=False):
-        return(self.boiler_generator_assn_eia(update=update))
+        return self.boiler_generator_assn_eia(update=update)
 
     def heat_rate_by_unit(self, update=False, verbose=False):
         if update or self._dfs['hr_by_unit'] is None:
             self._dfs['hr_by_unit'] = mcoe.heat_rate_by_unit(self,
                                                              verbose=verbose)
-        return(self._dfs['hr_by_unit'])
+        return self._dfs['hr_by_unit']
 
     def heat_rate_by_gen(self, update=False, verbose=False):
         if update or self._dfs['hr_by_gen'] is None:
             self._dfs['hr_by_gen'] = mcoe.heat_rate_by_gen(self,
                                                            verbose=verbose)
-        return(self._dfs['hr_by_gen'])
+        return self._dfs['hr_by_gen']
 
     def fuel_cost(self, update=False, verbose=False):
         if update or self._dfs['fc'] is None:
             self._dfs['fc'] = mcoe.fuel_cost(self, verbose=verbose)
-        return(self._dfs['fc'])
+        return self._dfs['fc']
 
     def capacity_factor(self, update=False, verbose=False):
         if update or self._dfs['cf'] is None:
             self._dfs['cf'] = mcoe.capacity_factor(self, verbose=verbose)
-        return(self._dfs['cf'])
+        return self._dfs['cf']
 
     def mcoe(self, update=False,
              min_heat_rate=5.5, min_fuel_cost_per_mwh=0.0,
@@ -268,7 +268,7 @@ class PudlOutput(object):
                           min_fuel_cost_per_mwh=min_fuel_cost_per_mwh,
                           min_cap_fact=min_cap_fact,
                           max_cap_fact=max_cap_fact)
-        return(self._dfs['mcoe'])
+        return self._dfs['mcoe']
 
 ###############################################################################
 ###############################################################################
@@ -294,7 +294,7 @@ def organize_cols(df, cols):
     data_cols = [c for c in df.columns.tolist() if c not in cols]
     data_cols.sort()
     organized_cols = cols + data_cols
-    return(df[organized_cols])
+    return df[organized_cols]
 
 
 def extend_annual(df, date_col='report_date', start_date=None, end_date=None):
@@ -335,7 +335,7 @@ def extend_annual(df, date_col='report_date', start_date=None, end_date=None):
             latest_date = pd.to_datetime(df[date_col].max())
 
     df[date_col] = pd.to_datetime(df[date_col])
-    return(df)
+    return df
 
 
 ###############################################################################
@@ -387,7 +387,7 @@ def plants_utils_eia(start_date=None, end_date=None, testing=False):
     out_df = out_df.dropna()
     out_df.plant_id_pudl = out_df.plant_id_pudl.astype(int)
     out_df.util_id_pudl = out_df.util_id_pudl.astype(int)
-    return(out_df)
+    return out_df
 
 
 def plants_utils_ferc1(testing=False):
@@ -403,7 +403,7 @@ def plants_utils_ferc1(testing=False):
     plants_ferc = pd.read_sql(plants_ferc_select, pudl_engine)
 
     out_df = pd.merge(plants_ferc, utils_ferc, on='respondent_id')
-    return(out_df)
+    return out_df
 
 
 def annotate_export(df1, df2, outfile='output.xlsx'):
@@ -509,7 +509,7 @@ def utilities_eia860(start_date=None, end_date=None, testing=False):
 
     out_df = organize_cols(out_df, first_cols)
     out_df = extend_annual(out_df, start_date=start_date, end_date=end_date)
-    return(out_df)
+    return out_df
 
 
 def boiler_generator_assn_eia(start_date=None, end_date=None,
@@ -531,7 +531,7 @@ def boiler_generator_assn_eia(start_date=None, end_date=None,
     bga_eia_df = pd.read_sql(bga_eia_select, pudl_engine)
     out_df = extend_annual(bga_eia_df,
                            start_date=start_date, end_date=end_date)
-    return(out_df)
+    return out_df
 
 
 def boiler_generator_assn_eia860(start_date=None, end_date=None,
@@ -553,7 +553,7 @@ def boiler_generator_assn_eia860(start_date=None, end_date=None,
     bga_eia860_df = pd.read_sql(bga_eia860_select, pudl_engine)
     out_df = extend_annual(bga_eia860_df,
                            start_date=start_date, end_date=end_date)
-    return(out_df)
+    return out_df
 
 
 def plants_eia860(start_date=None, end_date=None, testing=False):
@@ -606,7 +606,7 @@ def plants_eia860(start_date=None, end_date=None, testing=False):
 
     out_df = organize_cols(out_df, first_cols)
     out_df = extend_annual(out_df, start_date=start_date, end_date=end_date)
-    return(out_df)
+    return out_df
 
 
 def generators_eia860(start_date=None, end_date=None, testing=False):
@@ -730,7 +730,7 @@ def generators_eia860(start_date=None, end_date=None, testing=False):
                                  'plant_id_eia',
                                  'generator_id'])
 
-    return(out_df)
+    return out_df
 
 
 def ownership_eia860(start_date=None, end_date=None, testing=False):
@@ -790,7 +790,7 @@ def ownership_eia860(start_date=None, end_date=None, testing=False):
     out_df['util_id_pudl'] = out_df.util_id_pudl.astype(int)
     out_df = extend_annual(out_df, start_date=start_date, end_date=end_date)
 
-    return(out_df)
+    return out_df
 
 
 ###############################################################################
@@ -904,7 +904,7 @@ def generation_fuel_eia923(freq=None, testing=False,
     out_df['operator_id'] = out_df.operator_id.astype(int)
     out_df['util_id_pudl'] = out_df.util_id_pudl.astype(int)
 
-    return(out_df)
+    return out_df
 
 
 def fuel_receipts_costs_eia923(freq=None, testing=False,
@@ -1048,7 +1048,7 @@ def fuel_receipts_costs_eia923(freq=None, testing=False,
     out_df['operator_id'] = out_df.operator_id.astype(int)
     out_df['util_id_pudl'] = out_df.util_id_pudl.astype(int)
 
-    return(out_df)
+    return out_df
 
 
 def boiler_fuel_eia923(freq=None, testing=False,
@@ -1171,7 +1171,7 @@ def boiler_fuel_eia923(freq=None, testing=False,
     out_df['util_id_pudl'] = out_df.util_id_pudl.astype(int)
     out_df['plant_id_pudl'] = out_df.plant_id_pudl.astype(int)
 
-    return(out_df)
+    return out_df
 
 
 def generation_eia923(freq=None, testing=False,
@@ -1251,7 +1251,7 @@ def generation_eia923(freq=None, testing=False,
     out_df['util_id_pudl'] = out_df.util_id_pudl.astype(int)
     out_df['plant_id_pudl'] = out_df.plant_id_pudl.astype(int)
 
-    return(out_df)
+    return out_df
 
 
 ###############################################################################
@@ -1294,7 +1294,7 @@ def plants_steam_ferc1(testing=False):
 
     out_df = organize_cols(out_df, first_cols)
 
-    return(out_df)
+    return out_df
 
 
 def fuel_ferc1(testing=False):
@@ -1350,4 +1350,4 @@ def fuel_ferc1(testing=False):
 
     out_df = organize_cols(out_df, first_cols)
 
-    return(out_df)
+    return out_df

--- a/pudl/transform/eia.py
+++ b/pudl/transform/eia.py
@@ -49,7 +49,7 @@ def plants(eia_transformed_dfs,
     eia_transformed_dfs['plants_annual_eia'] = plants_annual
     entities_dfs['plants_entity_eia'] = plants
 
-    return(entities_dfs, eia_transformed_dfs)
+    return entities_dfs, eia_transformed_dfs
 
 
 def generators(eia_transformed_dfs,
@@ -98,7 +98,7 @@ def generators(eia_transformed_dfs,
     eia_transformed_dfs['generators_annual_eia'] = gens_annual
     entities_dfs['generators_entity_eia'] = gens
 
-    return(entities_dfs, eia_transformed_dfs)
+    return entities_dfs, eia_transformed_dfs
 
 
 def boilers(eia_transformed_dfs,
@@ -152,7 +152,7 @@ def boilers(eia_transformed_dfs,
     # eia_transformed_dfs['boilder_annual_eia'] = boilers_annual
     entities_dfs['boilers_entity_eia'] = boilers
 
-    return(entities_dfs, eia_transformed_dfs)
+    return entities_dfs, eia_transformed_dfs
 
 
 def boiler_generator_assn(eia_transformed_dfs,
@@ -479,7 +479,7 @@ def boiler_generator_assn(eia_transformed_dfs,
 
     eia_transformed_dfs['boiler_generator_assn_eia'] = bga_out
 
-    return(eia_transformed_dfs)
+    return eia_transformed_dfs
 
 
 def _restrict_years(df,
@@ -488,7 +488,7 @@ def _restrict_years(df,
     """Restrict eia years for boiler generator association"""
     bga_years = set(eia860_years) & set(eia923_years)
     df = df[df.report_date.dt.year.isin(bga_years)]
-    return(df)
+    return df
 
 
 def transform(eia_transformed_dfs,
@@ -528,4 +528,4 @@ def transform(eia_transformed_dfs,
                                            debug=debug,
                                            verbose=verbose)
 
-    return(entities_dfs, eia_transformed_dfs)
+    return entities_dfs, eia_transformed_dfs

--- a/pudl/transform/eia860.py
+++ b/pudl/transform/eia860.py
@@ -41,7 +41,7 @@ def ownership(eia860_dfs, eia860_transformed_dfs):
     # which should then feed into a yet to be created standardized 'load' step
     eia860_transformed_dfs['ownership_eia860'] = o_df
 
-    return(eia860_transformed_dfs)
+    return eia860_transformed_dfs
 
 
 def generators(eia860_dfs, eia860_transformed_dfs):
@@ -188,7 +188,7 @@ def generators(eia860_dfs, eia860_transformed_dfs):
 
     eia860_transformed_dfs['generators_eia860'] = gens_df
 
-    return(eia860_transformed_dfs)
+    return eia860_transformed_dfs
 
 
 def plants(eia860_dfs, eia860_transformed_dfs):
@@ -292,7 +292,7 @@ def plants(eia860_dfs, eia860_transformed_dfs):
 
     eia860_transformed_dfs['plants_eia860'] = p_df
 
-    return(eia860_transformed_dfs)
+    return eia860_transformed_dfs
 
 
 def boiler_generator_assn(eia860_dfs, eia860_transformed_dfs):
@@ -343,7 +343,7 @@ def boiler_generator_assn(eia860_dfs, eia860_transformed_dfs):
 
     eia860_transformed_dfs['boiler_generator_assn_eia860'] = b_g_df
 
-    return(eia860_transformed_dfs)
+    return eia860_transformed_dfs
 
 
 def utilities(eia860_dfs, eia860_transformed_dfs):
@@ -382,7 +382,7 @@ def utilities(eia860_dfs, eia860_transformed_dfs):
 
     eia860_transformed_dfs['utilities_eia860'] = u_df
 
-    return(eia860_transformed_dfs)
+    return eia860_transformed_dfs
 
 
 def transform(eia860_raw_dfs,
@@ -407,4 +407,4 @@ def transform(eia860_raw_dfs,
             eia860_transform_functions[table](eia860_raw_dfs,
                                               eia860_transformed_dfs)
 
-    return(eia860_transformed_dfs)
+    return eia860_transformed_dfs

--- a/pudl/transform/eia923.py
+++ b/pudl/transform/eia923.py
@@ -67,7 +67,7 @@ def yearly_to_monthly_eia923(df, md):
         # Add this new year's worth of data to the big dataframe we'll return
         all_years = pd.concat([all_years, this_year])
 
-    return(all_years)
+    return all_years
 
 
 def coalmine_cleanup(cmi_df):
@@ -119,7 +119,7 @@ def coalmine_cleanup(cmi_df):
     #                                   float_na=np.nan,
     #                                   int_na=-1,
     #                                   str_na='')
-    return(cmi_df)
+    return cmi_df
 
 ###############################################################################
 ###############################################################################
@@ -187,7 +187,7 @@ def plants(eia923_dfs, eia923_transformed_dfs):
 
     eia923_transformed_dfs['plants_eia923'] = plant_info_df
 
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs
 
 
 def generation_fuel(eia923_dfs, eia923_transformed_dfs):
@@ -250,7 +250,7 @@ def generation_fuel(eia923_dfs, eia923_transformed_dfs):
 
     eia923_transformed_dfs['generation_fuel_eia923'] = gf_df
 
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs
 
 
 def boilers(eia923_dfs, eia923_transformed_dfs):
@@ -283,7 +283,7 @@ def boilers(eia923_dfs, eia923_transformed_dfs):
 
     eia923_transformed_dfs['boilers_eia923'] = boilers_df
 
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs
 
 
 def boiler_fuel(eia923_dfs, eia923_transformed_dfs):
@@ -331,7 +331,7 @@ def boiler_fuel(eia923_dfs, eia923_transformed_dfs):
 
     eia923_transformed_dfs['boiler_fuel_eia923'] = bf_df
 
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs
 
 
 def generation(eia923_dfs, eia923_transformed_dfs):
@@ -379,7 +379,7 @@ def generation(eia923_dfs, eia923_transformed_dfs):
 
     eia923_transformed_dfs['generation_eia923'] = generation_df
 
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs
 
 
 def generators(eia923_dfs, eia923_transformed_dfs):
@@ -412,7 +412,7 @@ def generators(eia923_dfs, eia923_transformed_dfs):
 
     eia923_transformed_dfs['generators_eia923'] = generators_df
 
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs
 
 
 def coalmine(eia923_dfs, eia923_transformed_dfs):
@@ -489,7 +489,7 @@ def coalmine(eia923_dfs, eia923_transformed_dfs):
 
     eia923_transformed_dfs['coalmine_eia923'] = cmi_df
 
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs
 
 
 def fuel_reciepts_costs(eia923_dfs, eia923_transformed_dfs, pudl_engine):
@@ -603,7 +603,7 @@ def fuel_reciepts_costs(eia923_dfs, eia923_transformed_dfs, pudl_engine):
 
     eia923_transformed_dfs['fuel_receipts_costs_eia923'] = frc_df
 
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs
 
 
 def transform(eia923_raw_dfs,
@@ -629,11 +629,11 @@ def transform(eia923_raw_dfs,
         if table in eia923_tables:
             if verbose:
                 print("    {}...".format(table))
-            if (table == 'fuel_receipts_costs_eia923'):
+            if table == 'fuel_receipts_costs_eia923':
                 eia923_transform_functions[table](eia923_raw_dfs,
                                                   eia923_transformed_dfs,
                                                   pudl_engine)
             else:
                 eia923_transform_functions[table](eia923_raw_dfs,
                                                   eia923_transformed_dfs)
-    return(eia923_transformed_dfs)
+    return eia923_transformed_dfs

--- a/pudl/transform/ferc1.py
+++ b/pudl/transform/ferc1.py
@@ -80,7 +80,7 @@ def multiplicative_error_correction(tofix, mask, minval, maxval, mults):
                                           else x)
     # Add our fixed records back to the complete data series and return it
     fixed = fixed.append(records_to_fix)
-    return(fixed)
+    return fixed
 
 
 ##############################################################################
@@ -224,7 +224,7 @@ def fuel(ferc1_raw_dfs, ferc1_transformed_dfs):
 
     ferc1_transformed_dfs['fuel_ferc1'] = fuel_ferc1_df
 
-    return(ferc1_transformed_dfs)
+    return ferc1_transformed_dfs
 
 
 def plants_steam(ferc1_raw_dfs, ferc1_transformed_dfs):
@@ -318,7 +318,7 @@ def plants_steam(ferc1_raw_dfs, ferc1_transformed_dfs):
 
     ferc1_transformed_dfs['plants_steam_ferc1'] = ferc1_steam_df
 
-    return(ferc1_transformed_dfs)
+    return ferc1_transformed_dfs
 
 
 def plants_small(ferc1_raw_dfs, ferc1_transformed_dfs):
@@ -456,7 +456,7 @@ def plants_small(ferc1_raw_dfs, ferc1_transformed_dfs):
 
     ferc1_transformed_dfs['plants_small_ferc1'] = ferc1_small_df
 
-    return(ferc1_transformed_dfs)
+    return ferc1_transformed_dfs
 
 
 def plants_hydro(ferc1_raw_dfs, ferc1_transformed_dfs):
@@ -534,7 +534,7 @@ def plants_hydro(ferc1_raw_dfs, ferc1_transformed_dfs):
 
     ferc1_transformed_dfs['plants_hydro_ferc1'] = ferc1_hydro_df
 
-    return(ferc1_transformed_dfs)
+    return ferc1_transformed_dfs
 
 
 def plants_pumped_storage(ferc1_raw_dfs, ferc1_transformed_dfs):
@@ -633,7 +633,7 @@ def plants_pumped_storage(ferc1_raw_dfs, ferc1_transformed_dfs):
 
     ferc1_transformed_dfs['plants_pumped_storage_ferc1'] = ferc1_pumped_storage_df
 
-    return(ferc1_transformed_dfs)
+    return ferc1_transformed_dfs
 
 
 def plant_in_service(ferc1_raw_dfs, ferc1_transformed_dfs):
@@ -682,7 +682,7 @@ def plant_in_service(ferc1_raw_dfs, ferc1_transformed_dfs):
 
     ferc1_transformed_dfs['plant_in_service_ferc1'] = ferc1_pis_df
 
-    return(ferc1_transformed_dfs)
+    return ferc1_transformed_dfs
 
 
 def purchased_power(ferc1_raw_dfs, ferc1_transformed_dfs):
@@ -732,7 +732,7 @@ def purchased_power(ferc1_raw_dfs, ferc1_transformed_dfs):
 
     ferc1_transformed_dfs['purchased_power_ferc1'] = ferc1_purchased_pwr_df
 
-    return(ferc1_transformed_dfs)
+    return ferc1_transformed_dfs
 
 
 def accumulated_depreciation(ferc1_raw_dfs, ferc1_transformed_dfs):
@@ -776,4 +776,4 @@ def accumulated_depreciation(ferc1_raw_dfs, ferc1_transformed_dfs):
     ferc1_transformed_dfs['accumulated_depreciation_ferc1'] = \
         ferc1_accumdepr_prvsn_df
 
-    return(ferc1_transformed_dfs)
+    return ferc1_transformed_dfs

--- a/pudl/transform/pudl.py
+++ b/pudl/transform/pudl.py
@@ -92,7 +92,7 @@ def fix_int_na(col, float_na=np.nan, int_na=-1, str_na=''):
             of values as the col argument, but stored as strings that are
             compatible with the postgresql COPY FROM command.
     """
-    return(col.replace(float_na, int_na).
+    return (col.replace(float_na, int_na).
            astype(int).
            astype(str).
            replace(str(int_na), str_na))
@@ -164,7 +164,7 @@ def month_year_to_date(df):
         # Now that we've replaced these fields with a date, we drop them.
         df = df.drop([month_col, year_col], axis=1)
 
-    return(df)
+    return df
 
 
 def convert_to_date(df,
@@ -188,7 +188,7 @@ def convert_to_date(df,
     """
     df = df.copy()
     if date_col in df.columns:
-        return(df)
+        return df
 
     year = df[year_col]
 
@@ -210,4 +210,4 @@ def convert_to_date(df,
         day_col, year_col, month_col] if x in df.columns]
     df.drop(cols_to_drop, axis=1, inplace=True)
 
-    return(df)
+    return df

--- a/pudl/zipper.py
+++ b/pudl/zipper.py
@@ -117,7 +117,7 @@ def partition(collection):
 def partition_k(collection, k):
     """Generate all partitions of a set having k elements."""
     for part in partition(collection):
-        if(len(part) == k):
+        if len(part) == k:
             yield part
 
 
@@ -272,7 +272,7 @@ def zippertestdata(gens=50, max_group_size=6, samples=10,
     # creating our synthetic lumped dataset for the algorithm to untangle.
     ferc_gb = ferc_df.groupby(['pudl_plant_id', 'ferc_plant_id', 'year'])
     ferc_df = ferc_gb.agg(sum).reset_index()
-    return(eia_df, ferc_df)
+    return eia_df, ferc_df
 
 
 def aggregate_by_pudl_plant(eia_df, ferc_df):
@@ -365,7 +365,7 @@ def aggregate_by_pudl_plant(eia_df, ferc_df):
         columns=lambda x: re.sub('(series[0-9]*$)', r'\1_ferc', x))
     both_df = eia_test_df.merge(ferc_df, on=['pudl_plant_id', 'year'])
 
-    return(both_df)
+    return both_df
 
 
 def correlate_by_generators(agg_df, eia_cols, ferc_cols, corr_cols):
@@ -404,7 +404,7 @@ def correlate_by_generators(agg_df, eia_cols, ferc_cols, corr_cols):
         newcorr = newcorr.rename(columns={eia_var: corr_var})
         corrs = corrs.merge(newcorr, on=index_cols)
 
-    return(corrs)
+    return corrs
 
 
 def score_all(df, corr_cols, verbose=False):
@@ -495,7 +495,7 @@ def score_all(df, corr_cols, verbose=False):
             candidates_df = candidates_df.append(candidate)
             cid = cid + 1
 
-    if(verbose):
+    if verbose:
         print('{} candidate generator ensembles identified.'.
               format(len(candidates_df)))
     candidates_df.candidate_id = candidates_df.candidate_id.astype(int)
@@ -518,7 +518,7 @@ def score_all(df, corr_cols, verbose=False):
     winners['success'] = \
         winners.eia_gen_subgroup == winners.ferc_plant_id.str.lower()
 
-    return(winners)
+    return winners
 
 
 def correlation_merge():

--- a/scripts/update_datastore.py
+++ b/scripts/update_datastore.py
@@ -83,7 +83,7 @@ def parse_command_line(argv):
     )
 
     arguments = parser.parse_args(argv[1:])
-    return(arguments)
+    return arguments
 
 
 def main():
@@ -100,14 +100,14 @@ def main():
     # being ignored because they aren't valid.
     yrs_by_src = {}
     for src in args.sources:
-        if(len(args.year) == 0):
+        if len(args.year) == 0:
             yrs_by_src[src] = constants.data_years[src]
         else:
             yrs_by_src[src] = [int(yr) for yr in args.year
                                if int(yr) in constants.data_years[src]]
             bad_yrs = [int(yr) for yr in args.year
                        if int(yr) not in constants.data_years[src]]
-            if(args.verbose and len(bad_yrs) > 0):
+            if args.verbose and len(bad_yrs) > 0:
                 print("Invalid {} years ignored: {}.".format(src, bad_yrs))
 
     for src in args.sources:

--- a/test/mcoe_test.py
+++ b/test/mcoe_test.py
@@ -25,7 +25,7 @@ def output_byfreq(live_pudl_db, request):
         freq=request.param, testing=(not live_pudl_db),
         start_date=start_date, end_date=end_date
     )
-    return(pudl_out)
+    return pudl_out
 
 
 @pytest.mark.eia860
@@ -121,4 +121,4 @@ def nonunique_gens(df,
     unique_gens = df.drop_duplicates(subset=key_cols)
     dupes = df[~df.isin(unique_gens)].dropna()
     dupes = dupes.sort_values(by=key_cols)
-    return(dupes)
+    return dupes


### PR DESCRIPTION
Since python doesn't require parentheses for `if` or `return` statements, many [style guides](https://google.github.io/styleguide/pyguide.html?showone=Parentheses#Parentheses) recommend against them. I've removed them from this code and re-run the tests.

Feel free to reject this PR!  It's not a big deal to include the extra parentheses.

Also worth noting, I think the line `if(page == 'boiler_generator_assn', 'utilty'):` in extract/eia860.py was a typo.  I replaced it with `if 'report_year' not in newdata.columns:`, but let me know if that's incorrect.
https://github.com/catalyst-cooperative/pudl/compare/master...karldw:python-formatting-changes#diff-fdb815569da69b17883b51b869df04cbL177