### PR TITLE
Fill in pre-2013 BA codes

### DIFF
--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -161,10 +161,14 @@ def find_timezone(*, lng=None, lat=None, state=None, strict=True):
     return tz
 
 
-def _occurrence_consistency(
-    entity_id, compiled_df, col, cols_to_consit, strictness=0.7
-):
-    """Find the occurence of plants & the consistency of records.
+def occurrence_consistency(
+    entity_idx: list[str],
+    compiled_df: pd.DataFrame,
+    col: str,
+    cols_to_consit: list[str],
+    strictness: float = 0.7,
+) -> pd.DataFrame:
+    """Find the occurence of entities & the consistency of records.
 
     We need to determine how consistent a reported value is in the records
     across all of the years or tables that the value is being reported, so we
@@ -173,16 +177,16 @@ def _occurrence_consistency(
     information we can determine if the reported records are strict enough.
 
     Args:
-        entity_id (list): a list of the id(s) for the entity. Ex: for a plant
-            entity, the entity_id is ['plant_id_eia']. For a generator entity,
-            the entity_id is ['plant_id_eia', 'generator_id'].
-        compiled_df (pandas.DataFrame): a dataframe with every instance of the
+        entity_idx: a list of the id(s) for the entity. Ex: for a plant
+            entity, the entity_idx is ['plant_id_eia']. For a generator entity,
+            the entity_idx is ['plant_id_eia', 'generator_id'].
+        compiled_df: a dataframe with every instance of the
             column we are trying to harvest.
-        col (str): the column name of the column we are trying to harvest.
-        cols_to_consit (list): a list of the columns to determine consistency.
+        col: the column name of the column we are trying to harvest.
+        cols_to_consit: a list of the columns to determine consistency.
             This either the [entity_id] or the [entity_id, 'report_date'],
             depending on whether the entity is static or annual.
-        strictness (float): How consistent do you want the column records to
+        strictness: How consistent do you want the column records to
             be? The default setting is .7 (so 70% of the records need to be
             consistent in order to accept harvesting the record).
 
@@ -194,7 +198,7 @@ def _occurrence_consistency(
     """
     # select only the colums you want and drop the NaNs
     # we want to drop the NaNs because
-    col_df = compiled_df[entity_id + ["report_date", col, "table"]].copy()
+    col_df = compiled_df[entity_idx + ["report_date", col]].copy()
     if get_pudl_dtypes(group="eia")[col] == "string":
         nan_str_mask = (col_df[col] == "nan").fillna(False)
         col_df.loc[nan_str_mask, col] = pd.NA
@@ -204,14 +208,13 @@ def _occurrence_consistency(
         col_df[f"{col}_consistent"] = pd.NA
         col_df[f"{col}_consistent_rate"] = pd.NA
         col_df["entity_occurences"] = pd.NA
-        col_df = col_df.drop(columns=["table"])
         return col_df
     # determine how many times each entity occurs in col_df
     occur = (
-        col_df.groupby(by=cols_to_consit, observed=True)[["table"]]
+        col_df.assign(entity_occurences=1)
+        .groupby(by=cols_to_consit, observed=True)[["entity_occurences"]]
         .count()
         .reset_index()
-        .rename(columns={"table": "entity_occurences"})
     )
 
     # add the occurances into the main dataframe
@@ -219,17 +222,17 @@ def _occurrence_consistency(
 
     # determine how many instances of each of the records in col exist
     consist_df = (
-        col_df.groupby(by=cols_to_consit + [col], observed=True)[["table"]]
+        col_df.assign(record_occurences=1)
+        .groupby(by=cols_to_consit + [col], observed=True)[["record_occurences"]]
         .count()
         .reset_index()
-        .rename(columns={"table": "record_occurences"})
     )
     # now in col_df we have # of times an entity occurred accross the tables
     # and we are going to merge in the # of times each value occured for each
     # entity record. When we merge the consistency in with the occurances, we
     # can determine if the records are more than 70% consistent across the
     # occurances of the entities.
-    col_df = col_df.merge(consist_df, how="outer").drop(columns=["table"])
+    col_df = col_df.merge(consist_df, how="outer")
     # change all of the fully consistent records to True
     col_df[f"{col}_consistent_rate"] = (
         col_df["record_occurences"] / col_df["entity_occurences"]
@@ -240,7 +243,7 @@ def _occurrence_consistency(
 
 
 def _lat_long(
-    dirty_df, clean_df, entity_id_df, entity_id, col, cols_to_consit, round_to=2
+    dirty_df, clean_df, entity_id_df, entity_idx, col, cols_to_consit, round_to=2
 ):
     """Harvests more complete lat/long in special cases.
 
@@ -256,9 +259,9 @@ def _lat_long(
             consistently reported lat/long.
         entity_id_df (pandas.DataFrame): a dataframe with a complete set of
             possible entity ids
-        entity_id (list): a list of the id(s) for the entity. Ex: for a plant
-            entity, the entity_id is ['plant_id_eia']. For a generator entity,
-            the entity_id is ['plant_id_eia', 'generator_id'].
+        entity_idx (list): a list of the id(s) for the entity. Ex: for a plant
+            entity, the entity_idx is ['plant_id_eia']. For a generator entity,
+            the entity_idx is ['plant_id_eia', 'generator_id'].
         col (string): the column name of the column we are trying to harvest.
         cols_to_consit (list): a list of the columns to determine consistency.
             This either the [entity_id] or the [entity_id, 'report_date'],
@@ -277,11 +280,11 @@ def _lat_long(
     ll_df = dirty_df.round(decimals={col: round_to})
     logger.debug(f"Dirty {col} records: {len(ll_df)}")
     ll_df["table"] = "special_case"
-    ll_df = _occurrence_consistency(entity_id, ll_df, col, cols_to_consit)
+    ll_df = occurrence_consistency(entity_idx, ll_df, col, cols_to_consit)
     # grab the clean plants
     ll_clean_df = clean_df.dropna()
     # find the new clean plant records by selecting the True consistent records
-    ll_df = ll_df[ll_df[f"{col}_consistent"]].drop_duplicates(subset=entity_id)
+    ll_df = ll_df[ll_df[f"{col}_consistent"]].drop_duplicates(subset=entity_idx)
     logger.debug(f"Clean {col} records: {len(ll_df)}")
     # add the newly cleaned records
     ll_clean_df = pd.concat([ll_clean_df, ll_df])
@@ -459,7 +462,7 @@ def harvesting(  # noqa: C901
     the outcome here to be perfect! We choose to pull the most consistent
     record as reported across all the EIA tables and years, but we also
     required a "strictness" level of 70% (this is currently a hard coded
-    argument for _occurrence_consistency). That means at least 70% of the
+    argument for :func:`occurrence_consistency`). That means at least 70% of the
     records must be the same for us to use that value. So if values for an
     entity haven't been reported 70% consistently, then it will show up as a
     null value. We built in the ability to add special cases for columns where
@@ -535,7 +538,7 @@ def harvesting(  # noqa: C901
             cols_to_consit = id_cols
 
         strictness = _manage_strictness(col, eia860m)
-        col_df = _occurrence_consistency(
+        col_df = occurrence_consistency(
             id_cols, compiled_df, col, cols_to_consit, strictness=strictness
         )
 

--- a/src/pudl/transform/eia861.py
+++ b/src/pudl/transform/eia861.py
@@ -440,17 +440,14 @@ def _filter_non_class_cols(df, class_list):
     return df.filter(regex=regex)
 
 
-def _ba_code_backfill(df):
-    """Backfill Balancing Authority Codes based on codes in later years.
-
-    Note:
-        The BA Code to ID mapping can change from year to year. If a Balancing Authority
-        is bought by another entity, the code may change, but the old EIA BA ID will be
-        retained.
+def make_backfilled_ba_code_column(df, by_cols: list[str]) -> pd.DataFrame:
+    """Make a backfilled Balancing Authority Codes based on codes in later years.
 
     Args:
-        ba_eia861 (pandas.DataFrame): The transformed EIA 861 Balancing Authority
-            dataframe (balancing_authority_eia861).
+        df: table with columns: ``balancing_authority_code_eia``, ``report_date`` and
+            all ``by_cols``
+        by_cols: list of columns to use as ``by`` argument in :meth:`pd.groupby`
+
 
     Returns:
         pandas.DataFrame: The balancing_authority_eia861 dataframe, but with many fewer
@@ -464,34 +461,52 @@ def _ba_code_backfill(df):
         f"records ({start_nas/start_len:.2%})"
     )
     ba_ids = (
-        df[
-            [
-                "balancing_authority_id_eia",
-                "balancing_authority_code_eia",
-                "report_date",
-            ]
-        ]
+        df[by_cols + ["balancing_authority_code_eia", "report_date"]]
         .drop_duplicates()
-        .sort_values(["balancing_authority_id_eia", "report_date"])
+        .sort_values(by_cols + ["report_date"])
     )
-    ba_ids["ba_code_filled"] = ba_ids.groupby("balancing_authority_id_eia")[
+    ba_ids["balancing_authority_code_eia_bfilled"] = ba_ids.groupby(by_cols)[
         "balancing_authority_code_eia"
     ].fillna(method="bfill")
     ba_eia861_filled = df.merge(ba_ids, how="left")
-    ba_eia861_filled = ba_eia861_filled.assign(
-        balancing_authority_code_eia=lambda x: x.ba_code_filled
-    ).drop("ba_code_filled", axis="columns")
+
     end_len = len(ba_eia861_filled)
     if start_len != end_len:
         raise AssertionError(
             f"Number of rows in the dataframe changed {start_len}!={end_len}!"
         )
     end_nas = len(
-        ba_eia861_filled.loc[ba_eia861_filled.balancing_authority_code_eia.isnull()]
+        ba_eia861_filled.loc[
+            ba_eia861_filled.balancing_authority_code_eia_bfilled.isnull()
+        ]
     )
     logger.info(
         f"Ended with {end_nas} missing BA Codes out of {end_len} "
         f"records ({end_nas/end_len:.2%})"
+    )
+    return ba_eia861_filled
+
+
+def backfill_ba_codes_by_ba_id(df: pd.DataFrame) -> pd.DataFrame:
+    """Fill in missing BA Codes by backfilling based on BA ID.
+
+    Note:
+        The BA Code to ID mapping can change from year to year. If a Balancing Authority
+        is bought by another entity, the code may change, but the old EIA BA ID will be
+        retained.
+
+    Args:
+        df: The transformed EIA 861 Balancing Authority dataframe
+            (balancing_authority_eia861).
+    """
+    ba_eia861_filled = (
+        make_backfilled_ba_code_column(
+            df, date_col="report_date", by_cols=["balancing_authority_id_eia"]
+        )
+        .assign(
+            balancing_authority_code_eia=lambda x: x.balancing_authority_code_eia_bfilled
+        )
+        .drop("balancing_authority_code_eia_bfilled", axis="columns")
     )
     return ba_eia861_filled
 
@@ -876,7 +891,7 @@ def balancing_authority(tfr_dfs):
     )
 
     # Backfill BA Codes based on BA IDs:
-    df = df.reset_index().pipe(_ba_code_backfill)
+    df = df.reset_index().pipe(backfill_ba_codes_by_ba_id)
     # Typo: NEVP, BA ID is 13407, but in 2014-2015 in UT, entered as 13047
     df.loc[
         (df.balancing_authority_code_eia == "NEVP")

--- a/src/pudl/transform/eia861.py
+++ b/src/pudl/transform/eia861.py
@@ -500,9 +500,7 @@ def backfill_ba_codes_by_ba_id(df: pd.DataFrame) -> pd.DataFrame:
             (balancing_authority_eia861).
     """
     ba_eia861_filled = (
-        make_backfilled_ba_code_column(
-            df, date_col="report_date", by_cols=["balancing_authority_id_eia"]
-        )
+        make_backfilled_ba_code_column(df, by_cols=["balancing_authority_id_eia"])
         .assign(
             balancing_authority_code_eia=lambda x: x.balancing_authority_code_eia_bfilled
         )

--- a/src/pudl/transform/eia861.py
+++ b/src/pudl/transform/eia861.py
@@ -440,8 +440,8 @@ def _filter_non_class_cols(df, class_list):
     return df.filter(regex=regex)
 
 
-def make_backfilled_ba_code_column(df, by_cols: list[str]) -> pd.DataFrame:
-    """Make a backfilled Balancing Authority Codes based on codes in later years.
+def add_backfilled_ba_code_column(df, by_cols: list[str]) -> pd.DataFrame:
+    """Make a backfilled Balancing Authority Code column based on codes in later years.
 
     Args:
         df: table with columns: ``balancing_authority_code_eia``, ``report_date`` and
@@ -450,8 +450,8 @@ def make_backfilled_ba_code_column(df, by_cols: list[str]) -> pd.DataFrame:
 
 
     Returns:
-        pandas.DataFrame: The balancing_authority_eia861 dataframe, but with many fewer
-        NA values in the balancing_authority_code_eia column.
+        pandas.DataFrame: An altered version of ``df`` with an additional column
+        ``balancing_authority_code_eia_bfilled``
 
     """
     start_len = len(df)
@@ -498,9 +498,14 @@ def backfill_ba_codes_by_ba_id(df: pd.DataFrame) -> pd.DataFrame:
     Args:
         df: The transformed EIA 861 Balancing Authority dataframe
             (balancing_authority_eia861).
+
+    Returns:
+        pandas.DataFrame: The balancing_authority_eia861 dataframe, but with many fewer
+        NA values in the balancing_authority_code_eia column.
+
     """
     ba_eia861_filled = (
-        make_backfilled_ba_code_column(df, by_cols=["balancing_authority_id_eia"])
+        add_backfilled_ba_code_column(df, by_cols=["balancing_authority_id_eia"])
         .assign(
             balancing_authority_code_eia=lambda x: x.balancing_authority_code_eia_bfilled
         )


### PR DESCRIPTION
See #1909 for discussion. 

## current logs:
```
Filled BA codes where no treatment had been applied. Currently 43.9% of records (81266) with no BA codes
Filled BA codes where backfilling and consistent value is the same. Currently 11.1% of records (20574) with no BA codes
Filled BA codes where consistent code is PACW and state is OR or CA. Currently 10.9% of records (20110) with no BA codes
Filled BA codes where consistent code is PACE and state is UT. Currently 10.9% of records (20107) with no BA codes
Filled BA codes where SWPP is most consistent value. Filled w/ oldest BA code. Currently 8.3% of records (15445) with no BA codes
Filled BA codes where most consistent BA code is less than 80% consistent. Used backfilled BA code. Currently 8.3% of records (15396) with no BA codes
```