### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2.4.0

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2.4.0

--- a/devtools/ci-environment.yml
+++ b/devtools/ci-environment.yml
@@ -4,10 +4,10 @@ channels:
   - defaults
   - intake
 dependencies:
-  - geopandas~=0.9.0
+  - geopandas>=0.9,<11
   - numba~=0.53
-  - pip~=21.2
-  - pygeos~=0.10.0
-  - python-snappy~=0.6.0
+  - pip~=21.0
+  - pygeos>=0.10,<0.13
+  - python-snappy>=0.6,<1
   - sqlite~=3.36
   - tox~=3.24

--- a/devtools/ci-environment.yml
+++ b/devtools/ci-environment.yml
@@ -5,7 +5,6 @@ channels:
   - intake
 dependencies:
   - geopandas>=0.9,<11
-  - numba~=0.53
   - pip~=21.0
   - pygeos>=0.10,<0.13
   - python-snappy>=0.6,<1

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   # Used to set up the environment
   - pip~=21.0
-  - python>=3.8,<3.10
+  - python>=3.8,<3.11
   # These packages are also specified in setup.py
   # However, they depend on or benefit from binary libraries
   # which conda can install.
@@ -16,7 +16,7 @@ dependencies:
   - sqlite~=3.36
   # These libraries aren't directly specified in setup.py as
   # dependencies, but they are helpful and provide binaries
-  - numba~=0.53  # First numba version that's compatible with Python 3.9
+  #- numba~=0.53  # First numba version that's compatible with Python 3.9
   - python-graphviz # For visualizing DAGs from Prefect
 
    # These are not normal Python packages available on PyPI

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "electricity", "energy", "data", "analysis", "mcoe", "climate change",
         "finance", "eia 923", "eia 860", "ferc", "form 1", "epa ampd",
         "epa cems", "coal", "natural gas", "eia 861", "ferc 714"],
-    python_requires=">=3.8,<3.10",
+    python_requires=">=3.8,<3.11",
     setup_requires=["setuptools_scm"],
     install_requires=[
         "addfips~=0.3.1",
@@ -109,6 +109,7 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering",
     ],
     packages=find_packages("src"),


### PR DESCRIPTION
With the exception of `numba` all of our dependencies now appear to be working with Python 3.10, and the tests are passing, so it seems like PUDL works with Python 3.10 now.  I think the biggest advantage for us at this point is the improvements that have been made to error messages, to make them more specific.

`numba` v0.55 (the next major release) is expected to [support Python 3.10](https://github.com/numba/numba/issues/7562). This isn't a strict requirement for our code -- it just speeds some things up. It'll probably come out in a few weeks. For now I've commented `numba` out of the `devtools/environment.yml` file.

I've also disabled `fast-fail` in the GitHub Actions testing matrix so that if the tests fail for one version of Python, it'll still try and run them for all the rest.

Closes #1372 