### PR TITLE
Pudl rmi

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -5,7 +5,7 @@ channels:
   - intake
 dependencies:
   - pip~=21.0
-  - python~=3.8
+  - python>=3.8,<3.9
   - setuptools_scm~=5.0
 
   # install_requires
@@ -81,8 +81,7 @@ dependencies:
   - pygeos~=0.8.0
   - pysal~=2.1
   - python-graphviz~=0.16.0
+  - recordlinkage~=0.14.0
 
   - pip:
     - flake8-use-fstring~=1.0     # development
-    - recordlinkage~=0.14.0       # user environment
-    - fredapi~=0.4.3              # user environment

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
         "electricity", "energy", "data", "analysis", "mcoe", "climate change",
         "finance", "eia 923", "eia 860", "ferc", "form 1", "epa ampd",
         "epa cems", "coal", "natural gas", "eia 861", "ferc 714"],
-    python_requires=">=3.8",
+    python_requires=">=3.8,<3.9",
     setup_requires=["setuptools_scm"],
     install_requires=install_requires,
     extras_require={


### PR DESCRIPTION
Since we're installing PUDL in some Docker containers and want the dependencies to come through clearly, I updated the setup.py to exclude python 3.9 -- (which is also required by numba, which is required by timezonefinder but we still got an install of python 3.9...). This also removes the `fredapi` dependency since we don't seem to be using it anywhere, and moves `recordlinkage` into the conda part of the environment.yml, since some kind soul has packaged it up for distribution via conda.