### PR TITLE
make generation allocation output mirror the standard generation table.

### DIFF
--- a/src/pudl/analysis/allocate_net_gen.py
+++ b/src/pudl/analysis/allocate_net_gen.py
@@ -147,6 +147,14 @@ def allocate_gen_fuel_by_gen(pudl_out):
     # aggregate the gen/pm/fuel records back to generator records
     gen_allocated = agg_by_generator(gen_pm_fuel)
     _test_gen_fuel_allocation(gen, gen_allocated)
+
+    # make the output mirror the gen_original_eia923()
+    gen_allocated = pudl.output.eia923.denorm_generation_eia923(
+        g_df=gen_allocated,
+        pudl_engine=pudl_out.pudl_engine,
+        start_date=pudl_out.start_date,
+        end_date=pudl_out.end_date
+    )
     return gen_allocated
 
 

--- a/src/pudl/output/eia923.py
+++ b/src/pudl/output/eia923.py
@@ -596,6 +596,31 @@ def generation_eia923(
         g_df = g_gb.agg(
             {'net_generation_mwh': pudl.helpers.sum_na}).reset_index()
 
+    out_df = denorm_generation_eia923(g_df, pudl_engine, start_date, end_date)
+
+    if freq is None:
+        out_df = out_df.drop(['id'], axis=1)
+
+    return out_df
+
+
+def denorm_generation_eia923(g_df, pudl_engine, start_date, end_date):
+    """
+    Denomralize generation_eia923 table.
+
+    Args:
+        g_df (pandas.DataFrame): generation_eia923 table. Should have columns:
+            ["plant_id_eia", "generator_id", "report_date",
+            "net_generation_mwh"]
+        pudl_engine (sqlalchemy.engine.Engine): SQLAlchemy connection engine
+            for the PUDL DB.
+        start_date (date-like): date-like object, including a string of the
+            form 'YYYY-MM-DD' which will be used to specify the date range of
+            records to be pulled.  Dates are inclusive.
+        end_date (date-like): date-like object, including a string of the
+            form 'YYYY-MM-DD' which will be used to specify the date range of
+            records to be pulled.  Dates are inclusive.
+    """
     # Grab EIA 860 plant and utility specific information:
     pu_eia = pudl.output.eia860.plants_utils_eia860(
         pudl_engine,
@@ -649,10 +674,6 @@ def generation_eia923(
             "utility_id_pudl": "eia",
         }))
     )
-
-    if freq is None:
-        out_df = out_df.drop(['id'], axis=1)
-
     return out_df
 
 

--- a/test/integration/fast_output_test.py
+++ b/test/integration/fast_output_test.py
@@ -144,3 +144,21 @@ def test_ferc714_respondents_georef_counties(ferc714_out):
     ferc714_gdf = ferc714_out.georef_counties()
     assert len(ferc714_gdf) > 0
     assert isinstance(ferc714_gdf, gpd.GeoDataFrame)
+
+
+@pytest.fixture(scope="module")
+def fast_out_filled(pudl_engine, pudl_datastore_fixture):
+    """A PUDL output object for use in CI with net generation filled."""
+    return pudl.output.pudltabl.PudlTabl(
+        pudl_engine,
+        ds=pudl_datastore_fixture,
+        freq="MS",
+        fill_fuel_cost=True,
+        roll_fuel_cost=True,
+        fill_net_gen=True,
+    )
+
+
+def test_mcoe_filled(fast_out_filled):
+    """Ensure the MCOE works with the net generation allocated."""
+    fast_out_filled.mcoe()


### PR DESCRIPTION
The cleanup of the clean_merge_as_of() function that Zane did (was great, no shade) was breaking the MCOE outputs when the allocate_net_gen flag is True. 

The generation table had different columns than the allocated generation table. The previous merges in the MCOE outputs were more "grab all of the columns every every single time" so it really didn't matter previously that these two tables had different columns and were being used interchangeably in the outputs. It was not ideal but not broken, and with the cleanup... it became broken.

**The solution**: Basically I pulled out all of the de-normalization of the generation table from the main generation output function (`pudl.output.eia923.generation_eia923`) into a stand-alone function so it can be used in both the main generation function as well as at the end of the generation allocation process. I also added a CI test (I think) that simply runs the MCOE output with the allocated net generation. There may be a more pin-pointed test to add here suggestions here are welcome.
