### PR TITLE
Use gcs cache in ci

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -72,7 +72,7 @@ jobs:
       - id: "auth"
         uses: "google-github-actions/auth@v0"
         with:
-          credentials_json: "${{ secrets.GCE_SA_KEY }}"
+          credentials_json: "${{ secrets.DEPLOY_PUDL_SA_KEY }}"
 
       # Setup gcloud CLI
       - name: Set up Cloud SDK

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           API_KEY_EIA: ${{ secrets.API_KEY_EIA }}
         run: |
-          conda run -n pudl-test tox -- --gcs-cache-path gs://zenodo-cache.catalyst.coop --loglevel DEBUG
+          conda run -n pudl-test tox -- --gcs-cache-path gs://zenodo-cache.catalyst.coop
 
       - name: Log post-test Zenodo datastore contents
         run: find ~/pudl-work/data/

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -55,6 +55,12 @@ jobs:
           conda run -n pudl-test which sqlite3
           conda run -n pudl-test sqlite3 --version
 
+      - name: Set default gcp credentials
+        id: gcloud-auth
+        uses: "google-github-actions/auth@v0"
+        with:
+          credentials_json: "${{ secrets.TOX_PYTEST_SA_KEY }}"
+
       - name: Run PyTest with Tox
         env:
           API_KEY_EIA: ${{ secrets.API_KEY_EIA }}

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -59,7 +59,7 @@ jobs:
         env:
           API_KEY_EIA: ${{ secrets.API_KEY_EIA }}
         run: |
-          conda run -n pudl-test tox
+          conda run -n pudl-test tox -- --gcs-cache-path gs://zenodo-cache.catalyst.coop
 
       - name: Log post-test Zenodo datastore contents
         run: find ~/pudl-work/data/

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -65,7 +65,7 @@ jobs:
         env:
           API_KEY_EIA: ${{ secrets.API_KEY_EIA }}
         run: |
-          conda run -n pudl-test tox -- --gcs-cache-path gs://zenodo-cache.catalyst.coop
+          conda run -n pudl-test tox -- --gcs-cache-path gs://zenodo-cache.catalyst.coop --loglevel DEBUG
 
       - name: Log post-test Zenodo datastore contents
         run: find ~/pudl-work/data/

--- a/docs/dev/nightly_data_builds.rst
+++ b/docs/dev/nightly_data_builds.rst
@@ -31,7 +31,7 @@ The ``gcloud`` command in ``build-deploy-pudl`` requires certain Google Cloud
 Platform (GCP) permissions to start and update the GCE instance. The
 ``gcloud`` command authenticates using a service account key for the
 ``deploy-pudl-github-action`` service account stored in PUDL's GitHub secrets
-as ``GCE_SA_KEY``. The ``deploy-pudl-github-action`` service account has
+as ``DEPLOY_PUDL_SA_KEY``. The ``deploy-pudl-github-action`` service account has
 the `Compute Instance Admin (v1) IAM <https://cloud.google.com/iam/docs/understanding-roles#compute-engine>`__
 role on the GCE instances to update the container and start the instance.
 

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -296,7 +296,7 @@ class Datastore:
             except DefaultCredentialsError:
                 logger.info(
                     f"Unable to obtain credentials for GCS Cache at {gcs_cache_path}. "
-                    "Falling back to obtaining archived data from Zenodo directly."
+                    "Falling back to Zenodo if necessary."
                 )
                 pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -259,7 +259,7 @@ addopts = --verbose --pdbcls=IPython.terminal.debugger:TerminalPdb
 log_format = %(asctime)s [%(levelname)8s] %(name)s:%(lineno)s %(message)s
 log_date_format= %Y-%m-%d %H:%M:%S
 log_cli = true
-log_cli_level = info
+log_cli_level = debug
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS
 filterwarnings =
     ignore:distutils Version classes are deprecated:DeprecationWarning


### PR DESCRIPTION
Tell Tox to tell pytest to default to pulling data from the GCS Cache in the Github CI workflow, to increase the reliability of the tests on here.