### PR TITLE
Clobber datapackage bundles not single datapackages

### DIFF
--- a/src/pudl/etl.py
+++ b/src/pudl/etl.py
@@ -852,6 +852,10 @@ def generate_datapkg_bundle(datapkg_bundle_settings,
 
     # Generate a random UUID to identify this ETL run / data package bundle
     datapkg_bundle_uuid = str(uuid.uuid4())
+    datapkg_bundle_dir = Path(pudl_settings["datapkg_dir"], datapkg_bundle_name)
+
+    # Create, or delete and re-create the top level datapackage bundle directory:
+    _ = pudl.helpers.prep_dir(datapkg_bundle_dir, clobber=clobber)
 
     metas = {}
     for datapkg_settings in validated_bundle_settings:
@@ -859,11 +863,9 @@ def generate_datapkg_bundle(datapkg_bundle_settings,
             pudl_settings["datapkg_dir"],  # PUDL datapackage output dir
             datapkg_bundle_name,           # Name of the datapackage bundle
             datapkg_settings["name"])      # Name of the datapackage
-        # Create the data directory for this datapackage, as well as any
-        # necessary parent directories. Don't save the Path though, because
-        # we need to use the output_dir path for both the data generation and
-        # the metadata generation.
-        _ = pudl.helpers.prep_dir(output_dir / "data", clobber=clobber)
+
+        # Create the datapackge directory, and its data subdir:
+        (output_dir / "data").mkdir(parents=True)
         # run the ETL functions for this pkg and return the list of tables
         # output to CSVs:
         datapkg_resources = etl(datapkg_settings, output_dir, pudl_settings)

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -178,11 +178,11 @@ def prep_dir(dir_path, clobber=False):
 
     """
     dir_path = pathlib.Path(dir_path)
-    if dir_path.exists() and (clobber is False):
-        raise FileExistsError(
-            f'{dir_path} already exists and clobber is set to {clobber}')
-    elif dir_path.exists() and (clobber is True):
-        shutil.rmtree(dir_path)
+    if dir_path.exists():
+        if clobber:
+            shutil.rmtree(dir_path)
+        else:
+            raise FileExistsError(f'{dir_path} exists and clobber is {clobber}')
     dir_path.mkdir(parents=True)
     return dir_path
 


### PR DESCRIPTION
Rather that checking for existence of individual datapackages and
clobbering them (if requested), apply the existence / clobbering to
whole datapackage bundles, since we don't want incompatible datapackages
accumulating within a supposedly unified bundle accidentally.

Closes #713