### PR TITLE
Dependency and data release script updates

### DIFF
--- a/devtools/databeta.sh
+++ b/devtools/databeta.sh
@@ -3,11 +3,11 @@
 # data environment.
 
 # Name of the directory to create the data release archive in
-RELEASE_DIR=pudl-v0.4.0-2021-07-15
+RELEASE_DIR=pudl-v0.4.0-2021-08-17
 # The PUDL working directory where we'll find the data to archive:
 PUDL_IN=$HOME/code/catalyst/pudl-work
 # Reference to an existing Docker image to pull
-DOCKER_TAG="2021.03.27"
+DOCKER_TAG="2021.08.17"
 
 echo "Started:" `date`
 # Start with a clean slate:
@@ -21,6 +21,8 @@ rm -rf $RELEASE_DIR/.git*
 mkdir -p $RELEASE_DIR/pudl_data
 mkdir -p $RELEASE_DIR/user_data
 
+# Make sure we have the specified version of the Docker container:
+docker pull catalystcoop/pudl-jupyter:$DOCKER_TAG
 # Freeze the version of the Docker container:
 cat $RELEASE_DIR/docker-compose.yml | sed -e "s/pudl-jupyter:latest/pudl-jupyter:$DOCKER_TAG/" > $RELEASE_DIR/new-docker-compose.yml
 mv $RELEASE_DIR/new-docker-compose.yml $RELEASE_DIR/docker-compose.yml

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -23,14 +23,15 @@ dependencies:
   - pandoc  # Useful for rendering RST files in Atom
 
   # Packages related to current projects but not the core package
-  - dask~=2021.2 # For processing CEMS and eventually Prefect cloud ETL
+  - dask~=2021.8 # For processing CEMS and eventually Prefect cloud ETL
   - pysal  # Used for making maps in LBL / GridLab work
   - recordlinkage~=0.14.0 # Used for fuzzy merge between FERC/EIA for RMI
 
   # Jupyter notebook specific packages:
-  - dask-labextension~=5.0
+  - dask-labextension~=5.1
   - jupyter-resource-usage~=0.5.0
-  - jupyterlab~=3.0
+    # Pinned b/c of this bug: https://github.com/jupyterlab/jupyterlab/issues/10840
+  - jupyterlab>=3.1,<3.1.5
 
   # Use pip to install the main PUDL repo / package for development:
   - pip:


### PR DESCRIPTION
There's a bug in JupyterLab 3.1.6-3.1.7 that causes notebook cells to
get skipped, hidden, or deleted when running all cells, or individual
cells. This was happening in the pudl-examples notebooks when I was
trying to compile the data release for v0.4.0. I pinned the environment
in that repo to 3.1.0-3.1.4, and have done so in the environment file
here as well.

Also checking in the databeta.sh script as it was used to generate the
data release which is currently uploading to Zenodo.