### PR TITLE
Use internal zenodo-cache bucket for nightly builds

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build Docker image, push to Docker Hub and deploy to a GCE VM
     runs-on: ubuntu-latest
     steps:
-      - name: Use pudl-deployment-dev vm and dev branch if running on a schedule or manually triggered
+      - name: Use pudl-deployment-dev vm and dev branch if running on a schedule
         if: ${{ (github.event_name == 'schedule') }}
         run: |
           echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "GITHUB_REF=dev" >> $GITHUB_ENV
@@ -77,6 +77,10 @@ jobs:
       # Setup gcloud CLI
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
+
+      # Make sure the public and private zenodo-cache buckets are in sync
+      - name: Sync zenodo-cache buckets
+        run: gsutil -m rsync -d -r gs://internal-zenodo-cache.catalyst.coop gs://zenodo-cache.catalyst.coop
 
       # Deploy PUDL image to GCE
       - name: Deploy

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -97,7 +97,6 @@ jobs:
             --container-env-file="./docker/.env" \
             --container-env ACTION_SHA=$ACTION_SHA \
             --container-env GITHUB_REF=${{ env.GITHUB_REF }} \
-            --container-env API_KEY_EIA=${{ secrets.API_KEY_EIA }} \
             --container-env SLACK_TOKEN=${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }} \
             --container-env GCE_INSTANCE=${{ env.GCE_INSTANCE }} \
             --container-env GCP_BILLING_PROJECT=${{ secrets.GCP_BILLING_PROJECT }}

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -52,16 +52,17 @@ jobs:
 
       - name: Skip build and deploy if deployment already exists
         id: check-deployment-exists
-        run: echo "::set-output name=exists::$(gsutil -q stat gs://pudl-etl-logs/$ACTION_SHA-$GITHUB_REF/pudl-etl.log)"
+        run: echo "::set-output name=exists::$(gsutil -q stat gs://pudl-etl-logs/$ACTION_SHA-$GITHUB_REF/pudl-etl.log; echo $?)"
 
   build_and_deploy_pudl:
     name: Build Docker image, push to Docker Hub and deploy to a GCE VM
     runs-on: ubuntu-latest
     needs: check_for_existing_deployments
-    if: needs.check.outputs.status == false
+    if: needs.check.outputs.exists != 0
     steps:
       - name: echo previous step outputs
-        run: echo ${{ needs.check.outputs.status }}
+        run: echo ${{ needs.check.outputs.exists }}
+
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule or manually triggered
         if: ${{ (github.event_name == 'schedule') }}
         run: |

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -60,6 +60,8 @@ jobs:
     needs: check_for_existing_deployments
     if: needs.check.outputs.status == false
     steps:
+      - name: echo previous step outputs
+        run: echo ${{ needs.check.outputs.status }}
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule or manually triggered
         if: ${{ (github.event_name == 'schedule') }}
         run: |

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -14,55 +14,10 @@ env:
   GCE_INSTANCE_ZONE: us-central1-a
 
 jobs:
-  check_for_existing_deployments:
-    name: Check if there is already a log file for this commit and branch.
-    runs-on: ubuntu-latest
-    outputs:
-      output1: ${{ steps.check-deployment-exists.outputs.exists }}
-    steps:
-      - name: Use pudl-deployment-dev vm and dev branch if running on a schedule or manually triggered
-        if: ${{ (github.event_name == 'schedule') }}
-        run: |
-          echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "GITHUB_REF=dev" >> $GITHUB_ENV
-
-      - name: Checkout Repository
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ env.GITHUB_REF }}
-
-      - name: Get HEAD of the branch (main or dev)
-        run: |
-          echo "ACTION_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
-
-      - name: Print action vars
-        run: |
-          echo "ACTION_SHA: $ACTION_SHA" && \
-          echo "GITHUB_REF: $GITHUB_REF" && \
-          echo "GCE_INSTANCE: $GCE_INSTANCE"
-
-      # Authentication via credentials json
-      - id: "auth"
-        uses: "google-github-actions/auth@v0"
-        with:
-          credentials_json: "${{ secrets.DEPLOY_PUDL_SA_KEY }}"
-
-      # Setup gcloud CLI
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0
-
-      - name: Skip build and deploy if deployment already exists
-        id: check-deployment-exists
-        run: echo "::set-output name=exists::$(gsutil -q stat gs://pudl-etl-logs/$ACTION_SHA-$GITHUB_REF/pudl-etl.log; echo $?)"
-
   build_and_deploy_pudl:
     name: Build Docker image, push to Docker Hub and deploy to a GCE VM
     runs-on: ubuntu-latest
-    needs: check_for_existing_deployments
-    if: needs.check.outputs.exists != 0
     steps:
-      - name: echo previous step outputs
-        run: echo ${{ needs.check.outputs.exists }}
-
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule or manually triggered
         if: ${{ (github.event_name == 'schedule') }}
         run: |
@@ -122,10 +77,6 @@ jobs:
       # Setup gcloud CLI
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
-
-      # Make sure the public and private zenodo-cache buckets are in sync
-      - name: Sync zenodo-cache buckets
-        run: gsutil -m rsync -d -r gs://zenodo-cache.catalyst.coop gs://zenodo-cache-internal
 
       # Deploy PUDL image to GCE
       - name: Deploy

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -14,9 +14,51 @@ env:
   GCE_INSTANCE_ZONE: us-central1-a
 
 jobs:
+  check_for_existing_deployments:
+    name: Check if there is already a log file for this commit and branch.
+    runs-on: ubuntu-latest
+    outputs:
+      output1: ${{ steps.check-deployment-exists.outputs.exists }}
+    steps:
+      - name: Use pudl-deployment-dev vm and dev branch if running on a schedule or manually triggered
+        if: ${{ (github.event_name == 'schedule') }}
+        run: |
+          echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "GITHUB_REF=dev" >> $GITHUB_ENV
+
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ env.GITHUB_REF }}
+
+      - name: Get HEAD of the branch (main or dev)
+        run: |
+          echo "ACTION_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
+
+      - name: Print action vars
+        run: |
+          echo "ACTION_SHA: $ACTION_SHA" && \
+          echo "GITHUB_REF: $GITHUB_REF" && \
+          echo "GCE_INSTANCE: $GCE_INSTANCE"
+
+      # Authentication via credentials json
+      - id: "auth"
+        uses: "google-github-actions/auth@v0"
+        with:
+          credentials_json: "${{ secrets.DEPLOY_PUDL_SA_KEY }}"
+
+      # Setup gcloud CLI
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+
+      - name: Skip build and deploy if deployment already exists
+        id: check-deployment-exists
+        run: echo "::set-output name=exists::$(gsutil -q stat gs://pudl-etl-logs/$ACTION_SHA-$GITHUB_REF/pudl-etl.log)"
+
   build_and_deploy_pudl:
     name: Build Docker image, push to Docker Hub and deploy to a GCE VM
     runs-on: ubuntu-latest
+    needs: check_for_existing_deployments
+    if: needs.check.outputs.status == false
     steps:
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule or manually triggered
         if: ${{ (github.event_name == 'schedule') }}

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -78,10 +78,6 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
 
-      # Make sure the public and private zenodo-cache buckets are in sync
-      - name: Sync zenodo-cache buckets
-        run: gsutil -m rsync -d -r gs://internal-zenodo-cache.catalyst.coop gs://zenodo-cache.catalyst.coop
-
       # Deploy PUDL image to GCE
       - name: Deploy
         run: |-

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -78,6 +78,10 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
 
+      # Make sure the public and private zenodo-cache buckets are in sync
+      - name: Sync zenodo-cache buckets
+        run: gsutil -m rsync -d -r gs://zenodo-cache.catalyst.coop gs://zenodo-cache-internal
+
       # Deploy PUDL image to GCE
       - name: Deploy
         run: |-

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -91,7 +91,8 @@ function run_deployment() {
 }
 
 if gsutil -q stat gs://pudl-etl-logs/$ACTION_SHA-$GITHUB_REF/pudl-etl.log; then
-    echo "Outputs for $ACTION_SHA-$GITHUB_REF already exist. Skipping the build.";
+    echo "Skipping deployment for $ACTION_SHA-$GITHUB_REF because outputs already exist for this commit.";
+    send_slack_msg "Skipping deployment for $ACTION_SHA-$GITHUB_REF because outputs already exist for this commit :cat:"
 else
     echo "Running the ETL"
     run_deployment

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -20,23 +20,23 @@ function run_pudl_etl() {
     && ferc1_to_sqlite \
         --clobber \
         --loglevel DEBUG \
-        --gcs-cache-path gs://zenodo-cache-internal \
+        --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         --bypass-local-cache \
         $PUDL_SETTINGS_YML \
     && pudl_etl \
         --clobber \
         --loglevel DEBUG \
-        --gcs-cache-path gs://zenodo-cache-internal \
+        --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         --bypass-local-cache \
         $PUDL_SETTINGS_YML \
     && epacems_to_parquet \
         --partition \
         --clobber \
         --loglevel DEBUG \
-        --gcs-cache-path gs://zenodo-cache-internal \
+        --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         --bypass-local-cache \
     && pytest \
-        --gcs-cache-path gs://zenodo-cache-internal \
+        --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         --bypass-local-cache \
         --etl-settings $PUDL_SETTINGS_YML \
         --live-dbs test
@@ -59,6 +59,7 @@ function copy_outputs_to_intake_bucket() {
     gsutil -m -u $GCP_BILLING_PROJECT cp -r "$CONTAINER_PUDL_OUT/sqlite/*" "gs://intake.catalyst.coop/$GITHUB_REF"
     gsutil -m -u $GCP_BILLING_PROJECT cp -r "$CONTAINER_PUDL_OUT/parquet/epacems/*" "gs://intake.catalyst.coop/$GITHUB_REF"
 }
+
 
 function notify_slack() {
     # Notify pudl-builds slack channel of deployment status

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -20,23 +20,23 @@ function run_pudl_etl() {
     && ferc1_to_sqlite \
         --clobber \
         --loglevel DEBUG \
-        --gcs-cache-path gs://zenodo-cache.catalyst.coop \
+        --gcs-cache-path gs://zenodo-cache-internal \
         --bypass-local-cache \
         $PUDL_SETTINGS_YML \
     && pudl_etl \
         --clobber \
         --loglevel DEBUG \
-        --gcs-cache-path gs://zenodo-cache.catalyst.coop \
+        --gcs-cache-path gs://zenodo-cache-internal \
         --bypass-local-cache \
         $PUDL_SETTINGS_YML \
     && epacems_to_parquet \
         --partition \
         --clobber \
         --loglevel DEBUG \
-        --gcs-cache-path gs://zenodo-cache.catalyst.coop \
+        --gcs-cache-path gs://zenodo-cache-internal \
         --bypass-local-cache \
     && pytest \
-        --gcs-cache-path gs://zenodo-cache.catalyst.coop \
+        --gcs-cache-path gs://zenodo-cache-internal \
         --bypass-local-cache \
         --etl-settings $PUDL_SETTINGS_YML \
         --live-dbs test


### PR DESCRIPTION
I created a private copy of `zenodo-cache.catalyst.coop` called `zenodo-cache-internal` using the [gsutil rsync](https://cloud.google.com/storage/docs/gsutil/commands/rsync#using--d-option-with-caution-to-mirror-source-and-destination.) command. 

I also added a `gsutil rsync` step to the `build-deploy-pudl.yml` workflow to make sure the VM has the most recent data from `gs://zenodo-cache.catalyst.coop`. We could also flip this, so the public bucket follows the internal bucket. This might make more sense, given the nightly builds will update the internal bucket more frequently. What do your think @zaneselvans 

Hopefully this solves the random `BadRequest` errors 🤞 