### PR TITLE
Remove some seldom used dependencies from pudl-dev environment.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ codecov.sh
 *wheel-metadata
 dask-worker-space*
 devtools/user-requirements.txt
+devtools/user-environment.yml
 .vscode/*
 commit.txt
 devtools/profiles/

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -26,15 +26,9 @@ dependencies:
   - recordlinkage>=0.14,<0.16 # Used for fuzzy merge between FERC/EIA for RMI
 
   # Jupyter notebook specific packages:
-  - dask-labextension~=5.1
   - jupyter-resource-usage~=0.5.0
   - nbconvert>=6,<7
-  - seaborn~=0.11.0
   - jupyterlab~=3.2
-  - nbdime~=3.1.0
-
-  # Helpful for profiling PUDL
-  - py-spy
 
   # Use pip to install the main PUDL repo / package for development:
   - pip:


### PR DESCRIPTION
The `dask-labextension`, `py-spy`, `nbdime` and `seaborn` packages are only used occasionally and only by some people, so I wanted to pull them out of the default `pudl-dev` environment to slim it down a little bit.