### PR TITLE
Rollback pandas-1.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         "matplotlib>=3.3,<3.7",  # Should make this optional with a "viz" extras
         "networkx>=2.2,<2.9",
         "numpy>=1.18.5,<1.24,!=1.23.0",
-        "pandas>=1.4,<1.5.1",
+        "pandas>=1.4,<1.4.5",
         "pyarrow>=5,<9.1",
         "pydantic[email]>=1.7,<2",
         "python-snappy>=0.6,<0.7",


### PR DESCRIPTION
Since updating to pandas-1.5, our nightly builds have doubled in memory use. I'm opening this PR to test the memory use with pandas 1.4.x.