### PR TITLE
Drop rows with null generator_id in ownership_eia860

### DIFF
--- a/src/pudl/metadata/resources.py
+++ b/src/pudl/metadata/resources.py
@@ -196,8 +196,6 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 "report_date",
                 "net_generation_mwh",
             ],
-            # Null values in the generator_id field. See:
-            # https://github.com/catalyst-cooperative/pudl/issues/1208
             "primary_key": ["plant_id_eia", "generator_id", "report_date"],
         },
         "sources": ["eia923"],
@@ -379,12 +377,9 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 "owner_zip_code",
                 "fraction_owned",
             ],
-            # Currently there are NULL falues in some of these fields. This needs
-            # to be fixed in the transform process. See this Github issue:
-            # https://github.com/catalyst-cooperative/pudl/issues/1207
-            # "primary_key": [
-            #     "report_date", "plant_id_eia", "generator_id", "owner_utility_id_eia"
-            # ],
+            "primary_key": [
+                "report_date", "plant_id_eia", "generator_id", "owner_utility_id_eia"
+            ],
         },
         "sources": ["eia860"],
     },

--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -107,7 +107,11 @@ def ownership(eia860_dfs, eia860_transformed_dfs):
             f"{remaining_dupes}"
         )
 
-    # Remove a couple of records known to have null values in the primary key
+    # Remove a couple of records known to have (literal) "nan" values in the
+    # generator_id column, which is part of the table's natural primary key.
+    # These "nan" strings get converted to true pd.NA values when the column
+    # datatypes are applied, which violates the primary key constraints.
+    # See https://github.com/catalyst-cooperative/pudl/issues/1207
     mask = (
         (own_df.report_date.isin(["2018-01-01", "2019-01-01"]))
         & (own_df.plant_id_eia == 62844)


### PR DESCRIPTION
Targeted drop of two rows in the `ownership_eia860` table during
transform. They had (literal) `nan` string values in the `generator_id`
column at that stage, which become true `pd.NA` values in the data type
assignment function later on, causing primary key constraints to be
violated.

Closes #1207