### PR TITLE
Timeseries unittest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,4 +75,4 @@ repos:
       verbose: false
       pass_filenames: false
       always_run: true
-      entry: pipenv run pytest src/pudl
+      entry: tox -e unit

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -61,7 +61,6 @@ dependencies:
   - isort~=5.0
   - jedi~=0.17.2
   - lxml~=4.6
-  - nbdime~=2.1
   - pandoc~=2.11
   - pdbpp~=0.10
   - tox~=3.20
@@ -69,9 +68,10 @@ dependencies:
 
   # user environment
   - dask~=2020.12
-  - dask-labextension~=4.0
+  - dask-labextension~=5.0
   - jupyter-resource-usage~=0.5.0
   - jupyterlab~=3.0
+  - nodejs~=12.19
   - pygeos~=0.8.0
   - pysal~=2.1.0
   - python-graphviz~=0.16.0

--- a/tox.ini
+++ b/tox.ini
@@ -129,12 +129,13 @@ commands =
       test/glue_test.py \
       test/fast_output_test.py \
       test/interim_etl_test.py \
+      test/timeseries_cleaning_test.py \
       test/zenodo_integration.py
 
 
 # Runs unit tests under src/pudl
 [testenv:unit]
-extras = 
+extras =
     test
 commands =
     pytest src/pudl


### PR DESCRIPTION
I added the unit tests that @ezwelty created for the `timeseries_cleaning` module into the CI -- but they're under the `test` driectory, while the unit tests written by @rousik are under `src/pudl` -- we should come to a consensus on where these should live.

I also switched to using `tox -e unit` in the `pre-commit` instead of `pipenv run pytest src/pudl` both to ensure that any changes made to what constitutes "unit" tests in `tox` are reflected in the pre-commit settings, and also to avoid needing to add `pipenv` to the overall environment specification (it failed when I tried to run it because it wasn't part of my environment)