### PR TITLE
add xfail test for ownership tbl and make count_records FASTER

### DIFF
--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -702,7 +702,8 @@ def fix_leading_zero_gen_ids(df):
         )
         num_fixes = len(
             df.loc[df["generator_id"].astype(str) != fixed_generator_id])
-        logger.debug("Fixed %s EIA generator IDs with leading zeros.", num_fixes)
+        logger.debug(
+            "Fixed %s EIA generator IDs with leading zeros.", num_fixes)
         df = (
             df.drop("generator_id", axis="columns")
             .assign(generator_id=fixed_generator_id)
@@ -1149,11 +1150,14 @@ def count_records(df, cols, new_count_col_name):
         pandas.DataFrame: dataframe with only the `cols` definted and the
         `new_count_col_name`.
     """
-    return (df.assign(count_me=1).
-            groupby(cols).
-            agg({'count_me': 'count'}).
-            reset_index().
-            rename(columns={'count_me': new_count_col_name}))
+    return (
+        df.assign(count_me=1)
+        .groupby(cols)
+        [['count_me']]
+        .count()
+        .reset_index()
+        .rename(columns={'count_me': new_count_col_name})
+    )
 
 
 def cleanstrings_snake(df, cols):

--- a/test/validate/eia860_test.py
+++ b/test/validate/eia860_test.py
@@ -53,16 +53,16 @@ def test_own_eia860(pudl_out_eia, live_dbs):
 
 
 @pytest.mark.xfail(reason="There are 730 generators that report multiple operators")
-def test_operator_id(pudl_out_eia, live_dbs):
+def test_unique_operator_id(pudl_out_eia, live_dbs):
     """
-    Test if the operator id in ownership table is consistent across generators.
+    Test that each generator in the ownership table has a unique operator ID.
 
-    The ``utility_id_eia`` column is supposed to be the operator, which should
-    only be one utility for each generator. The ``owner_utility_id_eia`` is
-    suppose to be the owner, which can be multiple utilities for each generator.
-    We have a known issue with 2010 data. Many generators are being reported
-    with the ``utility_id_eia`` with what appears to be the
-    ``owner_utility_id_eia`` instead.
+    The ``utility_id_eia`` column is supposed to be the operator, which should only be
+    one utility for each generator in each report year, while ``owner_utility_id_eia``
+    is supposed to represent the owner, of which there can be several for each
+    generator.  We have a known issue with 2010 data. Many generators are being reported
+    with multiple ``utility_id_eia`` values, which appear to actually be the
+    ``owner_utility_id_eia``.
 
     Raises:
         AssertionError: If there are generators with multiple reported operators

--- a/test/validate/eia860_test.py
+++ b/test/validate/eia860_test.py
@@ -52,6 +52,44 @@ def test_own_eia860(pudl_out_eia, live_dbs):
         )
 
 
+@pytest.mark.xfail(reason="There are 730 generators that report multiple operators")
+def test_operator_id(pudl_out_eia, live_dbs):
+    """
+    Test if the operator id in ownership table is consistent across generators.
+
+    The ``utility_id_eia`` column is supposed to be the operator, which should
+    only be one utility for each generator. The ``owner_utility_id_eia`` is
+    suppose to be the owner, which can be multiple utilities for each generator.
+    We have a known issue with 2010 data. Many generators are being reported
+    with the ``utility_id_eia`` with what appears to be the
+    ``owner_utility_id_eia`` instead.
+
+    Raises:
+        AssertionError: If there are generators with multiple reported operators
+
+    """
+    if not live_dbs:
+        pytest.skip("Data validation only works with a live PUDL DB.")
+    if pudl_out_eia.freq is not None:
+        pytest.skip()
+
+    own_out = pudl_out_eia.own_eia860()
+    operator_check = (
+        own_out.groupby(
+            ['report_date', 'plant_id_eia', 'generator_id'],
+            dropna=True)
+        [['utility_id_eia']].nunique()
+    )
+    multi_operator = operator_check[operator_check.utility_id_eia > 1]
+    years = multi_operator.report_date.dt.year.unique()
+    if not multi_operator.empty:
+        raise AssertionError(
+            f"There are {len(multi_operator)} generator records across "
+            f"{list(years)} that are being reported as having multiple "
+            "operators."
+        )
+
+
 @pytest.mark.xfail(reason="There are 40 known inconsistent generator IDs.")
 def test_generator_id_consistency(pudl_out_eia, live_dbs):
     """


### PR DESCRIPTION
small xfail ownership test which corresponds to #1116

and make pudl.helpers.count_records() faster by switching `agg({column: 'sum'})` to `[column].sum()`