### PR TITLE
Update generation_fuel_eia923 documentation with nuclear unit change.

### DIFF
--- a/src/pudl/metadata/resources.py
+++ b/src/pudl/metadata/resources.py
@@ -198,7 +198,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923"],
     },
     "generation_fuel_eia923": {
-        "description": "Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a plant. This table does not include nuclear fuels because nuclear fuels are reported by generator unit where as non nuclear fuels are reported by plant_id, prime_mover and fuel_type. See the generation_fuel_nuclear_eia923 table for nuclear fuel data.",
+        "description": "Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a plant. This table does not include nuclear electricity generation and fuel consumption because they are reported by generator unit where as non nuclear information is reported by plant_id, prime_mover and fuel_type. See the generation_fuel_nuclear_eia923 table for nuclear electricity generation and fuel consumption data.",
         "schema": {
             "fields": [
                 "plant_id_eia",

--- a/src/pudl/metadata/resources.py
+++ b/src/pudl/metadata/resources.py
@@ -198,7 +198,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923"],
     },
     "generation_fuel_eia923": {
-        "description": "Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a plant.",
+        "description": "Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a plant. This table does not include nuclear fuels because nuclear fuels are reported by generator unit where as non nuclear fuels are reported by plant_id, prime_mover and fuel_type. See the generation_fuel_nuclear_eia923 table for nuclear fuel data.",
         "schema": {
             "fields": [
                 "plant_id_eia",


### PR DESCRIPTION
We split the nuclear units out from `generation_fuel_eia923` in #1296 because nuclear fuels are reported at the generation unit level and non-nuclear unit fuels are reported at the plant, prime mover, and fuel level. [Some users](https://twitter.com/CatalystCoop/status/1456346092270862336) were confused by this so I included this explanation in the `generation_fuel_eia923` data dictionary docs. 