### PR TITLE
Investigate why EPA CEMS is sooo dang slooow

### DIFF
--- a/src/pudl/constants.py
+++ b/src/pudl/constants.py
@@ -6,8 +6,6 @@ used throughout PUDL to populate static lists within the data packages or for
 data cleaning purposes.
 """
 
-import importlib.resources
-
 import pandas as pd
 import sqlalchemy as sa
 
@@ -1386,116 +1384,8 @@ entities = {
     to keep for those tables (values).
 """
 
-# EPA CEMS constants #####
-
-epacems_rename_dict = {
-    "STATE": "state",
-    # "FACILITY_NAME": "plant_name",  # Not reading from CSV
-    "ORISPL_CODE": "plant_id_eia",
-    "UNITID": "unitid",
-    # These op_date, op_hour, and op_time variables get converted to
-    # operating_date, operating_datetime and operating_time_interval in
-    # transform/epacems.py
-    "OP_DATE": "op_date",
-    "OP_HOUR": "op_hour",
-    "OP_TIME": "operating_time_hours",
-    "GLOAD (MW)": "gross_load_mw",
-    "GLOAD": "gross_load_mw",
-    "SLOAD (1000 lbs)": "steam_load_1000_lbs",
-    "SLOAD (1000lb/hr)": "steam_load_1000_lbs",
-    "SLOAD": "steam_load_1000_lbs",
-    "SO2_MASS (lbs)": "so2_mass_lbs",
-    "SO2_MASS": "so2_mass_lbs",
-    "SO2_MASS_MEASURE_FLG": "so2_mass_measurement_code",
-    # "SO2_RATE (lbs/mmBtu)": "so2_rate_lbs_mmbtu",  # Not reading from CSV
-    # "SO2_RATE": "so2_rate_lbs_mmbtu",  # Not reading from CSV
-    # "SO2_RATE_MEASURE_FLG": "so2_rate_measure_flg",  # Not reading from CSV
-    "NOX_RATE (lbs/mmBtu)": "nox_rate_lbs_mmbtu",
-    "NOX_RATE": "nox_rate_lbs_mmbtu",
-    "NOX_RATE_MEASURE_FLG": "nox_rate_measurement_code",
-    "NOX_MASS (lbs)": "nox_mass_lbs",
-    "NOX_MASS": "nox_mass_lbs",
-    "NOX_MASS_MEASURE_FLG": "nox_mass_measurement_code",
-    "CO2_MASS (tons)": "co2_mass_tons",
-    "CO2_MASS": "co2_mass_tons",
-    "CO2_MASS_MEASURE_FLG": "co2_mass_measurement_code",
-    # "CO2_RATE (tons/mmBtu)": "co2_rate_tons_mmbtu",  # Not reading from CSV
-    # "CO2_RATE": "co2_rate_tons_mmbtu",  # Not reading from CSV
-    # "CO2_RATE_MEASURE_FLG": "co2_rate_measure_flg",  # Not reading from CSV
-    "HEAT_INPUT (mmBtu)": "heat_content_mmbtu",
-    "HEAT_INPUT": "heat_content_mmbtu",
-    "FAC_ID": "facility_id",
-    "UNIT_ID": "unit_id_epa",
-}
-"""dict: A dictionary containing EPA CEMS column names (keys) and replacement
-    names to use when reading those columns into PUDL (values).
-"""
-# Any column that exactly matches one of these won't be read
-epacems_columns_to_ignore = {
-    "FACILITY_NAME",
-    "SO2_RATE (lbs/mmBtu)",
-    "SO2_RATE",
-    "SO2_RATE_MEASURE_FLG",
-    "CO2_RATE (tons/mmBtu)",
-    "CO2_RATE",
-    "CO2_RATE_MEASURE_FLG",
-}
-"""set: The set of EPA CEMS columns to ignore when reading data.
-"""
-# Specify dtypes to for reading the CEMS CSVs
-epacems_csv_dtypes = {
-    "STATE": pd.StringDtype(),
-    # "FACILITY_NAME": str,  # Not reading from CSV
-    "ORISPL_CODE": pd.Int64Dtype(),
-    "UNITID": pd.StringDtype(),
-    # These op_date, op_hour, and op_time variables get converted to
-    # operating_date, operating_datetime and operating_time_interval in
-    # transform/epacems.py
-    "OP_DATE": pd.StringDtype(),
-    "OP_HOUR": pd.Int64Dtype(),
-    "OP_TIME": float,
-    "GLOAD (MW)": float,
-    "GLOAD": float,
-    "SLOAD (1000 lbs)": float,
-    "SLOAD (1000lb/hr)": float,
-    "SLOAD": float,
-    "SO2_MASS (lbs)": float,
-    "SO2_MASS": float,
-    "SO2_MASS_MEASURE_FLG": pd.StringDtype(),
-    # "SO2_RATE (lbs/mmBtu)": float,  # Not reading from CSV
-    # "SO2_RATE": float,  # Not reading from CSV
-    # "SO2_RATE_MEASURE_FLG": str,  # Not reading from CSV
-    "NOX_RATE (lbs/mmBtu)": float,
-    "NOX_RATE": float,
-    "NOX_RATE_MEASURE_FLG": pd.StringDtype(),
-    "NOX_MASS (lbs)": float,
-    "NOX_MASS": float,
-    "NOX_MASS_MEASURE_FLG": pd.StringDtype(),
-    "CO2_MASS (tons)": float,
-    "CO2_MASS": float,
-    "CO2_MASS_MEASURE_FLG": pd.StringDtype(),
-    # "CO2_RATE (tons/mmBtu)": float,  # Not reading from CSV
-    # "CO2_RATE": float,  # Not reading from CSV
-    # "CO2_RATE_MEASURE_FLG": str,  # Not reading from CSV
-    "HEAT_INPUT (mmBtu)": float,
-    "HEAT_INPUT": float,
-    "FAC_ID": pd.Int64Dtype(),
-    "UNIT_ID": pd.Int64Dtype(),
-}
-"""dict: A dictionary containing column names (keys) and data types (values)
-for EPA CEMS.
-"""
-
 epacems_tables = ("hourly_emissions_epacems")
 """tuple: A tuple containing tables of EPA CEMS data to pull into PUDL.
-"""
-
-epacems_additional_plant_info_file = importlib.resources.open_text(
-    'pudl.package_data.epa.cems', 'plant_info_for_additional_cems_plants.csv')
-"""typing.TextIO:
-
-    Todo:
-        Return to
 """
 
 files_dict_epaipm = {

--- a/src/pudl/extract/epacems.py
+++ b/src/pudl/extract/epacems.py
@@ -9,10 +9,109 @@ from zipfile import ZipFile
 
 import pandas as pd
 
-from pudl import constants as pc
 from pudl.workspace import datastore as datastore
 
 logger = logging.getLogger(__name__)
+
+# EPA CEMS constants #####
+RENAME_DICT = {
+    "STATE": "state",
+    # "FACILITY_NAME": "plant_name",  # Not reading from CSV
+    "ORISPL_CODE": "plant_id_eia",
+    "UNITID": "unitid",
+    # These op_date, op_hour, and op_time variables get converted to
+    # operating_date, operating_datetime and operating_time_interval in
+    # transform/epacems.py
+    "OP_DATE": "op_date",
+    "OP_HOUR": "op_hour",
+    "OP_TIME": "operating_time_hours",
+    "GLOAD (MW)": "gross_load_mw",
+    "GLOAD": "gross_load_mw",
+    "SLOAD (1000 lbs)": "steam_load_1000_lbs",
+    "SLOAD (1000lb/hr)": "steam_load_1000_lbs",
+    "SLOAD": "steam_load_1000_lbs",
+    "SO2_MASS (lbs)": "so2_mass_lbs",
+    "SO2_MASS": "so2_mass_lbs",
+    "SO2_MASS_MEASURE_FLG": "so2_mass_measurement_code",
+    # "SO2_RATE (lbs/mmBtu)": "so2_rate_lbs_mmbtu",  # Not reading from CSV
+    # "SO2_RATE": "so2_rate_lbs_mmbtu",  # Not reading from CSV
+    # "SO2_RATE_MEASURE_FLG": "so2_rate_measure_flg",  # Not reading from CSV
+    "NOX_RATE (lbs/mmBtu)": "nox_rate_lbs_mmbtu",
+    "NOX_RATE": "nox_rate_lbs_mmbtu",
+    "NOX_RATE_MEASURE_FLG": "nox_rate_measurement_code",
+    "NOX_MASS (lbs)": "nox_mass_lbs",
+    "NOX_MASS": "nox_mass_lbs",
+    "NOX_MASS_MEASURE_FLG": "nox_mass_measurement_code",
+    "CO2_MASS (tons)": "co2_mass_tons",
+    "CO2_MASS": "co2_mass_tons",
+    "CO2_MASS_MEASURE_FLG": "co2_mass_measurement_code",
+    # "CO2_RATE (tons/mmBtu)": "co2_rate_tons_mmbtu",  # Not reading from CSV
+    # "CO2_RATE": "co2_rate_tons_mmbtu",  # Not reading from CSV
+    # "CO2_RATE_MEASURE_FLG": "co2_rate_measure_flg",  # Not reading from CSV
+    "HEAT_INPUT (mmBtu)": "heat_content_mmbtu",
+    "HEAT_INPUT": "heat_content_mmbtu",
+    "FAC_ID": "facility_id",
+    "UNIT_ID": "unit_id_epa",
+}
+"""dict: A dictionary containing EPA CEMS column names (keys) and replacement
+    names to use when reading those columns into PUDL (values).
+"""
+
+# Any column that exactly matches one of these won't be read
+IGNORE_COLS = {
+    "FACILITY_NAME",
+    "SO2_RATE (lbs/mmBtu)",
+    "SO2_RATE",
+    "SO2_RATE_MEASURE_FLG",
+    "CO2_RATE (tons/mmBtu)",
+    "CO2_RATE",
+    "CO2_RATE_MEASURE_FLG",
+}
+"""set: The set of EPA CEMS columns to ignore when reading data."""
+
+# Specify dtypes to for reading the CEMS CSVs
+CSV_DTYPES = {
+    "STATE": pd.StringDtype(),
+    # "FACILITY_NAME": str,  # Not reading from CSV
+    "ORISPL_CODE": pd.Int64Dtype(),
+    "UNITID": pd.StringDtype(),
+    # These op_date, op_hour, and op_time variables get converted to
+    # operating_date, operating_datetime and operating_time_interval in
+    # transform/epacems.py
+    "OP_DATE": pd.StringDtype(),
+    "OP_HOUR": pd.Int64Dtype(),
+    "OP_TIME": float,
+    "GLOAD (MW)": float,
+    "GLOAD": float,
+    "SLOAD (1000 lbs)": float,
+    "SLOAD (1000lb/hr)": float,
+    "SLOAD": float,
+    "SO2_MASS (lbs)": float,
+    "SO2_MASS": float,
+    "SO2_MASS_MEASURE_FLG": pd.StringDtype(),
+    # "SO2_RATE (lbs/mmBtu)": float,  # Not reading from CSV
+    # "SO2_RATE": float,  # Not reading from CSV
+    # "SO2_RATE_MEASURE_FLG": str,  # Not reading from CSV
+    "NOX_RATE (lbs/mmBtu)": float,
+    "NOX_RATE": float,
+    "NOX_RATE_MEASURE_FLG": pd.StringDtype(),
+    "NOX_MASS (lbs)": float,
+    "NOX_MASS": float,
+    "NOX_MASS_MEASURE_FLG": pd.StringDtype(),
+    "CO2_MASS (tons)": float,
+    "CO2_MASS": float,
+    "CO2_MASS_MEASURE_FLG": pd.StringDtype(),
+    # "CO2_RATE (tons/mmBtu)": float,  # Not reading from CSV
+    # "CO2_RATE": float,  # Not reading from CSV
+    # "CO2_RATE_MEASURE_FLG": str,  # Not reading from CSV
+    "HEAT_INPUT (mmBtu)": float,
+    "HEAT_INPUT": float,
+    "FAC_ID": pd.Int64Dtype(),
+    "UNIT_ID": pd.Int64Dtype(),
+}
+"""dict: A dictionary containing column names (keys) and data types (values)
+for EPA CEMS.
+"""
 
 
 class EpaCemsDatastore(datastore.Datastore):
@@ -55,25 +154,19 @@ def csv_to_dataframe(csv):
     """
     Convert a CEMS csv file into a :class:`pandas.DataFrame`.
 
-    Note that some columns are not read. See
-    :mod:`pudl.constants.epacems_columns_to_ignore`. Data types for the columns
-    are specified in :mod:`pudl.constants.epacems_csv_dtypes` and names of the
-    output columns are set by :mod:`pudl.constants.epacems_rename_dict`.
+    Note that some columns are not read, see IGNORE_COLS. Data types for the columns are
+    specified by CSV_DTYPES and names of the output columns are set by RENAME_DICT.
 
     Args:
         csv (file-like object): data to be read
 
     Returns:
-        pandas.DataFrame: A DataFrame containing the contents of the
-        CSV file.
+        pandas.DataFrame: A DataFrame containing the contents of the CSV file.
 
     """
-    df = pd.read_csv(
-        csv,
-        index_col=False,
-        usecols=lambda col: col not in pc.epacems_columns_to_ignore,
-        dtype=pc.epacems_csv_dtypes,
-    ).rename(columns=pc.epacems_rename_dict)
+    df = pd.read_csv(csv, index_col=False, usecols=lambda col: col not in IGNORE_COLS)
+    df = df.astype({col: CSV_DTYPES[col] for col in CSV_DTYPES if col in df.columns})
+    df = df.rename(columns=RENAME_DICT)
     return df
 
 


### PR DESCRIPTION
After seeing the speedups that @ezwelty was able to eek out of the FERC 714 ETL process and missing value imputations, I've become suspicious that the EPA CEMS ETL does not need to take anywhere near as long as it currently does.  I did some poking around to see where the bottleneck is, and it seems to be the datastore -- not the extract or transform. While I haven't tracked down the issue, I did move some of the constants that pertain only to the EPA CEMS ETL into that module, and out of the
`constants.py` graveyard.

Just a branch / draft PR, for whatever comes out of addressing #877 