### PR TITLE
Allocate dtype fix

### DIFF
--- a/src/pudl/analysis/allocate_net_gen.py
+++ b/src/pudl/analysis/allocate_net_gen.py
@@ -238,8 +238,11 @@ def agg_by_generator(gen_pm_fuel):
             `allocate_gen_fuel_by_gen_pm_fuel()`
     """
     data_cols = ['net_generation_mwh', 'fuel_consumed_mmbtu']
-    gen = (gen_pm_fuel.groupby(by=IDX_GENS)
-           [data_cols].sum(min_count=1).reset_index())
+    gen = (
+        gen_pm_fuel.groupby(by=IDX_GENS)
+        [data_cols].sum(min_count=1).reset_index()
+        .pipe(pudl.helpers.convert_cols_dtypes, 'eia')
+    )
 
     return gen
 
@@ -472,7 +475,7 @@ def _associate_energy_source_only(gen_assoc, gf):
 
     gen_assoc = pd.merge(
         gen_assoc,
-        gf_missing_pm,
+        gf_missing_pm.pipe(pudl.helpers.convert_cols_dtypes, 'eia'),
         how='outer',
         on=IDX_FUEL,
         indicator=True


### PR DESCRIPTION
bb pr. this fixes two instances of dtype loss in the portion of the allocate_net_gen process that only gets run on the generators that do not have prime movers. This process is currently only run on the RMI hub teams older years of EIA. In PUDL old EIA years, we have been effectively back-filling through the harvesting process.

The whole process for generators w/o prime movers will be retired as soon as the RMI team converts over to using PUDL's pre-processed data as their main EIA input - which is on the docket!