### PR TITLE
Na values

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   # which conda can install.
   - geopandas>=0.9,<0.11
   - pygeos>=0.10,<0.13  # Python wrappers for the GEOS spatial libraries
-  - python-snappy~=0.6.0
+  - python-snappy>=0.6,<1
   - sqlite~=3.36
   # These libraries aren't directly specified in setup.py as
   # dependencies, but they are helpful and provide binaries

--- a/src/pudl/constants.py
+++ b/src/pudl/constants.py
@@ -262,6 +262,7 @@ COLUMN_DTYPES: Dict[str, Dict[str, Any]] = {
         "report_year": pd.Int64Dtype(),
         "utility_id_ferc1": pd.Int64Dtype(),
         "utility_id_pudl": pd.Int64Dtype(),
+        "construction_type": pd.StringDtype(),
     },
     "ferc714": {  # INCOMPLETE
         "demand_mwh": float,

--- a/src/pudl/metadata/enums.py
+++ b/src/pudl/metadata/enums.py
@@ -214,6 +214,5 @@ EPACEMS_MEASUREMENT_CODES: List[str] = [
     "Substitute",
     "Undetermined",  # Should be replaced with NA
     "Unknown Code",  # Should be replaced with NA
-    "",  # Should be replaced with NA
 ]
 """Valid emissions measurement codes for the EPA CEMS hourly data."""

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -229,7 +229,7 @@ FIELD_METADATA: Dict[str, Dict[str, Any]] = {
         "type": "string",
         "description": "Type of plant construction ('outdoor', 'semioutdoor', or 'conventional'). Categorized by PUDL based on our best guess of intended value in FERC1 freeform strings.",
         "constraints": {
-            "enum": ["", "unknown", "conventional", "outdoor", "semioutdoor"]
+            "enum": ["unknown", "conventional", "outdoor", "semioutdoor"]
         }
     },
     "construction_year": {

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -229,7 +229,7 @@ FIELD_METADATA: Dict[str, Dict[str, Any]] = {
         "type": "string",
         "description": "Type of plant construction ('outdoor', 'semioutdoor', or 'conventional'). Categorized by PUDL based on our best guess of intended value in FERC1 freeform strings.",
         "constraints": {
-            "enum": ["unknown", "conventional", "outdoor", "semioutdoor"]
+            "enum": ["conventional", "outdoor", "semioutdoor"]
         }
     },
     "construction_year": {
@@ -2293,7 +2293,6 @@ FIELD_METADATA_BY_GROUP: Dict[str, Dict[str, Any]] = {
         "fuel_units": {
             "constraints": {
                 "enum": [
-                    "unknown",
                     "mmbtu",
                     "gramsU",
                     "kgU",
@@ -2323,6 +2322,14 @@ FIELD_METADATA_BY_RESOURCE: Dict[str, Dict[str, Any]] = {
     "sector_consolidated_eia": {
         "code": {
             "type": "integer"
+        }
+    },
+    "plants_steam_ferc1": {
+        "plant_type": {
+            "type": "string",
+            "constraints": {
+                "enum": ['steam', 'combustion_turbine', 'combined_cycle', 'nuclear', 'geothermal', 'internal_combustion', 'wind', 'photovoltaic', 'solar_thermal']
+            }
         }
     }
 }

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -1077,7 +1077,7 @@ FIELD_METADATA: Dict[str, Dict[str, Any]] = {
         "type": "string",
         "description": "Contract type for natrual gas delivery service:",
         "constraints": {
-            "enum": ["", "firm", "interruptible"]
+            "enum": ["firm", "interruptible"]
         }
     },
     "natural_gas_local_distribution_company": {
@@ -1105,7 +1105,7 @@ FIELD_METADATA: Dict[str, Dict[str, Any]] = {
         "type": "string",
         "description": "Contract type for natural gas transportation service.",
         "constraints": {
-            "enum": ["", "firm", "interruptible"]
+            "enum": ["firm", "interruptible"]
         }
     },
     "nerc_region": {

--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -579,6 +579,7 @@ def utilities(eia860_dfs, eia860_transformed_dfs):
             entity_type=lambda x: x.entity_type.map(ENTITY_TYPES)
         )
         .pipe(pudl.helpers.convert_to_date)
+        .fillna({'entity_type': pd.NA})
     )
 
     eia860_transformed_dfs['utilities_eia860'] = u_df

--- a/src/pudl/transform/eia923.py
+++ b/src/pudl/transform/eia923.py
@@ -1103,7 +1103,7 @@ def fuel_receipts_costs(eia923_dfs, eia923_transformed_dfs):
               'natural_gas_delivery_contract_type_code'],
              [{'firm': ['F'], 'interruptible': ['I']},
               {'firm': ['F'], 'interruptible': ['I']}],
-             unmapped='')
+             unmapped=pd.NA)
     )
     frc_df = PUDL_META.get_resource("fuel_receipts_costs_eia923").encode(frc_df)
     frc_df["fuel_type_code_pudl"] = (

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -405,7 +405,6 @@ CONSTRUCTION_TYPE_STRINGS: Dict[str, List[str]] = {
         '3 indoor boilers', 'fully contained', 'conv - b', 'conventional/boiler',
         'cnventional', 'comb. cycle indooor', 'sonventional', 'ind enclosures',
         'conentional', 'conventional - boilr', 'indoor boiler and st',
-        'underground', 'pump storage',
     ],
     "unknown": [
         '', 'automatic operation', 'comb. turb. installn', 'comb. turb. instaln',
@@ -432,6 +431,7 @@ CONSTRUCTION_TYPE_STRINGS: Dict[str, List[str]] = {
         'tower - 165 units', 'wind turbine', 'fixed tilt pv', 'tracking pv', 'o',
         'wind trubine', 'subcritical', 'sucritical', 'simple cycle',
         'simple & reciprocat', 'solar', 'pre-fab power plant', 'prefab power plant',
+        'pump storage', 'underground',
     ],
 }
 """

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -1271,7 +1271,6 @@ def plants_hydro(ferc1_raw_dfs, ferc1_transformed_dfs):
                     "capacity_mw"],
             keep=False)
     )
-
     ferc1_transformed_dfs['plants_hydro_ferc1'] = ferc1_hydro_df
     return ferc1_transformed_dfs
 

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -774,8 +774,7 @@ def _plants_steam_clean(ferc1_steam_df):
             "expns_kwh": 'opex_per_kwh'})
         .pipe(_clean_cols, "f1_steam")
         .pipe(pudl.helpers.simplify_strings, ['plant_name_ferc1'])
-        .pipe(pudl.helpers.cleanstrings, ['construction_type'], [CONSTRUCTION_TYPE_STRINGS], unmapped=pd.NA)
-        .pipe(pudl.helpers.cleanstrings, ['plant_type'], [PLANT_KIND_STRINGS], unmapped=pd.NA)
+        .pipe(pudl.helpers.cleanstrings, ['construction_type', 'plant_type'], [CONSTRUCTION_TYPE_STRINGS, PLANT_KIND_STRINGS], unmapped=pd.NA)
         .pipe(pudl.helpers.oob_to_nan,
               cols=["construction_year", "installation_year"],
               lb=1850, ub=max(pc.WORKING_PARTITIONS["ferc1"]["years"]) + 1)

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -399,11 +399,13 @@ CONSTRUCTION_TYPE_STRINGS: Dict[str, List[str]] = {
         'conventionsl', 'conventiional', 'convntl steam plants', 'indoor const.',
         'full indoor', 'indoor', 'indoor automatic', 'indoor boiler',
         '(peak load) indoor', 'conventionl,indoor', 'conventionl, indoor',
-        'conventional, indoor', 'comb. cycle indoor', '3 indoor boiler',
+        'conventional, indoor', 'conventional;outdoor', 'conven./outdoor',
+        'conventional;semi-ou', 'comb. cycle indoor', '3 indoor boiler',
         '2 indoor boilers', '1 indoor boiler', '2 indoor boiler',
         '3 indoor boilers', 'fully contained', 'conv - b', 'conventional/boiler',
         'cnventional', 'comb. cycle indooor', 'sonventional', 'ind enclosures',
         'conentional', 'conventional - boilr', 'indoor boiler and st',
+        'underground', 'pump storage',
     ],
     "unknown": [
         '', 'automatic operation', 'comb. turb. installn', 'comb. turb. instaln',
@@ -429,7 +431,7 @@ CONSTRUCTION_TYPE_STRINGS: Dict[str, List[str]] = {
         'tower -10 unit', 'tower - 101 unit', '3 on 1 gas turbine', 'tower - 10 units',
         'tower - 165 units', 'wind turbine', 'fixed tilt pv', 'tracking pv', 'o',
         'wind trubine', 'subcritical', 'sucritical', 'simple cycle',
-        'simple & reciprocat', 'solar',
+        'simple & reciprocat', 'solar', 'pre-fab power plant', 'prefab power plant',
     ],
 }
 """
@@ -781,7 +783,10 @@ def _plants_steam_clean(ferc1_steam_df):
         )
         .drop(columns=["capex_per_kw", "opex_per_kwh", "net_generation_kwh"])
     )
-
+    if ferc1_steam_df['construction_type'].isnull().any() is True:
+        raise AssertionError(
+            "NA values found in construction_type column, add string to CONSTRUCTION_TYPE_STRINGS"
+        )
     return ferc1_steam_df
 
 
@@ -1271,6 +1276,10 @@ def plants_hydro(ferc1_raw_dfs, ferc1_transformed_dfs):
                     "capacity_mw"],
             keep=False)
     )
+    if ferc1_hydro_df['construction_type'].isnull().any() is True:
+        raise AssertionError(
+            "NA values found in construction_type column, add string to CONSTRUCTION_TYPE_STRINGS"
+        )
     ferc1_transformed_dfs['plants_hydro_ferc1'] = ferc1_hydro_df
     return ferc1_transformed_dfs
 
@@ -1357,7 +1366,10 @@ def plants_pumped_storage(ferc1_raw_dfs, ferc1_transformed_dfs):
                     "capacity_mw"],
             keep=False)
     )
-
+    if ferc1_pump_df['construction_type'].isnull().any() is True:
+        raise AssertionError(
+            "NA values found in construction_type column, add string to CONSTRUCTION_TYPE_STRINGS"
+        )
     ferc1_transformed_dfs['plants_pumped_storage_ferc1'] = ferc1_pump_df
     return ferc1_transformed_dfs
 

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -769,10 +769,8 @@ def _plants_steam_clean(ferc1_steam_df):
             "expns_kwh": 'opex_per_kwh'})
         .pipe(_clean_cols, "f1_steam")
         .pipe(pudl.helpers.simplify_strings, ['plant_name_ferc1'])
-        .pipe(pudl.helpers.cleanstrings,
-              ['construction_type', 'plant_type'],
-              [CONSTRUCTION_TYPE_STRINGS, PLANT_KIND_STRINGS],
-              unmapped='')
+        .pipe(pudl.helpers.cleanstrings, ['construction_type'], [CONSTRUCTION_TYPE_STRINGS], unmapped=pd.NA)
+        .pipe(pudl.helpers.cleanstrings, ['plant_type'], [PLANT_KIND_STRINGS], unmapped="")
         .pipe(pudl.helpers.oob_to_nan,
               cols=["construction_year", "installation_year"],
               lb=1850, ub=max(pc.WORKING_PARTITIONS["ferc1"]["years"]) + 1)
@@ -1217,7 +1215,7 @@ def plants_hydro(ferc1_raw_dfs, ferc1_transformed_dfs):
         # white space -- necesary b/c plant_name is part of many foreign keys.
         .pipe(pudl.helpers.simplify_strings, ['plant_name'])
         .pipe(pudl.helpers.cleanstrings, ['plant_const'],
-              [CONSTRUCTION_TYPE_STRINGS], unmapped='')
+              [CONSTRUCTION_TYPE_STRINGS], unmapped=pd.NA)
         .assign(
             # Converting kWh to MWh
             net_generation_mwh=lambda x: x.net_generation / 1000.0,
@@ -1301,7 +1299,7 @@ def plants_pumped_storage(ferc1_raw_dfs, ferc1_transformed_dfs):
         .pipe(pudl.helpers.simplify_strings, ['plant_name'])
         # Clean up the messy plant construction type column:
         .pipe(pudl.helpers.cleanstrings, ['plant_kind'],
-              [CONSTRUCTION_TYPE_STRINGS], unmapped='')
+              [CONSTRUCTION_TYPE_STRINGS], unmapped=pd.NA)
         .assign(
             # Converting from kW/kWh to MW/MWh
             net_generation_mwh=lambda x: x.net_generation / 1000.0,


### PR DESCRIPTION
The following columns are filled with `pd.NA` in their respective datasets when going through the extract and transform steps of the pipeline. 
### FERC 1

- `construction_type`  
### EIA 

- `natural_gas_delivery_contract_type_code`
- `natural_gas_transport_code`

The call `df.to_sql()` in `sqlite.py` converts the `pd.NA` values to NoneType since the column dtypes are not preserved. This problem is fixed after the fact by recasting the column to a string type once pudl.sqlite is read into a pandas dataframe. Preserving the column dtype is maybe something that should be addressed at some point.

The following columns are filled with `np.nan` in the EPA CEMS datasets, not `pd.NA`. This is because they are categorical type columns and thus do not allow for `pd.NA`. 
### EPA CEMS

- `co2_mass_measurement_code`
- `nox_mass_measurement_code`
- `nox_rate_measurement_code`
- `so2_mass_measurement_code`

### Note
The column `purchase_type` is listed in the issue as an EIA column with an empty string in the enum. However this appears to be a FERC 1 column and the enum is based off the dictionary `POWER_PURCHASE_TYPES_FERC1` in `labels.py`. There is no empty string listed in the `POWER_PURCHASE_TYPES_FERC1` dictionary, so I didn't do anything about the `purchase_type` column.