### PR TITLE
Fix utility_id_eia issues in ownership & plants tables

### DIFF
--- a/src/pudl/metadata/resources.py
+++ b/src/pudl/metadata/resources.py
@@ -233,11 +233,11 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             "fields": [
                 "plant_id_eia",
                 "generator_id",
+                "utility_id_eia",
                 "report_date",
                 "operational_status_code",
                 "operational_status",
                 "ownership_code",
-                "utility_id_eia",
                 "capacity_mw",
                 "summer_capacity_mw",
                 "summer_capacity_estimate",
@@ -378,7 +378,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_date",
-                # "utility_id_eia",
+                "utility_id_eia",
                 "plant_id_eia",
                 "generator_id",
                 "owner_utility_id_eia",

--- a/src/pudl/metadata/resources.py
+++ b/src/pudl/metadata/resources.py
@@ -378,7 +378,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_date",
-                "utility_id_eia",
+                # "utility_id_eia",
                 "plant_id_eia",
                 "generator_id",
                 "owner_utility_id_eia",
@@ -882,7 +882,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 # table, but do show up in plants_eia860 data. This needs to be
                 # addressed somehow, but for the moment I'm excluding this FK
                 # See: https://github.com/catalyst-cooperative/pudl/issues/1262
-                "exclude": ["plants_eia860"]
+                # "exclude": ["plants_eia860"]
             },
         },
         "sources": ["eia860"],

--- a/src/pudl/metadata/resources.py
+++ b/src/pudl/metadata/resources.py
@@ -878,11 +878,6 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                     # https://github.com/catalyst-cooperative/pudl/issues/1196
                     # ["owner_utility_id_eia", "report_date"],
                 ],
-                # 541 Utility IDs are missing from the 2010 utilities_eia860
-                # table, but do show up in plants_eia860 data. This needs to be
-                # addressed somehow, but for the moment I'm excluding this FK
-                # See: https://github.com/catalyst-cooperative/pudl/issues/1262
-                # "exclude": ["plants_eia860"]
             },
         },
         "sources": ["eia860"],

--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -395,7 +395,12 @@ def _compile_all_entity_records(entity, eia_transformed_dfs):
                 # remove the static columns, with an exception
                 if (
                     (entity in ('generators', 'plants'))
-                    and (table_name in ('utilities_eia860', 'plants_eia860', 'generators_eia860'))
+                    and (table_name in (
+                        'generators_eia860',
+                        'ownership_eia860',
+                        'plants_eia860',
+                        'utilities_eia860',
+                    ))
                 ):
                     cols.remove('utility_id_eia')
                 transformed_df = transformed_df.drop(columns=cols)

--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -393,10 +393,10 @@ def _compile_all_entity_records(entity, eia_transformed_dfs):
                 dfs.append(df)
 
                 # remove the static columns, with an exception
-                if ((entity in ('generators', 'plants'))
-                    and (table_name in ('ownership_eia860',
-                                        'utilities_eia860',
-                                        'generators_eia860'))):
+                if (
+                    (entity in ('generators', 'plants'))
+                    and (table_name in ('utilities_eia860', 'plants_eia860', 'generators_eia860'))
+                ):
                     cols.remove('utility_id_eia')
                 transformed_df = transformed_df.drop(columns=cols)
                 eia_transformed_dfs[table_name] = transformed_df

--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -148,8 +148,6 @@ def ownership(eia860_dfs, eia860_transformed_dfs):
         & (own_df.fraction_owned == 1.0)
     )
     own_df.loc[single_owner_operator, "utility_id_eia"] = pd.NA
-    # Utility ID doesn't end up in this table, so neither should utility name...
-    own_df = own_df.drop("utility_name_eia", axis="columns")
 
     eia860_transformed_dfs['ownership_eia860'] = own_df
 


### PR DESCRIPTION
This fixes a couple of issues that flowed from owner IDs being reported in the operator ID column in the `ownership_eia860` table, as well as the accidental omission of the `plants_eia860` table from the list of exceptions in the harvesting process (where utility ID should be retained.