### PR TITLE
Fix parsing of supplier_name in eia 923 fuel receipts & costs

### DIFF
--- a/pudl/transform/eia923.py
+++ b/pudl/transform/eia923.py
@@ -534,6 +534,9 @@ def fuel_reciepts_costs(eia923_dfs, eia923_transformed_dfs):
     frc_df = pudl.helpers.fix_eia_na(frc_df)
 
     # These come in ALL CAPS from EIA...
+    # Integers and strings are mixed in together, cast everything to string
+    # Without this step, strip_lower converts the ints to nulls
+    frc_df['supplier_name'] = [str(x) for x in frc_df['supplier_name']]
     frc_df = pudl.helpers.strip_lower(
         frc_df, columns=['supplier_name'])
 

--- a/pudl/transform/eia923.py
+++ b/pudl/transform/eia923.py
@@ -534,7 +534,7 @@ def fuel_reciepts_costs(eia923_dfs, eia923_transformed_dfs):
     frc_df = pudl.helpers.fix_eia_na(frc_df)
 
     # These come in ALL CAPS from EIA...
-    frc_df['supplier_name'] = pudl.helpers.strip_lower(
+    frc_df = pudl.helpers.strip_lower(
         frc_df, columns=['supplier_name'])
 
     # Standardize case on transportaion codes -- all upper case!


### PR DESCRIPTION
There are two issues addressed here: 
- The `supplier_name` was previously assigned the values from the ash content percent column, since `pudl.helpers.strip_lower` returns the whole data frame, and not just the single column it processes.
- The`supplier_name` column contains a mix of integers and strings, and running `pudl.helpers.strip_lower` without an explicit type conversion results in all the integer values being converted to nulls.