### PR TITLE
Simplify datapkg_to_sqlite script

### DIFF
--- a/src/pudl/convert/datapkg_to_sqlite.py
+++ b/src/pudl/convert/datapkg_to_sqlite.py
@@ -1,31 +1,30 @@
 """
-Merge a compatible PUDL datapackages and load the result into an SQLite DB.
+Merge compatible PUDL datapackages and load the result into an SQLite DB.
 
 This script merges a set of compatible PUDL datapackages into a single
-tabular datapackage that can be loaded into an SQLite database (or potentially
-other storage media like Google BigQuery, PostgreSQL, etc.). The input
-datapackages must all have been produced in the same ETL run, and share the
-same ``datapkg-bundle-uuid`` value. Any data sources (e.g. ferc1, eia923) that
-appear in more than one of the datapackages to be merged must also share
-identical ETL parameters (years, tables, states, etc.), allowing easy
-deduplication of resources.
+tabular datapackage, and then loads that package into the PUDL SQLite DB
+
+The input datapackages must all have been produced in the same ETL run, and
+share the same ``datapkg-bundle-uuid`` value. Any data sources (e.g. ferc1,
+eia923) that appear in more than one of the datapackages to be merged must
+also share identical ETL parameters (years, tables, states, etc.), allowing
+easy deduplication of resources.
 
 Having the ability to load only a subset of the datapackages resulting from an
-ETL run into the SQLite database is helpful because larger datasets like the
-EPA CEMS hourly emissions table which have ~1 billion records and take up
-~100 GB of space when uncompressed are much easier to work with via columnar
-datastores like Apache Parquet -- loading all of EPA CEMS into SQLite can take
-more than 24 hours. PUDL also provides a separate epacems_to_parquet script
-that can be used to generate a Parquet dataset that is partitioned by state
-and year, which can be read directly into pandas or dask dataframes, for use
-in conjunction with the other PUDL data that is stored in the SQLite DB.
+ETL run into the SQLite database is helpful because larger datasets are much
+easier to work with via columnar datastores like Apache Parquet -- loading all
+of EPA CEMS into SQLite can take more than 24 hours. PUDL also provides a
+separate epacems_to_parquet script that can be used to generate a Parquet
+dataset that is partitioned by state and year, which can be read directly into
+pandas or dask dataframes, for use in conjunction with the other PUDL data that
+is stored in the SQLite DB.
 
 """
 import argparse
 import logging
 import pathlib
-import shutil
 import sys
+import tempfile
 
 import coloredlogs
 import datapackage
@@ -99,28 +98,11 @@ def parse_command_line(argv):
     """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        '-m',
-        '--merge_only',
-        dest="load_sqlite",
-        action="store_false",
-        default=True,
-        help="""Only merge the datapackages, don't attempt to load the
-        resulting datapackage into the SQLite database.""")
-    parser.add_argument(
-        '-o',
-        '--out_path',
-        required=True,
-        help="""Path to the directory in which the datapackage.json for the
-        merged datapackage will be output. The last element of the path will
-        also be used as the name of the output datapackage.""")
-    parser.add_argument(
         '-c',
         '--clobber',
         action='store_true',
-        help="""If the output directory already exists, remove it and replace
-        it with the newly merged datapackage. Similarly, overwrite the existing
-        sqlite database if it exists. Otherwise, the pre-existing directory or
-        database will cause the process to fail.""",
+        help="""Overwrite the existing PUDL sqlite database if it exists. Otherwise,
+        the existence of a pre-existing database will cause the conversion to fail.""",
         default=False)
     parser.add_argument(
         'in_paths',
@@ -144,9 +126,12 @@ def main():
     logger.info(f"pudl_in={pudl_settings['pudl_in']}")
     logger.info(f"pudl_out={pudl_settings['pudl_out']}")
 
-    logger.info("Merging datapackages.")
-    # Verify that the input data package descriptors exist, and if so create
-    # datapackage objects using them:
+    # Check if there's already a PUDL SQLite DB that we should not clobber:
+    if not args.clobber and pathlib.Path(pudl_settings["pudl_db"]).exists():
+        raise FileExistsError(
+            f"SQLite DB at {pudl_settings['pudl_db']} exists and clobber is False.")
+
+    # Verify that the input data package descriptors exist
     dps = []
     for path in args.in_paths:
         if not pathlib.Path(path).exists():
@@ -154,23 +139,11 @@ def main():
                 f"Input datapackage path {path} does not exist.")
         dps.append(datapackage.DataPackage(descriptor=path))
 
-    # Check whether the output destination exists if we're not clobbering
-    out_path = pathlib.Path(args.out_path)
-    # If it exists we either fail (because we're not clobbering) or we remove
-    # the whole directory (if we are clobbering)
-    if out_path.exists():
-        if args.clobber is False:
-            raise FileExistsError(
-                f"Output directory {out_path} exists and clobber is False.")
-        shutil.rmtree(out_path)
-
-    merge_datapkgs(dps, out_path, clobber=args.clobber)
-
-    if args.load_sqlite is True:
+    logger.info("Merging datapackages.")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        out_path = pathlib.Path(tmpdir)
+        merge_datapkgs(dps, out_path, clobber=args.clobber)
         logger.info("Loading merged datapackage into an SQLite database.")
-        datapkg_to_sqlite(
-            pudl_settings['pudl_db'], out_path, clobber=args.clobber)
-        logger.info("Success! You can connect to the PUDL DB at this URL:")
-        logger.info(f"{pudl_settings['pudl_db']}")
-    else:
-        logger.info("Not loading merged datapackage into SQLite database.")
+        datapkg_to_sqlite(pudl_settings['pudl_db'], out_path, clobber=args.clobber)
+    logger.info("Success! You can connect to the PUDL DB at this URL:")
+    logger.info(f"{pudl_settings['pudl_db']}")


### PR DESCRIPTION
Merging datapackages is very fast, and this script is really just about loading
a bundle of datapackages into SQLite (hence the name) so I've simplified the
options to focus on doing just those things, and to only store the merged
data package temporarily, in an automatically generated temporary directory,
until the SQLite load is finished.

This change was inspired by accidentally wiping out an entire pudl-work
directory including all downloaded data by giving the script a bad argument
for the output directory path in conjunction with the --clobber arg!

Now --clobber only pertains to the sqlite database file.

Closes #711