### PR TITLE
CEMS tweaks: logged tables and timers

### DIFF
--- a/pudl/extract/epacems.py
+++ b/pudl/extract/epacems.py
@@ -129,7 +129,7 @@ def extract(epacems_years, states, verbose):
                 filename = get_epacems_file(year, month, state)
 
                 if verbose:
-                    print(f"Extracting: {filename}")
+                    print(f"        Extracting: {filename}")
                 # Return a dictionary where the key identifies this dataset
                 # (just like the other extract functions), but unlike the
                 # others, this is yielded as a generator (and it's a one-item


### PR DESCRIPTION
- Add a step to convert the UNLOGGED table to LOGGED after all the data are written
- Move the add-index commands to a `finalize` function in models/epacems.py
- Make the unique constraint a unique index instead
- Add timers for CEMS loading and improve logging