### PR TITLE
Clean output types and verbose arguments in epacems_to_parquet.py

### DIFF
--- a/scripts/epacems_to_parquet.py
+++ b/scripts/epacems_to_parquet.py
@@ -55,12 +55,14 @@ IN_DTYPES = {
     'unit_id_epa': str,
 }
 
+# Note that parquet's internal representation doesn't use unsigned numbers or
+# 16-bit ints, so just keep things simple here and always use int32 and float32.
 OUT_DTYPES = {
-    'year': 'uint16',
+    'year': 'int32',
     'state': 'category',
     # 'plant_name': 'category',
-    'plant_id_eia': 'uint16',
-    'unitid': 'category',
+    'plant_id_eia': 'int32',
+    'unitid': 'str',
     'gross_load_mw': 'float32',
     'steam_load_1000_lbs': 'float32',
     'so2_mass_lbs': 'float32',
@@ -72,8 +74,8 @@ OUT_DTYPES = {
     'co2_mass_tons': 'float32',
     'co2_mass_measurement_code': 'category',
     'heat_content_mmbtu': 'float32',
-    'facility_id': 'category',
-    'unit_id_epa': 'category',
+    'facility_id': 'int32',
+    'unit_id_epa': 'int32',
     'operating_datetime_utc': pd.DatetimeTZDtype(tz="UTC"),
     'operating_time_hours': 'float32'
 }
@@ -86,15 +88,6 @@ def parse_command_line(argv):
     :param argv: arguments on the command line must include caller file name.
     """
     parser = argparse.ArgumentParser()
-
-    parser.add_argument(
-        '-q',
-        '--quiet',
-        dest='verbose',
-        action='store_false',
-        help="Quiet mode. Suppress download progress indicators and warnings.",
-        default=True
-    )
     parser.add_argument(
         '-d',
         '--datadir',
@@ -162,14 +155,6 @@ def parse_command_line(argv):
     return arguments
 
 
-def downcast_numeric(df, from_dtype, to_dtype):
-    """Downcast columns from_dtype to_dtype to save space."""
-    to_downcast = df.select_dtypes(include=[from_dtype])
-    for col in to_downcast.columns:
-        df[col] = pd.to_numeric(to_downcast[col], downcast=to_dtype)
-    return df
-
-
 def year_from_operating_datetime(df):
     """Add a 'year' column based on the year in the operating_datetime."""
     df['year'] = df.operating_datetime_utc.dt.year
@@ -199,12 +184,6 @@ def cems_to_parquet(transformed_df_dicts, outdir=None, schema=None,
             if not df.empty:
                 df = (
                     df.astype(IN_DTYPES)
-                    .pipe(downcast_numeric,
-                          from_dtype='float',
-                          to_dtype='float')
-                    .pipe(downcast_numeric,
-                          from_dtype='int',
-                          to_dtype='unsigned')
                     .pipe(year_from_operating_datetime)
                     .astype(OUT_DTYPES)
                 )
@@ -233,11 +212,10 @@ def main():
     # original raw data from EPA as needed.
     raw_dfs = pudl.extract.epacems.extract(
         epacems_years=args.years,
-        states=args.states,
-        verbose=args.verbose
+        states=args.states
     )
     transformed_dfs = pudl.transform.epacems.transform(
-        pudl_engine=pudl_engine, epacems_raw_dfs=raw_dfs, verbose=args.verbose
+        pudl_engine=pudl_engine, epacems_raw_dfs=raw_dfs
     )
 
     # Do a few additional manipulations specific to the Apache Parquet output,

--- a/scripts/epacems_to_parquet.py
+++ b/scripts/epacems_to_parquet.py
@@ -57,11 +57,13 @@ IN_DTYPES = {
 
 # Note that parquet's internal representation doesn't use unsigned numbers or
 # 16-bit ints, so just keep things simple here and always use int32 and float32.
+# Fields that may be NaN have to be float32, not int32 or pandas' Int32
+# (float32 can accurately hold integers up to 16,777,216 so no need for float64)
 OUT_DTYPES = {
-    'year': 'int32',
+    'year': 'int32', # never missing; note that this is UTC year
     'state': 'category',
     # 'plant_name': 'category',
-    'plant_id_eia': 'int32',
+    'plant_id_eia': 'int32', # never missing
     'unitid': 'str',
     'gross_load_mw': 'float32',
     'steam_load_1000_lbs': 'float32',
@@ -74,8 +76,8 @@ OUT_DTYPES = {
     'co2_mass_tons': 'float32',
     'co2_mass_measurement_code': 'category',
     'heat_content_mmbtu': 'float32',
-    'facility_id': 'int32',
-    'unit_id_epa': 'int32',
+    'facility_id': 'float32', # sometimes missing, max value  8,421
+    'unit_id_epa': 'float32', # sometimes missing, max value 91,294
     'operating_datetime_utc': pd.DatetimeTZDtype(tz="UTC"),
     'operating_time_hours': 'float32'
 }


### PR DESCRIPTION
- The `extract` and `transform` functions no longer accept a `verbose` argument
- A few of what were category types are actually integers
- Parquet doesn't benefit from using specialized integer types (16-bit or unsigned)
    - They're apparently all treated as int32, int64, or int96 internally