### PR TITLE
Require Python 3.10 in the pudl-dev conda environment

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   # Used to set up the environment
   - pip>=21,<23
-  - python>=3.8,<3.11
+  - python>=3.10,<3.11
   - setuptools<63
   # These packages are also specified in setup.py
   # However, they depend on or benefit from binary libraries


### PR DESCRIPTION
Require Python 3.10 in our `pudl-dev` conda environment.  This was overlooked in the previous Lib to App PR.