### PR TITLE
Constrain setuptools to <60.0.0 in environment.yml and pyproject.toml to avoid breaking changes

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   # Used to set up the environment
   - pip~=21.0
   - python>=3.8,<3.11
+  - setuptools<60.0.0
   # These packages are also specified in setup.py
   # However, they depend on or benefit from binary libraries
   # which conda can install.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools", "pip", "wheel", "setuptools_scm"]
+requires = ["setuptools<60.0.0", "pip", "wheel", "setuptools_scm"]
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Fixes #1383