### PR TITLE
WIP: Dagster EPA CEMS Prototype

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -39,11 +39,11 @@ dependencies:
   # Helpful for profiling PUDL
   - py-spy
 
-  # dagster testing
-  - dagster~=0.13.0
-  - dagit~=0.13.0
-  - dagster-pandas~=0.13.0
 
   # Use pip to install the main PUDL repo / package for development:
   - pip:
     - --editable ../[doc,test,dev]
+    # dagster testing
+    - dagster~=0.14.0
+    - dagit~=0.14.0
+    - dagster-pandas~=0.14.0

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -42,6 +42,7 @@ dependencies:
   # dagster testing
   - dagster~=0.13.0
   - dagit~=0.13.0
+  - dagster-pandas~=0.13.0
 
   # Use pip to install the main PUDL repo / package for development:
   - pip:

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -39,6 +39,10 @@ dependencies:
   # Helpful for profiling PUDL
   - py-spy
 
+  # dagster testing
+  - dagster~=0.13.0
+  - dagit~=0.13.0
+
   # Use pip to install the main PUDL repo / package for development:
   - pip:
     - --editable ../[doc,test,dev]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     install_requires=[
         "addfips~=0.3.1",
         "catalystcoop.dbfread~=3.0",
-        "coloredlogs~=15.0",
+        "coloredlogs~=14.0",
         "datapackage~=1.11",  # Transition datastore to use frictionless.
         # "email-validator>=1.0.3",  # pydantic[email] dependency
         "fsspec>=2021.7,<2023.0",

--- a/src/pudl/dagster_etl.py
+++ b/src/pudl/dagster_etl.py
@@ -41,6 +41,8 @@ def load_epacems(context, transformed_df: pd.DataFrame):
     )
     yield Output(root_path)
 
+# The configurable @resources the ETL depends on.
+
 
 @resource
 def pudl_settings(init_context):
@@ -66,6 +68,8 @@ def datastore(init_context):
         ds_kwargs["local_cache_path"] = Path(
             init_context.resources.pudl_settings["pudl_in"]) / "data"
     return Datastore(**ds_kwargs)
+
+# The @job that links the ETL @ops together
 
 
 @job(resource_defs={"pudl_settings": pudl_settings, "datastore": datastore, "pudl_engine": pudl_engine})

--- a/src/pudl/dagster_etl.py
+++ b/src/pudl/dagster_etl.py
@@ -4,7 +4,8 @@ from pathlib import Path
 import pandas as pd
 import sqlalchemy as sa
 from dagster import (AssetMaterialization, EventMetadata, Field, In, Output,
-                     job, op, resource, static_partitioned_config)
+                     job, multiprocess_executor, op, resource,
+                     static_partitioned_config)
 
 import pudl
 from pudl.helpers import (compute_dataframe_summary_statistics,
@@ -79,7 +80,12 @@ def partition_config(partition_key: str):
     return {"ops": {"extract": {"config": {"partition": partition_key}}}}
 
 
-@job(resource_defs={"pudl_settings": pudl_settings, "datastore": datastore, "pudl_engine": pudl_engine}, config=partition_config)
+mutliprocess_forserver = multiprocess_executor.configured(
+    {"start_method": {"forkserver": {}}}
+)
+
+
+@job(resource_defs={"pudl_settings": pudl_settings, "datastore": datastore, "pudl_engine": pudl_engine}, config=partition_config, executor_def=mutliprocess_forserver)
 def etl_epacems_dagster():
     """Run the full EPA CEMS ETL."""
     epacems_raw_dfs = pudl.extract.epacems.extract()

--- a/src/pudl/dagster_etl.py
+++ b/src/pudl/dagster_etl.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pandas as pd
 import sqlalchemy as sa
 from dagster import (AssetMaterialization, EventMetadata, Field, In, Output,
-                     job, multiprocess_executor, op, resource,
+                     in_process_executor, job, op, resource,
                      static_partitioned_config)
 
 import pudl
@@ -80,12 +80,7 @@ def partition_config(partition_key: str):
     return {"ops": {"extract": {"config": {"partition": partition_key}}}}
 
 
-mutliprocess_forserver = multiprocess_executor.configured(
-    {"start_method": {"forkserver": {}}}
-)
-
-
-@job(resource_defs={"pudl_settings": pudl_settings, "datastore": datastore, "pudl_engine": pudl_engine}, config=partition_config, executor_def=mutliprocess_forserver)
+@job(resource_defs={"pudl_settings": pudl_settings, "datastore": datastore, "pudl_engine": pudl_engine}, config=partition_config, executor_def=in_process_executor)
 def etl_epacems_dagster():
     """Run the full EPA CEMS ETL."""
     epacems_raw_dfs = pudl.extract.epacems.extract()

--- a/src/pudl/dagster_etl.py
+++ b/src/pudl/dagster_etl.py
@@ -23,8 +23,9 @@ def load_epacems(context, transformed_df):
 
     # Format of the mapping key makes it difficult to recreate the final parquet path.
     yield AssetMaterialization(
-        asset_key=context.get_mapping_key(),
+        asset_key="hourly_emissions_epacems",
         description="Persisted result to storage",
+        partition=context.get_mapping_key(),
         metadata={
             "Description": "Parquet file.",
             "Path": EventMetadata.path(str(root_path)),

--- a/src/pudl/dagster_etl.py
+++ b/src/pudl/dagster_etl.py
@@ -1,0 +1,41 @@
+"""Dagster version of EPA CEMS ETL."""
+from pathlib import Path
+
+from dagster import job, op, resource
+
+import pudl
+from pudl.workspace.datastore import Datastore
+
+
+@op(required_resource_keys={"pudl_settings"})
+def load_epacems(context, transformed_df):
+    """Load epacems to parquet."""
+    pudl.load.df_to_parquet(
+        transformed_df,
+        resource_id="hourly_emissions_epacems",
+        root_path=Path(context.resources.pudl_settings["parquet_dir"]) / "epacems",
+        partition_cols=["year", "state"]
+    )
+
+
+@resource
+def pudl_settings(init_context):
+    """Create a pudl engine Resource."""
+    # TODO: figure out how to config the pudl workspace using dagster instead of just pulling the defaults.
+    return pudl.workspace.setup.get_defaults()
+
+
+@resource(config_schema={"gcs_cache_path": str, "local_cache_path": str})
+def datastore(init_context):
+    """Datastore resource. This can be configured in the dagit UI."""
+    gcs_cache_path = init_context.resource_config["gcs_cache_path"]
+    local_cache_path = init_context.resource_config["local_cache_path"]
+    return Datastore(gcs_cache_path=gcs_cache_path, local_cache_path=local_cache_path)
+
+
+@job(resource_defs={"pudl_settings": pudl_settings, "datastore": datastore})
+def etl_epacems_dagster():
+    """Run the full EPA CEMS ETL."""
+    epacems_raw_dfs = pudl.extract.epacems.extract()
+    epacems_transformed_dfs = epacems_raw_dfs.map(pudl.transform.epacems.transform)
+    epacems_transformed_dfs.map(load_epacems)

--- a/src/pudl/dagster_etl.py
+++ b/src/pudl/dagster_etl.py
@@ -1,6 +1,7 @@
 """Dagster version of EPA CEMS ETL."""
 from pathlib import Path
 
+import pandas as pd
 import sqlalchemy as sa
 from dagster import (AssetMaterialization, EventMetadata, Field, Output, job,
                      op, resource)
@@ -10,7 +11,7 @@ from pudl.workspace.datastore import Datastore
 
 
 @op(required_resource_keys={"pudl_settings"})
-def load_epacems(context, transformed_df):
+def load_epacems(context, transformed_df: pd.DataFrame):
     """Load epacems to parquet."""
     root_path = Path(context.resources.pudl_settings["parquet_dir"]) / "epacems"
 

--- a/src/pudl/dagster_etl.py
+++ b/src/pudl/dagster_etl.py
@@ -28,9 +28,9 @@ def load_epacems(context, transformed_df: pd.DataFrame):
         description="Persisted result to storage",
         partition=context.get_mapping_key(),
         metadata={
-            "Description": "Parquet file.",
+            "Description": f"Parquet file of {context.get_mapping_key()} EPA CEMS data.",
             "Path": EventMetadata.path(str(root_path)),
-            "DataFrame Size (Bytes)": int(transformed_df.memory_usage().sum())
+            "Number of Rows": len(transformed_df)
         },
     )
     yield Output(root_path)

--- a/src/pudl/extract/epacems.py
+++ b/src/pudl/extract/epacems.py
@@ -199,16 +199,12 @@ def gather_partitions(context):
 
 
 @op(required_resource_keys={"datastore"})
-def extract(context, partition):
+def extract(context, partition: EpaCemsPartition) -> pd.DataFrame:
     """
     Coordinate the extraction of EPA CEMS hourly DataFrames.
 
     Args:
-        epacems_years (list): The years of CEMS data to extract, as 4-digit
-            integers.
-        states (list): The states whose CEMS data we want to extract, indicated
-            by 2-letter US state codes.
-        ds (:class:`Datastore`): Initialized datastore
+        partition: A single EPA CEMS partitions (year, state).
 
     Yields:
         pandas.DataFrame: A single state-year of EPA CEMS hourly emissions data.

--- a/src/pudl/extract/epacems.py
+++ b/src/pudl/extract/epacems.py
@@ -198,8 +198,8 @@ def gather_partitions(context):
             yield DynamicOutput(EpaCemsPartition(state=state, year=year), mapping_key=f"{state}{year}")
 
 
-@op(required_resource_keys={"datastore"})
-def extract(context, partition: EpaCemsPartition) -> pd.DataFrame:
+@op(required_resource_keys={"datastore"}, config_schema={"partition": str})
+def extract(context) -> pd.DataFrame:
     """
     Coordinate the extraction of EPA CEMS hourly DataFrames.
 
@@ -210,6 +210,8 @@ def extract(context, partition: EpaCemsPartition) -> pd.DataFrame:
         pandas.DataFrame: A single state-year of EPA CEMS hourly emissions data.
 
     """
+    year, state = context.op_config["partition"].split("-")
+    partition = EpaCemsPartition(state=state, year=int(year))
     ds = EpaCemsDatastore(context.resources.datastore)
     logger.info(
         f"Processing EPA CEMS hourly data for {partition.state}-{partition.year}")

--- a/src/pudl/extract/epacems.py
+++ b/src/pudl/extract/epacems.py
@@ -10,7 +10,7 @@ from zipfile import ZipFile
 
 import pandas as pd
 import sqlalchemy as sa
-from dagster import DynamicOut, DynamicOutput, Field, Output, op
+from dagster import Any, DynamicOut, DynamicOutput, Field, Output, op
 
 import pudl.constants as pc
 from pudl.settings import EpaCemsSettings
@@ -152,13 +152,13 @@ class EpaCemsDatastore:
 @op(
     out=DynamicOut(EpaCemsPartition),
     config_schema={
-        'years': Field(list, description='years', default_value=[2020]),
-        'states': Field(list, default_value=["ID"]),
+        'years': Field(Any, description='Years to process.', default_value=list(pc.WORKING_PARTITIONS['epacems']['years'])),
+        'states': Field(Any, description='States to process.', default_value=list(pc.WORKING_PARTITIONS['epacems']['states'])),
     },
     required_resource_keys={"pudl_engine"}
 )
 def gather_partitions(context):
-    """Gather CEMS partitions."""
+    """Gather CEMS partitions, validate settings and PUDL DB plant attributes."""
     # Validate the partitions
     # Could maybe replace our pydantic settings models with
     # Dagster Types that check working partitions and tables.

--- a/src/pudl/extract/epacems.py
+++ b/src/pudl/extract/epacems.py
@@ -10,7 +10,7 @@ from zipfile import ZipFile
 
 import pandas as pd
 import sqlalchemy as sa
-from dagster import DynamicOut, DynamicOutput, Field, op
+from dagster import DynamicOut, DynamicOutput, Field, Output, op
 
 import pudl.constants as pc
 from pudl.settings import EpaCemsSettings
@@ -218,4 +218,4 @@ def extract(context, partition: EpaCemsPartition) -> pd.DataFrame:
         ds.get_data_frame(partition)
         .assign(year=partition.year)
     )
-    return df
+    return Output(df, metadata={"Number of Rows": len(df)})

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -1251,3 +1251,12 @@ def compute_dataframe_summary_statistics(df):
         "columns": str(df.columns),
         "is_na_pct": (df.isna().sum() / len(df)).to_dict()
     }
+
+
+def create_epacems_partitions():
+    """Create tuple partitions of EPA CEMS partitions."""
+    states = pc.WORKING_PARTITIONS['epacems']['states']
+    years = pc.WORKING_PARTITIONS['epacems']['years']
+
+    partitions = itertools.product(years, states)
+    return list(map(lambda par: f"{par[0]}-{par[1]}", partitions))

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -1242,3 +1242,12 @@ def convert_df_to_excel_file(df: pd.DataFrame, **kwargs) -> pd.ExcelFile:
     workbook = bio.read()
 
     return pd.ExcelFile(workbook)
+
+
+def compute_dataframe_summary_statistics(df):
+    """Compute dataframe summary stats for dagster runs."""
+    return {
+        "n_rows": len(df),
+        "columns": str(df.columns),
+        "is_na_pct": (df.isna().sum() / len(df)).to_dict()
+    }

--- a/src/pudl/metadata/constants.py
+++ b/src/pudl/metadata/constants.py
@@ -5,6 +5,7 @@ from typing import Callable, Dict, List, Type
 import pandas as pd
 import pyarrow as pa
 import sqlalchemy as sa
+from dagster_pandas import PandasColumn
 
 FIELD_DTYPES_PANDAS: Dict[str, str] = {
     "string": "string",
@@ -55,6 +56,16 @@ CONSTRAINT_DTYPES: Dict[str, Type] = {
 """
 Python types for field constraints by PUDL field type (Data Package `field.type`).
 """
+
+DAGSTER_DTYPES: Dict[str, PandasColumn] = {
+    'string': PandasColumn.string_column,
+    'integer': PandasColumn.integer_column,
+    'year': PandasColumn.integer_column,
+    'number': PandasColumn.float_column,
+    'boolean': PandasColumn.boolean_column,
+    'date': PandasColumn.datetime_column,
+    'datetime': PandasColumn.datetime_column
+}
 
 LICENSES: Dict[str, Dict[str, str]] = {
     "cc-by-4.0": {

--- a/src/pudl/transform/epacems.py
+++ b/src/pudl/transform/epacems.py
@@ -211,7 +211,7 @@ def correct_gross_load_mw(df):
 
 
 @op(
-    required_resource_keys={"pudl_settings"}
+    required_resource_keys={"pudl_engine"}
 )
 def transform(context, raw_df):
     """
@@ -227,9 +227,7 @@ def transform(context, raw_df):
         pandas.Dataframe: A single year-state of EPA CEMS data,
 
     """
-    # epacems_raw_dfs is a generator. Pull out one dataframe, run it through
-    # a transformation pipeline, and yield it back as another generator.
-    pudl_engine = sa.create_engine(context.resources.pudl_settings["pudl_db"])
+    pudl_engine = context.resources.pudl_engine
     plant_utc_offset = _load_plant_utc_offset(pudl_engine)
     transformed_df = (
         raw_df.fillna({

--- a/src/pudl/transform/epacems.py
+++ b/src/pudl/transform/epacems.py
@@ -7,7 +7,7 @@ import numpy as np
 import pandas as pd
 import pytz
 import sqlalchemy as sa
-from dagster import op
+from dagster import Output, op
 
 import pudl
 
@@ -224,6 +224,8 @@ def transform(context, raw_df: pd.DataFrame) -> pd.DataFrame:
         pandas.Dataframe: A single year-state of EPA CEMS data,
 
     """
+    # TODO: Each of these transform functions could be their own
+    # @op within a transform subgraph
     pudl_engine = context.resources.pudl_engine
     plant_utc_offset = _load_plant_utc_offset(pudl_engine)
     transformed_df = (
@@ -241,4 +243,4 @@ def transform(context, raw_df: pd.DataFrame) -> pd.DataFrame:
             "hourly_emissions_epacems"
         )
     )
-    return transformed_df
+    return Output(transformed_df, metadata={"Number of Rows": len(transformed_df)})

--- a/src/pudl/transform/epacems.py
+++ b/src/pudl/transform/epacems.py
@@ -213,15 +213,12 @@ def correct_gross_load_mw(df):
 @op(
     required_resource_keys={"pudl_engine"}
 )
-def transform(context, raw_df):
+def transform(context, raw_df: pd.DataFrame) -> pd.DataFrame:
     """
     Transform EPA CEMS hourly data and ready it for export to Parquet.
 
     Args:
-        epacems_raw_dfs: a :class:`pandas.Dataframe` generator that yields raw
-            epacems data, one state-year at a time.
-        pudl_engine: a :class:`sqlalchemy.engine.Engine` for connecting to an
-            existing PUDL DB.
+        raw_df: An extracted partition of EPA CEMS data.
 
     Yields:
         pandas.Dataframe: A single year-state of EPA CEMS data,

--- a/workspace.yaml
+++ b/workspace.yaml
@@ -1,0 +1,2 @@
+load_from:
+  - python_package: pudl.dagster_etl


### PR DESCRIPTION
This PR contains a [Dagster](https://dagster.io/) EPA CEMS prototype. 

#1406 contains our reasoning for exploring Dagster. #1432 contain our goals for the prototype. 

# README
## Setup
Recreate your `pudl-dev` environment to install dagster and dagit. 

To start the dagster UI (dagit), run this command from the pudl root directory:
```
dagit -m pudl.dagster_etl
```

Then start the dagster-daemon in a separate terminal window: 
```
dagster-daemon run
```

## Run the ETL
Dagit should be running at http://127.0.0.1:3000/. You will see a window with three tabs, Overview, Launchpad, and Runs. The Overview tab contains a DAG of our CEMS pipeline. You can click on the different nodes to explore information about the op. 

To process all of Idaho's data, go to the Launchpad tab. The Launchpad tab contains a little text editor to specify a run config. It's kind of like our settings yaml files. Copy and paste this config into the window:
```
ops:
  gather_partitions:
    config:
      states:
        - ID
```
Click, Launch Run in the very bottom right corner of the screen. That should kick off a run and bring you to a window with a fun gantt chart and logging information. A green circle should say "Success" at the top of the screen when the run finishes. The run will take a couple of minutes (I will write up my findings on performance). 

Once the run finishes, you can go to the Asset window in the upper right-hand corner of the screen. Click on the `hourly_emissions_epacems` asset. There should be a list of processed partitions. You can click on each partition to view its metadata, like the number of rows and location. 

## Findings
If you review the code or run the ETL, feel free to add your findings to #1432.