### PR TITLE
Fix bug in gens mega and plant part list creation

### DIFF
--- a/src/pudl/analysis/mcoe.py
+++ b/src/pudl/analysis/mcoe.py
@@ -26,6 +26,17 @@ DEFAULT_GENS_COLS = [
     "fuel_type_code_pudl",
     "planned_retirement_date",
 ]
+"""
+list: default list of columns from the EIA 860 generators table that will be included
+in the MCOE table. These default columns are necessary for the creation of the EIA
+plant parts table.
+
+The ID and name columns are all that's needed to create a bare-bones MCOE table.
+
+The remaining columns are used during the creation of the plant parts list as
+different attributes to aggregate the plant parts by or are attributes necessary
+for inclusion in the final table.
+"""
 
 
 def heat_rate_by_unit(pudl_out):

--- a/src/pudl/analysis/mcoe.py
+++ b/src/pudl/analysis/mcoe.py
@@ -16,8 +16,15 @@ DEFAULT_GENS_COLS = [
     "utility_id_eia",
     "utility_id_pudl",
     "utility_name_eia",
-    "fuel_type_code_pudl",
+    "technology_description",
+    "energy_source_code_1",
+    "prime_mover_code",
+    "operating_date",
+    "retirement_date",
+    "operational_status",
     "capacity_mw",
+    "fuel_type_code_pudl",
+    "planned_retirement_date",
 ]
 
 

--- a/src/pudl/output/pudltabl.py
+++ b/src/pudl/output/pudltabl.py
@@ -1121,7 +1121,7 @@ class PudlTabl:
             gens_cols: equal to the string "all", None, or a list of
                 additional column attributes to include from the EIA 860 generators table
                 in the output mega gens table. By default all columns necessary to create
-                the mega generators table are included.
+                the plant parts EIA table are included.
 
         Returns:
             A table of all of the generators with identifying
@@ -1154,6 +1154,8 @@ class PudlTabl:
                     "retirement_date",
                     "operational_status",
                     "capacity_mw",
+                    "fuel_type_code_pudl",
+                    "planned_retirement_date",
                 ]
                 gens_cols = list(set(gens_cols + default_cols))
             self._dfs[


### PR DESCRIPTION
This fixes a bug with the default generator columns argument in the output tables for `mcoe`, `gens_mega`, and `plant_parts_eia` described in [this issue](https://github.com/catalyst-cooperative/pudl/issues/1755). The default generator columns argument was introduced through `date_merge`.

**What is the bug?**
The `plant_parts_eia` table relies on the `gens_mega` table and in turn the `gens_mega` table relies on the `mcoe` table. 
Each of these tables requires certain generator columns in order to be created. The `plant_parts_eia` table requires the most columns and the `mcoe` table requires the fewest number of columns. I initially thought it would be okay for each of these tables to have their own set of default generator columns (only the columns necessary for the creation of that individual table). 

When you call `pudl_out.plant_parts_eia()` first, this works fine, because the `plant_parts_eia` list of generator columns are passed to `mcoe` and `gens_mega` and each of these tables are newly generated with this set of PPL columns.

But when you call `pudl_out.mcoe()` or `pudl_out.gens_mega` before calling `pudl_out.plant_parts_eia`, then the MCOE and `gens_mega` tables don't update because they are cached and thus these tables don't have the complete list of generator columns necessary to create the plant parts list. 

**What does this fix do?**
I didn't want to set `update=True` for the MCOE and `gens_mega` table every time the `plant_parts_eia` table is created because this is inefficient if the user has already gone to the trouble of creating the `gens_mega` or MCOE table. So I fixed this issue by changing the default generator columns in the `gens_mega` and `mcoe` tables to be the same as the default columns for `plant_parts_eia`. This was the easiest and safest fix. However this means that by default, extra columns (those necessary to make the PPL) will be included when creating these tables, which isn't ideal. 

An alternative would be to check what columns are in the cached MCOE and `gens_mega` table, and update the table if the complete list of `gens_cols` aren't already in the table. I think this would be faster than fully regenerating the tables because the input dependencies for these tables are already cached. 

Closes #1755 