### PR TITLE
Support reading and writing to S3 

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   # install_requires
   - addfips~=0.3.0
   - bokeh>=0.13.0
+  - boto3~=1.17
   - catalystcoop.dbfread~=3.0
   - coloredlogs~=15.0
   - contextily~=1.0

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -28,6 +28,7 @@ dependencies:
   - pyyaml~=5.0
   - python~=3.8
   - python-snappy~=0.5.4
+  - s3fs0~=.4.2
   - scikit-learn~=0.24
   - scipy~=1.6
   - seaborn~=0.11.1

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     "prefect[viz, gcp]~=0.14.2",
     "pyarrow~=3.0",
     "pyyaml~=5.0",
+    "s3fs~=0.4.2",
     "scikit-learn~=0.24",
     "scipy~=1.6",
     "seaborn~=0.11.1",

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import find_packages, setup
 install_requires = [
     "addfips~=0.3.0",
     "bokeh>=0.13.0",
+    "boto3~=1.17",
     "catalystcoop.dbfread~=3.0",
     "coloredlogs~=15.0",
     "contextily~=1.0",

--- a/src/pudl/dfc.py
+++ b/src/pudl/dfc.py
@@ -94,7 +94,7 @@ class DataFrameCollection:
         if name in self._table_ids:
             raise TableExists(f'Table {name} already present in the DFC.')
         filename = self._get_filename(name, self._instance_id)
-        if not filename.startswith("gs://"):
+        if not (filename.startswith("gs://") or filename.startswith("s3://")):
             # Do not make directories when dealing with remote storage.
             # TODO(rousik): this is fairly crude solution and won't work
             # for non gcs remote storage.

--- a/src/pudl/etl.py
+++ b/src/pudl/etl.py
@@ -32,6 +32,10 @@ from prefect.executors import DaskExecutor
 from prefect.executors.local import LocalExecutor
 from prefect.tasks.shell import ShellTask
 
+from s3fs import S3FileSystem
+from gcsfs import GCSFileSystem
+
+
 import pudl
 from pudl import dfc
 from pudl.convert import datapkg_to_sqlite
@@ -549,6 +553,11 @@ def configure_prefect_context(etl_settings, pudl_settings, commandline_args):
     prefect.context.pudl_datapkg_bundle_name = etl_settings['datapkg_bundle_name']
     prefect.context.pudl_commandline_args = commandline_args
     prefect.context.pudl_upload_to_gcs = commandline_args.upload_to_gcs
+    prefect.context.pudl_filesystem = None
+    if commandline_args.upload_to_gcs.startswith("gs://"):
+        prefect.context.pudl_filesystem = GCSFileSystem()
+    elif commandline_args.upload_to_gcs.startswith("s3://"):
+        prefect.context.pudl_filesystem = S3FileSystem()
 
     local_cache_path = None
     if not commandline_args.bypass_local_cache:

--- a/src/pudl/workflow/epacems.py
+++ b/src/pudl/workflow/epacems.py
@@ -70,6 +70,7 @@ def write_epacems_parquet_files(df: pd.DataFrame, table_name: str, partition: Ep
     parquet.write_to_dataset(
         table,
         root_path=output_path,
+        filesystem=prefect.context.pudl_filesystem,
         partition_cols=['year', 'state'],
         compression='snappy')
 

--- a/src/pudl/workflow/epacems.py
+++ b/src/pudl/workflow/epacems.py
@@ -63,7 +63,8 @@ def write_epacems_parquet_files(df: pd.DataFrame, table_name: str, partition: Ep
     # once we update our dependency.
     if prefect.context.pudl_upload_to_gcs:
         output_path = os.path.join(
-            prefect.context.pudl_upload_to_gcs, "parquet", "epacems")
+            prefect.context.pudl_upload_to_gcs, prefect.context.pudl_run_id,
+            "parquet", "epacems")
     else:
         output_path = os.path.join(
             prefect.context.pudl_settings["parquet_dir"], "epacems")

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -268,8 +268,12 @@ class Datastore:
             self._cache.add_cache_layer(
                 resource_cache.LocalFileCache(local_cache_path))
         if gcs_cache_path:
-            self._cache.add_cache_layer(
-                resource_cache.GoogleCloudStorageCache(gcs_cache_path))
+            if gcs_cache_path.startswith("s3://"):
+                self._cache.add_cache_layer(
+                    resource_cache.AWSS3Cache(gcs_cache_path))
+            else:
+                self._cache.add_cache_layer(
+                    resource_cache.GoogleCloudStorageCache(gcs_cache_path))
 
         self._zenodo_fetcher = ZenodoFetcher(
             sandbox=sandbox,

--- a/src/pudl/workspace/resource_cache.py
+++ b/src/pudl/workspace/resource_cache.py
@@ -10,6 +10,7 @@ from google.cloud import storage
 from google.cloud.storage.blob import Blob
 
 import boto3
+from botocore.exceptions import ClientError
 
 logger = logging.getLogger(__name__)
 
@@ -181,7 +182,7 @@ class AWSS3Cache(AbstractCache):
         try:
             self._blob(resource).load()
             return True
-        except botocore.exceptions.ClientError as e:
+        except ClientError as e:
             if e.response['Error']['Code'] == "404":
                 # The object does not exist.
                 return False

--- a/src/pudl/workspace/resource_cache.py
+++ b/src/pudl/workspace/resource_cache.py
@@ -181,8 +181,13 @@ class AWSS3Cache(AbstractCache):
         try:
             self._blob(resource).load()
             return True
-        except:
-            return False
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == "404":
+                # The object does not exist.
+                return False
+            else:
+                # Something else has gone wrong.
+                raise
 
 
 class LayeredCache(AbstractCache):


### PR DESCRIPTION
This PR is to the `prefect` branch, to support using S3 as the cache and the output location.

I wanted to try with S3 and since this seems to work, I thought i'd open a PR, mostly for visibility at this point.  I'd be happy for someone to take over this / open a PR superseding this. I've not written python for quite a while, so i'm sure some of the code here can be improved, and i'm not sure how we want to go about testing this... but this at least works as far as i've verified personally by using `pudl_etl` and `pudl_datastore` commands while pointing to S3, e.g. like
```sh
$ pudl_etl settings.yml \
  --bypass-local-cache \
  --gcs-cache-path "s3://my-pudl-bucket/cache/" \
  --upload-to-gcs "s3://my-pudl-bucket/output/" \
  --run-id "run1"
```

for writing to S3:
- adds support for writing epacems parquet files to S3 via passing a `filesystem` keyword to `parquet.write_to_dataset` (in `write_epacems_parquet_files`). 
   - The `filesystem` is stored in a new `prefect.context.pudl_filesystem` variable, and determined by if the output path startswith `gs://` or `s3://`.
   - This adds a dependency on `s3fs`.
   - I suspect, a change like this is probably needed to support writing parquet to GCS too, but i've not verified that.
   - I changed the path to save parquet files under `{bucket}/{run_id}/parquet/` rather than `{bucket}/parquet/`, to mirror where `{bucket}/{run_id}/datapkg/`.
- support for writing `datapkg/` files seems to have just worked out the box, as far as i've tested

for using S3 as the input/cache:
- adds a `AWSS3Cache` class
  - this adds a dependency on `boto3`
- similar to with the `filesystem`, `cache_path.startswith("s3://")` is used to determine if a `AWSS3Cache` layer should be used.

Notes:
- we probably want to rename `gcs-cache-path` and `upload-to-gcs` something GCS agnostic
- we may want something nicer than the `startswith("s3://")`/`startswith("gc://")` if-else checks
- for the dependencies, i just listed the versions i used, potentially other versions could work too
