### PR TITLE
Update to pip 22, setuptools 61. Add nbconvert to pudl-dev

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -4,9 +4,9 @@ channels:
   - defaults
 dependencies:
   # Used to set up the environment
-  - pip>=21.0,<22
+  - pip>=21,<23
   - python>=3.8,<3.11
-  - setuptools<60.0.0
+  - setuptools<62
   # These packages are also specified in setup.py
   # However, they depend on or benefit from binary libraries
   # which conda can install.
@@ -28,7 +28,7 @@ dependencies:
   # Jupyter notebook specific packages:
   - dask-labextension~=5.1
   - jupyter-resource-usage~=0.5.0
-  - jupyter_contrib_nbextensions~=0.5.1
+  - nbconvert>=6,<7
   - seaborn~=0.11.0
   - jupyterlab~=3.2
   - nbdime~=3.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools<60.0.0", "pip", "wheel", "setuptools_scm"]
+requires = ["setuptools<62", "pip>=21,<23", "wheel", "setuptools_scm"]
 
 [tool.setuptools_scm]
 


### PR DESCRIPTION
Update a couple of build environment packages that don't get automatically bumped by dependabot since they aren't in `setup.py`. Also replace the huge and old `jupyter_contrib_nbextensions` package with the small and current `nbconvert` which is all we really need to clear notebook outputs in pre-commit land.