### PR TITLE
Convert Census DP1 to SQLite

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -33,8 +33,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt install libsnappy-dev
-        sudo apt install gdal-bin
+        sudo apt-get install libsnappy-dev gdal-bin
         python -m pip install --upgrade pip
         pip install tox
 

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -33,7 +33,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get install libsnappy-dev
+        sudo apt install libsnappy-dev
+        sudo apt install gdal-bin
         python -m pip install --upgrade pip
         pip install tox
 

--- a/docs/api/pudl.convert.censusdp1tract_to_sqlite.rst
+++ b/docs/api/pudl.convert.censusdp1tract_to_sqlite.rst
@@ -1,0 +1,7 @@
+pudl.convert.censusdp1tract\_to\_sqlite module
+==============================================
+
+.. automodule:: pudl.convert.censusdp1tract_to_sqlite
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/pudl.convert.rst
+++ b/docs/api/pudl.convert.rst
@@ -7,6 +7,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   pudl.convert.censusdp1tract_to_sqlite
    pudl.convert.datapkg_to_rst
    pudl.convert.datapkg_to_sqlite
    pudl.convert.epacems_to_parquet

--- a/docs/api/pudl.output.censusdp1tract.rst
+++ b/docs/api/pudl.output.censusdp1tract.rst
@@ -1,0 +1,7 @@
+pudl.output.censusdp1tract module
+=================================
+
+.. automodule:: pudl.output.censusdp1tract
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/api/pudl.output.rst
+++ b/docs/api/pudl.output.rst
@@ -7,6 +7,7 @@ Submodules
 .. toctree::
    :maxdepth: 4
 
+   pudl.output.censusdp1tract
    pudl.output.eia860
    pudl.output.eia923
    pudl.output.epacems

--- a/setup.py
+++ b/setup.py
@@ -134,15 +134,16 @@ setup(
     include_package_data=True,
     # This defines the interfaces to the command line scripts we"re including:
     entry_points={
-        'console_scripts': [
-            'pudl_datastore = pudl.workspace.datastore:main',
-            'pudl_setup = pudl.workspace.setup_cli:main',
-            'pudl_etl = pudl.cli:main',
-            'datapkg_to_sqlite = pudl.convert.datapkg_to_sqlite:main',
-            'ferc1_to_sqlite = pudl.convert.ferc1_to_sqlite:main',
-            'epacems_to_parquet = pudl.convert.epacems_to_parquet:main',
-            'pudl_territories = pudl.analysis.service_territory:main',
-            'datapkg_to_rst = pudl.convert.datapkg_to_rst:main',
+        "console_scripts": [
+            "censusdp1tract_to_sqlite = pudl.convert.censusdp1tract_to_sqlite:main",
+            "datapkg_to_rst = pudl.convert.datapkg_to_rst:main",
+            "datapkg_to_sqlite = pudl.convert.datapkg_to_sqlite:main",
+            "epacems_to_parquet = pudl.convert.epacems_to_parquet:main",
+            "ferc1_to_sqlite = pudl.convert.ferc1_to_sqlite:main",
+            "pudl_datastore = pudl.workspace.datastore:main",
+            "pudl_etl = pudl.cli:main",
+            "pudl_setup = pudl.workspace.setup_cli:main",
+            "pudl_territories = pudl.analysis.service_territory:main",
         ]
     },
 )

--- a/src/pudl/__init__.py
+++ b/src/pudl/__init__.py
@@ -11,6 +11,7 @@ import pudl.analysis.mcoe
 import pudl.analysis.service_territory
 import pudl.cli
 import pudl.constants
+import pudl.convert.censusdp1tract_to_sqlite
 import pudl.convert.datapkg_to_rst
 import pudl.convert.datapkg_to_sqlite
 import pudl.convert.epacems_to_parquet
@@ -32,6 +33,7 @@ import pudl.helpers
 import pudl.load.csv
 import pudl.load.metadata
 # Output modules by data source:
+import pudl.output.censusdp1tract
 import pudl.output.eia860
 import pudl.output.eia923
 import pudl.output.epacems

--- a/src/pudl/analysis/service_territory.py
+++ b/src/pudl/analysis/service_territory.py
@@ -468,8 +468,7 @@ def main():
     pudl_out = pudl.output.pudltabl.PudlTabl(pudl_engine)
     # Load the US Census DP1 county data:
     county_gdf = pudl.output.censusdp1tract.get_layer(
-        "county",
-        pudl_settings=pudl_settings
+        layer="county", pudl_settings=pudl_settings
     )
 
     kwargs_dicts = [

--- a/src/pudl/convert/censusdp1tract_to_sqlite.py
+++ b/src/pudl/convert/censusdp1tract_to_sqlite.py
@@ -1,0 +1,99 @@
+"""
+Convert the US Census DP1 ESRI GeoDatabase into an SQLite Database.
+
+This is a thin wrapper around GDAL's ogr2ogr utility, which does the actual
+conversion. The code in this module tells that utility where to find the input
+data in the PUDL Datastore, and where to output the SQLite DB, alongside our
+other SQLite Databases (ferc1.sqlite and pudl.sqlite)
+
+"""
+
+import argparse
+import logging
+import os
+import subprocess  # nosec: B404
+import sys
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import coloredlogs
+
+import pudl
+from pudl.workspace.datastore import Datastore
+
+logger = logging.getLogger(__name__)
+
+
+def censusdp1tract_to_sqlite(pudl_settings=None, year=2010):
+    """
+    Use GDAL's ogr2ogr utility to convert the Census DP1 GeoDB to an SQLite DB.
+
+    The Census DP1 GeoDB is read from the datastore, unzipped into a temporary
+    directory, and then converted to SQLite using an external process. The
+    resulting SQLite DB is put in the PUDL output directory alongside the ferc1
+    and pudl SQLite databases.
+
+    Args:
+        pudl_settings (dict): A PUDL settings dictionary.
+        year (int): Year of Census data to extract (currently must be 2010)
+
+    Returns:
+        None
+
+    """
+    if pudl_settings is None:
+        pudl_settings = pudl.workspace.setup.get_defaults()
+    ds = Datastore(local_cache_path=pudl_settings["data_dir"])
+
+    # Avoid executing any random program that happens to be named ogr2ogr
+    # If we're in a conda environment, use the ogr2ogr there
+    # Otherwise assume it's where Ubuntu installs it /usr/bin/ogr2ogr
+    prefix_dir = os.environ.get("CONDA_PREFIX", "/usr")
+    ogr2ogr = prefix_dir + "/bin/ogr2ogr"
+
+    # Do all this work in a temporary directory since it's transient and big:
+    with TemporaryDirectory() as tmpdir:
+        # Use datastore to grab the Census DP1 zipfile
+        tmpdir_path = Path(tmpdir)
+        zip_ref = ds.get_zipfile_resource("censusdp1tract", year=year)
+        extract_root = tmpdir_path / Path(zip_ref.filelist[0].filename)
+        out_path = Path(pudl_settings["sqlite_dir"]) / "censusdp1tract.sqlite"
+        logger.info("Extracting the Census DP1 GeoDB to %s", out_path)
+        zip_ref.extractall(tmpdir_path)
+        logger.info("extract_root = %s", extract_root)
+        logger.info("out_path = %s", out_path)
+        subprocess.run(  # nosec: B603 Trying to use absolute paths.
+            [ogr2ogr, str(out_path), str(extract_root)],
+            check=True
+        )
+
+
+def parse_command_line(argv):
+    """
+    Parse command line arguments. See the -h option.
+
+    Args:
+        argv (str): Command line arguments, including caller filename.
+
+    Returns:
+        dict: Dictionary of command line arguments and their parsed values.
+
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    arguments = parser.parse_args(argv[1:])
+    return arguments
+
+
+def main():
+    """Convert the Census DP1 GeoDatabase into an SQLite Database."""
+    log_format = '%(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s'
+    coloredlogs.install(fmt=log_format, level='INFO', logger=logger)
+
+    # Currently have no arguments, but want to generate a usage message.
+    _ = parse_command_line(sys.argv)
+
+    censusdp1tract_to_sqlite()
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/src/pudl/convert/ferc1_to_sqlite.py
+++ b/src/pudl/convert/ferc1_to_sqlite.py
@@ -35,8 +35,12 @@ def parse_command_line(argv):
 
     """
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("settings_file", type=str, default='',
-                        help="path to YAML settings file.")
+    parser.add_argument(
+        "settings_file",
+        type=str,
+        default='',
+        help="path to YAML settings file."
+    )
     parser.add_argument(
         '-c',
         '--clobber',
@@ -44,10 +48,14 @@ def parse_command_line(argv):
         help="""Clobber existing sqlite database if it exists. If clobber is
         not included but the sqlite databse already exists the _build will
         fail.""",
-        default=False)
+        default=False
+    )
     parser.add_argument(
-        "--sandbox", action="store_true", default=False,
-        help="Use the Zenodo sandbox rather than production")
+        "--sandbox",
+        action="store_true",
+        default=False,
+        help="Use the Zenodo sandbox rather than production"
+    )
 
     arguments = parser.parse_args(argv[1:])
     return arguments
@@ -56,7 +64,6 @@ def parse_command_line(argv):
 def main():  # noqa: C901
     """Clone the FERC Form 1 FoxPro database into SQLite."""
     # Display logged output from the PUDL package:
-    logger = logging.getLogger(pudl.__name__)
     log_format = '%(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s'
     coloredlogs.install(fmt=log_format, level='INFO', logger=logger)
 

--- a/src/pudl/output/censusdp1tract.py
+++ b/src/pudl/output/censusdp1tract.py
@@ -1,0 +1,81 @@
+"""Functions for reading data out of the Census DP1 SQLite Database."""
+
+import logging
+from pathlib import Path
+from typing import Literal
+
+import geopandas as gpd
+import pandas as pd
+import sqlalchemy as sa
+
+import pudl
+from pudl.convert.censusdp1tract_to_sqlite import censusdp1tract_to_sqlite
+
+logger = logging.getLogger(__name__)
+
+
+def get_layer(
+    layer: Literal["state", "county", "tract"],
+    pudl_settings=None,
+) -> gpd.GeoDataFrame:
+    """
+    Select one layer from the Census DP1 database.
+
+    Uses information within the Census DP1 database to set the coordinate
+    reference system and to identify the column containing the geometry. The
+    geometry column is renamed to "geom" as that's the default withing
+    Geopandas. No other column names or types are altered.
+
+    Args:
+        layer (str): Which set of geometries to read, must be one of "state",
+            "county", or "tract".
+        pudl_settings (dict or None): A dictionary of PUDL settings, including
+            paths to various resources like the Census DP1 SQLite database. If
+            None, the user defaults are used.
+
+    Returns:
+        geopandas.GeoDataFrame
+
+    """
+    if not isinstance(layer, str):
+        raise TypeError(
+            f"Argument 'layer' must be a string, got arg of type {layer}."
+        )
+    layer = layer.lower()
+    if layer not in ["state", "county", "tract"]:
+        raise ValueError(
+            "Census DP1 layer must be one of 'state', 'county' or 'tract', "
+            f"but got {layer}."
+        )
+    if pudl_settings is None:
+        pudl_settings = pudl.workspace.setup.get_defaults()
+    # Check if we have the Census DP1 database. If not, create it.
+    if not Path(pudl_settings["sqlite_dir"], "censusdp1tract.sqlite").exists():
+        logger.info("Census DP1 SQLite DB is missing. Creating it.")
+        censusdp1tract_to_sqlite(pudl_settings=pudl_settings)
+
+    dp1_engine = sa.create_engine(pudl_settings["censusdp1tract_db"])
+
+    table_name = f"{layer}_2010census_dp1"
+    df = pd.read_sql("""
+SELECT geom_cols.f_table_name as table_name,
+       geom_cols.f_geometry_column as geom_col,
+       crs.auth_name as auth_name,
+       crs.auth_srid as auth_srid
+  FROM geometry_columns geom_cols
+ INNER JOIN spatial_ref_sys crs
+    ON geom_cols.srid = crs.srid
+ WHERE table_name = ?
+""", dp1_engine, params=[table_name, ])
+    if len(df) != 1:
+        raise AssertionError(
+            f"Expected exactly 1 geometry description, but found {len(df)}"
+        )
+
+    geom_col = df.at[0, "geom_col"]
+    crs_auth_str = f"{df.at[0, 'auth_name']}:{df.at[0, 'auth_srid']}".lower()
+
+    gdf = gpd.read_postgis(table_name, dp1_engine, geom_col=geom_col, crs=crs_auth_str)
+    gdf.rename_geometry("geometry", inplace=True)
+
+    return gdf

--- a/src/pudl/output/ferc714.py
+++ b/src/pudl/output/ferc714.py
@@ -563,7 +563,7 @@ class Respondents(object):
         """
         if update or self._respondents_gdf is None:
             census_counties = pudl.analysis.service_territory.get_census2010_gdf(
-                pudl_settings=self.pudl_settings, layer="county")
+                pudl_settings=self.pudl_settings, layer="county", ds=self.pudl_out.ds)
             self._respondents_gdf = (
                 pudl.analysis.service_territory.add_geometries(
                     self.fipsify(update=update),

--- a/src/pudl/output/ferc714.py
+++ b/src/pudl/output/ferc714.py
@@ -531,8 +531,7 @@ class Respondents(object):
         """
         if update or self._counties_gdf is None:
             census_counties = pudl.output.censusdp1tract.get_layer(
-                "county",
-                pudl_settings=self.pudl_settings,
+                layer="county", pudl_settings=self.pudl_settings,
             )
             self._counties_gdf = (
                 pudl.analysis.service_territory.add_geometries(
@@ -565,8 +564,7 @@ class Respondents(object):
         """
         if update or self._respondents_gdf is None:
             census_counties = pudl.output.censusdp1tract.get_layer(
-                "county",
-                pudl_settings=self.pudl_settings,
+                layer="county", pudl_settings=self.pudl_settings,
             )
             self._respondents_gdf = (
                 pudl.analysis.service_territory.add_geometries(

--- a/src/pudl/output/ferc714.py
+++ b/src/pudl/output/ferc714.py
@@ -530,8 +530,10 @@ class Respondents(object):
         analyses.
         """
         if update or self._counties_gdf is None:
-            census_counties = pudl.analysis.service_territory.get_census2010_gdf(
-                pudl_settings=self.pudl_settings, layer="county", ds=self.pudl_out.ds)
+            census_counties = pudl.output.censusdp1tract.get_layer(
+                "county",
+                pudl_settings=self.pudl_settings,
+            )
             self._counties_gdf = (
                 pudl.analysis.service_territory.add_geometries(
                     self.fipsify(update=update), census_gdf=census_counties)
@@ -562,8 +564,10 @@ class Respondents(object):
         from year to year, etc.
         """
         if update or self._respondents_gdf is None:
-            census_counties = pudl.analysis.service_territory.get_census2010_gdf(
-                pudl_settings=self.pudl_settings, layer="county", ds=self.pudl_out.ds)
+            census_counties = pudl.output.censusdp1tract.get_layer(
+                "county",
+                pudl_settings=self.pudl_settings,
+            )
             self._respondents_gdf = (
                 pudl.analysis.service_territory.add_geometries(
                     self.fipsify(update=update),

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -8,9 +8,9 @@ import logging
 import re
 import sys
 import zipfile
-from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional, Tuple, Set
 from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Set, Tuple
 
 import coloredlogs
 import datapackage
@@ -187,13 +187,13 @@ class ZenodoFetcher:
         self.http.mount("https://", adapter)
 
     def _fetch_from_url(self, url: str) -> requests.Response:
-        # logger.info(f"Retrieving {url} from zenodo")
+        logger.info(f"Retrieving {url} from zenodo")
         response = self.http.get(
             url,
             params={"access_token": self._token},
             timeout=self.timeout)
         if response.status_code == requests.codes.ok:
-            # logger.info(f"Successfully downloaded {url}")
+            logger.debug(f"Successfully downloaded {url}")
             return response
         else:
             raise ValueError(f"Could not download {url}: {response.text}")

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -134,6 +134,9 @@ def derive_paths(pudl_in, pudl_out):
     ps['pudl_db'] = "sqlite:///" + str(pathlib.Path(
         ps['sqlite_dir'], 'pudl.sqlite'))
 
+    ps['censusdp1tract_db'] = "sqlite:///" + str(pathlib.Path(
+        ps['sqlite_dir'], 'censusdp1tract.sqlite'))
+
     return ps
 
 


### PR DESCRIPTION
Rather than the ad-hoc ETL that we were using to extract the zip archive
of the Census DP1 GeoDataBase into a local folder, this commit treats the
DP1 as a standard data source, and converts it into an SQLite DB alongside
the PUDL and FERC 1 DBs in the PUDL_OUT/sqlite directory. It uses GDAL's
`ogr2ogr` command line utility to do this, calling it as a subprocess. This
means that this utility will need to be installed on your system for it to
work. Our `pudl-dev` conda environment will install it for you, or it can
be installed in /usr/bin/ogr2ogr with `apt install gdal-bin`. Other non-conda
installation options are certainly possible but... it'll get complicated to
cover all of them. Hopefully this setup will work fine in our Docker and CI
environments, and anyone else who is using it on a desktop will use the
conda environment.

I did not end up using the SpatiaLite extensions to SQLite, since they weren't
necessary to get GeoPandas reading out of the DB just fine, and they introduce
some complexity into how one reads data out of the DB with SQLAlchemy/pandas.

The baby DP1 ETL is housed in a module / script called
`src/pudl/convert/censusdp1tract_to_sqlite.py` since we have a couple of other
`_to_sqlite` scripts in there, so it seemed conceptually simple. It's just a
single function, wrapping `ogr2ogr` so that it knows where to get the inputs
from (using the Datastore) and send the outputs to (the sqlite dir) based on
the `pudl_settings` dictionary.

Also added installation of `gdal-bin` to the setup for our CI. We'll see if it
actually works!

Closes #920
