### PR TITLE
Add forms 6 and 60 to datasources

### DIFF
--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -351,9 +351,9 @@ SOURCES: dict[str, Any] = {
         "description": (
             "The Federal Energy Regulatory Commission (FERC) Form 60 is a "
             "comprehensive financial and operating report submitted for centralized "
-            "centralized service companies."
+            "service companies."
         ),
-        "field_namespace": "ferc6",
+        "field_namespace": "ferc60",
         "working_partitions": {
             "years": [],  # Not yet working!
         },

--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -330,6 +330,36 @@ SOURCES: dict[str, Any] = {
         "license_raw": LICENSES["us-govt"],
         "license_pudl": LICENSES["cc-by-4.0"],
     },
+    "ferc6": {
+        "title": "FERC Form 6",
+        "path": "https://www.ferc.gov/general-information-1/oil-industry-forms/form-6-6q-historical-vfp-data",
+        "description": (
+            "The Federal Energy Regulatory Commission (FERC) Form 6 is a "
+            "comprehensive financial and operating report submitted for oil "
+            "pipelines rate regulation and financial audits."
+        ),
+        "field_namespace": "ferc6",
+        "working_partitions": {
+            "years": [],  # Not yet working!
+        },
+        "license_raw": LICENSES["us-govt"],
+        "license_pudl": LICENSES["cc-by-4.0"],
+    },
+    "ferc60": {
+        "title": "FERC Form 60",
+        "path": "https://www.ferc.gov/general-information-1/oil-industry-forms/form-6-6q-historical-vfp-data",
+        "description": (
+            "The Federal Energy Regulatory Commission (FERC) Form 60 is a "
+            "comprehensive financial and operating report submitted for centralized "
+            "centralized service companies."
+        ),
+        "field_namespace": "ferc6",
+        "working_partitions": {
+            "years": [],  # Not yet working!
+        },
+        "license_raw": LICENSES["us-govt"],
+        "license_pudl": LICENSES["cc-by-4.0"],
+    },
     "ferc714": {
         "title": "FERC Form 714: Annual Electric Balancing Authority Area and Planning Area Report",
         "path": "https://www.ferc.gov/industries-data/electric/general-information/electric-industry-forms/form-no-714-annual-electric",


### PR DESCRIPTION
# Background
This pull request adds FERC Forms 6 and 60 datasources. It does not integrate these forms into PUDL in any way, but it will enable us to archive them on Zenodo. This will enable the use of the [FERC XBRL Extractor](https://github.com/catalyst-cooperative/ferc-xbrl-extractor/tree/main/src/ferc_xbrl_extractor) to create raw SQLite databases containing data extracted from filings of these forms.