### PR TITLE
Update ETL settings files to work with XBRL+DBF and new Ferc1Settings

### DIFF
--- a/src/pudl/package_data/settings/etl_fast.yml
+++ b/src/pudl/package_data/settings/etl_fast.yml
@@ -53,12 +53,12 @@ datasets:
     tables:
       - fuel_ferc1 # requires plants_steam_ferc1 to load properly
       - plants_steam_ferc1
-      - plants_small_ferc1
-      - plants_hydro_ferc1
-      - plants_pumped_storage_ferc1
-      - plant_in_service_ferc1
-      - purchased_power_ferc1
-    years: [2020]
+      # - plants_small_ferc1
+      # - plants_hydro_ferc1
+      # - plants_pumped_storage_ferc1
+      # - plant_in_service_ferc1
+      # - purchased_power_ferc1
+    years: [2020, 2021]
   eia:
     eia923:
       tables:

--- a/src/pudl/package_data/settings/ferc1_solo_test.yml
+++ b/src/pudl/package_data/settings/ferc1_solo_test.yml
@@ -28,12 +28,7 @@ description: >
 version: 0.1.0
 datasets:
   ferc1:
-    ferc1_dbf_settings:
-      tables:
-        - fuel_ferc1 # requires plants_steam_ferc1 to load properly
-        - plants_steam_ferc1
-      years: [2020]
-    ferc1_xbrl_settings:
-      tables:
-        - steam_electric_generating_plant_statistics_large_plants_fuel_statistics_402_duration
-      years: [2021]
+    tables:
+      - fuel_ferc1 # requires plants_steam_ferc1 to load properly
+      - plants_steam_ferc1
+    years: [2020, 2021]

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -1593,9 +1593,7 @@ def transform(
             )
 
     if "plants_steam_ferc1" in ferc1_settings.tables:
-        ferc1_transformed_dfs["plants_steam_ferc1"] = PlantsSteamFerc1(
-            table_name="plants_steam_ferc"
-        ).execute(
+        ferc1_transformed_dfs["plants_steam_ferc1"] = PlantsSteamFerc1().execute(
             raw_dbf=ferc1_dbf_raw_dfs.get(table),
             raw_xbrl_instant=ferc1_xbrl_raw_dfs.get(table).get("instant", None),
             raw_xbrl_duration=ferc1_xbrl_raw_dfs.get(table).get("duration", None),

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -1593,7 +1593,9 @@ def transform(
             )
 
     if "plants_steam_ferc1" in ferc1_settings.tables:
-        ferc1_transformed_dfs["plants_steam_ferc1"] = PlantsSteamFerc1().execute(
+        ferc1_transformed_dfs["plants_steam_ferc1"] = PlantsSteamFerc1(
+            table_name="plants_steam_ferc"
+        ).execute(
             raw_dbf=ferc1_dbf_raw_dfs.get(table),
             raw_xbrl_instant=ferc1_xbrl_raw_dfs.get(table).get("instant", None),
             raw_xbrl_duration=ferc1_xbrl_raw_dfs.get(table).get("duration", None),


### PR DESCRIPTION
As of 8/31:
### Done:
- Makes settings files line up with new settings classes/add both 2020 + 2021 so both xbrl and dbf are tested.
### Currently Breaking:
-  (If we merge in the `xbrl_steam_but_really` branch) PKs! which should break until we get #1705 under control