### PR TITLE
Aggregate data_maturity in gfn_eia923, update EIA ETL debugging Notebook

### DIFF
--- a/devtools/eia-etl-debug.ipynb
+++ b/devtools/eia-etl-debug.ipynb
@@ -15,7 +15,7 @@
    "outputs": [],
    "source": [
     "%load_ext autoreload\n",
-    "%autoreload 2\n",
+    "%autoreload 3\n",
     "import pudl\n",
     "import logging\n",
     "import sys\n",
@@ -64,15 +64,24 @@
     "from pudl.metadata.classes import DataSource\n",
     "\n",
     "eia860_data_source = DataSource.from_id(\"eia860\")\n",
-    "eia860_years = eia860_data_source.working_partitions[\"years\"]\n",
-    "#eia860_years = [2020]\n",
-    "eia860_settings = Eia860Settings(years=eia860_years)\n",
+    "eia860_settings = Eia860Settings(\n",
+    "# Limit the years as needed if you're testing only a few of them. E.g.:\n",
+    "    years=[2021],\n",
+    "#   years=eia860_data_source.working_partitions[\"years\"]\n",
+    "# By default all of the tables will be processed.\n",
+    "# Select the relevant tables as needed if you're testing only a few of them. E.g.:\n",
+    "#   tables=[\"generation_fuel_nuclear_eia923\", \"generation_fuel_eia923\"]\n",
+    ")\n",
     "\n",
-    "# Uncomment to use all available years:\n",
     "eia923_data_source = DataSource.from_id(\"eia923\")\n",
-    "eia923_years = eia923_data_source.working_partitions[\"years\"]\n",
-    "#eia923_years = [2020]\n",
-    "eia923_settings = Eia923Settings(years=eia923_years)\n",
+    "eia923_settings = Eia923Settings(\n",
+    "# Limit the years as needed if you're testing only a few of them. E.g.:\n",
+    "    years = [2021]\n",
+    "    # years = eia923_data_source.working_partitions[\"years\"]\n",
+    "# By default all of the tables will be processed.\n",
+    "# Select the relevant tables as needed if you're testing only a few of them. E.g.:\n",
+    "#   tables=[\"generation_fuel_nuclear_eia923\", \"generation_fuel_eia923\"]\n",
+    ")\n",
     "\n",
     "eia_settings = EiaSettings(eia860=eia860_settings, eia923=eia923_settings)"
    ]
@@ -116,10 +125,12 @@
    "source": [
     "%%time\n",
     "eia860_extractor = pudl.extract.eia860.Extractor(ds)\n",
-    "eia860_raw_dfs = eia860_extractor.extract(year=eia860_settings.years)\n",
+    "eia860_raw_dfs = eia860_extractor.extract(settings=eia860_settings)\n",
+    "\n",
+    "eia860m_extractor = pudl.extract.eia860m.Extractor(ds)\n",
     "if eia860_settings.eia860m:\n",
-    "    eia860m_raw_dfs = pudl.extract.eia860m.Extractor(ds).extract(\n",
-    "        year_month=eia860_settings.eia860m_date\n",
+    "    eia860m_raw_dfs = eia860m_extractor.extract(\n",
+    "        settings=eia860_settings\n",
     "    )\n",
     "    eia860_raw_dfs = pudl.extract.eia860m.append_eia860m(\n",
     "        eia860_raw_dfs=eia860_raw_dfs,\n",
@@ -143,7 +154,7 @@
     "%%time\n",
     "eia860_transformed_dfs = pudl.transform.eia860.transform(\n",
     "    eia860_raw_dfs,\n",
-    "    eia860_tables=eia860_settings.tables,\n",
+    "    eia860_settings=eia860_settings,\n",
     ")"
    ]
   },
@@ -169,7 +180,7 @@
    "source": [
     "%%time\n",
     "eia923_extractor = pudl.extract.eia923.Extractor(ds)\n",
-    "eia923_raw_dfs = eia923_extractor.extract(year=eia923_settings.years)"
+    "eia923_raw_dfs = eia923_extractor.extract(settings=eia_settings.eia923)"
    ]
   },
   {
@@ -188,7 +199,7 @@
     "%%time\n",
     "eia923_transformed_dfs = pudl.transform.eia923.transform(\n",
     "    eia923_raw_dfs,\n",
-    "    eia923_tables=eia923_settings.tables,\n",
+    "    eia923_settings=eia923_settings,\n",
     ")"
    ]
   },
@@ -224,14 +235,12 @@
     "    \n",
     "entities_dfs, eia_transformed_dfs = pudl.transform.eia.transform(\n",
     "    eia_transformed_dfs,\n",
-    "    eia860_years=eia860_settings.years,\n",
-    "    eia923_years=eia923_settings.years,\n",
-    "    eia860m=eia860_settings.eia860m,\n",
+    "    eia_settings=eia_settings,\n",
     ")\n",
     "\n",
     "# Assign appropriate types to new entity tables:\n",
     "entities_dfs = {\n",
-    "    name: pudl.helpers.apply_pudl_dtypes(df, group=\"eia\")\n",
+    "    name: pudl.metadata.fields.apply_pudl_dtypes(df, group=\"eia\")\n",
     "    for name, df in entities_dfs.items()\n",
     "}\n",
     "\n",
@@ -242,10 +251,17 @@
     "        .encode(entities_dfs[table])\n",
     "    )\n",
     "\n",
-    "out_dfs = pudl.etl._read_static_tables_eia()\n",
+    "out_dfs = pudl.etl._read_static_encoding_tables(etl_group=\"static_eia\")\n",
     "out_dfs.update(entities_dfs)\n",
     "out_dfs.update(eia_transformed_dfs)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -264,7 +280,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fix the aggregation of the `data_maturity` column in the transform step for the `generation_fuel_nuclear_eia923` table, so the aggregated records we create (to fix some missing primary key values) get the `data_maturity` value of their input records and we don't have NA values messing things up downstream.

Also update the EIA ETL Debugging notebook to reflect the current state of the system on `dev`.

Closes #1914