### PR TITLE
Add 2018 CEMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ We also want to bring best practices from the world of software engineering and 
  * [Good enough practices in scientific computing](https://doi.org/10.1371/journal.pcbi.1005510) (PLOS Computational Biology, 2017)
 
 ---
-# Status (as of 2018-11-21)
+# Status (as of 2019-02-10)
 
 ## Available Data
 ### [FERC Form 1 (2004-2017)](https://www.ferc.gov/docs-filing/forms/form-1/data.asp)
@@ -78,7 +78,7 @@ PUDL database, for the years 2011-2017. Earlier years use a different
 reporting format, and will require more work to integrate. Monthly year to date
 releases are not yet being integrated.
 
-### [EPA CEMS (1995-2017)](https://ampd.epa.gov/ampd/)
+### [EPA CEMS (1995-2018)](https://ampd.epa.gov/ampd/)
 The EPA's hourly Continuous Emissions Monitoring System (CEMS) data is in the
 process of being integrated. However, it is a much larger dataset than the FERC
 or EIA data we've already brought in, and so has required some changes to the

--- a/pudl/constants.py
+++ b/pudl/constants.py
@@ -1460,7 +1460,7 @@ data_years = {
     'eia860': tuple(range(2001, 2018)),
     'eia861': tuple(range(1990, 2018)),
     'eia923': tuple(range(2001, 2018)),
-    'epacems': tuple(range(1995, 2018)),
+    'epacems': tuple(range(1995, 2019)),
     'ferc1': tuple(range(1994, 2018)),
     'ferc714': tuple(range(2006, 2018)),
     'msha': tuple(range(2000, 2018)),
@@ -1471,7 +1471,7 @@ working_years = {
     'eia860': tuple(range(2011, 2018)),
     'eia861': (),
     'eia923': tuple(range(2009, 2018)),
-    'epacems': tuple(range(1995, 2018)),
+    'epacems': tuple(range(1995, 2019)),
     'ferc1': tuple(range(2004, 2018)),
     'msha': (),
 }

--- a/scripts/settings.yml
+++ b/scripts/settings.yml
@@ -68,8 +68,9 @@ eia860_years: [2011, 2012, 2013, 2014, 2015, 2016, 2017]
 # states requires ~100GB of free disk space and takes around 8 hours on a
 # reasonably fast laptop.
 epacems_years: [2015]
-# epacems_years: [2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008,
-#                2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017]
+# epacems_years: [1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004,
+#                 2005, 2006, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014,
+#                 2015, 2016, 2017, 2018]
 # epacems_states: []
 epacems_states: [CO]
 #epacems_states: [ALL]


### PR DESCRIPTION
The 2018 hourly CEMS are now [available](ftp://newftp.epa.gov/DMDnLoad/emissions/hourly/monthly/2018/). This commit adds them in.

I also changed the `epacems_years` in `settings.yml` to mention the 1995-1999 data, which are less complete than later years, but can still be ingested.