### PR TITLE
Update the name of the EPA CAMD to EIA crosswalk data source.

### DIFF
--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -192,7 +192,7 @@ SOURCES: dict[str, Any] = {
     },
     "epacems": {
         "title": "EPA Hourly Continuous Emission Monitoring System (CEMS)",
-        "path": "https://ampd.epa.gov/ampd",
+        "path": "https://campd.epa.gov/",
         "description": (
             "US EPA hourly Continuous Emissions Monitoring System (CEMS) data."
             "Hourly CO2, SO2, NOx emissions and gross load."
@@ -230,12 +230,12 @@ SOURCES: dict[str, Any] = {
         "license_raw": LICENSES["us-govt"],
         "license_pudl": LICENSES["cc-by-4.0"],
     },
-    "epacems_unitid_eia_plant_crosswalk": {
-        "title": "EPA CEMS unitid to EIA Plant Crosswalk",
+    "epacamd_eia": {
+        "title": "EPA CAMD to EIA Data Crosswalk",
         "path": "https://github.com/USEPA/camd-eia-crosswalk",
         "description": (
-            "A file created collaboratively by EPA and EIA that connects EPA CEMS "
-            "smokestacks (unitids) with cooresponding EIA plant part ids reported in "
+            "A file created collaboratively by EPA and EIA that connects EPA CAMD "
+            "smokestacks (units) with cooresponding EIA plant part ids reported in "
             "EIA Forms 860 and 923 (plant_id_eia, boiler_id, generator_id). This "
             "one-to-many connection is necessary because pollutants from various plant "
             "parts are collecitvely emitted and measured from one point-source."


### PR DESCRIPTION
Updating the metadata for the EPA CAMD to EIA crosswalk, so that we can use it to create a new Zenodo archive of this data with the new name.

Hopefully this is the only file that needs to be updated. But if not we can grab additional ones piecemeal from the crosswalk branch as needed.