### PR TITLE
Address issue where 861 ETL fails w/o all years of data

### DIFF
--- a/src/pudl/transform/eia861.py
+++ b/src/pudl/transform/eia861.py
@@ -856,9 +856,23 @@ def balancing_authority(tfr_dfs):
     )
 
     # Fill in BA IDs based on date, utility ID, and BA Name:
-    df.loc[
-        BA_ID_NAME_FIXES.index, "balancing_authority_id_eia"
-    ] = BA_ID_NAME_FIXES.balancing_authority_id_eia
+    # using merge and then reverse backfilling balancing_authority_id_eia means
+    # that this will work even if not all years are requested
+    df = (  # this replaces the previous process to address #828
+        df.merge(
+            BA_ID_NAME_FIXES,
+            on=["report_date", "balancing_authority_name_eia", "utility_id_eia"],
+            how="left",
+            validate="m:1",
+            suffixes=(None, "_"),
+        )
+        .assign(
+            balancing_authority_id_eia=lambda x: x.balancing_authority_id_eia_.fillna(
+                x.balancing_authority_id_eia
+            )
+        )
+        .drop(columns=["balancing_authority_id_eia_"])
+    )
 
     # Backfill BA Codes based on BA IDs:
     df = df.reset_index().pipe(_ba_code_backfill)


### PR DESCRIPTION
Proposing a minor change to how balancing authority fixes are applied so that not all years of data are required to make the fixes work. This should address #828.

In the existing process, when I try do something like this:

```python
pudl_out = PudlTabl(...)
pudl_out.etl_eia861(eia861_settings=Eia861Settings(years=sorted(range(2005, 2021)))
```

I get an error in these lines of code because there are values in `BA_ID_NAME_FIXES.index` that are not in `df.index`.

https://github.com/catalyst-cooperative/pudl/blob/6e71bfa1a848f67ffeb1f10a161af01db75073b8/src/pudl/transform/eia861.py#L859-L861

I played around a little bit and I think replacing that with the merge I suggest here addresses the problem and all the tests appear to pass when I run them locally.

Given the small size of the change, I didn't think any additional documentation beyond the brief comment was needed but happy to add if that would be helpful.


