### PR TITLE
Categorize eia codes with either Util or BA priority

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
 
 # Make sure import statements are sorted uniformly.
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.0.9
+  rev: v5.1.0
   hooks:
   - id: isort
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
 
 # Make sure import statements are sorted uniformly.
 - repo: https://github.com/pre-commit/mirrors-isort
-  rev: v5.1.0
+  rev: v5.1.1
   hooks:
   - id: isort
 

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -49,7 +49,7 @@ dependencies:
   - scikit-learn>=0.20  # base pandas integration added in v0.20
   - scipy               # base
   - setuptools_scm      # dev
-  - sphinx<3.0          # dev
+  - sphinx>=3.0         # dev
   - sphinx-issues       # dev
   - sphinx_rtd_theme    # dev
   - sqlalchemy>=1.3.0   # base Security issues below v1.3.0

--- a/devtools/jupyterlab_build.sh
+++ b/devtools/jupyterlab_build.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+jupyter labextension install --no-build --log-level=INFO \
+    @axlair/jupyterlab_vim \
+    @jupyterlab/toc \
+    @jupyterlab/debugger \
+    jupyterlab-flake8 \
+    @jupyter-widgets/jupyterlab-manager \
+    dask-labextension
+
+jupyter serverextension enable dask_labextension
+
+# Rebuild the jupyterlab application with the extensions:
+jupyter lab build
+
+# Show us what all we've got installed...
+jupyter labextension list
+jupyter serverextension list

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if not os.getenv("READTHEDOCS"):
 
 doc_requires = [
     "doc8",
-    "sphinx<3.0",
+    "sphinx>=3.0",
     "sphinx-issues",
     "sphinx_rtd_theme",
 ]

--- a/src/pudl/analysis/demand_mapping.py
+++ b/src/pudl/analysis/demand_mapping.py
@@ -635,13 +635,12 @@ def categorize_eia_code(eia_codes, ba_ids, util_ids, priority="balancing_authori
     priority with all utility IDs
 
     Args:
-        eia_codes (ordered collection): A dataframe based on the respondent_id_ferc714
-            table, having at least the two columns: ``respondent_id_ferc714`` and
-            ``eia_code``. Other columns may be present.
-        ba_ids_eia (iterable of ints): A collection of IDs which should be interpreted
-            as belonging to EIA Balancing Authorities.
-        util_ids_eia (iterable of ints): A collection of IDs which should be interpreted
-            as belonging to EIA Utilities.
+        eia_codes (ordered collection of ints): A collection of IDs which may be either
+            associated with EIA balancing authorities or utilities, to be categorized.
+        ba_ids_eia (ordered collection of ints): A collection of IDs which should be
+            interpreted as belonging to EIA Balancing Authorities.
+        util_ids_eia (ordered collection of ints): A collection of IDs which should be
+            interpreted as belonging to EIA Utilities.
         priorty (str): Which respondent_type to give priority to if the eia_code shows
             up in both util_ids_eia and ba_ids_eia. Must be one of "utility" or
             "balancing_authority". The default is "balanacing_authority".

--- a/src/pudl/analysis/demand_mapping.py
+++ b/src/pudl/analysis/demand_mapping.py
@@ -607,11 +607,11 @@ def allocate_and_aggregate(
 ################################################################################
 def categorize_eia_code(eia_codes, ba_ids, util_ids, priority="balancing_authority"):
     """
-    Categorize EIA Codes in FERC 714 as either balancing authority or utility IDs.
+    Categorize FERC 714 ``eia_codes`` as either balancing authority or utility IDs.
 
     Most FERC 714 respondent IDs are associated with an ``eia_code`` which refers to
-    either a ``balancing_authority_id_eia`` or a ``utility_id_eia`` but no indication is
-    given as to which type of ID each one is. This is further complicated by the fact
+    either a ``balancing_authority_id_eia`` or a ``utility_id_eia`` but no indication
+    as to which type of ID each one is. This is further complicated by the fact
     that EIA uses the same numerical ID to refer to the same entity in most but not all
     cases, when that entity acts as both a utility and as a balancing authority.
 
@@ -626,6 +626,13 @@ def categorize_eia_code(eia_codes, ba_ids, util_ids, priority="balancing_authori
     assigned ``pandas.NA``.
     * If ``eia_code`` appears in both sets of IDs, then whichever ``respondent_type``
     has been selected with the ``priority`` flag will be assigned.
+
+    Note that the vast majority of ``balancing_authority_id_eia`` values also show up
+    as ``utility_id_eia`` values, but only a small subset of the ``utility_id_eia``
+    values are associated with balancing authorities. If you use
+    ``priority="utility"`` you should probably also be specifically compiling the list
+    of Utility IDs because you know they should take precedence. If you use utility
+    priority with all utility IDs
 
     Args:
         eia_codes (ordered collection): A dataframe based on the respondent_id_ferc714

--- a/src/pudl/extract/excel.py
+++ b/src/pudl/extract/excel.py
@@ -177,25 +177,26 @@ class GenericExtractor(object):
             testing (boolean): if testing is True, the datastore manager will
                 know to use the zenodo sandbox DOIs.
         """
+        raw_dfs = {}
         # TODO: should we run verify_years(?) here?
         if not years:
-            logger.info(
+            logger.warning(
                 f'No years given. Not extracting {self._dataset_name} spreadsheet data.')
-            return {}
+            return raw_dfs
+        logger.info(f'Extracting {self._dataset_name} spreadsheet data.')
 
-        raw_dfs = {}
         for page in self._metadata.get_all_pages():
             if page in self.BLACKLISTED_PAGES:
-                logger.info(f'Skipping blacklisted page {page}.')
+                logger.debug(f'Skipping blacklisted page {page}.')
                 continue
             df = pd.DataFrame()
             for yr in years:
                 # we are going to skip
                 if self.excel_filename(yr, page) == '-1':
-                    logger.info(
+                    logger.debug(
                         f'No page for {self._dataset_name} {page} {yr}')
                     continue
-                logger.info(
+                logger.debug(
                     f'Loading dataframe for {self._dataset_name} {page} {yr}')
                 newdata = pd.read_excel(
                     self.load_excel_file(yr, page, testing=testing),
@@ -215,7 +216,7 @@ class GenericExtractor(object):
             df = pd.concat([df, empty_cols], sort=True)
             if len(self.METADATA._column_map[page].index) != len(df.columns):
                 # raise AssertionError(
-                logger.info(
+                logger.warning(
                     f'Columns for {page} are off: should be '
                     f'{len(self.METADATA._column_map[page].index)} but got '
                     f'{len(df.columns)}'


### PR DESCRIPTION
Simplified and generalized the `categorize_eia_code()` function to allow either balancing authorities or utilities to take precedence, and to allow a specific set of utility and balancing authority IDs to be passed in. This will let us compile a set of individual utility IDs that we want to override the default balancing authority IDs if need be -- using all BA and all Util IDs and setting the priority to Utility just means everything (except 4 entities) are interpreted as utilities which is... clearly not right.

Closes #628

### Other minor changes:
* Changed the loglevels for log output in the Excel extractor to use a variety of debug, info, warning, so that we can have more or less output as desired -- rather than having basically everything at info, per feedback from @ptvirgo 
* Updated `pudl-dev` environment to use `sphinx>=3.0` since it no longer causes problems with our docs build, and it's been out of many months now.
* Updated pre-commit hooks to use isort 5.1.0
* Added a jupyterlab build script under devtools to install extensions & build the application with a single command. Useful for getting all the extensions back after recreating your conda environment. We should talk about how to make this not user-specific.