### PR TITLE
Fix dependabot automerge

### DIFF
--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -1,5 +1,5 @@
 ---
-name: pre-commit-ci-auto-merge
+name: bot-auto-merge
 
 on:
   workflow_run:

--- a/.github/workflows/pre-commit-ci-auto-merge.yaml
+++ b/.github/workflows/pre-commit-ci-auto-merge.yaml
@@ -8,12 +8,21 @@ on:
 
 jobs:
   bot-auto-merge:
-    name: Auto-merge passing pre-commit-ci PRs
+    name: Auto-merge passing bot PRs
     runs-on: ubuntu-latest
     steps:
+      - name: Auto-merge passing dependabot PRs
+        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+        uses: ridedott/merge-me-action@v2
+        with:
+          # For clarity only. dependabot is default.
+          GITHUB_LOGIN: dependabot
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLED_FOR_MANUAL_CHANGES: "true"
       - name: Auto-merge passing pre-commit-ci PRs
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: ridedott/merge-me-action@v2
         with:
           GITHUB_LOGIN: pre-commit-ci
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENABLED_FOR_MANUAL_CHANGES: "true"

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -90,14 +90,3 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }} # required
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
           MATRIX_CONTEXT: ${{ toJson(matrix) }} # required
-
-  dependabot-auto-merge:
-    runs-on: ubuntu-latest
-    needs: ci-test
-    if: ${{ needs.ci-test.result == 'success' }}
-    steps:
-      - name: Automerge passing dependabot PR
-        uses: ridedott/merge-me-action@v2
-        with:
-          GITHUB_LOGIN: dependabot # For clarity only. dependabot is default.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Apply the same post-workflow `merge-me-action` to the dependabot PRs as we use for the pre-commit-ci merges, since the dependabot permissions within the `tox-pytest` workflow seem to be insufficient.