### PR TITLE
Fix the convert_cols_dtypes warning

### DIFF
--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -919,10 +919,9 @@ def convert_cols_dtypes(df, data_source, name=None):
         :mod:`pudl.constants` ``column_dtypes`` dictionary.
 
     """
-    source_dtypes = pc.column_dtypes[data_source]
     # get me all of the columns for the table in the constants dtype dict
     col_dtypes = {col: col_dtype for col, col_dtype
-                  in source_dtypes.items()
+                  in pc.column_dtypes[data_source].items()
                   if col in list(df.columns)}
 
     # grab only the boolean columns (we only need their names)
@@ -937,18 +936,6 @@ def convert_cols_dtypes(df, data_source, name=None):
     string_cols = {col: col_dtype for col, col_dtype
                    in col_dtypes.items()
                    if col_dtype == pd.StringDtype()}
-
-    # check for non-nullable string dtypes. we need them to all be the nullable
-    # type, otherwise string cols w/ nulls will not be able to be assigned
-    non_nullable_string_cols = [
-        c for c in source_dtypes.keys()
-        if (source_dtypes[c] == 'string')
-        & (source_dtypes[c] != pd.StringDtype())
-    ]
-    if non_nullable_string_cols:
-        raise TypeError(
-            "All string types must be nullable. Found basic string types for: "
-            f"{non_nullable_string_cols}")
 
     # If/when we have the columns exhaustively typed, we can do it like this,
     # but right now we don't have the FERC columns done, so we can't:

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -933,6 +933,10 @@ def convert_cols_dtypes(df, data_source, name=None):
     non_bool_cols = {col: col_dtype for col, col_dtype
                      in col_dtypes.items()
                      if col_dtype != pd.BooleanDtype()}
+    # Grab only the string columns...
+    string_cols = {col: col_dtype for col, col_dtype
+                   in col_dtypes.items()
+                   if col_dtype == pd.StringDtype()}
 
     # check for non-nullable string dtypes. we need them to all be the nullable
     # type, otherwise string cols w/ nulls will not be able to be assigned
@@ -983,7 +987,10 @@ def convert_cols_dtypes(df, data_source, name=None):
         if df.utility_id_eia.dtypes is np.dtype('object'):
             df = df.astype({'utility_id_eia': 'float'})
     df = (
-        df.astype(non_bool_cols).astype(bool_cols))
+        df.astype(non_bool_cols)
+        .astype(bool_cols)
+        .replace(to_replace="nan", value={col: pd.NA for col in string_cols})
+    )
 
     # Zip codes are highly coorelated with datatype. If they datatype gets
     # converted at any point it may mess up the accuracy of the data. For

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -110,9 +110,11 @@ def clean_eia_counties(df, fixes, state_col="state", county_col="county"):
     df = df.copy()
     df[county_col] = (
         df[county_col].str.strip()
-        .str.replace(r"\s+", " ", regex=True)  # Condense multiple whitespace chars.
+        # Condense multiple whitespace chars.
+        .str.replace(r"\s+", " ", regex=True)
         .str.replace(r"^St ", "St. ", regex=True)  # Standardize abbreviation.
-        .str.replace(r"^Ste ", "Ste. ", regex=True)  # Standardize abbreviation.
+        # Standardize abbreviation.
+        .str.replace(r"^Ste ", "Ste. ", regex=True)
         .str.replace("Kent & New Castle", "Kent, New Castle")  # Two counties
         # Fix ordering, remove comma
         .str.replace("Borough, Kodiak Island", "Kodiak Island Borough")
@@ -659,7 +661,8 @@ def fix_leading_zero_gen_ids(df):
             .astype(str)
             .apply(lambda x: re.sub(r'^0+(\d+$)', r'\1', x))
         )
-        num_fixes = len(df.loc[df["generator_id"].astype(str) != fixed_generator_id])
+        num_fixes = len(
+            df.loc[df["generator_id"].astype(str) != fixed_generator_id])
         logger.info("Fixed %s EIA generator IDs with leading zeros.", num_fixes)
         df = (
             df.drop("generator_id", axis="columns")
@@ -916,24 +919,32 @@ def convert_cols_dtypes(df, data_source, name=None):
         :mod:`pudl.constants` ``column_dtypes`` dictionary.
 
     """
+    source_dtypes = pc.column_dtypes[data_source]
     # get me all of the columns for the table in the constants dtype dict
     col_dtypes = {col: col_dtype for col, col_dtype
-                  in pc.column_dtypes[data_source].items()
+                  in source_dtypes.items()
                   if col in list(df.columns)}
 
     # grab only the boolean columns (we only need their names)
     bool_cols = {col: col_dtype for col, col_dtype
                  in col_dtypes.items()
                  if col_dtype == pd.BooleanDtype()}
-    # Grab only the string columns...
-    string_cols = {col: col_dtype for col, col_dtype
-                   in col_dtypes.items()
-                   if col_dtype == pd.StringDtype()}
-
     # grab all of the non boolean columns
     non_bool_cols = {col: col_dtype for col, col_dtype
                      in col_dtypes.items()
                      if col_dtype != pd.BooleanDtype()}
+
+    # check for non-nullable string dtypes. we need them to all be the nullable
+    # type, otherwise string cols w/ nulls will not be able to be assigned
+    non_nullable_string_cols = [
+        c for c in source_dtypes.keys()
+        if (source_dtypes[c] == 'string')
+        & (source_dtypes[c] != pd.StringDtype())
+    ]
+    if non_nullable_string_cols:
+        raise TypeError(
+            "All string types must be nullable. Found basic string types for: "
+            f"{non_nullable_string_cols}")
 
     # If/when we have the columns exhaustively typed, we can do it like this,
     # but right now we don't have the FERC columns done, so we can't:
@@ -972,12 +983,7 @@ def convert_cols_dtypes(df, data_source, name=None):
         if df.utility_id_eia.dtypes is np.dtype('object'):
             df = df.astype({'utility_id_eia': 'float'})
     df = (
-        df.replace(to_replace="<NA>", value={
-                   col: pd.NA for col in string_cols})
-        .replace(to_replace="nan", value={col: pd.NA for col in string_cols})
-        .astype(non_bool_cols)
-        .astype(bool_cols)
-    )
+        df.astype(non_bool_cols).astype(bool_cols))
 
     # Zip codes are highly coorelated with datatype. If they datatype gets
     # converted at any point it may mess up the accuracy of the data. For
@@ -988,9 +994,9 @@ def convert_cols_dtypes(df, data_source, name=None):
         zip_cols = [col for col in df.columns if 'zip_code' in col]
         for col in zip_cols:
             if '4' in col:
-                df[col] = zero_pad_zips(df[col], 4)
+                df.loc[:, col] = zero_pad_zips(df.loc[:, col], 4)
             else:
-                df[col] = zero_pad_zips(df[col], 5)
+                df.loc[:, col] = zero_pad_zips(df.loc[:, col], 5)
 
     return df
 

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -1001,9 +1001,9 @@ def convert_cols_dtypes(df, data_source, name=None):
         zip_cols = [col for col in df.columns if 'zip_code' in col]
         for col in zip_cols:
             if '4' in col:
-                df.loc[:, col] = zero_pad_zips(df.loc[:, col], 4)
+                df.loc[:, col] = zero_pad_zips(df[col], 4)
             else:
-                df.loc[:, col] = zero_pad_zips(df.loc[:, col], 5)
+                df.loc[:, col] = zero_pad_zips(df[col], 5)
 
     return df
 

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -990,6 +990,7 @@ def convert_cols_dtypes(df, data_source, name=None):
         df.astype(non_bool_cols)
         .astype(bool_cols)
         .replace(to_replace="nan", value={col: pd.NA for col in string_cols})
+        .replace(to_replace="<NA>", value={col: pd.NA for col in string_cols})
     )
 
     # Zip codes are highly coorelated with datatype. If they datatype gets


### PR DESCRIPTION
- removed the replaces that were dealing with null values for string  types.
- added a check to ensure all string types in pc.column_dtypes are the nullable string types
- inserted `loc`s in the zip code zero padding