### PR TITLE
Remove 2017 from CEMS years

### DIFF
--- a/pudl/constants.py
+++ b/pudl/constants.py
@@ -3353,7 +3353,7 @@ data_years = {
     'eia860': range(2001, 2018),
     'eia861': range(1990, 2018),
     'eia923': range(2001, 2018),
-    'epacems': range(1995, 2018),
+    'epacems': range(1995, 2017),
     'ferc1': range(1994, 2018),
     'msha': range(2000, 2018),
 }
@@ -3363,7 +3363,7 @@ working_years = {
     'eia860': range(2011, 2018),
     'eia861': [],
     'eia923': range(2009, 2018),
-    'epacems': range(1995, 2018),
+    'epacems': range(1995, 2017),
     'ferc1': range(2004, 2017),
     'msha': [],
 }

--- a/scripts/settings.yml
+++ b/scripts/settings.yml
@@ -2,7 +2,7 @@
 
 # You can create several different settings files if you wish, and specify
 # which one the initialization script uses on the command line:
-# 
+#
 # ./init_pudl.py -f custom_settings.yml
 #
 # The default settings load nothing into the database, but there are commented
@@ -65,11 +65,11 @@ eia860_years: []
 # The EPA CEMS data goes back as far as 1995, but before 2000 it is not as
 # complete.  Note that the EPA CEMS data set is much larger than any of the
 # other data sets here.  Pulling in all the years of data for all of the
-# states requires ~100GB of free disk space and takes around 8 hours on a 
+# states requires ~100GB of free disk space and takes around 8 hours on a
 # reasonably fast laptop.
 epacems_years: []
 #epacems_years: [2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008,
-#                2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017]
+#                2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016]
 epacems_states: []
 #epacems_states: [CO]
 #epacems_states: [ALL]


### PR DESCRIPTION
October, November, and December 2017 aren't available, and our code is written to work with full years of data.