### PR TITLE
Add a static table of political subdivision attributes.

### DIFF
--- a/src/pudl/analysis/state_demand.py
+++ b/src/pudl/analysis/state_demand.py
@@ -37,78 +37,22 @@ import sqlalchemy as sa
 import pudl.analysis.timeseries_cleaning
 import pudl.output.pudltabl
 import pudl.workspace.setup
+from pudl.metadata.dfs import POLITICAL_SUBDIVISIONS
 
 logger = logging.getLogger(__name__)
 
 
 # --- Constants --- #
 
-
-STATES: list[dict[str, str | int]] = [
-    {"name": "Alabama", "code": "AL", "fips": "01"},
-    {"name": "Alaska", "code": "AK", "fips": "02"},
-    {"name": "Arizona", "code": "AZ", "fips": "04"},
-    {"name": "Arkansas", "code": "AR", "fips": "05"},
-    {"name": "California", "code": "CA", "fips": "06"},
-    {"name": "Colorado", "code": "CO", "fips": "08"},
-    {"name": "Connecticut", "code": "CT", "fips": "09"},
-    {"name": "Delaware", "code": "DE", "fips": "10"},
-    {"name": "District of Columbia", "code": "DC", "fips": "11"},
-    {"name": "Florida", "code": "FL", "fips": "12"},
-    {"name": "Georgia", "code": "GA", "fips": "13"},
-    {"name": "Hawaii", "code": "HI", "fips": "15"},
-    {"name": "Idaho", "code": "ID", "fips": "16"},
-    {"name": "Illinois", "code": "IL", "fips": "17"},
-    {"name": "Indiana", "code": "IN", "fips": "18"},
-    {"name": "Iowa", "code": "IA", "fips": "19"},
-    {"name": "Kansas", "code": "KS", "fips": "20"},
-    {"name": "Kentucky", "code": "KY", "fips": "21"},
-    {"name": "Louisiana", "code": "LA", "fips": "22"},
-    {"name": "Maine", "code": "ME", "fips": "23"},
-    {"name": "Maryland", "code": "MD", "fips": "24"},
-    {"name": "Massachusetts", "code": "MA", "fips": "25"},
-    {"name": "Michigan", "code": "MI", "fips": "26"},
-    {"name": "Minnesota", "code": "MN", "fips": "27"},
-    {"name": "Mississippi", "code": "MS", "fips": "28"},
-    {"name": "Missouri", "code": "MO", "fips": "29"},
-    {"name": "Montana", "code": "MT", "fips": "30"},
-    {"name": "Nebraska", "code": "NE", "fips": "31"},
-    {"name": "Nevada", "code": "NV", "fips": "32"},
-    {"name": "New Hampshire", "code": "NH", "fips": "33"},
-    {"name": "New Jersey", "code": "NJ", "fips": "34"},
-    {"name": "New Mexico", "code": "NM", "fips": "35"},
-    {"name": "New York", "code": "NY", "fips": "36"},
-    {"name": "North Carolina", "code": "NC", "fips": "37"},
-    {"name": "North Dakota", "code": "ND", "fips": "38"},
-    {"name": "Ohio", "code": "OH", "fips": "39"},
-    {"name": "Oklahoma", "code": "OK", "fips": "40"},
-    {"name": "Oregon", "code": "OR", "fips": "41"},
-    {"name": "Pennsylvania", "code": "PA", "fips": "42"},
-    {"name": "Rhode Island", "code": "RI", "fips": "44"},
-    {"name": "South Carolina", "code": "SC", "fips": "45"},
-    {"name": "South Dakota", "code": "SD", "fips": "46"},
-    {"name": "Tennessee", "code": "TN", "fips": "47"},
-    {"name": "Texas", "code": "TX", "fips": "48"},
-    {"name": "Utah", "code": "UT", "fips": "49"},
-    {"name": "Vermont", "code": "VT", "fips": "50"},
-    {"name": "Virginia", "code": "VA", "fips": "51"},
-    {"name": "Washington", "code": "WA", "fips": "53"},
-    {"name": "West Virginia", "code": "WV", "fips": "54"},
-    {"name": "Wisconsin", "code": "WI", "fips": "55"},
-    {"name": "Wyoming", "code": "WY", "fips": "56"},
-    {"name": "American Samoa", "code": "AS", "fips": "60"},
-    {"name": "Guam", "code": "GU", "fips": "66"},
-    {"name": "Northern Mariana Islands", "code": "MP", "fips": "69"},
-    {"name": "Puerto Rico", "code": "PR", "fips": "72"},
-    {"name": "Virgin Islands", "code": "VI", "fips": "78"},
+STATES: list[dict[str, str]] = [
+    {
+        "name": x.subdivision_name,
+        "code": x.subdivision_code,
+        "fips": x.state_id_fips,
+    }
+    for x in POLITICAL_SUBDIVISIONS.itertuples()
+    if x.state_id_fips is not pd.NA
 ]
-"""Attributes of US states and territories.
-
-* `name` (str): Full name.
-* `code` (str): US Postal Service (USPS) two-letter alphabetic code.
-* `fips` (int): Federal Information Processing Standard (FIPS) code.
-"""
-
 
 STANDARD_UTC_OFFSETS: dict[str, str] = {
     "Pacific/Honolulu": -10,

--- a/src/pudl/etl.py
+++ b/src/pudl/etl.py
@@ -29,7 +29,11 @@ import sqlalchemy as sa
 import pudl
 from pudl.helpers import convert_cols_dtypes
 from pudl.metadata.classes import Package, Resource
-from pudl.metadata.dfs import FERC_ACCOUNTS, FERC_DEPRECIATION_LINES
+from pudl.metadata.dfs import (
+    FERC_ACCOUNTS,
+    FERC_DEPRECIATION_LINES,
+    POLITICAL_SUBDIVISIONS,
+)
 from pudl.metadata.fields import apply_pudl_dtypes
 from pudl.settings import (
     EiaSettings,
@@ -408,6 +412,11 @@ def _read_static_encoding_tables(
     }
 
 
+def _read_static_pudl_tables() -> dict[str, pd.DataFrame]:
+    """Read static tables compiled as part of PUDL and not from any agency dataset."""
+    return {"political_subdivisions": POLITICAL_SUBDIVISIONS}
+
+
 ###############################################################################
 # Coordinating functions
 ###############################################################################
@@ -469,7 +478,7 @@ def etl(  # noqa: C901
         epacems_pq_path = Path(pudl_settings["parquet_dir"]) / "epacems"
         epacems_pq_path.mkdir(exist_ok=True)
 
-    sqlite_dfs = {}
+    sqlite_dfs = _read_static_pudl_tables()
     # This could be cleaner if we simplified the settings file format:
     if datasets.get("ferc1", False):
         sqlite_dfs.update(_etl_ferc1(datasets["ferc1"], pudl_settings))

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1165,6 +1165,7 @@ class Resource(Base):
         "static_ferc1",
         "static_eia",
         "static_eia_disabled",
+        "static_pudl",
     ] = None
 
     _check_unique = _validator(

--- a/src/pudl/metadata/dfs.py
+++ b/src/pudl/metadata/dfs.py
@@ -237,7 +237,7 @@ utility plant (Account 108).
 POLITICAL_SUBDIVISIONS: pd.DataFrame = pd.read_csv(
     StringIO(
         """
-subdivision_code,subdivision_name,country_code,country_name,subdivision_type,timezone,state_id_fips,division_name_us_census,division_code_us_census,region_name_us_census,is_epacems_state
+subdivision_code,subdivision_name,country_code,country_name,subdivision_type,timezone_approx,state_id_fips,division_name_us_census,division_code_us_census,region_name_us_census,is_epacems_state
 AB,Alberta,CAN,Canada,province,America/Edmonton,,,,,0
 AK,Alaska,USA,United States of America,state,America/Anchorage,"02",Pacific Noncontiguous,PCN,West,0
 AL,Alabama,USA,United States of America,state,America/Chicago,"01",East South Central,ESC,South,1

--- a/src/pudl/metadata/dfs.py
+++ b/src/pudl/metadata/dfs.py
@@ -1,4 +1,6 @@
 """Static database tables."""
+from io import StringIO
+
 import pandas as pd
 
 FERC_ACCOUNTS: pd.DataFrame = pd.DataFrame(
@@ -230,4 +232,100 @@ Row numbers, FERC account IDs, and FERC account descriptions.
 
 From FERC Form 1 page 219, Accumulated Provision for Depreciation of electric
 utility plant (Account 108).
+"""
+
+POLITICAL_SUBDIVISIONS: pd.DataFrame = pd.read_csv(
+    StringIO(
+        """
+subdivision_code,subdivision_name,country_code,country_name,subdivision_type,timezone,state_id_fips,division_name_us_census,division_code_us_census,region_name_us_census,is_epacems_state
+AB,Alberta,CAN,Canada,province,America/Edmonton,,,,,0
+AK,Alaska,USA,United States of America,state,America/Anchorage,"02",Pacific Noncontiguous,PCN,West,0
+AL,Alabama,USA,United States of America,state,America/Chicago,"01",East South Central,ESC,South,1
+AR,Arkansas,USA,United States of America,state,America/Chicago,"05",West South Central,WSC,South,1
+AS,American Samoa,USA,United States of America,outlying_area,Pacific/Pago_Pago,"60",,,,0
+AZ,Arizona,USA,United States of America,state,America/Phoenix,"04",Mountain,MTN,West,1
+BC,British Columbia,CAN,Canada,province,America/Vancouver,,,,,0
+CA,California,USA,United States of America,state,America/Los_Angeles,"06",Pacific Contiguous,PCC,West,1
+CO,Colorado,USA,United States of America,state,America/Denver,"08",Mountain,MTN,West,1
+CT,Connecticut,USA,United States of America,state,America/New_York,"09",New England,NEW,Northeast,1
+DC,District of Columbia,USA,United States of America,district,America/New_York,"11",South Atlantic,SAT,South,1
+DE,Delaware,USA,United States of America,state,America/New_York,"10",South Atlantic,SAT,South,1
+FL,Florida,USA,United States of America,state,America/New_York,"12",South Atlantic,SAT,South,1
+GA,Georgia,USA,United States of America,state,America/New_York,"13",South Atlantic,SAT,South,1
+GU,Guam,USA,United States of America,outlying_area,Pacific/Guam,"66",,,,0
+HI,Hawaii,USA,United States of America,state,Pacific/Honolulu,"15",Pacific Noncontiguous,PCN,West,0
+IA,Iowa,USA,United States of America,state,America/Chicago,"19",West North Central,WNC,Midwest,1
+ID,Idaho,USA,United States of America,state,America/Denver,"16",Mountain,MTN,West,1
+IL,Illinois,USA,United States of America,state,America/Chicago,"17",East North Central,ENC,Midwest,1
+IN,Indiana,USA,United States of America,state,America/New_York,"18",East North Central,ENC,Midwest,1
+KS,Kansas,USA,United States of America,state,America/Chicago,"20",West North Central,WNC,Midwest,1
+KY,Kentucky,USA,United States of America,state,America/New_York,"21",East South Central,ESC,South,1
+LA,Louisiana,USA,United States of America,state,America/Chicago,"22",West South Central,WSC,South,1
+MA,Massachusetts,USA,United States of America,state,America/New_York,"25",New England,NEW,Northeast,1
+MB,Manitoba,CAN,Canada,province,America/Winnipeg,,,,,0
+MD,Maryland,USA,United States of America,state,America/New_York,"24",South Atlantic,SAT,South,1
+ME,Maine,USA,United States of America,state,America/New_York,"23",New England,NEW,Northeast,1
+MI,Michigan,USA,United States of America,state,America/Detroit,"26",East North Central,ENC,Midwest,1
+MN,Minnesota,USA,United States of America,state,America/Chicago,"27",West North Central,WNC,Midwest,1
+MO,Missouri,USA,United States of America,state,America/Chicago,"29",West North Central,WNC,Midwest,1
+MP,Northern Mariana Islands,USA,United States of America,outlying_area,Pacific/Guam,"69",,,,0
+MS,Mississippi,USA,United States of America,state,America/Chicago,"28",East South Central,ESC,South,1
+MT,Montana,USA,United States of America,state,America/Denver,"30",Mountain,MTN,West,1
+NB,New Brunswick,CAN,Canada,province,America/Moncton,,,,,0
+NC,North Carolina,USA,United States of America,state,America/New_York,"37",South Atlantic,SAT,South,1
+ND,North Dakota,USA,United States of America,state,America/Chicago,"38",West North Central,WNC,Midwest,1
+NE,Nebraska,USA,United States of America,state,America/Chicago,"31",West North Central,WNC,Midwest,1
+NH,New Hampshire,USA,United States of America,state,America/New_York,"33",New England,NEW,Northeast,1
+NJ,New Jersey,USA,United States of America,state,America/New_York,"34",Middle Atlantic,MAT,Northeast,1
+NL,Newfoundland and Labrador,CAN,Canada,province,America/St_Johns,,,,,0
+NM,New Mexico,USA,United States of America,state,America/Denver,"35",Mountain,MTN,West,1
+NS,Nova Scotia,CAN,Canada,province,America/Halifax,,,,,0
+NT,Northwest Territories,CAN,Canada,territory,America/Yellowknife,,,,,0
+NU,Nunavut,CAN,Canada,territory,America/Iqaluit,,,,,0
+NV,Nevada,USA,United States of America,state,America/Los_Angeles,"32",Mountain,MTN,West,1
+NY,New York,USA,United States of America,state,America/New_York,"36",Middle Atlantic,MAT,Northeast,1
+OH,Ohio,USA,United States of America,state,America/New_York,"39",East North Central,ENC,Midwest,1
+OK,Oklahoma,USA,United States of America,state,America/Chicago,"40",West South Central,WSC,South,1
+ON,Ontario,CAN,Canada,province,America/Toronto,,,,,0
+OR,Oregon,USA,United States of America,state,America/Los_Angeles,"41",Pacific Contiguous,PCC,West,1
+PA,Pennsylvania,USA,United States of America,state,America/New_York,"42",Middle Atlantic,MAT,Northeast,1
+PE,Prince Edwards Island,CAN,Canada,province,America/Halifax,,,,,0
+PR,Puerto Rico,USA,United States of America,outlying_area,America/Puerto_Rico,"72",,,,0
+QC,Quebec,CAN,Canada,province,America/Montreal,,,,,0
+RI,Rhode Island,USA,United States of America,state,America/New_York,"44",New England,NEW,Northeast,1
+SC,South Carolina,USA,United States of America,state,America/New_York,"45",South Atlantic,SAT,South,1
+SD,South Dakota,USA,United States of America,state,America/Chicago,"46",West North Central,WNC,Midwest,1
+SK,Saskatchewan,CAN,Canada,province,America/Regina,,,,,0
+TN,Tennessee,USA,United States of America,state,America/Chicago,"47",East South Central,ESC,South,1
+TX,Texas,USA,United States of America,state,America/Chicago,"48",West South Central,WSC,South,1
+UT,Utah,USA,United States of America,state,America/Denver,"49",Mountain,MTN,West,1
+VA,Virginia,USA,United States of America,state,America/New_York,"51",South Atlantic,SAT,South,1
+VI,Virgin Islands,USA,United States of America,outlying_area,America/Port_of_Spain,"78",,,,0
+VT,Vermont,USA,United States of America,state,America/New_York,"50",New England,NEW,Northeast,1
+WA,Washington,USA,United States of America,state,America/Los_Angeles,"53",Pacific Contiguous,PCC,West,1
+WI,Wisconsin,USA,United States of America,state,America/Chicago,"55",East North Central,ENC,Midwest,1
+WV,West Virginia,USA,United States of America,state,America/New_York,"54",South Atlantic,SAT,South,1
+WY,Wyoming,USA,United States of America,state,America/Denver,"56",Mountain,MTN,West,1
+YT,Yukon Territory,CAN,Canada,territory,America/Whitehorse,,,,,0
+    """
+    ),
+    dtype={
+        "subdivision_code": "string",
+        "subdivision_name": "string",
+        "country_code": "string",
+        "country_name": "string",
+        "subdivision_type": "string",
+        "timezone": "string",
+        "state_id_fips": "string",
+        "division_name_us_census": "string",
+        "division_code_us_census": "string",
+        "region_name_us_census": "string",
+        "is_epacems_state": bool,
+    },
+)
+"""
+Static attributes of sub-national political jurisdictions.
+
+Note AK and PR have incomplete EPA CEMS data, and so are excluded from is_epacems_state:
+See https://github.com/catalyst-cooperative/pudl/issues/1264
 """

--- a/src/pudl/metadata/enums.py
+++ b/src/pudl/metadata/enums.py
@@ -1,97 +1,39 @@
 """Enumerations of valid field values."""
 
-US_STATES: dict[str, str] = {
-    "AK": "Alaska",
-    "AL": "Alabama",
-    "AR": "Arkansas",
-    "AZ": "Arizona",
-    "CA": "California",
-    "CO": "Colorado",
-    "CT": "Connecticut",
-    "DE": "Delaware",
-    "FL": "Florida",
-    "GA": "Georgia",
-    "HI": "Hawaii",
-    "IA": "Iowa",
-    "ID": "Idaho",
-    "IL": "Illinois",
-    "IN": "Indiana",
-    "KS": "Kansas",
-    "KY": "Kentucky",
-    "LA": "Louisiana",
-    "MA": "Massachusetts",
-    "MD": "Maryland",
-    "ME": "Maine",
-    "MI": "Michigan",
-    "MN": "Minnesota",
-    "MO": "Missouri",
-    "MS": "Mississippi",
-    "MT": "Montana",
-    "NC": "North Carolina",
-    "ND": "North Dakota",
-    "NE": "Nebraska",
-    "NH": "New Hampshire",
-    "NJ": "New Jersey",
-    "NM": "New Mexico",
-    "NV": "Nevada",
-    "NY": "New York",
-    "OH": "Ohio",
-    "OK": "Oklahoma",
-    "OR": "Oregon",
-    "PA": "Pennsylvania",
-    "RI": "Rhode Island",
-    "SC": "South Carolina",
-    "SD": "South Dakota",
-    "TN": "Tennessee",
-    "TX": "Texas",
-    "UT": "Utah",
-    "VA": "Virginia",
-    "VT": "Vermont",
-    "WA": "Washington",
-    "WI": "Wisconsin",
-    "WV": "West Virginia",
-    "WY": "Wyoming",
+from pudl.metadata.dfs import POLITICAL_SUBDIVISIONS
+
+COUNTRY_CODES_ISO3166: set[str] = set(POLITICAL_SUBDIVISIONS.country_code)
+SUBDIVISION_CODES_ISO3166: set[str] = set(POLITICAL_SUBDIVISIONS.subdivision_code)
+EPACEMS_STATES: set[str] = set(
+    POLITICAL_SUBDIVISIONS.loc[
+        POLITICAL_SUBDIVISIONS.is_epacems_state, "subdivision_code"
+    ]
+)
+DIVISION_CODES_US_CENSUS: set[str] = set(
+    POLITICAL_SUBDIVISIONS.division_code_us_census.dropna()
+)
+
+APPROXIMATE_TIMEZONES: dict[str, str] = {
+    x.subdivision_code: x.timezone for x in POLITICAL_SUBDIVISIONS.itertuples()
 }
-"""Mapping of US state abbreviations to their full names."""
+"""Mapping of political subdivision code to the most common timezone in that area.
 
-US_TERRITORIES: dict[str, str] = {
-    "AS": "American Samoa",
-    "DC": "District of Columbia",
-    "GU": "Guam",
-    "MP": "Northern Mariana Islands",
-    "PR": "Puerto Rico",
-    "VI": "Virgin Islands",
+This is imperfect for states that have split timezones. See:
+https://en.wikipedia.org/wiki/List_of_time_offsets_by_U.S._state_and_territory
+
+For states that are split, we chose the timezone with a larger population.
+List of timezones in pytz.common_timezones
+Canada: https://en.wikipedia.org/wiki/Time_in_Canada#IANA_time_zone_database
+"""
+
+STATE_TO_CENSUS_DIVISION: dict[str, str] = {
+    x.subdivision_code: x.division_code_us_census
+    for x in POLITICAL_SUBDIVISIONS.itertuples()
 }
-"""Mapping of US territory abbreviations to their full names."""
 
-US_STATES_TERRITORIES: dict[str, str] = {**US_STATES, **US_TERRITORIES}
-
-EPACEMS_STATES: list[str] = [
-    state
-    for state in US_STATES_TERRITORIES
-    # AK and PR have data but only a few years, and that breaks the Datastore.
-    # See https://github.com/catalyst-cooperative/pudl/issues/1264
-    if state not in {"AK", "AS", "GU", "HI", "MP", "PR", "VI"}
-]
-"""The US states and territories that are present in the EPA CEMS dataset."""
-
-CANADA_PROVINCES_TERRITORIES: dict[str, str] = {
-    "AB": "Alberta",
-    "BC": "British Columbia",
-    "CN": "Canada",
-    "MB": "Manitoba",
-    "NB": "New Brunswick",
-    "NS": "Nova Scotia",
-    "NL": "Newfoundland and Labrador",
-    "NT": "Northwest Territories",
-    "NU": "Nunavut",
-    "ON": "Ontario",
-    "PE": "Prince Edwards Island",
-    "QC": "Quebec",
-    "SK": "Saskatchewan",
-    "YT": "Yukon Territory",
+STATE_ID_FIPS: dict[str, str] = {
+    x.state_id_fips: x.subdivision_code for x in POLITICAL_SUBDIVISIONS.itertuples()
 }
-"""Mapping of Canadian province and territory abbreviations to their full names"""
 
 NERC_REGIONS: list[str] = [
     "BASN",  # ASSESSMENT AREA Basin (WECC)

--- a/src/pudl/metadata/enums.py
+++ b/src/pudl/metadata/enums.py
@@ -26,11 +26,6 @@ List of timezones in pytz.common_timezones
 Canada: https://en.wikipedia.org/wiki/Time_in_Canada#IANA_time_zone_database
 """
 
-STATE_TO_CENSUS_DIVISION: dict[str, str] = {
-    x.subdivision_code: x.division_code_us_census
-    for x in POLITICAL_SUBDIVISIONS.itertuples()
-}
-
 NERC_REGIONS: list[str] = [
     "BASN",  # ASSESSMENT AREA Basin (WECC)
     "CALN",  # ASSESSMENT AREA California (WECC)

--- a/src/pudl/metadata/enums.py
+++ b/src/pudl/metadata/enums.py
@@ -14,7 +14,7 @@ DIVISION_CODES_US_CENSUS: set[str] = set(
 )
 
 APPROXIMATE_TIMEZONES: dict[str, str] = {
-    x.subdivision_code: x.timezone for x in POLITICAL_SUBDIVISIONS.itertuples()
+    x.subdivision_code: x.timezone_approx for x in POLITICAL_SUBDIVISIONS.itertuples()
 }
 """Mapping of political subdivision code to the most common timezone in that area.
 
@@ -29,10 +29,6 @@ Canada: https://en.wikipedia.org/wiki/Time_in_Canada#IANA_time_zone_database
 STATE_TO_CENSUS_DIVISION: dict[str, str] = {
     x.subdivision_code: x.division_code_us_census
     for x in POLITICAL_SUBDIVISIONS.itertuples()
-}
-
-STATE_ID_FIPS: dict[str, str] = {
-    x.state_id_fips: x.subdivision_code for x in POLITICAL_SUBDIVISIONS.itertuples()
 }
 
 NERC_REGIONS: list[str] = [

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -1973,6 +1973,14 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "IANA timezone name",
         "constraints": {"enum": all_timezones},
     },
+    "timezone_approx": {
+        "type": "string",
+        "description": (
+            "IANA timezone name of the timezone which encompasses the largest portion "
+            "of the population in the associated geographic area."
+        ),
+        "constraints": {"enum": all_timezones},
+    },
     "topping_bottoming_code": {
         "type": "string",
         "description": "If the generator is associated with a combined heat and power system, indicates whether the generator is part of a topping cycle or a bottoming cycle",

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -8,8 +8,9 @@ from pytz import all_timezones
 from pudl.metadata.codes import CODE_METADATA
 from pudl.metadata.constants import FIELD_DTYPES_PANDAS
 from pudl.metadata.enums import (
-    CANADA_PROVINCES_TERRITORIES,
+    COUNTRY_CODES_ISO3166,
     CUSTOMER_CLASSES,
+    DIVISION_CODES_US_CENSUS,
     EPACEMS_MEASUREMENT_CODES,
     EPACEMS_STATES,
     FUEL_CLASSES,
@@ -18,9 +19,9 @@ from pudl.metadata.enums import (
     RELIABILITY_STANDARDS,
     REVENUE_CLASSES,
     RTO_CLASSES,
+    SUBDIVISION_CODES_ISO3166,
     TECH_CLASSES,
     TECH_DESCRIPTIONS,
-    US_STATES_TERRITORIES,
 )
 from pudl.metadata.labels import (
     ESTIMATED_OR_ACTUAL,
@@ -292,6 +293,15 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
             "pattern": r"^\d{5}$",
         },
     },
+    "country_code": {
+        "type": "string",
+        "description": "Three letter ISO-3166 country code (e.g. USA or CAN).",
+        "constraints": {"enum": COUNTRY_CODES_ISO3166},
+    },
+    "country_name": {
+        "type": "string",
+        "description": "Full country name (e.g. United States of America).",
+    },
     "credits_or_adjustments": {"type": "number"},
     "critical_peak_pricing": {"type": "boolean"},
     "critical_peak_rebate": {"type": "boolean"},
@@ -422,6 +432,21 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     "distribution_total": {
         "type": "number",
         "description": "Distribution Plant Total (FERC Accounts 360-374).",
+    },
+    "division_code_us_census": {
+        "type": "string",
+        "description": (
+            "Three-letter US Census division code as it appears in the bulk "
+            "electricity data published by the EIA. Note that EIA splits the Pacific "
+            "division into distinct contiguous (CA, OR, WA) and non-contiguous (AK, "
+            "HI) states. For reference see this US Census region and division map: "
+            "https://www2.census.gov/geo/pdfs/maps-data/maps/reference/us_regdiv.pdf"
+        ),
+        "constraints": {"enum": DIVISION_CODES_US_CENSUS},
+    },
+    "division_name_us_census": {
+        "type": "string",
+        "description": "Longer human readable name describing the US Census division.",
     },
     "duct_burners": {
         "type": "boolean",
@@ -895,6 +920,13 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     "intangible_total": {
         "type": "number",
         "description": "Intangible Plant Total (FERC Accounts 301-303).",
+    },
+    "is_epacems_state": {
+        "type": "boolean",
+        "description": (
+            "Indicates whether the associated state reports data within the EPA's "
+            "Continuous Emissions Monitoring System."
+        ),
     },
     "iso_rto_code": {
         "type": "string",
@@ -1370,18 +1402,16 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Whether any part of generator is owned by a nonutilty",
     },
     "owner_city": {"type": "string", "description": "City of owner."},
+    "owner_country": {
+        "type": "string",
+        "description": "Three letter ISO-3166 country code.",
+        "constraints": {"enum": COUNTRY_CODES_ISO3166},
+    },
     "owner_name": {"type": "string", "description": "Name of owner."},
     "owner_state": {
         "type": "string",
-        "description": "Two letter US & Canadian state and territory abbreviations.",
-        "constraints": {
-            "enum": sorted(
-                {
-                    **US_STATES_TERRITORIES,
-                    **CANADA_PROVINCES_TERRITORIES,
-                }.keys()
-            )
-        },
+        "description": "Two letter ISO-3166 political subdivision code.",
+        "constraints": {"enum": SUBDIVISION_CODES_ISO3166},
     },
     "owner_street_address": {
         "type": "string",
@@ -1634,6 +1664,10 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
         "type": "string",
         "description": "Identifier indicating original FERC Form 1 source record. format: {table_name}_{report_year}_{report_prd}_{respondent_id}_{spplmnt_num}_{row_number}. Unique within FERC Form 1 DB tables which are not row-mapped.",  # noqa: FS003
     },
+    "region_name_us_census": {
+        "type": "string",
+        "description": "Human-readable name of a US Census region.",
+    },
     "regulatory_status_code": {
         "type": "string",
         "description": "Indicates whether the plant is regulated or non-regulated.",
@@ -1861,6 +1895,27 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     "subcritical_tech": {
         "type": "boolean",
         "description": "Indicates whether the generator uses subcritical technology",
+    },
+    "subdivision_code": {
+        "type": "string",
+        "description": (
+            "Two-letter ISO-3166 political subdivision code (e.g. US state "
+            "or Canadian provice abbreviations like CA or AB)."
+        ),
+        "constraints": {"enum": SUBDIVISION_CODES_ISO3166},
+    },
+    "subdivision_name": {
+        "type": "string",
+        "description": (
+            "Full name of political subdivision (e.g. US state or Canadian "
+            "province names like California or Alberta."
+        ),
+    },
+    "subdivision_type": {
+        "type": "string",
+        "description": (
+            "ISO-3166 political subdivision type. E.g. state, province, outlying_area."
+        ),
     },
     "sulfur_content_pct": {
         "type": "number",

--- a/src/pudl/metadata/resources/eia860.py
+++ b/src/pudl/metadata/resources/eia860.py
@@ -137,6 +137,7 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "owner_name",
                 "owner_state",
                 "owner_city",
+                "owner_country",
                 "owner_street_address",
                 "owner_zip_code",
                 "fraction_owned",

--- a/src/pudl/metadata/resources/pudl.py
+++ b/src/pudl/metadata/resources/pudl.py
@@ -18,7 +18,7 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "subdivision_code",
                 "subdivision_name",
                 "subdivision_type",
-                "timezone",
+                "timezone_approx",
                 "state_id_fips",
                 "division_name_us_census",
                 "division_code_us_census",

--- a/src/pudl/metadata/resources/pudl.py
+++ b/src/pudl/metadata/resources/pudl.py
@@ -5,6 +5,32 @@ Most of this is compiled from handmapping records.
 from typing import Any
 
 RESOURCE_METADATA: dict[str, dict[str, Any]] = {
+    "political_subdivisions": {
+        "title": "Political Subdivisions",
+        "description": (
+            "Various static attributes associated with states, provinces, and other "
+            "sub-national political subdivisions."
+        ),
+        "schema": {
+            "fields": [
+                "country_code",
+                "country_name",
+                "subdivision_code",
+                "subdivision_name",
+                "subdivision_type",
+                "timezone",
+                "state_id_fips",
+                "division_name_us_census",
+                "division_code_us_census",
+                "region_name_us_census",
+                "is_epacems_state",
+            ],
+            "primary_key": ["country_code", "subdivision_code"],
+        },
+        "etl_group": "static_pudl",
+        "field_namespace": "pudl",
+        "sources": ["pudl"],
+    },
     "plants_pudl": {
         "title": "PUDL Plants",
         "description": "Home table for PUDL assigned plant IDs. These IDs are manually generated each year when new FERC and EIA reporting is integrated, and any newly identified plants are added to the list with a new ID. Each ID maps to a power plant which is reported in at least one FERC or EIA data set. This table is read in from a spreadsheet stored in the PUDL repository: src/pudl/package_data/glue/pudl_id_mapping.xlsx",

--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -238,7 +238,7 @@ SOURCES: dict[str, Any] = {
         "field_namespace": "epacems",
         "working_partitions": {
             "years": sorted(set(range(1995, 2022))),
-            "states": sorted(set(EPACEMS_STATES)),
+            "states": sorted(EPACEMS_STATES),
         },
         "contributors": [
             CONTRIBUTORS["catalyst-cooperative"],

--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -27,6 +27,7 @@ import timezonefinder
 
 import pudl
 from pudl.metadata.classes import DataSource
+from pudl.metadata.enums import APPROXIMATE_TIMEZONES
 from pudl.metadata.fields import apply_pudl_dtypes, get_pudl_dtypes
 from pudl.metadata.resources import ENTITIES
 from pudl.settings import EiaSettings
@@ -35,87 +36,6 @@ logger = logging.getLogger(__name__)
 
 TZ_FINDER = timezonefinder.TimezoneFinder()
 """A global TimezoneFinder to cache geographies in memory for faster access."""
-
-APPROXIMATE_TIMEZONES: dict[str, str] = {
-    "AK": "America/Anchorage",  # Alaska
-    "AL": "America/Chicago",  # Alabama
-    "AR": "America/Chicago",  # Arkansas
-    "AS": "Pacific/Pago_Pago",  # American Samoa; Not in CEMS
-    "AZ": "America/Phoenix",  # Arizona
-    "CA": "America/Los_Angeles",  # California
-    "CO": "America/Denver",  # Colorado
-    "CT": "America/New_York",  # Connecticut
-    "DC": "America/New_York",  # District of Columbia
-    "DE": "America/New_York",  # Delaware
-    "FL": "America/New_York",  # Florida (split state)
-    "GA": "America/New_York",  # Georgia
-    "GU": "Pacific/Guam",  # Guam; Not in CEMS
-    "HI": "Pacific/Honolulu",  # Hawaii; Not in CEMS
-    "IA": "America/Chicago",  # Iowa
-    "ID": "America/Denver",  # Idaho (split state)
-    "IL": "America/Chicago",  # Illinois
-    "IN": "America/New_York",  # Indiana (split state)
-    "KS": "America/Chicago",  # Kansas (split state)
-    "KY": "America/New_York",  # Kentucky (split state)
-    "LA": "America/Chicago",  # Louisiana
-    "MA": "America/New_York",  # Massachusetts
-    "MD": "America/New_York",  # Maryland
-    "ME": "America/New_York",  # Maine
-    "MI": "America/Detroit",  # Michigan (split state)
-    "MN": "America/Chicago",  # Minnesota
-    "MO": "America/Chicago",  # Missouri
-    "MP": "Pacific/Guam",  # Northern Mariana Islands; Not in CEMS
-    "MS": "America/Chicago",  # Mississippi
-    "MT": "America/Denver",  # Montana
-    "NC": "America/New_York",  # North Carolina
-    "ND": "America/Chicago",  # North Dakota (split state)
-    "NE": "America/Chicago",  # Nebraska (split state)
-    "NH": "America/New_York",  # New Hampshire
-    "NJ": "America/New_York",  # New Jersey
-    "NM": "America/Denver",  # New Mexico
-    "NV": "America/Los_Angeles",  # Nevada
-    "NY": "America/New_York",  # New York
-    "OH": "America/New_York",  # Ohio
-    "OK": "America/Chicago",  # Oklahoma
-    "OR": "America/Los_Angeles",  # Oregon (split state)
-    "PA": "America/New_York",  # Pennsylvania
-    "PR": "America/Puerto_Rico",  # Puerto Rico; Not in CEMS
-    "RI": "America/New_York",  # Rhode Island
-    "SC": "America/New_York",  # South Carolina
-    "SD": "America/Chicago",  # South Dakota (split state)
-    "TN": "America/Chicago",  # Tennessee
-    "TX": "America/Chicago",  # Texas
-    "UT": "America/Denver",  # Utah
-    "VA": "America/New_York",  # Virginia
-    "VI": "America/Port_of_Spain",  # Virgin Islands; Not in CEMS
-    "VT": "America/New_York",  # Vermont
-    "WA": "America/Los_Angeles",  # Washington
-    "WI": "America/Chicago",  # Wisconsin
-    "WV": "America/New_York",  # West Virginia
-    "WY": "America/Denver",  # Wyoming
-    # Canada (none of these are in CEMS)
-    "AB": "America/Edmonton",  # Alberta
-    "BC": "America/Vancouver",  # British Columbia (split province)
-    "MB": "America/Winnipeg",  # Manitoba
-    "NB": "America/Moncton",  # New Brunswick
-    "NS": "America/Halifax",  # Nova Scotia
-    "NL": "America/St_Johns",  # Newfoundland and Labrador (split province)
-    "NT": "America/Yellowknife",  # Northwest Territories (split province)
-    "NU": "America/Iqaluit",  # Nunavut (split province)
-    "ON": "America/Toronto",  # Ontario (split province)
-    "PE": "America/Halifax",  # Prince Edwards Island
-    "QC": "America/Montreal",  # Quebec (split province)
-    "SK": "America/Regina",  # Saskatchewan  (split province)
-    "YT": "America/Whitehorse",  # Yukon Territory
-}
-"""Approximate mapping of US & Canadian jurisdictions to canonical timezones
-
-This is imperfect for states that have split timezones. See:
-https://en.wikipedia.org/wiki/List_of_time_offsets_by_U.S._state_and_territory
-For states that are split, the timezone that has more people in it.
-List of timezones in pytz.common_timezones
-Canada: https://en.wikipedia.org/wiki/Time_in_Canada#IANA_time_zone_database
-"""
 
 
 def find_timezone(*, lng=None, lat=None, state=None, strict=True):

--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pudl
 from pudl.metadata.classes import DataSource
 from pudl.metadata.codes import CODE_METADATA
+from pudl.metadata.dfs import POLITICAL_SUBDIVISIONS
 from pudl.metadata.fields import apply_pudl_dtypes
 from pudl.settings import Eia860Settings
 from pudl.transform.eia861 import clean_nerc
@@ -161,7 +162,13 @@ def ownership(eia860_dfs, eia860_transformed_dfs):
         .get_resource("ownership_eia860")
         .encode(own_df)
     )
-
+    # CN is an invalid political subdivision code used by a few respondents to indicate
+    # that the owner is in Canada. At least we can recover the country:
+    state_to_country = {
+        x.subdivision_code: x.country_code for x in POLITICAL_SUBDIVISIONS.itertuples()
+    } | {"CN": "CAN"}
+    own_df["owner_country"] = own_df["owner_state"].map(state_to_country)
+    own_df.loc[own_df.owner_state == "CN", "owner_state"] = pd.NA
     eia860_transformed_dfs["ownership_eia860"] = own_df
 
     return eia860_transformed_dfs


### PR DESCRIPTION
Consolidates several dictionaries and enumerations that we had scattered across the codebase into a single static table, with information about states, territories, provinces, etc. Including membership in various geographic aggregations, FIPS codes, etc.

In the process, also added a new `ownership_country` column to the `ownership_eia860` table, to clearly differentiate between country and political subdivision information, which was comingled in the state column previously.

Closes #1958