### PR TITLE
Unpin apt-get packages

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -105,3 +105,12 @@ jobs:
       # Start the VM
       - name: Start the deploy-pudl-vm
         run: gcloud compute instances start "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE"
+
+      - name: Post to a pudl-deployments channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.19.0
+        with:
+          channel-id: "C03FHB9N0PQ"
+          slack-message: "build-deploy-pudl status: ${{ job.status }}\n$ACTION_SHA-$CHECKOUT_BRANCH"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GCP_BILLING_PROJECT: ${{ secrets.GCP_BILLING_PROJECT }}
-  CHECKOUT_BRANCH: ${{ github.ref_name }} # This is changed to dev if running on a schedule
+  GITHUB_REF: ${{ github.ref_name }} # This is changed to dev if running on a schedule
   GCE_INSTANCE: pudl-deployment-tag # This is changed to pudl-deployment-tag if running on a schedule
   GCE_INSTANCE_ZONE: us-central1-a
 
@@ -21,12 +21,12 @@ jobs:
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule or manually triggered
         if: ${{ (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch') }}
         run: |
-          echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "CHECKOUT_BRANCH=dev" >> $GITHUB_ENV
+          echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "GITHUB_REF=dev" >> $GITHUB_ENV
 
       - name: Checkout Repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ env.CHECKOUT_BRANCH }}
+          ref: ${{ env.GITHUB_REF }}
 
       - name: Get HEAD of the branch (main or dev)
         run: |
@@ -35,7 +35,7 @@ jobs:
       - name: Print action vars
         run: |
           echo "ACTION_SHA: $ACTION_SHA" && \
-          echo "CHECKOUT_BRANCH: $CHECKOUT_BRANCH" && \
+          echo "GITHUB_REF: $GITHUB_REF" && \
           echo "GCE_INSTANCE: $GCE_INSTANCE"
 
       - name: Docker Metadata
@@ -46,7 +46,7 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=ref,event=branch
+            type=raw,value=${{ env.GITHUB_REF }}
             type=ref,event=tag
 
       - name: Set up Docker Buildx
@@ -86,7 +86,7 @@ jobs:
             --metadata-from-file startup-script=./docker/vm_startup_script.sh
           gcloud compute instances update-container "$GCE_INSTANCE" \
             --zone "$GCE_INSTANCE_ZONE" \
-            --container-image "docker.io/catalystcoop/pudl-etl:${{github.ref_name}}" \
+            --container-image "docker.io/catalystcoop/pudl-etl:${{ env.GITHUB_REF }}" \
             --container-command "conda" \
             --container-arg="run" \
             --container-arg="--no-capture-output" \
@@ -96,11 +96,15 @@ jobs:
             --container-arg="./docker/gcp_pudl_etl.sh" \
             --container-env-file="./docker/.env" \
             --container-env ACTION_SHA=$ACTION_SHA \
-            --container-env GITHUB_REF=${{ github.ref_name }} \
+            --container-env GITHUB_REF=${{ env.GITHUB_REF }} \
             --container-env API_KEY_EIA=${{ secrets.API_KEY_EIA }} \
             --container-env SLACK_TOKEN=${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }} \
             --container-env GCE_INSTANCE=${{ env.GCE_INSTANCE }} \
             --container-env GCP_BILLING_PROJECT=${{ secrets.GCP_BILLING_PROJECT }}
+
+      # Start the VM
+      - name: Start the deploy-pudl-vm
+        run: gcloud compute instances start "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE"
 
       # Start the VM
       - name: Start the deploy-pudl-vm
@@ -111,6 +115,6 @@ jobs:
         uses: slackapi/slack-github-action@v1.19.0
         with:
           channel-id: "C03FHB9N0PQ"
-          slack-message: "build-deploy-pudl status: ${{ job.status }}\n$ACTION_SHA-$CHECKOUT_BRANCH"
+          slack-message: "build-deploy-pudl status: ${{ job.status }}\n${{ env.ACTION_SHA }}-${{ env.GITHUB_REF }}"
         env:
           SLACK_BOT_TOKEN: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule or manually triggered
-        if: ${{ (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch') }}
+        if: ${{ (github.event_name == 'schedule') }}
         run: |
           echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "GITHUB_REF=dev" >> $GITHUB_ENV
 

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -106,10 +106,6 @@ jobs:
       - name: Start the deploy-pudl-vm
         run: gcloud compute instances start "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE"
 
-      # Start the VM
-      - name: Start the deploy-pudl-vm
-        run: gcloud compute instances start "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE"
-
       - name: Post to a pudl-deployments channel
         id: slack
         uses: slackapi/slack-github-action@v1.19.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
 FROM condaforge/mambaforge:4.12.0-0
 
 # Install curl and js
-RUN apt-get update && apt-get install --no-install-recommends -y curl=7.68.0-1ubuntu2.11 jq=1.6-1ubuntu0.20.04.1 \
+# hadolint ignore=DL3008
+RUN apt-get update && apt-get install --no-install-recommends -y curl jq \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Unpin apt-get packages so we don't have to update the Dockerfile every time there is a new version of `curl` and `jq`. The most recent nightly build failed because it couldn't find an old version of curl. 

This PR also adds a step that notifies slack of the final status of the github action. 