### PR TITLE
Remove duplicates in the mine_id_msha column

### DIFF
--- a/src/pudl/transform/eia923.py
+++ b/src/pudl/transform/eia923.py
@@ -1011,10 +1011,17 @@ def coalmine(eia923_dfs, eia923_transformed_dfs):
             "mine_id_msha",
         ]
     )
-    cmi_df.drop(cmi_df[cmi_df["mine_id_msha"] > 0].index)
+    cmi_df = cmi_df.drop(cmi_df[cmi_df["mine_id_msha"] > 0].index)
     cmi_df = pd.concat([cmi_df, cmi_with_msha])
 
     cmi_df = cmi_df.drop_duplicates(subset=coalmine_cols)
+
+    # ensure mine_id_msha values are unique
+    assert cmi_df[
+        ~cmi_df.mine_id_msha.isna()
+    ].mine_id_msha.is_unique, (
+        "Found duplicate values for mine_id_msha in the coalmine_eia923 table."
+    )
 
     # drop null values if they occur in vital fields....
     cmi_df.dropna(subset=["mine_name", "state"], inplace=True)


### PR DESCRIPTION
Based on the comment in `src/pudl/transform/eia923.py` the mine_id_msha column should have unique ids:
https://github.com/catalyst-cooperative/pudl/blob/d294cb52b62b6adf18384b2bbb1be15c84667e6f/src/pudl/transform/eia923.py#L1001-L1015
But they aren't because the `cmi_df` isn't overwritten on line 1014. 

To improve matching with MSHA data, we could keep the most recent record for each mine_id_msha value instead of  dropping the records indiscriminately.