### PR TITLE
Update to heat_rate_by_gen

### DIFF
--- a/src/pudl/analysis/mcoe.py
+++ b/src/pudl/analysis/mcoe.py
@@ -99,7 +99,7 @@ def heat_rate_by_gen(pudl_out):
                                'plant_id_eia',
                                'unit_id_pudl',
                                'generator_id']].drop_duplicates()
-    gens_simple = pd.merge(gens_simple, bga_gens,
+    bga_gens = pd.merge(gens_simple, bga_gens,
                            on=['report_date', 'plant_id_eia', 'generator_id'],
                            validate='one_to_one')
     # Associate those heat rates with individual generators. This also means


### PR DESCRIPTION
I was playing around with the heat_rate_by_gen function and noticed that you define gens_simple and merge bga_gens with it, but then you do not use gens_simple again in the function. I am wondering if you meant to call this merge bga_gens instead, since you do use bga_gens in line 110 when defining your hr_by_gen dataframe. (Not sure if this is the proper way to initiate a pull request so please let me know if there is a different protocol)