### PR TITLE
Fix breakage resulting from dask v2022.4.2

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -23,7 +23,7 @@ jobs:
         channel-priority: true
         python-version: ${{ matrix.python-version }}
         activate-environment: pudl-test
-        environment-file: devtools/ci-environment.yml
+        environment-file: test/test-environment.yml
     - shell: bash -l {0}
       run: |
         conda info

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -18,6 +18,21 @@ Database Schema Changes
   column to an annually harvested data column (i.e. from :ref:`generators_entity_eia`
   to :ref:`generators_eia860`) :pr:`1600`. See :issue:`1585` for more details.
 
+Bug Fixes
+^^^^^^^^^
+
+* `Dask v2022.4.2 <https://docs.dask.org/en/stable/changelog.html#v2022-04-2>`__
+  introduced breaking changes into :meth:`dask.dataframe.read_parquet`.  However, we
+  didn't catch this when it happened because it's only a problem when there's more than
+  one row-group. Now we're processing 2019-2020 data for both ID and ME (two of the
+  smallest states) in the tests. Also restricted the allowed Dask versions in our
+  ``setup.py`` so that we get notified by the dependabot any time even a minor update.
+  happens to any of the packages we depend on that use calendar versioning. See
+  :pr:`1618`.
+* Fixed a testing bug where the partitioned EPA CEMS outputs generated using parallel
+  processing were getting output in the same output directory as the real ETL, which
+  should never happen. See :pr:`1618`.
+
 .. _release-v0-6-0:
 
 ---------------------------------------------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -51,11 +51,11 @@ setup(
         "addfips~=0.3.1",
         "catalystcoop.dbfread~=3.0",
         "coloredlogs~=15.0",
-        "dask>=2021.8,<2023.0",
+        "dask>=2021.8,<2022.5.1",
         "datapackage~=1.11",  # Transition datastore to use frictionless.
         # "email-validator>=1.0.3",  # pydantic[email] dependency
-        "fsspec>=2021.7,<2023.0",  # For caching datastore on GCS
-        "gcsfs>=2021.7,<2023.0",  # For caching datastore on GCS
+        "fsspec>=2021.7,<2022.3.1",  # For caching datastore on GCS
+        "gcsfs>=2021.7,<2022.3.1",  # For caching datastore on GCS
         "geopandas>=0.9,<0.11",
         "jinja2>=2,<4",
         "matplotlib>=3.3,<4",  # Should make this optional with a "viz" extras

--- a/src/pudl/output/epacems.py
+++ b/src/pudl/output/epacems.py
@@ -165,6 +165,8 @@ def epacems(
         use_nullable_dtypes=True,
         columns=columns,
         engine="pyarrow",
+        index=False,
+        split_row_groups=True,
         filters=year_state_filter(
             states=epacems_settings.states,
             years=epacems_settings.years,

--- a/src/pudl/package_data/settings/etl_fast.yml
+++ b/src/pudl/package_data/settings/etl_fast.yml
@@ -63,8 +63,7 @@ datasets:
       # Note that the CEMS data relies on EIA 860 data for plant locations,
       # so if you're loading CEMS data for a particular year, you should
       # also load the EIA 860 data for that year if possible
-      # Just Idaho, because it is tiny:
-      states: [ID]
+      states: [ID, ME]
       years: [
-          2020
+          2019, 2020
       ]

--- a/src/pudl/package_data/settings/etl_full.yml
+++ b/src/pudl/package_data/settings/etl_full.yml
@@ -10,127 +10,125 @@ ferc1_to_sqlite_settings:
     ]
     # A list of tables to be loaded into the local SQLite database. These are
     # the table names as they appear in the 2015 FERC Form 1 database.
-    tables: [
-        f1_respondent_id,
-        f1_acb_epda,
-        f1_accumdepr_prvsn,
-        f1_accumdfrrdtaxcr,
-        f1_adit_190_detail,
-        f1_adit_190_notes,
-        f1_adit_amrt_prop,
-        f1_adit_other,
-        f1_adit_other_prop,
-        f1_allowances,
-        f1_bal_sheet_cr,
-        f1_capital_stock,
-        f1_cash_flow,
-        f1_cmmn_utlty_p_e,
-        f1_comp_balance_db,
-        f1_construction,
-        f1_control_respdnt,
-        f1_co_directors,
-        f1_cptl_stk_expns,
-        f1_csscslc_pcsircs,
-        f1_dacs_epda,
-        f1_dscnt_cptl_stk,
-        f1_edcfu_epda,
-        f1_elctrc_erg_acct,
-        f1_elctrc_oper_rev,
-        f1_elc_oper_rev_nb,
-        f1_elc_op_mnt_expn,
-        f1_electric,
-        f1_envrnmntl_expns,
-        f1_envrnmntl_fclty,
-        f1_fuel,
-        f1_general_info,
-        f1_gnrt_plant,
-        f1_important_chg,
-        f1_incm_stmnt_2,
-        f1_income_stmnt,
-        f1_miscgen_expnelc,
-        f1_misc_dfrrd_dr,
-        f1_mthly_peak_otpt,
-        f1_mtrl_spply,
-        f1_nbr_elc_deptemp,
-        f1_nonutility_prop,
-        f1_nuclear_fuel,
-        f1_officers_co,
-        f1_othr_dfrrd_cr,
-        f1_othr_pd_in_cptl,
-        f1_othr_reg_assets,
-        f1_othr_reg_liab,
-        f1_overhead,
-        f1_pccidica,
-        f1_plant_in_srvce,
-        f1_pumped_storage,
-        f1_purchased_pwr,
-        f1_reconrpt_netinc,
-        f1_reg_comm_expn,
-        f1_respdnt_control,
-        f1_retained_erng,
-        f1_r_d_demo_actvty,
-        f1_sales_by_sched,
-        f1_sale_for_resale,
-        f1_sbsdry_totals,
-        f1_schedules_list,
-        f1_security_holder,
-        f1_slry_wg_dstrbtn,
-        f1_substations,
-        f1_taxacc_ppchrgyr,
-        f1_unrcvrd_cost,
-        f1_utltyplnt_smmry,
-        f1_work,
-        f1_xmssn_adds,
-        f1_xmssn_elc_bothr,
-        f1_xmssn_elc_fothr,
-        f1_xmssn_line,
-        f1_xtraordnry_loss,
-        f1_codes_val,
-        f1_sched_lit_tbl,
-        f1_audit_log,
-        f1_col_lit_tbl,
-        f1_load_file_names,
-        f1_privilege,
-        f1_sys_error_log,
-        f1_unique_num_val,
-        f1_row_lit_tbl,
-        f1_hydro,
-        f1_ident_attsttn,
-        f1_steam,
-        f1_leased,
-        f1_sbsdry_detail,
-        f1_plant,
-        f1_long_term_debt,
-        f1_106_2009,
-        f1_106a_2009,
-        f1_106b_2009,
-        f1_208_elc_dep,
-        f1_231_trn_stdycst,
-        f1_324_elc_expns,
-        f1_325_elc_cust,
-        f1_331_transiso,
-        f1_338_dep_depl,
-        f1_397_isorto_stl,
-        f1_398_ancl_ps,
-        f1_399_mth_peak,
-        f1_400_sys_peak,
-        f1_400a_iso_peak,
-        f1_429_trans_aff,
-        f1_allowances_nox,
-        f1_cmpinc_hedge_a,
-        f1_cmpinc_hedge,
-        f1_email,
-        f1_rg_trn_srv_rev,
-        f1_s0_checks,
-        f1_s0_filing_log,
-        f1_security
-    #   f1_note_fin_stmnt, # Huge junk table, 52% of the data by MB
-    #   f1_footnote_tbl,   # Huge junk table, 37% of DB
-    #   f1_footnote_data,  # Only useful with f1_footnote_tbl
-    #   f1_pins,    # private database table, not publicly distributed
-    #   f1_freeze,  # private database table, not publicly distributed
-    ]
-
+    tables:
+      - f1_respondent_id
+      - f1_acb_epda
+      - f1_accumdepr_prvsn
+      - f1_accumdfrrdtaxcr
+      - f1_adit_190_detail
+      - f1_adit_190_notes
+      - f1_adit_amrt_prop
+      - f1_adit_other
+      - f1_adit_other_prop
+      - f1_allowances
+      - f1_bal_sheet_cr
+      - f1_capital_stock
+      - f1_cash_flow
+      - f1_cmmn_utlty_p_e
+      - f1_comp_balance_db
+      - f1_construction
+      - f1_control_respdnt
+      - f1_co_directors
+      - f1_cptl_stk_expns
+      - f1_csscslc_pcsircs
+      - f1_dacs_epda
+      - f1_dscnt_cptl_stk
+      - f1_edcfu_epda
+      - f1_elctrc_erg_acct
+      - f1_elctrc_oper_rev
+      - f1_elc_oper_rev_nb
+      - f1_elc_op_mnt_expn
+      - f1_electric
+      - f1_envrnmntl_expns
+      - f1_envrnmntl_fclty
+      - f1_fuel
+      - f1_general_info
+      - f1_gnrt_plant
+      - f1_important_chg
+      - f1_incm_stmnt_2
+      - f1_income_stmnt
+      - f1_miscgen_expnelc
+      - f1_misc_dfrrd_dr
+      - f1_mthly_peak_otpt
+      - f1_mtrl_spply
+      - f1_nbr_elc_deptemp
+      - f1_nonutility_prop
+      - f1_nuclear_fuel
+      - f1_officers_co
+      - f1_othr_dfrrd_cr
+      - f1_othr_pd_in_cptl
+      - f1_othr_reg_assets
+      - f1_othr_reg_liab
+      - f1_overhead
+      - f1_pccidica
+      - f1_plant_in_srvce
+      - f1_pumped_storage
+      - f1_purchased_pwr
+      - f1_reconrpt_netinc
+      - f1_reg_comm_expn
+      - f1_respdnt_control
+      - f1_retained_erng
+      - f1_r_d_demo_actvty
+      - f1_sales_by_sched
+      - f1_sale_for_resale
+      - f1_sbsdry_totals
+      - f1_schedules_list
+      - f1_security_holder
+      - f1_slry_wg_dstrbtn
+      - f1_substations
+      - f1_taxacc_ppchrgyr
+      - f1_unrcvrd_cost
+      - f1_utltyplnt_smmry
+      - f1_work
+      - f1_xmssn_adds
+      - f1_xmssn_elc_bothr
+      - f1_xmssn_elc_fothr
+      - f1_xmssn_line
+      - f1_xtraordnry_loss
+      - f1_codes_val
+      - f1_sched_lit_tbl
+      - f1_audit_log
+      - f1_col_lit_tbl
+      - f1_load_file_names
+      - f1_privilege
+      - f1_sys_error_log
+      - f1_unique_num_val
+      - f1_row_lit_tbl
+      - f1_hydro
+      - f1_ident_attsttn
+      - f1_steam
+      - f1_leased
+      - f1_sbsdry_detail
+      - f1_plant
+      - f1_long_term_debt
+      - f1_106_2009
+      - f1_106a_2009
+      - f1_106b_2009
+      - f1_208_elc_dep
+      - f1_231_trn_stdycst
+      - f1_324_elc_expns
+      - f1_325_elc_cust
+      - f1_331_transiso
+      - f1_338_dep_depl
+      - f1_397_isorto_stl
+      - f1_398_ancl_ps
+      - f1_399_mth_peak
+      - f1_400_sys_peak
+      - f1_400a_iso_peak
+      - f1_429_trans_aff
+      - f1_allowances_nox
+      - f1_cmpinc_hedge_a
+      - f1_cmpinc_hedge
+      - f1_email
+      - f1_rg_trn_srv_rev
+      - f1_s0_checks
+      - f1_s0_filing_log
+      - f1_security
+    # - f1_note_fin_stmnt  # Huge junk table, 52% of the data by MB
+    # - f1_footnote_tbl    # Huge junk table, 37% of DB
+    # - f1_footnote_data   # Only useful with f1_footnote_tbl
+    # - f1_pins     # private database table, not publicly distributed
+    # - f1_freeze   # private database table, not publicly distributed
 
 name: pudl-full
 title: PUDL Full ETL
@@ -181,7 +179,6 @@ datasets:
       # Note that the CEMS data relies on EIA 860 data for plant locations,
       # so if you're loading CEMS data for a particular year, you should
       # also load the EIA 860 data for that year if possible
-      # Just Idaho, because it is tiny:
       states: [all]
       years: [
           1995, 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004,

--- a/test/integration/epacems_test.py
+++ b/test/integration/epacems_test.py
@@ -67,15 +67,25 @@ def test_epacems_subset_input_validation(epacems_year_and_state, epacems_parquet
             epacems(epacems_path=path, **combo)
 
 
-def test_epacems_parallel(pudl_settings_fixture, pudl_ds_kwargs):
+def test_epacems_parallel(pudl_settings_fixture, pudl_ds_kwargs, tmpdir_factory):
     """Test that we can run the EPA CEMS ETL in parallel."""
     epacems_settings = EpaCemsSettings(
-        years=[2019, 2020], states=["ID", "WY"], partition=True
+        years=[2019, 2020], states=["ID", "ME"], partition=True
     )
-    etl_epacems(epacems_settings, pudl_settings_fixture, pudl_ds_kwargs)
+    # We need a temporary output directory to avoid dropping the ID/ME 2019/2020
+    # parallel outputs in the real output directory and interfering with the normal
+    # monolithic outputs.
+    parquet_tmp = tmpdir_factory.mktemp("parquet_tmp")
+    epacems_tmp = Path(parquet_tmp, "epacems")
+    epacems_tmp.mkdir()
+    settings_tmp = {k: v for k, v in pudl_settings_fixture.items()}
+    settings_tmp["parquet_dir"] = parquet_tmp
+    etl_epacems(epacems_settings, settings_tmp, pudl_ds_kwargs)
     df = dd.read_parquet(
-        Path(pudl_settings_fixture["parquet_dir"]) / "epacems",
-        filters=year_state_filter(years=[2019], states=["WY"]),
+        epacems_tmp,
+        filters=year_state_filter(years=[2019], states=["ME"]),
         index=False,
+        engine="pyarrow",
+        split_row_groups=True,
     ).compute()
-    assert df.shape == (219000, 19)  # nosec: B101
+    assert df.shape == (96_360, 19)  # nosec: B101

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -1,7 +1,6 @@
 name: pudl-test
 channels:
   - conda-forge
-  - defaults
 dependencies:
   - geopandas>=0.9,<11
   - numba>=0.55.1,<0.56


### PR DESCRIPTION
Dask introduced breaking changes to `dd.read_parquet()` in v 2022.4.2:
https://docs.dask.org/en/stable/changelog.html#v2022-04-2

However, we didn't catch this when it happened because it's only a
problem when there's more than one row-group. So now I'm processing
2019-2020 data for both ID and ME (two of the smallest states).  I was
already processing 4 state-years when testing the parallelized CEMS ETL
so this isn't any more data that we were pulling before.

Also fixed a bug that the parallelized ETL test introduced, where it was
writing the partitioned output to the same directory as the other CEMS
output, which might have been creating weird behavior.

I put more stringent bounds around the Dask versions in `setup.py` so
we'll at least be notified by @dependabot if a version changes now.

Moved the CI environment file under tests, since it's more related to
them than "devtools" and in preparation for configuring `tox-conda` to
use conda environments to (partly) manage the tox builds:

https://github.com/tox-dev/tox-conda