### PR TITLE
Specify min/max versions for all dependencies in setup.py

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -2,70 +2,80 @@ name: pudl-dev
 channels:
   - conda-forge
   - defaults
+  - intake
 dependencies:
-  - addfips>=0.3        # base
-  - autopep8            # dev
-  - bandit              # dev
-  - catalystcoop.dbfread>=3.0 # base
-  - coloredlogs         # base
-  - contextily          # base (OSM basemap) TODO: Is this needed?
-  - coverage            # dev
-  - dask                # user
-  - dask-labextension   # user (allows dask control within JupyterLab)
-  - datapackage>=1.11.0 # base We depend on features introduced in v1.9.0
-  - doc8                # dev
-  - flake8              # dev
-  - flake8-colors       # dev
-  - flake8-docstrings   # dev
-  - flake8-rst-docstrings # dev
-  - flake8-builtins     # dev
-  - geopandas>=0.8.0    # base
-  - goodtables>=2.4.2   # base
-  - ipdb                # dev
-  - isort>=5.0          # dev
-  - jedi                # dev
-  - jupyter             # user
-  - jupyterlab          # user
-  - lxml                # dev -- used for pd.read_html
-  - matplotlib          # base
-  - mccabe              # dev
-  - nbdime              # dev
-  - nbval               # dev
-  - networkx>=2.2       # base We depend on features introduced in v2.2
-  - numpy               # base
-  - pandas>=1.2         # base Extensive nullable data type use
-  - pandoc              # dev
-  - pdbpp               # dev
-  - pep8-naming         # dev
-  - pip                 # N/A
-  - pre_commit          # dev
-  - pyarrow>=2.0.0      # base
-  - pydocstyle          # dev
-  - pygeos              # user (speeds up geopandas operations)
-  - pysal               # user (required for making maps w/ geopandas)
-  - pytest              # dev
-  - pytest-cov          # dev
-  - python>=3.8         # N/A zipfile.Path() use requires 3.8
-  - python-graphviz     # user (for use with dask)
-  - python-snappy       # base
-  - pyyaml              # base
-  - seaborn             # dev
-  - scikit-learn>=0.20  # base pandas integration added in v0.20
-  - scipy               # base
-  - setuptools_scm      # dev
-  - sphinx>=3.0         # dev
-  - sphinx-issues       # dev
-  - sphinx_rtd_theme    # dev
-  - sqlalchemy>=1.3.0   # base Security issues below v1.3.0
-  - tableschema>=1.12   # base
-  - tableschema-sql>=1.1.0 # base
-  - timezonefinder      # base
-  - tox                 # dev
-  - tqdm                # base TODO: find usage. Does it need to be in base?
-  - twine               # dev
-  - xlsxwriter          # base
+  # install_requires
+  - addfips~=0.3.0
+  - catalystcoop.dbfread~=3.0
+  - coloredlogs~=15.0
+  - contextily~=1.0
+  - datapackage~=1.11
+  - geopandas~=0.8.1
+  - matplotlib~=3.0
+  - networkx~=2.2
+  - numpy~=1.19
+  - pandas~=1.2
+  - pip~=20.3
+  - pyarrow~=2.0
+  - pyyaml~=5.0
+  - python~=3.8
+  - python-snappy~=0.5.4
+  - scikit-learn~=0.24
+  - scipy~=1.6
+  - seaborn~=0.11.1
+  - setuptools_scm~=5.0.1
+  - sqlalchemy~=1.3
+  - tableschema~=1.12
+  - tableschema-sql~=1.3
+  - timezonefinder~=5.0
+  - tqdm~=4.0
+  - xlsxwriter~=1.3
+
+  # doc_requires
+  - doc8~=0.8.0
+  - sphinx~=3.0
+  - sphinx-issues~=1.2
+  - sphinx_rtd_theme~=0.5.0
+
+  # test_requires
+  - bandit~=1.6
+  - coverage~=5.3
+  - flake8~=3.8
+  - flake8-builtins~=1.5
+  - flake8-colors~=0.1.0
+  - flake8-docstrings~=1.5
+  - flake8-rst-docstrings~=0.0.14
+  - mccabe~=0.6.0
+  - nbval~=0.9.0
+  - pep8-naming~=0.11.0
+  - pre_commit~=2.9
+  - pydocstyle~=5.1
+  - pytest~=6.2
+  - pytest-cov~=2.10
+
+  # development
+  - autopep8~=1.5
+  - ipdb~=0.13.4
+  - isort~=5.0
+  - jedi~=0.17.2
+  - lxml~=4.6
+  - nbdime~=2.1
+  - pandoc~=2.11
+  - pdbpp~=0.10
+  - tox~=3.20
+  - twine~=3.3
+
+  # user environment
+  - dask~=2020.12
+  - dask-labextension~=4.0
+  - jupyter-resource-usage~=0.5.0
+  - jupyterlab~=3.0
+  - pygeos~=0.8.0
+  - pysal~=2.1.0
+  - python-graphviz~=0.16.0
+
   - pip:
-    - flake8-use-fstring # dev
-    - goodtables-pandas-py>=0.2.0  # base get in conda!
-    - recordlinkage      # dev for now... base if it ends up in ETL
-    - fredapi            # dev
+    - flake8-use-fstring~=1.0     # development
+    - goodtables-pandas-py~=0.2.0 # install_requires
+    - recordlinkage~=0.14.0       # user environment
+    - fredapi~=0.4.3              # user environment

--- a/docs/api/pudl.analysis.timeseries_cleaning.rst
+++ b/docs/api/pudl.analysis.timeseries_cleaning.rst
@@ -1,0 +1,7 @@
+pudl.analysis.timeseries\_cleaning module
+=========================================
+
+.. automodule:: pudl.analysis.timeseries_cleaning
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/setup.py
+++ b/setup.py
@@ -8,10 +8,10 @@ from setuptools import find_packages, setup
 
 install_requires = [
     "addfips~=0.3.0",
+    "catalystcoop.dbfread~=3.0",
     "coloredlogs~=15.0",
     "contextily~=1.0",
     "datapackage~=1.11",
-    "catalystcoop.dbfread~=3.0",
     "geopandas~=0.8.1",
     "goodtables-pandas-py~=0.2.0",
     "matplotlib~=3.0",
@@ -53,7 +53,7 @@ test_requires = [
     "flake8-builtins~=1.5",
     "flake8-colors~=0.1.0",
     "flake8-docstrings~=1.5",
-    "flake8-rst-docstrings",
+    "flake8-rst-docstrings~=0.0.14",
     "flake8-use-fstring~=1.0",
     "mccabe~=0.6.0",
     "nbval~=0.9",

--- a/setup.py
+++ b/setup.py
@@ -7,28 +7,28 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 install_requires = [
-    "addfips>=0.3,<0.4",
-    "coloredlogs>=15.0,<16.0",
-    "contextily>=1.0,<2.0",
-    "datapackage>=1.11,<2.0",
-    "catalystcoop.dbfread>=3.0,<4.0",
-    "geopandas>=0.8.1,<0.9",
-    "goodtables-pandas-py>=0.2,<0.3",
-    "matplotlib>=3.0,<4.0",
-    "networkx>=2.2,<3.0",
-    "numpy>=1.19,<2.0",
-    "pandas>=1.2,<2.0",
-    "pyarrow>=2.0,<3.0",
-    "pyyaml>=5.0,<6.0",
-    "scikit-learn>=0.20,<1.0",
-    "scipy>=1.6,<2.0",
-    "seaborn>=0.11,<0.12",
-    "sqlalchemy>=1.3,<2.0",
-    "tableschema>=1.12.3,<2.0",
-    "tableschema-sql>=1.3.1,<2.0",
-    "timezonefinder>=5.0,<6.0",
-    "tqdm>=4.0,<5.0",
-    "xlsxwriter>=1.3,<2.0",
+    "addfips~=0.3.0",
+    "coloredlogs~=15.0",
+    "contextily~=1.0",
+    "datapackage~=1.11",
+    "catalystcoop.dbfread~=3.0",
+    "geopandas~=0.8.1",
+    "goodtables-pandas-py~=0.2.0",
+    "matplotlib~=3.0",
+    "networkx~=2.2",
+    "numpy~=1.19",
+    "pandas~=1.2",
+    "pyarrow~=2.0",
+    "pyyaml~=5.0",
+    "scikit-learn~=0.24",
+    "scipy~=1.6",
+    "seaborn~=0.11.1",
+    "sqlalchemy~=1.3",
+    "tableschema~=1.12",
+    "tableschema-sql~=1.3",
+    "timezonefinder~=5.0",
+    "tqdm~=4.0",
+    "xlsxwriter~=1.3",
 ]
 
 # We are installing the PUDL module to build the docs, but the C libraries
@@ -36,32 +36,32 @@ install_requires = [
 # from the installed dependencies here, and mock it for import in docs/conf.py
 # using the autodoc_mock_imports parameter:
 if not os.getenv("READTHEDOCS"):
-    install_requires.append("python-snappy>=0.5.4,<0.6")
+    install_requires.append("python-snappy~=0.5.4")
 
 doc_requires = [
-    "doc8>=0.8,<0.9",
-    "sphinx>=3.0,<4.0",
-    "sphinx-issues>=1.2,<2.0",
-    "sphinx_rtd_theme>=0.5,<0.6",
+    "doc8~=0.8.0",
+    "sphinx~=3.0",
+    "sphinx-issues~=1.2",
+    "sphinx_rtd_theme~=0.5.0",
 ]
 
 test_requires = [
-    "bandit>=1.6,<2.0",
-    "coverage>=5.3,<6.0",
-    "doc8>=0.8,<0.9",
-    "flake8>=3.8,<4.0",
-    "flake8-builtins>=1.5,<2.0",
-    "flake8-colors>=0.1,<0.2",
-    "flake8-docstrings>=1.5,<2.0",
+    "bandit~=1.6",
+    "coverage~=5.3",
+    "doc8~=0.8.0",
+    "flake8~=3.8",
+    "flake8-builtins~=1.5",
+    "flake8-colors~=0.1.0",
+    "flake8-docstrings~=1.5",
     "flake8-rst-docstrings",
-    "flake8-use-fstring>=1.0,<2.0",
-    "mccabe>=0.6,<0.7",
-    "nbval>=0.9,<1.0",
-    "pep8-naming>=0.11,<0.12",
-    "pre-commit>=2.9,<3.0",
-    "pydocstyle>=5.1,<6.0",
-    "pytest>=6.0,<7.0",
-    "pytest-cov>=2.10,<3.0",
+    "flake8-use-fstring~=1.0",
+    "mccabe~=0.6.0",
+    "nbval~=0.9",
+    "pep8-naming~=0.11.0",
+    "pre-commit~=2.9",
+    "pydocstyle~=5.1",
+    "pytest~=6.2",
+    "pytest-cov~=2.10",
 ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -7,28 +7,28 @@ from pathlib import Path
 from setuptools import find_packages, setup
 
 install_requires = [
-    "addfips",
-    "coloredlogs",
-    "contextily",
-    "datapackage>=1.11",
-    "catalystcoop.dbfread>=3.0",
-    "geopandas>=0.8.0",
-    "goodtables-pandas-py>=0.1.1",
-    "matplotlib",
-    "networkx>=2.2",
-    "numpy",
-    "pandas>=1.2",
-    "pyarrow>=2.0.0",
-    "pyyaml",
-    "scikit-learn>=0.20",
-    "scipy",
-    "seaborn",
-    "sqlalchemy>=1.3.0",
-    "tableschema>=1.12.3",
-    "tableschema-sql>=1.3.1",
-    "timezonefinder",
-    "tqdm",
-    "xlsxwriter",
+    "addfips>=0.3,<0.4",
+    "coloredlogs>=15.0,<16.0",
+    "contextily>=1.0,<2.0",
+    "datapackage>=1.11,<2.0",
+    "catalystcoop.dbfread>=3.0,<4.0",
+    "geopandas>=0.8.1,<0.9",
+    "goodtables-pandas-py>=0.2,<0.3",
+    "matplotlib>=3.0,<4.0",
+    "networkx>=2.2,<3.0",
+    "numpy>=1.19,<2.0",
+    "pandas>=1.2,<2.0",
+    "pyarrow>=2.0,<3.0",
+    "pyyaml>=5.0,<6.0",
+    "scikit-learn>=0.20,<1.0",
+    "scipy>=1.6,<2.0",
+    "seaborn>=0.11,<0.12",
+    "sqlalchemy>=1.3,<2.0",
+    "tableschema>=1.12.3,<2.0",
+    "tableschema-sql>=1.3.1,<2.0",
+    "timezonefinder>=5.0,<6.0",
+    "tqdm>=4.0,<5.0",
+    "xlsxwriter>=1.3,<2.0",
 ]
 
 # We are installing the PUDL module to build the docs, but the C libraries
@@ -36,32 +36,32 @@ install_requires = [
 # from the installed dependencies here, and mock it for import in docs/conf.py
 # using the autodoc_mock_imports parameter:
 if not os.getenv("READTHEDOCS"):
-    install_requires.append("python-snappy")
+    install_requires.append("python-snappy>=0.5.4,<0.6")
 
 doc_requires = [
-    "doc8",
-    "sphinx>=3.0",
-    "sphinx-issues",
-    "sphinx_rtd_theme",
+    "doc8>=0.8,<0.9",
+    "sphinx>=3.0,<4.0",
+    "sphinx-issues>=1.2,<2.0",
+    "sphinx_rtd_theme>=0.5,<0.6",
 ]
 
 test_requires = [
-    "bandit",
-    "coverage",
-    "doc8",
-    "flake8",
-    "flake8-builtins",
-    "flake8-colors",
-    "flake8-docstrings",
+    "bandit>=1.6,<2.0",
+    "coverage>=5.3,<6.0",
+    "doc8>=0.8,<0.9",
+    "flake8>=3.8,<4.0",
+    "flake8-builtins>=1.5,<2.0",
+    "flake8-colors>=0.1,<0.2",
+    "flake8-docstrings>=1.5,<2.0",
     "flake8-rst-docstrings",
-    "flake8-use-fstring",
-    "mccabe",
-    "nbval",
-    "pep8-naming",
-    "pre-commit",
-    "pydocstyle",
-    "pytest",
-    "pytest-cov",
+    "flake8-use-fstring>=1.0,<2.0",
+    "mccabe>=0.6,<0.7",
+    "nbval>=0.9,<1.0",
+    "pep8-naming>=0.11,<0.12",
+    "pre-commit>=2.9,<3.0",
+    "pydocstyle>=5.1,<6.0",
+    "pytest>=6.0,<7.0",
+    "pytest-cov>=2.10,<3.0",
 ]
 
 


### PR DESCRIPTION
At @ezwelty's suggestion (after some unexpected breakage) I've tried to set minimum and maximum versions for all of our direct dependencies in `setup.py` so that unexpected major breaking updates should be much less frequent. I'm not entirely sure how this will interact with our use of `environment.yml` to specify the `pudl-dev` environment, but so far it seems to work fine with `tox` and `pip`. Recreating my `pudl-dev` environment locally from scratch, and then installing pudl inside it using pip seems to work fine though.