### PR TITLE
Fill in some null BA codes using BA names

### DIFF
--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -1142,7 +1142,7 @@ def fillna_balancing_authority_codes_via_names(df: pd.DataFrame) -> pd.DataFrame
     # associated BA name. Here the argument to map() is a Series containing
     # balancing_authority_code that's indexed by balancing_authority_name.
     ba_codes = df.loc[null_ba_code_mask, "balancing_authority_name_eia"].map(
-        ba_name_to_code_map
+        ba_name_to_code_map.balancing_authority_code_eia
     )
     # Fill in the null BA codes
     df.loc[null_ba_code_mask, "balancing_authority_code_eia"] = ba_codes

--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -1120,7 +1120,7 @@ def map_balancing_authority_names_to_codes(df: pd.DataFrame) -> pd.DataFrame:
 def fillna_balancing_authority_codes_via_names(df: pd.DataFrame) -> pd.DataFrame:
     """Fill null balancing authority (BA) codes via a map of the BA names to codes.
 
-    There are a handfull of missing ``balancing_authority_code_eia``'s that are easy to
+    There are a handful of missing ``balancing_authority_code_eia``'s that are easy to
     map given the balancing_authority_name_eia. This function fills in null BA codes
     using the BA names. The map ofo the BA names to codes is generated via
     :func:`map_balancing_authority_names_to_codes`.


### PR DESCRIPTION
Fill in a handful of BA codes w/ BA names.

There are two strange things in the PR (imo):
* how to grab the "correct" map between codes and names. There are three options:
   * (my choice) use the cleaned/harvested/encoded plants table to compile the most frequently reported association of codes and names.
   * build a lil map of names and codes that are known to have missing codes/known names. There aren't that many, but these names could stray so I don't love this:
   ``` 
   bac_map = {
        "Hawaiian Electric Co Inc": "HECO",
        "PJM Interconnection, LLC": "PJM",
        "Midcontinent Independent Transmission System Operator, Inc..": "MISO",
        "Duke Energy Progress East": "CPLE",
    }
   ```

   * use the map in `CODE_METADATA`. I used the BA names as the `description` column, so we could use this. BUT this is an implied connection and it would not be good to couple these two things and make an implied requirement for future codes/descriptions
* Where to do this? I choose after the harvesting process for several reasons. Mostly because this moment is when  we have presumably cleaner data (harvested and encoded). But most practically because these codes and names show up in SO MANY of the input tables, and this is the only moment where they are all in one place.