### PR TITLE
Widen allowable Jinja versions to 2-3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "fsspec~=2021.7",
         "gcsfs~=2021.7",
         "geopandas>=0.9,<0.11",
-        "jinja2~=3.0",
+        "jinja2>=2,<4",
         "matplotlib~=3.0",  # Should make this optional with a "viz" extras
         "networkx~=2.2",
         "numpy~=1.20",


### PR DESCRIPTION
Jinja2 versions 2.x or 3.x appear to work with our system, and the restriction to only 3.x was causing some version conflicts downstream in the OS-C environment, so I expanded the range of allowable versions. See #1352 