### PR TITLE
 More improvements to CEMS

### DIFF
--- a/pudl/constants.py
+++ b/pudl/constants.py
@@ -3134,5 +3134,6 @@ need_fix_inting = {'generators_eia860': ['sector', 'turbines'],
                    'plants_hydro_ferc1': ['year_constructed',
                                           'year_installed'],
                    'plants_pumped_storage_ferc1': ['year_constructed',
-                                                   'year_installed']
+                                                   'year_installed'],
+                   'hourly_emissions_epacems': ['fac_id', 'unit_id'],
                    }

--- a/pudl/constants.py
+++ b/pudl/constants.py
@@ -3024,6 +3024,51 @@ natural_gas_transport_eia923 = {
     'I': 'Interruptible'
 }
 
+
+##### EPA CEMS constants #####
+
+epacems_rename_dict = {
+    "STATE": "state",
+    "FACILITY_NAME": "facility_name",
+    "ORISPL_CODE": "orispl_code",
+    "UNITID": "unitid",
+    # These op_date, op_hour, and op_time variables get converted to
+    # operating_date, operating_datetime and operating_interval in
+    # transform/epacems.py
+    "OP_DATE": "op_date",
+    "OP_HOUR": "op_hour",
+    "OP_TIME": "op_time",
+    "GLOAD (MW)": "gross_load_mw",
+    "GLOAD": "gross_load_mw",
+    "SLOAD (1000 lbs)": "steam_load_1000_lbs",
+    "SLOAD (1000lb/hr)": "steam_load_1000_lbs",
+    "SLOAD": "steam_load_1000_lbs",
+    "SO2_MASS (lbs)": "so2_mass_lbs",
+    "SO2_MASS": "so2_mass_lbs",
+    "SO2_MASS_MEASURE_FLG": "so2_mass_measure_flg",
+    "SO2_RATE (lbs/mmBtu)": "so2_rate_lbs_mmbtu",
+    "SO2_RATE": "so2_rate_lbs_mmbtu",
+    "SO2_RATE_MEASURE_FLG": "so2_rate_measure_flg",
+    "NOX_RATE (lbs/mmBtu)": "nox_rate_lbs_mmbtu",
+    "NOX_RATE": "nox_rate_lbs_mmbtu",
+    "NOX_RATE_MEASURE_FLG": "nox_rate_measure_flg",
+    "NOX_MASS (lbs)": "nox_mass_lbs",
+    "NOX_MASS": "nox_mass_lbs",
+    "NOX_MASS_MEASURE_FLG": "nox_mass_measure_flg",
+    "CO2_MASS (tons)": "co2_mass_tons",
+    "CO2_MASS": "co2_mass_tons",
+    "CO2_MASS_MEASURE_FLG": "co2_mass_measure_flg",
+    "CO2_RATE (tons/mmBtu)": "co2_rate_tons_mmbtu",
+    "CO2_RATE": "co2_rate_tons_mmbtu",
+    "CO2_RATE_MEASURE_FLG": "co2_rate_measure_flg",
+    "HEAT_INPUT (mmBtu)": "heat_input_mmbtu",
+    "HEAT_INPUT": "heat_input_mmbtu",
+    "FAC_ID": "fac_id",
+    "UNIT_ID": "unit_id",
+}
+
+epacems_tables = ["hourly_emissions_epacems"]
+
 data_sources = [
     'eia860',
     # 'eia861',
@@ -3063,6 +3108,7 @@ pudl_tables = {
     'eia860': eia860_pudl_tables,
     'eia923': eia923_pudl_tables,
     'ferc1': ferc1_pudl_tables,
+    'epacems': epacems_tables,
 }
 
 base_data_urls = {

--- a/pudl/extract/eia923.py
+++ b/pudl/extract/eia923.py
@@ -268,7 +268,8 @@ def get_eia923_plants(years, eia923_xlsx):
 
     plant_ids = pd.concat(
         [pf.plant_id_eia, gf.plant_id_eia, bf.plant_id_eia, g.plant_id_eia,
-            frc.plant_id_eia],)
+            frc.plant_id_eia],
+        sort=True)
     plant_ids = plant_ids.unique()
 
     plant_info_compiled = pd.DataFrame(columns=['plant_id_eia'])
@@ -333,7 +334,7 @@ def yearly_to_monthly_eia923(df, md):
         # Add a numerical month column corresponding to this month.
         this_month['month'] = m
         # Add this month's data to the monthly DataFrame we're building.
-        monthly = pd.concat([monthly, this_month])
+        monthly = pd.concat([monthly, this_month], sort=True)
 
     # Merge the monthly data we've built up with the remaining fields in the
     # data frame we started with -- all of which should be independent of the

--- a/pudl/extract/epacems.py
+++ b/pudl/extract/epacems.py
@@ -63,6 +63,31 @@ def add_fac_id_unit_id(df):
         df["unit_id"] = np.NaN
     return df
 
+def _all_na_or_values(series, values):
+    """Test whether every element in the series is either missing or in values
+
+    This is fiddly because isin() changes behavior if the series is totally NaN
+    (because of type issues)
+    Demo: x = pd.DataFrame({'a': ['x', np.NaN], 'b': [np.NaN, np.NaN]})
+    x.isin({'x', np.NaN})
+
+    Args:
+        series (pd.Series): A data column
+        values (set): A set of values
+    Returns:
+        True or False
+    """
+    series_excl_na = series[series.notna()]
+    if not len(series_excl_na):
+        out = True
+    elif series_excl_na.isin(values).all():
+        out = True
+    else:
+        out = False
+    return out
+
+
+
 def drop_calculated_rates(df):
     """Drop these calculated rates because they don't provide any information.
 
@@ -78,8 +103,9 @@ def drop_calculated_rates(df):
         The same DataFrame, without the variables so2_rate_measure_flg,
         so2_rate_lbs_mmbtu, co2_rate_measure_flg, or co2_rate_tons_mmbtu
     """
-    assert df["so2_rate_measure_flg"].isin({"Calculated", np.NaN}).all()
-    assert df["co2_rate_measure_flg"].isin({"Calculated", np.NaN}).all()
+
+    assert _all_na_or_values(df["so2_rate_measure_flg"], {"Calculated"})
+    assert _all_na_or_values(df["co2_rate_measure_flg"], {"Calculated"})
     del df["so2_rate_measure_flg"], df["so2_rate_lbs_mmbtu"]
     del df["co2_rate_measure_flg"], df["co2_rate_tons_mmbtu"]
     return df

--- a/pudl/extract/epacems.py
+++ b/pudl/extract/epacems.py
@@ -46,64 +46,6 @@ def get_epacems_file(year, month, state):
     return full_path
 
 
-def fix_names(df):
-    rename_dict = {
-        "STATE": "state",
-        "FACILITY_NAME": "facility_name",
-        "ORISPL_CODE": "orispl_code",
-        "UNITID": "unitid",
-        "OP_DATE": "op_date",
-        "OP_HOUR": "op_hour",
-        "OP_TIME": "op_time",
-        "GLOAD (MW)": "gload_mw",
-        "GLOAD": "gload_mw",
-        "SLOAD (1000 lbs)": "sload_1000_lbs",
-        "SLOAD (1000lb/hr)": "sload_1000_lbs",
-        "SLOAD": "sload_1000_lbs",
-        "SO2_MASS (lbs)": "so2_mass_lbs",
-        "SO2_MASS": "so2_mass_lbs",
-        "SO2_MASS_MEASURE_FLG": "so2_mass_measure_flg",
-        "SO2_RATE (lbs/mmBtu)": "so2_rate_lbs_mmbtu",
-        "SO2_RATE": "so2_rate_lbs_mmbtu",
-        "SO2_RATE_MEASURE_FLG": "so2_rate_measure_flg",
-        "NOX_RATE (lbs/mmBtu)": "nox_rate_lbs_mmbtu",
-        "NOX_RATE": "nox_rate_lbs_mmbtu",
-        "NOX_RATE_MEASURE_FLG": "nox_rate_measure_flg",
-        "NOX_MASS (lbs)": "nox_mass_lbs",
-        "NOX_MASS": "nox_mass_lbs",
-        "NOX_MASS_MEASURE_FLG": "nox_mass_measure_flg",
-        "CO2_MASS (tons)": "co2_mass_tons",
-        "CO2_MASS": "co2_mass_tons",
-        "CO2_MASS_MEASURE_FLG": "co2_mass_measure_flg",
-        "CO2_RATE (tons/mmBtu)": "co2_rate_tons_mmbtu",
-        "CO2_RATE": "co2_rate_tons_mmbtu",
-        "CO2_RATE_MEASURE_FLG": "co2_rate_measure_flg",
-        "HEAT_INPUT (mmBtu)": "heat_input_mmbtu",
-        "HEAT_INPUT": "heat_input_mmbtu",
-        "FAC_ID": "fac_id",
-        "UNIT_ID": "unit_id",
-    }
-    return df.rename(columns=rename_dict)
-
-
-def drop_columns(df, to_drop=["fac_id", "unit_id"]):
-    """
-    Delete columns, if they exist. Used for columns that are added in 2008.
-
-    Args:
-        df(pandas.DataFrame): A CEMS hourly dataframe for one year-month-state
-        to_drop(list): A list of columns to drop, if they exist
-    Output:
-        pandas.DataFrame: The same data, with the indicated columns removed
-    """
-    for col in to_drop:
-        try:
-            del df[col]
-        except KeyError:
-            pass
-    return df
-
-
 def extract(epacems_years, states, verbose):
     """
     Extract the EPA CEMS hourly data.
@@ -129,16 +71,8 @@ def extract(epacems_years, states, verbose):
                 # others, this is yielded as a generator (and it's a one-item
                 # dictionary).
                 # TODO: set types explicitly
-                try:
-                    df = (
-                        pd.read_csv(filename, low_memory=False)
-                        .pipe(fix_names)
-                        .pipe(drop_columns)
-                    )
-                # TODO: remove this try/except once all files can be read.
-                except:
-                    print(
-                        f"ERROR: Failed to extract EPA CEMs data for {state}, {year}-{month}."
-                    )
-                    df = None
+                df = (
+                    pd.read_csv(filename, low_memory=False)
+                    .rename(columns=pc.epacems_rename_dict)
+                )
                 yield {(year, month, state): df}

--- a/pudl/init.py
+++ b/pudl/init.py
@@ -640,12 +640,12 @@ def _ETL_cems(pudl_engine, epacems_years, verbose, csvdir, keep_csv, states):
     # index names follow SQLAlchemy's convention ix_tablename_columnname, but
     # this doesn't matter
     indexes_to_create = [
-        sa.Index("ix_hourly_emissions_epacems_op_datetime",
-                 pudl.models.epacems.HourlyEmissions.op_datetime),
+        sa.Index("ix_hourly_emissions_epacems_operating_datetime",
+                 pudl.models.epacems.HourlyEmissions.operating_datetime),
         sa.Index("ix_hourly_emissions_epacems_orispl_code",
                  pudl.models.epacems.HourlyEmissions.orispl_code),
-        sa.Index("ix_hourly_emissions_epacems_op_date_part",
-                 sa.cast(pudl.models.epacems.HourlyEmissions.op_datetime, sa.Date)),
+        sa.Index("ix_hourly_emissions_epacems_opperating_date_part",
+                 sa.cast(pudl.models.epacems.HourlyEmissions.operating_datetime, sa.Date)),
     ]
     for index in indexes_to_create:
         try:
@@ -659,8 +659,8 @@ def _ETL_cems(pudl_engine, epacems_years, verbose, csvdir, keep_csv, states):
         sa.UniqueConstraint(
             pudl.models.epacems.HourlyEmissions.orispl_code,
             pudl.models.epacems.HourlyEmissions.unitid,
-            pudl.models.epacems.HourlyEmissions.op_datetime,
-            name = "uq_hourly_emissions_epacems_orispl_code_unitid_op_datetime"
+            pudl.models.epacems.HourlyEmissions.operating_datetime,
+            name = "uq_hourly_emissions_epacems_orispl_code_unitid_operating_datetime"
         )
     except sa.exc.SQLAlchemyError as e:  # Any kind of SQLAlchemy error
         print("Failed to create CEMS uniqness constraint")

--- a/pudl/init.py
+++ b/pudl/init.py
@@ -631,6 +631,14 @@ def _ETL_eia(pudl_engine, eia923_tables, eia923_years, eia860_tables, eia860_yea
 
 
 def _ETL_cems(pudl_engine, epacems_years, verbose, csvdir, keep_csv, states):
+    """"""
+    # If we're not doing CEMS, just stop here to avoid printing messages like
+    # "Reading EPA CEMS data...", which could be confusing.
+    if states[0].lower() == 'none':
+        return None
+    if states[0].lower() =='all':
+        states = list(pc.cems_states.keys())
+
     # NOTE: This a generator for raw dataframes
     epacems_raw_dfs = pudl.extract.epacems.extract(
         epacems_years=epacems_years, states=states, verbose=verbose)

--- a/pudl/models/epacems.py
+++ b/pudl/models/epacems.py
@@ -1,8 +1,9 @@
 """Database models for PUDL tables derived from EPA CEMS Data."""
 
-from sqlalchemy import Integer, String, Float, DateTime, Column, Enum, Interval, Date
+from sqlalchemy import Integer, SmallInteger, String, Float, DateTime, Column, Enum, Interval, Date
 from sqlalchemy.dialects.postgresql import TSRANGE
 import pudl.models.entities
+import pudl.constants as pc
 
 # Three types of Enum here, one for things that are sort of measured, one for
 # things that are only calculated, and a special case for NOx rate and mass.
@@ -16,20 +17,7 @@ import pudl.models.entities
 # - nox_rate_measure_flg
 # - nox_mass_measure_flg
 
-measurement_flag_enum = Enum(
-    "LME",
-    "Measured",
-    "Measured and Substitute",
-    "Other",
-    "Substitute",
-    "Unknown Code",
-    "",
-    name="measurement_flag_enum",
-)
-calculated_flag_enum = Enum("Calculated", "", name="calculated_flag_enum")
-
-nox_enum = Enum(
-    "Calculated",
+ENUM_FLAG_MEASUREMENT = Enum(
     "LME",
     "Measured",
     "Measured and Substitute",
@@ -38,8 +26,25 @@ nox_enum = Enum(
     "Undetermined",
     "Unknown Code",
     "",
-    name="nox_rate_enum",
+    name="enum_measurement_flag",
 )
+ENUM_FLAG_CALCULATED = Enum("Calculated", "", name="enum_calculated_flag")
+
+ENUM_NOX = Enum(
+    "Calculated",
+    "LME",
+    "Measured",
+    "Measured and Substitute",
+    "Not Applicable",
+    "Other",
+    "Substitute",
+    "Undetermined",
+    "Unknown Code",
+    "",
+    name="enum_nox",
+)
+
+ENUM_STATES = Enum(*pc.cems_states.keys(), name="enum_states")
 
 
 class HourlyEmissions(pudl.models.entities.PUDLBase):
@@ -52,7 +57,7 @@ class HourlyEmissions(pudl.models.entities.PUDLBase):
     __tablename__ = "hourly_emissions_epacems"
     __table_args__ = {"prefixes": ["UNLOGGED"]}
     id = Column(Integer, autoincrement=True, primary_key=True)  # surrogate key
-    state = Column(String, nullable=False)
+    state = Column(ENUM_STATES, nullable=False)
     facility_name = Column(String, nullable=False)
     # TODO: Link to EIA plant ID
     orispl_code = Column(Integer, nullable=False)
@@ -63,17 +68,17 @@ class HourlyEmissions(pudl.models.entities.PUDLBase):
     gross_load_mw = Column(Float)
     steam_load_1000_lbs = Column(Float)
     so2_mass_lbs = Column(Float)
-    so2_mass_measure_flg = Column(measurement_flag_enum)
+    so2_mass_measure_flg = Column(ENUM_FLAG_MEASUREMENT)
     so2_rate_lbs_mmbtu = Column(Float)
-    so2_rate_measure_flg = Column(calculated_flag_enum)
+    so2_rate_measure_flg = Column(ENUM_FLAG_CALCULATED)
     nox_rate_lbs_mmbtu = Column(Float)
-    nox_rate_measure_flg = Column(nox_enum)
+    nox_rate_measure_flg = Column(ENUM_NOX)
     nox_mass_lbs = Column(Float)
-    nox_mass_measure_flg = Column(nox_enum)
+    nox_mass_measure_flg = Column(ENUM_NOX)
     co2_mass_tons = Column(Float)
-    co2_mass_measure_flg = Column(measurement_flag_enum)
+    co2_mass_measure_flg = Column(ENUM_FLAG_MEASUREMENT)
     co2_rate_tons_mmbtu = Column(Float)
-    co2_rate_measure_flg = Column(calculated_flag_enum)
+    co2_rate_measure_flg = Column(ENUM_FLAG_CALCULATED)
     heat_input_mmbtu = Column(Float)
-    fac_id = Column(Integer)
+    fac_id = Column(SmallInteger)  # max value is 8421
     unit_id = Column(Integer)

--- a/pudl/models/epacems.py
+++ b/pudl/models/epacems.py
@@ -1,49 +1,79 @@
 """Database models for PUDL tables derived from EPA CEMS Data."""
 
-from sqlalchemy import Integer, String, Float, DateTime, Column
+from sqlalchemy import Integer, String, Float, DateTime, Column, Enum, Interval, Date
+from sqlalchemy.dialects.postgresql import TSRANGE
 import pudl.models.entities
+
+# Three types of Enum here, one for things that are sort of measured, one for
+# things that are only calculated, and a special case for NOx rate and mass.
+# Measured:
+# - so2_mass_measure_flg
+# - co2_mass_measure_flg
+# Calculated:
+# - so2_rate_measure_flg
+# - co2_rate_measure_flg
+# NOx:
+# - nox_rate_measure_flg
+# - nox_mass_measure_flg
+
+measurement_flag_enum = Enum(
+    "LME",
+    "Measured",
+    "Measured and Substitute",
+    "Other",
+    "Substitute",
+    "Unknown Code",
+    "",
+    name="measurement_flag_enum",
+)
+calculated_flag_enum = Enum("Calculated", "", name="calculated_flag_enum")
+
+nox_enum = Enum(
+    "Calculated",
+    "LME",
+    "Measured",
+    "Measured and Substitute",
+    "Other",
+    "Substitute",
+    "Undetermined",
+    "Unknown Code",
+    "",
+    name="nox_rate_enum",
+)
 
 
 class HourlyEmissions(pudl.models.entities.PUDLBase):
     """Hourly emissions data by month as reported to EPA CEMS."""
-    # TODO: Add these constraints and indexes *after* loading all the data in.
-    # UniqueConstraint("orispl_code", "unitid", "op_date", "op_hour")
-    # indexes on: orispl_code, op_datetime, orispl_code, and the date part of
-    # op_datetime (each individually)
-    # Command to create an index for the date part of op_datetime
-    # CREATE INDEX op_date_idx (op_datetime::date)
 
+    # TODO(low priority):
+    # - Make a view that divides heat_input_mmbtu / gload_mwh to get heatrate
+    #   And also has a bad_heatrate flag.
+    # - Make a view that multiplies op_time and gload_mw to get gload_mwh
     __tablename__ = "hourly_emissions_epacems"
-    __table_args__ = {'prefixes': ['UNLOGGED']}
+    __table_args__ = {"prefixes": ["UNLOGGED"]}
     id = Column(Integer, autoincrement=True, primary_key=True)  # surrogate key
     state = Column(String, nullable=False)
     facility_name = Column(String, nullable=False)
     # TODO: Link to EIA plant ID
     orispl_code = Column(Integer, nullable=False)
     unitid = Column(String, nullable=False)
-    op_datetime = Column(DateTime, nullable=False)
-    # TODO: Make a view that multiplies op_time and gload_mw to get gload_mwh
-    op_time = Column(Float)
-    gload_mw = Column(Float)
-    sload_1000_lbs = Column(Float)
+    operating_date = Column(Date, nullable=False)
+    operating_datetime = Column(DateTime, nullable=False)
+    operating_interval = Column(Interval)
+    gross_load_mw = Column(Float)
+    steam_load_1000_lbs = Column(Float)
     so2_mass_lbs = Column(Float)
-    so2_mass_measure_flg = Column(String)
+    so2_mass_measure_flg = Column(measurement_flag_enum)
     so2_rate_lbs_mmbtu = Column(Float)
-    so2_rate_measure_flg = Column(String)
+    so2_rate_measure_flg = Column(calculated_flag_enum)
     nox_rate_lbs_mmbtu = Column(Float)
-    nox_rate_measure_flg = Column(String)
+    nox_rate_measure_flg = Column(nox_enum)
     nox_mass_lbs = Column(Float)
-    nox_mass_measure_flg = Column(String)
+    nox_mass_measure_flg = Column(nox_enum)
     co2_mass_tons = Column(Float)
-    co2_mass_measure_flg = Column(String)
+    co2_mass_measure_flg = Column(measurement_flag_enum)
     co2_rate_tons_mmbtu = Column(Float)
-    co2_rate_measure_flg = Column(String)
+    co2_rate_measure_flg = Column(calculated_flag_enum)
     heat_input_mmbtu = Column(Float)
-    # TODO: Make a view that divides heat_input_mmbtu / gload_mwh to get heatrate
-    #   And also has a bad_heatrate flag.
-    # heatrate = Column(Float)
-    # bad_heatrate = Column(Boolean, nullable=False)
-    # TODO: I think these are the same as orispl_code and unitid, but check.
-    # These are currently being dropped in extract/epacems.py
-    # fac_id = Column(Integer)
-    # unit_id = Column(Integer)
+    fac_id = Column(Integer)
+    unit_id = Column(Integer)

--- a/pudl/models/epacems.py
+++ b/pudl/models/epacems.py
@@ -1,6 +1,6 @@
 """Database models for PUDL tables derived from EPA CEMS Data."""
 
-from sqlalchemy import Integer, SmallInteger, String, Float, DateTime, Column, Enum, Interval, Date
+from sqlalchemy import Integer, SmallInteger, String, REAL, DateTime, Column, Enum, Interval, Date
 from sqlalchemy.dialects.postgresql import TSRANGE
 import pudl.models.entities
 import pudl.constants as pc
@@ -28,7 +28,7 @@ ENUM_FLAG_MEASUREMENT = Enum(
     "",
     name="enum_measurement_flag",
 )
-ENUM_FLAG_CALCULATED = Enum("Calculated", "", name="enum_calculated_flag")
+# ENUM_FLAG_CALCULATED = Enum("Calculated", "", name="enum_calculated_flag")
 
 ENUM_NOX = Enum(
     "Calculated",
@@ -54,6 +54,7 @@ class HourlyEmissions(pudl.models.entities.PUDLBase):
     # - Make a view that divides heat_input_mmbtu / gload_mwh to get heatrate
     #   And also has a bad_heatrate flag.
     # - Make a view that multiplies op_time and gload_mw to get gload_mwh
+    # - And has an operating_date
     __tablename__ = "hourly_emissions_epacems"
     __table_args__ = {"prefixes": ["UNLOGGED"]}
     id = Column(Integer, autoincrement=True, primary_key=True)  # surrogate key
@@ -62,23 +63,54 @@ class HourlyEmissions(pudl.models.entities.PUDLBase):
     # TODO: Link to EIA plant ID
     orispl_code = Column(Integer, nullable=False)
     unitid = Column(String, nullable=False)
-    operating_date = Column(Date, nullable=False)
+    # operating_date = Column(Date, nullable=False)
     operating_datetime = Column(DateTime, nullable=False)
     operating_interval = Column(Interval)
-    gross_load_mw = Column(Float)
-    steam_load_1000_lbs = Column(Float)
-    so2_mass_lbs = Column(Float)
+    gross_load_mw = Column(REAL)
+    steam_load_1000_lbs = Column(REAL)
+    so2_mass_lbs = Column(REAL)
     so2_mass_measure_flg = Column(ENUM_FLAG_MEASUREMENT)
-    so2_rate_lbs_mmbtu = Column(Float)
-    so2_rate_measure_flg = Column(ENUM_FLAG_CALCULATED)
-    nox_rate_lbs_mmbtu = Column(Float)
+    # so2_rate_lbs_mmbtu = Column(REAL)
+    # so2_rate_measure_flg = Column(ENUM_FLAG_CALCULATED)
+    nox_rate_lbs_mmbtu = Column(REAL)
     nox_rate_measure_flg = Column(ENUM_NOX)
-    nox_mass_lbs = Column(Float)
+    nox_mass_lbs = Column(REAL)
     nox_mass_measure_flg = Column(ENUM_NOX)
-    co2_mass_tons = Column(Float)
+    co2_mass_tons = Column(REAL)
     co2_mass_measure_flg = Column(ENUM_FLAG_MEASUREMENT)
-    co2_rate_tons_mmbtu = Column(Float)
-    co2_rate_measure_flg = Column(ENUM_FLAG_CALCULATED)
-    heat_input_mmbtu = Column(Float)
+    # co2_rate_tons_mmbtu = Column(REAL)
+    # co2_rate_measure_flg = Column(ENUM_FLAG_CALCULATED)
+    heat_input_mmbtu = Column(REAL)
     fac_id = Column(SmallInteger)  # max value is 8421
     unit_id = Column(Integer)
+
+DROP_VIEWS = ["DROP VIEW IF EXISTS hourly_emissions_epacems_view"]
+CREATE_VIEWS = ["""
+    CREATE VIEW hourly_emissions_epacems_view AS
+    SELECT
+        id,
+        state,
+        facility_name,
+        orispl_code,
+        unitid,
+        operating_datetime,
+        operating_datetime::date AS operating_date,
+        operating_interval,
+        gross_load_mw,
+        steam_load_1000_lbs,
+        so2_mass_lbs,
+        so2_mass_measure_flg,
+        so2_mass_lbs / heat_input_mmbtu AS so2_rate_lbs_mmbtu,
+        nox_rate_lbs_mmbtu,
+        nox_rate_measure_flg,
+        nox_mass_lbs,
+        nox_mass_measure_flg,
+        co2_mass_tons,
+        co2_mass_measure_flg,
+        co2_mass_tons / heat_input_mmbtu AS co2_rate_tons_mmbtu,
+        heat_input_mmbtu,
+        fac_id,
+        unit_id
+    FROM hourly_emissions_epacems
+    """,
+    ]

--- a/pudl/transform/eia923.py
+++ b/pudl/transform/eia923.py
@@ -57,7 +57,7 @@ def yearly_to_monthly_eia923(df, md):
             this_month['report_month'] = m
 
             # Add this month's data to the monthly DataFrame we're building.
-            monthly = pd.concat([monthly, this_month])
+            monthly = pd.concat([monthly, this_month], sort=True)
 
         # Merge the monthly data we've built up with the remaining fields in
         # the data frame we started with -- all of which should be independent
@@ -65,7 +65,7 @@ def yearly_to_monthly_eia923(df, md):
         # from each of the # initial annual records.
         this_year = this_year.merge(monthly, left_index=True, right_index=True)
         # Add this new year's worth of data to the big dataframe we'll return
-        all_years = pd.concat([all_years, this_year])
+        all_years = pd.concat([all_years, this_year], sort=True)
 
     return all_years
 

--- a/pudl/transform/epacems.py
+++ b/pudl/transform/epacems.py
@@ -33,13 +33,21 @@ def fix_up_dates(df):
     # Convert op_date and op_hour from string and integer to datetime:
     # Note that doing this conversion, rather than reading the CSV with
     # `parse_dates=True` is >10x faster.
-    df["op_datetime"] = pd.to_datetime(
-        df['op_date'].str.cat(df['op_hour'].astype(str), sep='-'),
-        format="%m-%d-%Y-%H",
-        exact=True,
-        cache=True)
-    del df['op_date']
-    del df['op_hour']
+    df["operating_date"] = pd.to_datetime(df.op_date,
+        format=r"%m-%d-%Y", exact=True, cache=True)
+
+    del df["op_date"]
+
+    # Make an operating timestamp (for this step, operating_date must be a
+    # datetime)
+    df["operating_datetime"] = df["operating_date"] + pd.to_timedelta(df["op_hour"], unit="h")
+    # Then convert from datetime to date:
+    df["operating_date"] = df["operating_date"].dt.date
+    del df["op_hour"]
+
+    # Make op_time into an time delta (called interval in postgres)
+    df["operating_interval"] = pd.to_timedelta(df["op_time"], unit="h")
+    del df["op_time"]
 
     # Add UTC timestamp ... not done.
     return df

--- a/pudl/transform/epacems.py
+++ b/pudl/transform/epacems.py
@@ -33,17 +33,12 @@ def fix_up_dates(df):
     # Convert op_date and op_hour from string and integer to datetime:
     # Note that doing this conversion, rather than reading the CSV with
     # `parse_dates=True` is >10x faster.
-    df["operating_date"] = pd.to_datetime(df.op_date,
-        format=r"%m-%d-%Y", exact=True, cache=True)
-
-    del df["op_date"]
-
-    # Make an operating timestamp (for this step, operating_date must be a
-    # datetime)
-    df["operating_datetime"] = df["operating_date"] + pd.to_timedelta(df["op_hour"], unit="h")
-    # Then convert from datetime to date:
-    df["operating_date"] = df["operating_date"].dt.date
-    del df["op_hour"]
+    # Make an operating timestamp
+    df["operating_datetime"] = (
+        pd.to_datetime(df["op_date"], format=r"%m-%d-%Y", exact=True, cache=True) +
+        pd.to_timedelta(df["op_hour"], unit="h")
+        )
+    del df["op_hour"], df["op_date"]
 
     # Make op_time into an time delta (called interval in postgres)
     df["operating_interval"] = pd.to_timedelta(df["op_time"], unit="h")

--- a/scripts/init_pudl.py
+++ b/scripts/init_pudl.py
@@ -72,9 +72,9 @@ def parse_command_line(argv):
                         default=max(constants.working_years['epacems']),
                         help="Last year of EPA hourly CEMS data to load.")
     parser.add_argument('--epacems_states', dest='epacems_states',
-                        nargs='+', default=['CO',],
+                        nargs='+', default=['none',],
                         help="Abbreviations of US states for which to load CEMS\
-                              data. Default: 'CO'. (Use 'all' to load all)")
+                              data. Default: 'none'. (Use 'all' to load all)")
     arguments = parser.parse_args(argv[1:])
 
     return arguments
@@ -92,10 +92,6 @@ def main():
     import pudl.models.ferc1
 
     args = parse_command_line(sys.argv)
-    if args.epacems_states[0]=='all':
-        epacems_states = list(constants.cems_states.keys())
-    else:
-        epacems_states = args.epacems_states
 
     extract.ferc1.init_db(ferc1_tables=constants.ferc1_default_tables,
                           refyear=args.ferc1_refyear,

--- a/scripts/init_pudl.py
+++ b/scripts/init_pudl.py
@@ -74,7 +74,7 @@ def parse_command_line(argv):
     parser.add_argument('--epacems_states', dest='epacems_states',
                         nargs='+', default=['CO',],
                         help="Abbreviations of US states for which to load CEMS\
-                              data. Default: 'CO'")
+                              data. Default: 'CO'. (Use 'all' to load all)")
     arguments = parser.parse_args(argv[1:])
 
     return arguments

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,11 @@ tag_prefix = v
 [tool:pytest]
 testpaths = .
 markers =
-    fast: mark a test as fast
-    network: mark a test as network
-    high_memory: mark a test as a high-memory only
+    etl: mark a test as part of the ETL
+    post_etl: mark a test as post-ETL
+    eia860: mark a test as part of EIA form 860 processing
+    eia923: mark a test as part of EIA form 923 processing
+    ferc1: mark a test as part of FERC form 1 processing
+    travis_ci: mark a test to run on Travis CI
+    tabular_output: mark a test for table output
+    mcoe: mark a test as for MCOE

--- a/test/etl_test.py
+++ b/test/etl_test.py
@@ -9,7 +9,7 @@ command line options by running pytest --help.
 import pytest
 
 
-@pytest.mark.ci
+@pytest.mark.travis_ci
 def test_travis_ci():
     """
     Dummy test to make sure Travis CI setup is working.


### PR DESCRIPTION
- Add `fac_id` and `unit_id` variables to data where they're missing,
  so the load into `BulkCopy` can always expect the same columns
- Add integer fixes for `fac_id` and `unit_id`
- Make `fac_id` column a `SmallInteger` (max value is 8421)
- Make `state` column an `Enum`
- Correct Enum values
- Format CEMS Enums in all caps for style
- Correct index names to use 'operating' instead of 'op'
- Improve help messages in `BulkCopy` (about which columns didn't
  match) and `init_pudl.py` (about how to load all CEMS states)