### PR TITLE
Automate docker image builds

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,22 @@
+name: Build and publish Docker image
+on:
+  push:
+    branches:
+      - main
+      - dev
+      - 'sprint*'
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+      - name: Push to Docker Hub
+        uses: docker/build-push-action@v1
+        with:
+          file: release/Dockerfile.tiny
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: catalystcoop/pudl_etl
+          tag_with_ref: true

--- a/devtools/print_requirements.py
+++ b/devtools/print_requirements.py
@@ -1,0 +1,7 @@
+#!/usr/bin/python3
+"""Print out install requirements from setup.py for use with pip install."""
+import distutils.core
+
+setup = distutils.core.run_setup("setup.py")
+for dep in setup.install_requires:
+    print(dep)

--- a/release/Dockerfile.tiny
+++ b/release/Dockerfile.tiny
@@ -1,3 +1,5 @@
+# syntax = docker/dockerfile:experimental
+
 # WIP: This is an attempt to make small docker image that
 # installs pypi tarball with pip and does not rely on
 # conda environment.
@@ -8,6 +10,7 @@ FROM python:3.8 AS pudl-source-build
 WORKDIR /pudl/repo
 COPY . /pudl/repo
 RUN mkdir /pudl/package && mkdir /pudl/src
+RUN python devtools/print_requirements.py > /pudl/package/requirements.txt
 RUN python setup.py sdist -d /pudl/package && mv /pudl/package/*tar.gz /pudl/package/pudl.tar.gz
 RUN tar xzf /pudl/package/pudl.tar.gz -C /pudl/src --strip-components=1
 RUN rm -Rf /pudl/repo
@@ -16,8 +19,9 @@ RUN rm -Rf /pudl/repo
 # because it is needed for the pip install.
 
 FROM python:3.8
-# TODO(rousik): use python:3.8-slim or python:3.8-slim-buster
 RUN apt-get update && apt-get -y install libsnappy-dev git
+COPY --from=pudl-source-build /pudl/package/requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,mode=0755,target=/root/.cache/pip pip install -r /tmp/requirements.txt
 COPY --from=pudl-source-build /pudl /pudl
 RUN pip install /pudl/package/pudl.tar.gz
 WORKDIR /pudl/src
@@ -29,4 +33,5 @@ VOLUME /pudl/inputs/data
 VOLUME /pudl/outputs
 
 ENV PUDL_SETTINGS=/pudl/src/release/settings/release.yml
-ENTRYPOINT /pudl/src/release/data-release.sh
+ENTRYPOINT ["pudl_etl"]
+CMD ["-c", "/pudl/src/release/settings/release.yml"]


### PR DESCRIPTION
- Run the github action on every commit to master, dev, sprint branches.
- Set image entrypoint to simply kick off pudl_etl (this will be
appropriate when ferc1_to_sqlite and other parts of the pipeline
are integrated into this main script).
- Extract install requirements and pip install those prior to injecting
pudl source code, use experimental features that mount pip caches when
building containers. These efforts should improve our ability to build
images quicker and to reuse native docker layer caching because
requirements should only change infrequently whereas the source code
will change often.