### PR TITLE
Separate resource definitions by data source

### DIFF
--- a/src/pudl/constants.py
+++ b/src/pudl/constants.py
@@ -14,8 +14,8 @@ from pudl.metadata.enums import (CUSTOMER_CLASSES, EPACEMS_MEASUREMENT_CODES,
                                  EPACEMS_STATES, FUEL_CLASSES, NERC_REGIONS,
                                  RELIABILITY_STANDARDS, REVENUE_CLASSES,
                                  TECH_CLASSES)
-from pudl.metadata.labels import (COALMINE_TYPES_EIA, ENTITY_TYPES,
-                                  ESTIMATED_OR_ACTUAL, MOMENTARY_INTERRUPTIONS)
+from pudl.metadata.labels import (COALMINE_TYPES_EIA, ESTIMATED_OR_ACTUAL,
+                                  MOMENTARY_INTERRUPTIONS)
 
 ENTITIES: Dict[str, Tuple[List[str], List[str], List[str], Dict[str, str]]] = {
     'plants': (
@@ -412,7 +412,7 @@ COLUMN_DTYPES: Dict[str, Dict[str, Any]] = {
         'energy_source_code_5': pd.StringDtype(),
         'energy_source_code_6': pd.StringDtype(),
         'energy_storage': pd.BooleanDtype(),
-        'entity_type': pd.CategoricalDtype(categories=ENTITY_TYPES.values()),
+        'entity_type': pd.StringDtype(),
         'estimated_or_actual_capacity_data': pd.CategoricalDtype(
             categories=ESTIMATED_OR_ACTUAL.values()
         ),

--- a/src/pudl/metadata/codes.py
+++ b/src/pudl/metadata/codes.py
@@ -4,6 +4,65 @@ from typing import Any, Dict
 import numpy as np
 import pandas as pd
 
+ENTITY_TYPES_EIA: Dict[str, Any] = {
+    "df": pd.DataFrame(
+        columns=[
+            'code',
+            'label',
+            'description',
+        ],
+        data=[
+            ('A', 'municipal_marketing_authority', 'Municipal Marketing Authority. Voted into existence by the residents of a municipality and given authority for creation by the state government. They are nonprofit organizations'),
+            ('B', 'behind_the_meter', 'Behind the Meter. Entities that install, own, and/or operate a system (usually photovoltaic), and sell, under a long term power purchase agreement (PPA) or lease, all the production from the system to the homeowner or business with which there is a net metering agreement. Third Party Owners (TPOs) of PV solar installations use this ownership code.'),
+            ('C', 'cooperative', 'Cooperative. Member-owned organizations.'),
+            ('COM', 'commercial', 'Commercial facility.'),
+            ('D', 'nonutility_dsm_administrator',
+             'Non-utility DSM Administrator. Only involved with Demand-Side Management activities.'),
+            ('F', 'federal', 'Federal. Government agencies with the authority to deliver energy to end-use customers.'),
+            ('G', 'community_choice_aggregator', 'Community Choice Aggregator.'),
+            ('I', 'investor_owned',
+             'Investor-owned Utilities. Entities that are privately owned and provide a public service.'),
+            ('IND', 'industrial', 'Industrial facility.'),
+            ('M', 'municipal', 'Municipal: Entities that are organized under authority of state statute to provide a public service to residents of that area.'),
+            ('O', 'other', 'Other entity type.'),
+            ('P', 'political_subdivision', 'Political Subdivision. (also called "public utility district"): Independent of city or county government and voted into existence by a majority of the residents of any given area for the specific purpose of providing utility service to the voters. State laws provide for the formation of such districts.'),
+            ('PO', 'power_marketer', 'Power marketer.'),
+            ('PR', 'private', 'Private entity.'),
+            ('Q', 'independent_power_producer',
+             'Independent Power Producer or Qualifying Facility. Entities that own power plants and sell their power into the wholesale market.'),
+            ('R', 'retail_power_marketer',
+             'Retail Power Marketer or Energy Service Provider: Entities that market power to customers in restructured markets.'),
+            ('S', 'state', 'State entities that own or operate facilities or provide a public service.'),
+            ('T', 'transmission', 'Transmission: Entities that operate or own high voltage transmission wires that provide bulk power services.'),
+            ('U', 'unknown', 'Unknown entity type.'),
+            ('W', 'wholesale_power_marketer',
+             'Wholesale Power Marketer: Entities that buy and sell power in the wholesale market.'),
+        ]
+    ).convert_dtypes(),
+
+    "code_fixes": {
+        'Behind the Meter': 'B',
+        'Community Choice Aggregator': 'G',
+        'Cooperative': 'C',
+        'Facility': 'Q',
+        'Federal': 'F',
+        'Investor Owned': 'I',
+        'Municipal': 'M',
+        'Political Subdivision': 'P',
+        'Power Marketer': 'PO',
+        'Retail Power Marketer': 'R',
+        'State': 'S',
+        'Unregulated': 'Q',
+        'Wholesale Power Marketer': 'W',
+    },
+    "ignored_codes": [],
+}
+"""
+Descriptive labels for EIA entity type and ownership codes.
+
+Descriptions taken from the EIA-861 form instructions valid through 2023-05-31.
+"""
+
 ENERGY_SOURCES_EIA: Dict[str, Any] = {
     "df": pd.DataFrame(
         columns=[

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -9,9 +9,8 @@ from .enums import (CANADA_PROVINCES_TERRITORIES, CUSTOMER_CLASSES,
                     EPACEMS_MEASUREMENT_CODES, EPACEMS_STATES, FUEL_CLASSES,
                     NERC_REGIONS, RELIABILITY_STANDARDS, REVENUE_CLASSES,
                     RTO_CLASSES, TECH_CLASSES, US_STATES_TERRITORIES)
-from .labels import (COALMINE_TYPES_EIA, ENTITY_TYPES, ESTIMATED_OR_ACTUAL,
-                     FUEL_UNITS_EIA, MOMENTARY_INTERRUPTIONS,
-                     POWER_PURCHASE_TYPES_FERC1)
+from .labels import (COALMINE_TYPES_EIA, ESTIMATED_OR_ACTUAL, FUEL_UNITS_EIA,
+                     MOMENTARY_INTERRUPTIONS, POWER_PURCHASE_TYPES_FERC1)
 
 FIELD_METADATA: Dict[str, Dict[str, Any]] = {
     "active": {
@@ -579,9 +578,6 @@ FIELD_METADATA: Dict[str, Dict[str, Any]] = {
     "entity_type": {
         "type": "string",
         "description": "Entity type of principal owner.",
-        "constraints": {
-            "enum": list(ENTITY_TYPES.values())
-        }
     },
     "estimated_or_actual_capacity_data": {
         "type": "string",

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -93,7 +93,7 @@ FIELD_METADATA: Dict[str, Dict[str, Any]] = {
     },
     "balancing_authority_code_eia": {
         "type": "string",
-        "description": "The plant's balancing authority code."
+        "description": "EIA short code identifying a balancing authority.",
     },
     "balancing_authority_id_eia": {
         "type": "integer"

--- a/src/pudl/metadata/labels.py
+++ b/src/pudl/metadata/labels.py
@@ -1,33 +1,6 @@
 """Descriptive labels for coded field values."""
 from typing import Dict
 
-ENTITY_TYPES: Dict[str, str] = {
-    'M': 'municipal',
-    'C': 'cooperative',
-    'R': 'retail_power_marketer',
-    'I': 'investor_owned',
-    'P': 'political_subdivision',
-    'T': 'transmission',
-    'S': 'state',
-    'W': 'wholesale_power_marketer',
-    'F': 'federal',
-    'A': 'municipal_marketing_authority',
-    'G': 'community_choice_aggregator',
-    'D': 'nonutility_dsm_administrator',
-    'B': 'behind_the_meter',
-    'Q': 'independent_power_producer',
-    'IND': 'industrial',
-    'COM': 'commercial',
-    'PR': 'private',
-    'PO': 'power_marketer',
-    'U': 'unknown',
-    'O': 'other',
-}
-"""
-Descriptive labels for EIA utility legal entity type codes.
-
-"""
-
 ESTIMATED_OR_ACTUAL: Dict[str, str] = {
     'E': 'estimated',
     'A': 'actual'

--- a/src/pudl/metadata/resources/__init__.py
+++ b/src/pudl/metadata/resources/__init__.py
@@ -9,6 +9,8 @@ from pudl.metadata.helpers import build_foreign_keys
 RESOURCE_METADATA = {}
 for module_info in pkgutil.iter_modules(__path__):
     module = importlib.import_module(f"{__name__}.{module_info.name}")
+    if module.__name__ == "pudl.metadata.resources.eia861":
+        continue
     resources = module.RESOURCE_METADATA
     for key in resources:
         if "group" not in resources[key]:

--- a/src/pudl/metadata/resources/eia.py
+++ b/src/pudl/metadata/resources/eia.py
@@ -8,6 +8,7 @@ from pudl.metadata.codes import (CONTRACT_TYPES_EIA, ENERGY_SOURCES_EIA,
 
 RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
     "boiler_fuel_eia923": {
+        "description": "EIA-923 Monthly Boiler Fuel Consumption and Emissions Time Series. From EIA-923 Schedule 3.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -30,6 +31,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923"],
     },
     "boiler_generator_assn_eia860": {
+        "description": "Associations between boilers and generators as reported in EIA-860 Schedule 6, Part A. Augmented with various heuristics within PUDL.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -42,16 +44,19 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             ],
             "primary_key": ["plant_id_eia", "report_date", "generator_id", "boiler_id"],
         },
-        "sources": ["eia860"],
+        "sources": ["eia860", "eia923"],
     },
     "boilers_entity_eia": {
+        "description": "Static boiler attributes compiled from the EIA-860 and EIA-923 data.",
         "schema": {
             "fields": ["plant_id_eia", "boiler_id", "prime_mover_code"],
             "primary_key": ["plant_id_eia", "boiler_id"],
             "foreign_key_rules": {"fields": [["plant_id_eia", "boiler_id"]]},
         },
+        "sources": ["eia860", "eia923"],
     },
     "coalmine_eia923": {
+        "description": "Coal mine attributes originally reported within the Fuel Receipts and Costs table via EIA-923 Schedule 2, Part C.",
         "schema": {
             "fields": [
                 "mine_id_pudl",
@@ -67,6 +72,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923"],
     },
     "contract_types_eia": {
+        "description": "A coding table describing the various types of fuel supply contracts reported in EIA-923.",
         "schema": {
             "fields": ["code", "label", "description"],
             "primary_key": ["code"],
@@ -75,10 +81,8 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "encoder": CONTRACT_TYPES_EIA,
         "sources": ["eia923"],
     },
-    "datasets": {
-        "schema": {"fields": ["datasource", "active"], "primary_key": ["datasource"]},
-    },
     "energy_sources_eia": {
+        "description": "Codes and metadata pertaining to energy sources reported to EIA. Compiled from EIA-860 instructions and EIA-923 file layout spreadsheets.",
         "schema": {
             "fields": [
                 "code",
@@ -111,9 +115,10 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             },
         },
         "encoder": ENERGY_SOURCES_EIA,
-        "sources": ["eia923"],
+        "sources": ["eia860", "eia923"],
     },
     "fuel_receipts_costs_eia923": {
+        "description": "Monthly fuel contract information, purchases, and costs reported in EIA-923 Schedule 2, Part A.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -142,6 +147,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923"],
     },
     "fuel_transportation_modes_eia": {
+        "description": "Long descriptions of the fuel transportation modes reported in the EIA-860 and EIA-923.",
         "schema": {
             "fields": ["code", "label", "description"],
             "primary_key": ["code"],
@@ -159,9 +165,10 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             }
         },
         "encoder": FUEL_TRANSPORTATION_MODES_EIA,
-        "sources": ["eia923"],
+        "sources": ["eia860", "eia923"],
     },
     "fuel_types_aer_eia": {
+        "description": "Descriptive labels for aggregated fuel types used in the Annual Energy Review. See EIA-923 Fuel Code table for additional information.",
         "schema": {
             "fields": ["code", "description"],
             "primary_key": ["code"],
@@ -171,6 +178,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923"],
     },
     "generation_eia923": {
+        "description": "EIA-923 Monthly Generating Unit Net Generation Time Series. From EIA-923 Schedule 3.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -183,8 +191,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923"],
     },
     "generation_fuel_eia923": {
-        "description": "Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a plant. Note that this table does not include data from nuclear plants as they report at the generation unit level, rather than the plant level. See the generation_fuel_nuclear_eia923 table for nuclear electricity generation and fuel consumption.",
-
+        "description": "EIA-923 Monthly Generation and Fuel Consumption Time Series. From EIA-923 Schedule 3. Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a plant. This table does not include data from nuclear plants as they report at the generation unit level, rather than the plant level. See the generation_fuel_nuclear_eia923 table for nuclear electricity generation and fuel consumption.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -210,7 +217,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923"],
     },
     "generation_fuel_nuclear_eia923": {
-        "description": "Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a nuclear generation unit.",
+        "description": "EIA-923 Monthly Generation and Fuel Consumption Time Series. From EIA-923 Schedule 3. Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a nuclear generation unit.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -238,6 +245,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923"],
     },
     "generators_eia860": {
+        "description": "Annually varying generator attributes compiled from across EIA-860 and EIA-923 data.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -321,9 +329,10 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 ]
             },
         },
-        "sources": ["eia860"],
+        "sources": ["eia860", "eia923"],
     },
     "generators_entity_eia": {
+        "description": "Static generator attributes compiled from across the EIA-860 and EIA-923 data.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -351,15 +360,10 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             "primary_key": ["plant_id_eia", "generator_id"],
             "foreign_key_rules": {"fields": [["plant_id_eia", "generator_id"]]},
         },
-    },
-    "natural_gas_transport_eia923": {
-        "schema": {
-            "fields": ["code", "status"],
-            "primary_key": ["code"]
-        },
-        "sources": ["eia923"],
+        "sources": ["eia860", "eia923"],
     },
     "ownership_eia860": {
+        "description": "Generator Ownership, reported in EIA-860 Schedule 4. Includes only jointly or third-party owned generators.",
         "schema": {
             "fields": [
                 "report_date",
@@ -381,12 +385,15 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia860"],
     },
     "plants_eia": {
+        "description": "Association between EIA Plant IDs and manually assigned PUDL Plant IDs",
         "schema": {
             "fields": ["plant_id_eia", "plant_name_eia", "plant_id_pudl"],
             "primary_key": ["plant_id_eia"],
         },
+        "sources": ["eia860", "eia923"],
     },
     "plants_eia860": {
+        "description": "Annually varying plant attributes, compiled from across all EIA-860 and EIA-923 data.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -433,9 +440,10 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 ]
             },
         },
-        "sources": ["eia860"],
+        "sources": ["eia860", "eia923"],
     },
     "plants_entity_eia": {
+        "description": "Static plant attributes, compiled from across all EIA-860 and EIA-923 data.",
         "schema": {
             "fields": [
                 "plant_id_eia",
@@ -472,8 +480,10 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 "exclude": ["plants_eia"],
             },
         },
+        "sources": ["eia860", "eia923"],
     },
     "prime_movers_eia": {
+        "description": "Long descriptions explaining the short prime mover codes reported in the EIA-860 and EIA-923.",
         "schema": {
             "fields": ["code", "label", "description"],
             "primary_key": ["code"],
@@ -488,21 +498,25 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["eia923", "eia860"],
     },
     "sector_consolidated_eia": {
+        "description": "Long descriptions for the EIA consolidated NAICS sector codes. Codes and descriptions taken from the EIA-923 File Layout spreadsheet.",
         "schema": {
             "fields": ["code", "label", "description"],
             "primary_key": ["code"],
             "foreign_key_rules": {"fields": [["sector_id_eia"]]},
         },
         "encoder": SECTOR_CONSOLIDATED_EIA,
-        "sources": ["eia923"],
+        "sources": ["eia860", "eia923"],
     },
     "utilities_eia": {
+        "description": "Associations between the EIA Utility IDs and the manually assigned PUDL Utility IDs.",
         "schema": {
             "fields": ["utility_id_eia", "utility_name_eia", "utility_id_pudl"],
             "primary_key": ["utility_id_eia"],
         },
+        "sources": ["eia860", "eia923"],
     },
     "utilities_eia860": {
+        "description": "Annually varying utility attributes, compiled from all EIA data.",
         "schema": {
             "fields": [
                 "utility_id_eia",
@@ -541,9 +555,10 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 ],
             },
         },
-        "sources": ["eia860"],
+        "sources": ["eia860", "eia923"],
     },
     "utilities_entity_eia": {
+        "description": "Static attributes of utilities, compiled from all EIA data.",
         "schema": {
             "fields": ["utility_id_eia", "utility_name_eia"],
             "primary_key": ["utility_id_eia"],
@@ -563,6 +578,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 "exclude": ["utilities_eia"],
             },
         },
+        "sources": ["eia860", "eia923"],
     },
 }
 """

--- a/src/pudl/metadata/resources/eia.py
+++ b/src/pudl/metadata/resources/eia.py
@@ -7,45 +7,6 @@ from pudl.metadata.codes import (CONTRACT_TYPES_EIA, ENERGY_SOURCES_EIA,
                                  SECTOR_CONSOLIDATED_EIA)
 
 RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
-    "boiler_fuel_eia923": {
-        "description": "EIA-923 Monthly Boiler Fuel Consumption and Emissions Time Series. From EIA-923 Schedule 3.",
-        "schema": {
-            "fields": [
-                "plant_id_eia",
-                "boiler_id",
-                "energy_source_code",
-                "fuel_type_code_pudl",
-                "report_date",
-                "fuel_consumed_units",
-                "fuel_mmbtu_per_unit",
-                "sulfur_content_pct",
-                "ash_content_pct",
-            ],
-            "primary_key": [
-                "plant_id_eia",
-                "boiler_id",
-                "energy_source_code",
-                "report_date"
-            ],
-        },
-        "sources": ["eia923"],
-    },
-    "boiler_generator_assn_eia860": {
-        "description": "Associations between boilers and generators as reported in EIA-860 Schedule 6, Part A. Augmented with various heuristics within PUDL.",
-        "schema": {
-            "fields": [
-                "plant_id_eia",
-                "report_date",
-                "generator_id",
-                "boiler_id",
-                "unit_id_eia",
-                "unit_id_pudl",
-                "bga_source",
-            ],
-            "primary_key": ["plant_id_eia", "report_date", "generator_id", "boiler_id"],
-        },
-        "sources": ["eia860", "eia923"],
-    },
     "boilers_entity_eia": {
         "description": "Static boiler attributes compiled from the EIA-860 and EIA-923 data.",
         "schema": {
@@ -54,22 +15,6 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             "foreign_key_rules": {"fields": [["plant_id_eia", "boiler_id"]]},
         },
         "sources": ["eia860", "eia923"],
-    },
-    "coalmine_eia923": {
-        "description": "Coal mine attributes originally reported within the Fuel Receipts and Costs table via EIA-923 Schedule 2, Part C.",
-        "schema": {
-            "fields": [
-                "mine_id_pudl",
-                "mine_name",
-                "mine_type",
-                "state",
-                "county_id_fips",
-                "mine_id_msha",
-            ],
-            "primary_key": ["mine_id_pudl"],
-            "foreign_key_rules": {"fields": [["mine_id_pudl"]]},
-        },
-        "sources": ["eia923"],
     },
     "contract_types_eia": {
         "description": "A coding table describing the various types of fuel supply contracts reported in EIA-923.",
@@ -117,35 +62,6 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "encoder": ENERGY_SOURCES_EIA,
         "sources": ["eia860", "eia923"],
     },
-    "fuel_receipts_costs_eia923": {
-        "description": "Monthly fuel contract information, purchases, and costs reported in EIA-923 Schedule 2, Part A.",
-        "schema": {
-            "fields": [
-                "plant_id_eia",
-                "report_date",
-                "contract_type_code",
-                "contract_expiration_date",
-                "energy_source_code",
-                "fuel_type_code_pudl",
-                "fuel_group_code",
-                "mine_id_pudl",
-                "supplier_name",
-                "fuel_received_units",
-                "fuel_mmbtu_per_unit",
-                "sulfur_content_pct",
-                "ash_content_pct",
-                "mercury_content_ppm",
-                "fuel_cost_per_mmbtu",
-                "primary_transportation_mode_code",
-                "secondary_transportation_mode_code",
-                "natural_gas_transport_code",
-                "natural_gas_delivery_contract_type_code",
-                "moisture_content_pct",
-                "chlorine_content_ppm",
-            ],
-        },
-        "sources": ["eia923"],
-    },
     "fuel_transportation_modes_eia": {
         "description": "Long descriptions of the fuel transportation modes reported in the EIA-860 and EIA-923.",
         "schema": {
@@ -176,160 +92,6 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         },
         "encoder": FUEL_TYPES_AER_EIA,
         "sources": ["eia923"],
-    },
-    "generation_eia923": {
-        "description": "EIA-923 Monthly Generating Unit Net Generation Time Series. From EIA-923 Schedule 3.",
-        "schema": {
-            "fields": [
-                "plant_id_eia",
-                "generator_id",
-                "report_date",
-                "net_generation_mwh",
-            ],
-            "primary_key": ["plant_id_eia", "generator_id", "report_date"],
-        },
-        "sources": ["eia923"],
-    },
-    "generation_fuel_eia923": {
-        "description": "EIA-923 Monthly Generation and Fuel Consumption Time Series. From EIA-923 Schedule 3. Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a plant. This table does not include data from nuclear plants as they report at the generation unit level, rather than the plant level. See the generation_fuel_nuclear_eia923 table for nuclear electricity generation and fuel consumption.",
-        "schema": {
-            "fields": [
-                "plant_id_eia",
-                "report_date",
-                "energy_source_code",
-                "fuel_type_code_pudl",
-                "fuel_type_code_aer",
-                "prime_mover_code",
-                "fuel_consumed_units",
-                "fuel_consumed_for_electricity_units",
-                "fuel_mmbtu_per_unit",
-                "fuel_consumed_mmbtu",
-                "fuel_consumed_for_electricity_mmbtu",
-                "net_generation_mwh",
-            ],
-            "primary_key": [
-                "plant_id_eia",
-                "report_date",
-                "energy_source_code",
-                "prime_mover_code"
-            ],
-        },
-        "sources": ["eia923"],
-    },
-    "generation_fuel_nuclear_eia923": {
-        "description": "EIA-923 Monthly Generation and Fuel Consumption Time Series. From EIA-923 Schedule 3. Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a nuclear generation unit.",
-        "schema": {
-            "fields": [
-                "plant_id_eia",
-                "report_date",
-                "nuclear_unit_id",
-                "energy_source_code",
-                "fuel_type_code_pudl",
-                "fuel_type_code_aer",
-                "prime_mover_code",
-                "fuel_consumed_units",
-                "fuel_consumed_for_electricity_units",
-                "fuel_mmbtu_per_unit",
-                "fuel_consumed_mmbtu",
-                "fuel_consumed_for_electricity_mmbtu",
-                "net_generation_mwh",
-            ],
-            "primary_key": [
-                "plant_id_eia",
-                "report_date",
-                "nuclear_unit_id",
-                "energy_source_code",
-                "prime_mover_code"
-            ],
-        },
-        "sources": ["eia923"],
-    },
-    "generators_eia860": {
-        "description": "Annually varying generator attributes compiled from across EIA-860 and EIA-923 data.",
-        "schema": {
-            "fields": [
-                "plant_id_eia",
-                "generator_id",
-                "utility_id_eia",
-                "report_date",
-                "operational_status_code",
-                "operational_status",
-                "ownership_code",
-                "capacity_mw",
-                "summer_capacity_mw",
-                "summer_capacity_estimate",
-                "winter_capacity_mw",
-                "winter_capacity_estimate",
-                "energy_source_code_1",
-                "energy_source_code_2",
-                "energy_source_code_3",
-                "energy_source_code_4",
-                "energy_source_code_5",
-                "energy_source_code_6",
-                "energy_source_1_transport_1",
-                "energy_source_1_transport_2",
-                "energy_source_1_transport_3",
-                "energy_source_2_transport_1",
-                "energy_source_2_transport_2",
-                "energy_source_2_transport_3",
-                "fuel_type_code_pudl",
-                "multiple_fuels",
-                "deliver_power_transgrid",
-                "distributed_generation",
-                "syncronized_transmission_grid",
-                "turbines_num",
-                "planned_modifications",
-                "planned_net_summer_capacity_uprate_mw",
-                "planned_net_winter_capacity_uprate_mw",
-                "planned_uprate_date",
-                "planned_net_summer_capacity_derate_mw",
-                "planned_net_winter_capacity_derate_mw",
-                "planned_derate_date",
-                "planned_new_prime_mover_code",
-                "planned_energy_source_code_1",
-                "planned_repower_date",
-                "other_planned_modifications",
-                "other_modifications_date",
-                "planned_retirement_date",
-                "carbon_capture",
-                "startup_source_code_1",
-                "startup_source_code_2",
-                "startup_source_code_3",
-                "startup_source_code_4",
-                "technology_description",
-                "turbines_inverters_hydrokinetics",
-                "time_cold_shutdown_full_load_code",
-                "planned_new_capacity_mw",
-                "cofire_fuels",
-                "switch_oil_gas",
-                "nameplate_power_factor",
-                "minimum_load_mw",
-                "uprate_derate_during_year",
-                "uprate_derate_completed_date",
-                "current_planned_operating_date",
-                "summer_estimated_capability_mw",
-                "winter_estimated_capability_mw",
-                "retirement_date",
-                "owned_by_non_utility",
-                "reactive_power_output_mvar",
-                "data_source",
-            ],
-            "primary_key": ["plant_id_eia", "generator_id", "report_date"],
-            "foreign_key_rules": {
-                "fields": [["plant_id_eia", "generator_id", "report_date"]],
-                # TODO: Excluding monthly data tables since their report_date
-                # values don't match up with generators_eia860, which is annual,
-                # so non-january records violate the constraint.
-                # See: https://github.com/catalyst-cooperative/pudl/issues/1196
-                "exclude": [
-                    "boiler_fuel_eia923",
-                    "fuel_receipts_costs_eia923",
-                    "generation_eia923",
-                    "generation_fuel_eia923",
-                ]
-            },
-        },
-        "sources": ["eia860", "eia923"],
     },
     "generators_entity_eia": {
         "description": "Static generator attributes compiled from across the EIA-860 and EIA-923 data.",
@@ -362,83 +124,11 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         },
         "sources": ["eia860", "eia923"],
     },
-    "ownership_eia860": {
-        "description": "Generator Ownership, reported in EIA-860 Schedule 4. Includes only jointly or third-party owned generators.",
-        "schema": {
-            "fields": [
-                "report_date",
-                "utility_id_eia",
-                "plant_id_eia",
-                "generator_id",
-                "owner_utility_id_eia",
-                "owner_name",
-                "owner_state",
-                "owner_city",
-                "owner_street_address",
-                "owner_zip_code",
-                "fraction_owned",
-            ],
-            "primary_key": [
-                "report_date", "plant_id_eia", "generator_id", "owner_utility_id_eia"
-            ],
-        },
-        "sources": ["eia860"],
-    },
     "plants_eia": {
         "description": "Association between EIA Plant IDs and manually assigned PUDL Plant IDs",
         "schema": {
             "fields": ["plant_id_eia", "plant_name_eia", "plant_id_pudl"],
             "primary_key": ["plant_id_eia"],
-        },
-        "sources": ["eia860", "eia923"],
-    },
-    "plants_eia860": {
-        "description": "Annually varying plant attributes, compiled from across all EIA-860 and EIA-923 data.",
-        "schema": {
-            "fields": [
-                "plant_id_eia",
-                "report_date",
-                "ash_impoundment",
-                "ash_impoundment_lined",
-                "ash_impoundment_status",
-                "datum",
-                "energy_storage",
-                "ferc_cogen_docket_no",
-                "ferc_exempt_wholesale_generator_docket_no",
-                "ferc_small_power_producer_docket_no",
-                "liquefied_natural_gas_storage",
-                "natural_gas_local_distribution_company",
-                "natural_gas_storage",
-                "natural_gas_pipeline_name_1",
-                "natural_gas_pipeline_name_2",
-                "natural_gas_pipeline_name_3",
-                "nerc_region",
-                "net_metering",
-                "pipeline_notes",
-                "regulatory_status_code",
-                "respondent_frequency",
-                "service_area",
-                "transmission_distribution_owner_id",
-                "transmission_distribution_owner_name",
-                "transmission_distribution_owner_state",
-                "utility_id_eia",
-                "water_source",
-            ],
-            "primary_key": ["plant_id_eia", "report_date"],
-            "foreign_key_rules": {
-                "fields": [["plant_id_eia", "report_date"]],
-                # TODO: Excluding monthly data tables since their report_date
-                # values don't match up with plants_eia860, which is annual, so
-                # non-january records fail.
-                # See: https://github.com/catalyst-cooperative/pudl/issues/1196
-                "exclude": [
-                    "boiler_fuel_eia923",
-                    "fuel_receipts_costs_eia923",
-                    "generation_eia923",
-                    "generation_fuel_eia923",
-                    "generation_fuel_nuclear_eia923",
-                ]
-            },
         },
         "sources": ["eia860", "eia923"],
     },
@@ -515,48 +205,6 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         },
         "sources": ["eia860", "eia923"],
     },
-    "utilities_eia860": {
-        "description": "Annually varying utility attributes, compiled from all EIA data.",
-        "schema": {
-            "fields": [
-                "utility_id_eia",
-                "report_date",
-                "street_address",
-                "city",
-                "state",
-                "zip_code",
-                "plants_reported_owner",
-                "plants_reported_operator",
-                "plants_reported_asset_manager",
-                "plants_reported_other_relationship",
-                "entity_type",
-                "attention_line",
-                "address_2",
-                "zip_code_4",
-                "contact_firstname",
-                "contact_lastname",
-                "contact_title",
-                "phone_number",
-                "phone_extension",
-                "contact_firstname_2",
-                "contact_lastname_2",
-                "contact_title_2",
-                "phone_number_2",
-                "phone_extension_2",
-            ],
-            "primary_key": ["utility_id_eia", "report_date"],
-            "foreign_key_rules": {
-                "fields": [
-                    ["utility_id_eia", "report_date"],
-                    # Failing because this column is not harvested in the old
-                    # system. TODO: re-enable when we switch to new system.
-                    # https://github.com/catalyst-cooperative/pudl/issues/1196
-                    # ["owner_utility_id_eia", "report_date"],
-                ],
-            },
-        },
-        "sources": ["eia860", "eia923"],
-    },
     "utilities_entity_eia": {
         "description": "Static attributes of utilities, compiled from all EIA data.",
         "schema": {
@@ -582,7 +230,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
     },
 }
 """
-EIA (860/861/923) resource attributes by PUDL identifier (``resource.name``).
+Generic EIA resource attributes organized by PUDL identifier (``resource.name``).
 
 Keys are in alphabetical order.
 

--- a/src/pudl/metadata/resources/eia860.py
+++ b/src/pudl/metadata/resources/eia860.py
@@ -1,0 +1,235 @@
+"""Definitions of data tables primarily coming from EIA-860."""
+from typing import Any, Dict
+
+RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
+    "boiler_generator_assn_eia860": {
+        "description": "Associations between boilers and generators as reported in EIA-860 Schedule 6, Part A. Augmented with various heuristics within PUDL.",
+        "schema": {
+            "fields": [
+                "plant_id_eia",
+                "report_date",
+                "generator_id",
+                "boiler_id",
+                "unit_id_eia",
+                "unit_id_pudl",
+                "bga_source",
+            ],
+            "primary_key": ["plant_id_eia", "report_date", "generator_id", "boiler_id"],
+        },
+        "group": "eia",
+        "sources": ["eia860", "eia923"],
+    },
+    "generators_eia860": {
+        "description": "Annually varying generator attributes compiled from across EIA-860 and EIA-923 data.",
+        "schema": {
+            "fields": [
+                "plant_id_eia",
+                "generator_id",
+                "utility_id_eia",
+                "report_date",
+                "operational_status_code",
+                "operational_status",
+                "ownership_code",
+                "capacity_mw",
+                "summer_capacity_mw",
+                "summer_capacity_estimate",
+                "winter_capacity_mw",
+                "winter_capacity_estimate",
+                "energy_source_code_1",
+                "energy_source_code_2",
+                "energy_source_code_3",
+                "energy_source_code_4",
+                "energy_source_code_5",
+                "energy_source_code_6",
+                "energy_source_1_transport_1",
+                "energy_source_1_transport_2",
+                "energy_source_1_transport_3",
+                "energy_source_2_transport_1",
+                "energy_source_2_transport_2",
+                "energy_source_2_transport_3",
+                "fuel_type_code_pudl",
+                "multiple_fuels",
+                "deliver_power_transgrid",
+                "distributed_generation",
+                "syncronized_transmission_grid",
+                "turbines_num",
+                "planned_modifications",
+                "planned_net_summer_capacity_uprate_mw",
+                "planned_net_winter_capacity_uprate_mw",
+                "planned_uprate_date",
+                "planned_net_summer_capacity_derate_mw",
+                "planned_net_winter_capacity_derate_mw",
+                "planned_derate_date",
+                "planned_new_prime_mover_code",
+                "planned_energy_source_code_1",
+                "planned_repower_date",
+                "other_planned_modifications",
+                "other_modifications_date",
+                "planned_retirement_date",
+                "carbon_capture",
+                "startup_source_code_1",
+                "startup_source_code_2",
+                "startup_source_code_3",
+                "startup_source_code_4",
+                "technology_description",
+                "turbines_inverters_hydrokinetics",
+                "time_cold_shutdown_full_load_code",
+                "planned_new_capacity_mw",
+                "cofire_fuels",
+                "switch_oil_gas",
+                "nameplate_power_factor",
+                "minimum_load_mw",
+                "uprate_derate_during_year",
+                "uprate_derate_completed_date",
+                "current_planned_operating_date",
+                "summer_estimated_capability_mw",
+                "winter_estimated_capability_mw",
+                "retirement_date",
+                "owned_by_non_utility",
+                "reactive_power_output_mvar",
+                "data_source",
+            ],
+            "primary_key": ["plant_id_eia", "generator_id", "report_date"],
+            "foreign_key_rules": {
+                "fields": [["plant_id_eia", "generator_id", "report_date"]],
+                # TODO: Excluding monthly data tables since their report_date
+                # values don't match up with generators_eia860, which is annual,
+                # so non-january records violate the constraint.
+                # See: https://github.com/catalyst-cooperative/pudl/issues/1196
+                "exclude": [
+                    "boiler_fuel_eia923",
+                    "fuel_receipts_costs_eia923",
+                    "generation_eia923",
+                    "generation_fuel_eia923",
+                ]
+            },
+        },
+        "group": "eia",
+        "sources": ["eia860", "eia923"],
+    },
+    "ownership_eia860": {
+        "description": "Generator Ownership, reported in EIA-860 Schedule 4. Includes only jointly or third-party owned generators.",
+        "schema": {
+            "fields": [
+                "report_date",
+                "utility_id_eia",
+                "plant_id_eia",
+                "generator_id",
+                "owner_utility_id_eia",
+                "owner_name",
+                "owner_state",
+                "owner_city",
+                "owner_street_address",
+                "owner_zip_code",
+                "fraction_owned",
+            ],
+            "primary_key": [
+                "report_date", "plant_id_eia", "generator_id", "owner_utility_id_eia"
+            ],
+        },
+        "group": "eia",
+        "sources": ["eia860"],
+    },
+    "plants_eia860": {
+        "description": "Annually varying plant attributes, compiled from across all EIA-860 and EIA-923 data.",
+        "schema": {
+            "fields": [
+                "plant_id_eia",
+                "report_date",
+                "ash_impoundment",
+                "ash_impoundment_lined",
+                "ash_impoundment_status",
+                "datum",
+                "energy_storage",
+                "ferc_cogen_docket_no",
+                "ferc_exempt_wholesale_generator_docket_no",
+                "ferc_small_power_producer_docket_no",
+                "liquefied_natural_gas_storage",
+                "natural_gas_local_distribution_company",
+                "natural_gas_storage",
+                "natural_gas_pipeline_name_1",
+                "natural_gas_pipeline_name_2",
+                "natural_gas_pipeline_name_3",
+                "nerc_region",
+                "net_metering",
+                "pipeline_notes",
+                "regulatory_status_code",
+                "respondent_frequency",
+                "service_area",
+                "transmission_distribution_owner_id",
+                "transmission_distribution_owner_name",
+                "transmission_distribution_owner_state",
+                "utility_id_eia",
+                "water_source",
+            ],
+            "primary_key": ["plant_id_eia", "report_date"],
+            "foreign_key_rules": {
+                "fields": [["plant_id_eia", "report_date"]],
+                # TODO: Excluding monthly data tables since their report_date
+                # values don't match up with plants_eia860, which is annual, so
+                # non-january records fail.
+                # See: https://github.com/catalyst-cooperative/pudl/issues/1196
+                "exclude": [
+                    "boiler_fuel_eia923",
+                    "fuel_receipts_costs_eia923",
+                    "generation_eia923",
+                    "generation_fuel_eia923",
+                    "generation_fuel_nuclear_eia923",
+                ]
+            },
+        },
+        "group": "eia",
+        "sources": ["eia860", "eia923"],
+    },
+    "utilities_eia860": {
+        "description": "Annually varying utility attributes, compiled from all EIA data.",
+        "schema": {
+            "fields": [
+                "utility_id_eia",
+                "report_date",
+                "street_address",
+                "city",
+                "state",
+                "zip_code",
+                "plants_reported_owner",
+                "plants_reported_operator",
+                "plants_reported_asset_manager",
+                "plants_reported_other_relationship",
+                "entity_type",
+                "attention_line",
+                "address_2",
+                "zip_code_4",
+                "contact_firstname",
+                "contact_lastname",
+                "contact_title",
+                "phone_number",
+                "phone_extension",
+                "contact_firstname_2",
+                "contact_lastname_2",
+                "contact_title_2",
+                "phone_number_2",
+                "phone_extension_2",
+            ],
+            "primary_key": ["utility_id_eia", "report_date"],
+            "foreign_key_rules": {
+                "fields": [
+                    ["utility_id_eia", "report_date"],
+                    # Failing because this column is not harvested in the old
+                    # system. TODO: re-enable when we switch to new system.
+                    # https://github.com/catalyst-cooperative/pudl/issues/1196
+                    # ["owner_utility_id_eia", "report_date"],
+                ],
+            },
+        },
+        "group": "eia",
+        "sources": ["eia860", "eia923"],
+    },
+}
+"""
+EIA-860 resource attributes organized by PUDL identifier (``resource.name``).
+
+Keys are in alphabetical order.
+
+See :func:`pudl.metadata.helpers.build_foreign_keys` for the expected format of
+``foreign_key_rules``.
+"""

--- a/src/pudl/metadata/resources/eia861.py
+++ b/src/pudl/metadata/resources/eia861.py
@@ -1,0 +1,386 @@
+"""Definitions of data tables primarily coming from EIA-861."""
+from typing import Any, Dict
+
+RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
+    # "advanced_metering_infrastructure_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    "balancing_authority_assn_eia861": {
+        "description": "",
+        "schema": {
+            "fields": [
+                'report_date',
+                'balancing_authority_id_eia',
+                'utility_id_eia',
+                'state',
+            ],
+            "primary_key": [
+                'report_date',
+                'balancing_authority_id_eia',
+                'utility_id_eia',
+                'state',
+            ],
+            "foreign_key_rules": {
+                "fields": [[]]
+            },
+        },
+        "group": "eia",
+        "sources": ["eia861"],
+    },
+    "balancing_authority_eia861": {
+        "description": "",
+        "schema": {
+            "fields": [
+                'report_date',
+                'balancing_authority_id_eia',
+                'balancing_authority_code_eia',
+                'balancing_authority_name_eia',
+            ],
+            "primary_key": [
+                'report_date',
+                'balancing_authority_id_eia',
+            ],
+            "foreign_key_rules": {
+                "fields": [[]]
+            },
+        },
+        "group": "eia",
+        "sources": ["eia861"],
+    },
+    # "demand_response_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "demand_response_water_heater_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "demand_side_management_ee_dr_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "demand_side_management_misc_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "demand_side_management_sales_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "distributed_generation_fuel_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "distributed_generation_misc_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "distributed_generation_tech_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "distribution_systems_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "dynamic_pricing_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "energy_efficiency_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "green_pricing_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "mergers_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "net_metering_customer_fuel_class_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "net_metering_misc_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "non_net_metering_customer_fuel_class_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "non_net_metering_misc_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "operational_data_misc_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "operational_data_revenue_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "reliability_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    "sales_eia861": {
+        "description": "",
+        "schema": {
+            "fields": [
+                'utility_id_eia',
+                'state',
+                'report_date',
+                'balancing_authority_code_eia',
+                'business_model',
+                'data_observed',
+                'entity_type',
+                'service_type',
+                'short_form',
+                'utility_name_eia',
+                'customer_class',
+                'customers',
+                'sales_mwh',
+                'sales_revenue'
+            ],
+            "primary_key": [],
+            "foreign_key_rules": {
+                "fields": [[]]
+            },
+        },
+        "group": "eia",
+        "sources": ["eia861"],
+    },
+    "service_territory_eia861": {
+        "description": "",
+        "schema": {
+            "fields": [],
+            "primary_key": [],
+            "foreign_key_rules": {
+                "fields": [[]]
+            },
+        },
+        "group": "eia",
+        "sources": ["eia861"],
+    },
+    "utility_assn_eia861": {
+        "description": "",
+        "schema": {
+            "fields": [],
+            "primary_key": [],
+            "foreign_key_rules": {
+                "fields": [[]]
+            },
+        },
+        "group": "eia",
+        "sources": ["eia861"],
+    },
+    # "utility_data_misc_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "utility_data_nerc_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+    # "utility_data_rto_eia861": {
+    #     "description": "",
+    #     "schema": {
+    #         "fields": [],
+    #         "primary_key": [],
+    #         "foreign_key_rules": {
+    #             "fields": [[]]
+    #         },
+    #     },
+    #     "group": "eia",
+    #     "sources": ["eia861"],
+    # },
+}

--- a/src/pudl/metadata/resources/eia923.py
+++ b/src/pudl/metadata/resources/eia923.py
@@ -1,0 +1,154 @@
+"""Definitions of data tables primarily coming from EIA-923."""
+from typing import Any, Dict
+
+RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
+    "boiler_fuel_eia923": {
+        "description": "EIA-923 Monthly Boiler Fuel Consumption and Emissions Time Series. From EIA-923 Schedule 3.",
+        "schema": {
+            "fields": [
+                "plant_id_eia",
+                "boiler_id",
+                "energy_source_code",
+                "fuel_type_code_pudl",
+                "report_date",
+                "fuel_consumed_units",
+                "fuel_mmbtu_per_unit",
+                "sulfur_content_pct",
+                "ash_content_pct",
+            ],
+            "primary_key": [
+                "plant_id_eia",
+                "boiler_id",
+                "energy_source_code",
+                "report_date"
+            ],
+        },
+        "group": "eia",
+        "sources": ["eia923"],
+    },
+    "coalmine_eia923": {
+        "description": "Coal mine attributes originally reported within the Fuel Receipts and Costs table via EIA-923 Schedule 2, Part C.",
+        "schema": {
+            "fields": [
+                "mine_id_pudl",
+                "mine_name",
+                "mine_type",
+                "state",
+                "county_id_fips",
+                "mine_id_msha",
+            ],
+            "primary_key": ["mine_id_pudl"],
+            "foreign_key_rules": {"fields": [["mine_id_pudl"]]},
+        },
+        "group": "eia",
+        "sources": ["eia923"],
+    },
+    "fuel_receipts_costs_eia923": {
+        "description": "Monthly fuel contract information, purchases, and costs reported in EIA-923 Schedule 2, Part A.",
+        "schema": {
+            "fields": [
+                "plant_id_eia",
+                "report_date",
+                "contract_type_code",
+                "contract_expiration_date",
+                "energy_source_code",
+                "fuel_type_code_pudl",
+                "fuel_group_code",
+                "mine_id_pudl",
+                "supplier_name",
+                "fuel_received_units",
+                "fuel_mmbtu_per_unit",
+                "sulfur_content_pct",
+                "ash_content_pct",
+                "mercury_content_ppm",
+                "fuel_cost_per_mmbtu",
+                "primary_transportation_mode_code",
+                "secondary_transportation_mode_code",
+                "natural_gas_transport_code",
+                "natural_gas_delivery_contract_type_code",
+                "moisture_content_pct",
+                "chlorine_content_ppm",
+            ],
+        },
+        "group": "eia",
+        "sources": ["eia923"],
+    },
+    "generation_eia923": {
+        "description": "EIA-923 Monthly Generating Unit Net Generation Time Series. From EIA-923 Schedule 3.",
+        "schema": {
+            "fields": [
+                "plant_id_eia",
+                "generator_id",
+                "report_date",
+                "net_generation_mwh",
+            ],
+            "primary_key": ["plant_id_eia", "generator_id", "report_date"],
+        },
+        "group": "eia",
+        "sources": ["eia923"],
+    },
+    "generation_fuel_eia923": {
+        "description": "EIA-923 Monthly Generation and Fuel Consumption Time Series. From EIA-923 Schedule 3. Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a plant. This table does not include data from nuclear plants as they report at the generation unit level, rather than the plant level. See the generation_fuel_nuclear_eia923 table for nuclear electricity generation and fuel consumption.",
+        "schema": {
+            "fields": [
+                "plant_id_eia",
+                "report_date",
+                "energy_source_code",
+                "fuel_type_code_pudl",
+                "fuel_type_code_aer",
+                "prime_mover_code",
+                "fuel_consumed_units",
+                "fuel_consumed_for_electricity_units",
+                "fuel_mmbtu_per_unit",
+                "fuel_consumed_mmbtu",
+                "fuel_consumed_for_electricity_mmbtu",
+                "net_generation_mwh",
+            ],
+            "primary_key": [
+                "plant_id_eia",
+                "report_date",
+                "energy_source_code",
+                "prime_mover_code"
+            ],
+        },
+        "group": "eia",
+        "sources": ["eia923"],
+    },
+    "generation_fuel_nuclear_eia923": {
+        "description": "EIA-923 Monthly Generation and Fuel Consumption Time Series. From EIA-923 Schedule 3. Monthly electricity generation and fuel consumption reported for each combination of fuel and prime mover within a nuclear generation unit.",
+        "schema": {
+            "fields": [
+                "plant_id_eia",
+                "report_date",
+                "nuclear_unit_id",
+                "energy_source_code",
+                "fuel_type_code_pudl",
+                "fuel_type_code_aer",
+                "prime_mover_code",
+                "fuel_consumed_units",
+                "fuel_consumed_for_electricity_units",
+                "fuel_mmbtu_per_unit",
+                "fuel_consumed_mmbtu",
+                "fuel_consumed_for_electricity_mmbtu",
+                "net_generation_mwh",
+            ],
+            "primary_key": [
+                "plant_id_eia",
+                "report_date",
+                "nuclear_unit_id",
+                "energy_source_code",
+                "prime_mover_code"
+            ],
+        },
+        "group": "eia",
+        "sources": ["eia923"],
+    },
+}
+"""
+EIA-923 resource attributes organized by PUDL identifier (``resource.name``).
+
+Keys are in alphabetical order.
+
+See :func:`pudl.metadata.helpers.build_foreign_keys` for the expected format of
+``foreign_key_rules``.
+"""

--- a/src/pudl/metadata/resources/epacems.py
+++ b/src/pudl/metadata/resources/epacems.py
@@ -28,7 +28,6 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             ],
             "primary_key": ["plant_id_eia", "unitid", "operating_datetime_utc"],
         },
-        "group": "epacems",
         "sources": ["eia860", "epacems"],
     },
 }

--- a/src/pudl/metadata/resources/epacems.py
+++ b/src/pudl/metadata/resources/epacems.py
@@ -3,6 +3,7 @@ from typing import Any, Dict
 
 RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
     "hourly_emissions_epacems": {
+        "description": "Hourly emissions and plant operational data reported via Continuous Emissions Monitoring Systems as required by 40 CFR Part 75.",
         "schema": {
             "fields": [
                 "state",
@@ -28,7 +29,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             "primary_key": ["plant_id_eia", "unitid", "operating_datetime_utc"],
         },
         "group": "epacems",
-        "sources": ["epacems"],
+        "sources": ["eia860", "epacems"],
     },
 }
 """

--- a/src/pudl/metadata/resources/ferc1.py
+++ b/src/pudl/metadata/resources/ferc1.py
@@ -25,6 +25,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             "fields": ["ferc_account_id", "ferc_account_description"],
             "primary_key": ["ferc_account_id"],
         },
+        "sources": ["ferc1"],
     },
     "ferc_depreciation_lines": {
         "description": "PUDL assigned FERC Form 1 line identifiers and long descriptions from FERC Form 1 page 219, Accumulated Provision for Depreciation of Electric Utility Plant (Account 108).",
@@ -33,6 +34,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             "primary_key": ["line_id"],
             "foreign_key_rules": {"fields": [["line_id"]]},
         },
+        "sources": ["ferc1"],
     },
     "fuel_ferc1": {
         "description": "Annual fuel cost and quanitiy for steam plants with a capacity of 25+ MW, internal combustion and gas-turbine plants of 10+ MW, and all nuclear plants. As reported on page 402 of FERC Form 1 and extracted from the f1_fuel table in FERC's FoxPro Database.",
@@ -51,6 +53,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 "fuel_cost_per_mmbtu",
             ],
         },
+        "sources": ["ferc1"],
     },
     "plant_in_service_ferc1": {
         "description": "Balances and changes to FERC Electric Plant in Service accounts, as reported on FERC Form 1. Data originally from the f1_plant_in_srvce table in FERC's FoxPro database. Account numbers correspond to the FERC Uniform System of Accounts for Electric Plant, which is defined in Code of Federal Regulations (CFR) Title 18, Chapter I, Subchapter C, Part 101. (See e.g. https://www.law.cornell.edu/cfr/text/18/part-101). Each FERC respondent reports starting and ending balances for each account annually. Balances are organization wide, and are not broken down on a per-plant basis. End of year balance should equal beginning year balance plus the sum of additions, retirements, adjustments, and transfers.",
@@ -159,7 +162,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
         "sources": ["ferc1"],
     },
     "plants_ferc1": {
-        "title": "FERC 1 Plants",
+        "description": "FERC 1 Plants and their associated manually assigned PUDL Plant IDs",
         "schema": {
             "fields": ["utility_id_ferc1", "plant_name_ferc1", "plant_id_pudl"],
             "primary_key": ["utility_id_ferc1", "plant_name_ferc1"],
@@ -169,6 +172,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 ],
             },
         },
+        "sources": ["ferc1"],
     },
     "plants_hydro_ferc1": {
         "description": "Hydroelectric generating plant statistics for large plants. Large plants have an installed nameplate capacity of more than 10 MW. As reported on FERC Form 1, pages 406-407, and extracted from the f1_hydro table in FERC's FoxPro database.",
@@ -369,6 +373,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             "primary_key": ["utility_id_ferc1"],
             "foreign_key_rules": {"fields": [["utility_id_ferc1"]]},
         },
+        "sources": ["ferc1"],
     },
 }
 """

--- a/src/pudl/metadata/resources/ferc714.py
+++ b/src/pudl/metadata/resources/ferc714.py
@@ -14,6 +14,7 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
             "primary_key": ["respondent_id_ferc714"],
             "foreign_key_rules": {"fields": [["respodnent_id_ferc714"]]}
         },
+        "sources": ["ferc714"],
     },
     "demand_hourly_pa_ferc714": {
         "description": "Hourly electricity demand by plannting area. FERC Form 714, Part III, Schedule 2a.",
@@ -26,7 +27,8 @@ RESOURCE_METADATA: Dict[str, Dict[str, Any]] = {
                 "demand_mwh",
             ],
             "primary_key": ["respondent_id_ferc714", "utc_datetime"]
-        }
+        },
+        "sources": ["ferc714"],
     }
 }
 """

--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -9,7 +9,6 @@ import pudl
 from pudl import constants as pc
 from pudl.constants import PUDL_TABLES
 from pudl.metadata.codes import ENERGY_SOURCES_EIA
-from pudl.metadata.labels import ENTITY_TYPES
 
 logger = logging.getLogger(__name__)
 
@@ -584,9 +583,6 @@ def utilities(eia860_dfs, eia860_transformed_dfs):
         u_df.astype({
             "utility_id_eia": "Int64"
         })
-        .assign(
-            entity_type=lambda x: x.entity_type.map(ENTITY_TYPES)
-        )
         .pipe(pudl.helpers.convert_to_date)
         .fillna({'entity_type': pd.NA})
     )

--- a/src/pudl/transform/eia861.py
+++ b/src/pudl/transform/eia861.py
@@ -14,8 +14,7 @@ from pudl.constants import PUDL_TABLES
 from pudl.metadata.enums import (CUSTOMER_CLASSES, FUEL_CLASSES, NERC_REGIONS,
                                  RELIABILITY_STANDARDS, REVENUE_CLASSES,
                                  RTO_CLASSES, TECH_CLASSES)
-from pudl.metadata.labels import (ENTITY_TYPES, ESTIMATED_OR_ACTUAL,
-                                  MOMENTARY_INTERRUPTIONS)
+from pudl.metadata.labels import ESTIMATED_OR_ACTUAL, MOMENTARY_INTERRUPTIONS
 
 logger = logging.getLogger(__name__)
 
@@ -1860,11 +1859,6 @@ def mergers(tfr_dfs):
     """
     Transform the EIA 861 Mergers table.
 
-    Transformations include:
-
-    * Map full spelling onto code values.
-    * Retain preceeding zeros in zipcode field.
-
     Args:
         tfr_dfs (dict): A dictionary of transformed EIA 861 DataFrames, keyed by table
             name. It will be mutated by this function.
@@ -1873,21 +1867,7 @@ def mergers(tfr_dfs):
         dict: A dictionary of transformed EIA 861 dataframes, keyed by table name.
 
     """
-    raw_mergers = tfr_dfs["mergers_eia861"].copy()
-
-    # No data tidying required
-
-    ###########################################################################
-    # Transform Values:
-    # * Turn ownership column from single-letter code to full ownership category.
-    # * Retain preceeding zeros in zip codes
-    ###########################################################################
-
-    transformed_mergers = (
-        raw_mergers.assign(
-            entity_type=lambda x: x.entity_type.map(ENTITY_TYPES),
-        )
-    )
+    transformed_mergers = tfr_dfs["mergers_eia861"].copy()
 
     # No duplicates to speak of but take measures to check just in case
     _check_for_dupes(

--- a/tox.ini
+++ b/tox.ini
@@ -95,7 +95,6 @@ extras =
     test
 commands =
     pytest {posargs} {[testenv]covargs} \
-# Ignore deprecated datapkg modules:
       --doctest-modules {envsitepackagesdir}/pudl \
       test/unit
 


### PR DESCRIPTION
Getting the table-level metadata integrated into `dev` now will help @katie-lamb close #1253 

To that end this PR does:
* [x] Update table-level descriptions and data sources #1333 
* [x] Split the EIA resource definitions into `eia`, `eia860`, `eia861` and `eia923` resource modules (they're getting looong).
* [x] Remove constraints on the `entity_type` field as it is so variable across different data sources and types. See #669 and #1392.