### PR TITLE
Bump allowed geopandas & pygeos conda versions

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -11,8 +11,8 @@ dependencies:
   # These packages are also specified in setup.py
   # However, they depend on or benefit from binary libraries
   # which conda can install.
-  - geopandas>=0.9,<0.12
-  - pygeos>=0.10,<0.13 # Python wrappers for the GEOS spatial libraries
+  - geopandas>=0.9,<0.13
+  - pygeos>=0.10,<0.14 # Python wrappers for the GEOS spatial libraries
   - python-snappy>=0.6,<1
   - sqlite>=3.36,<4
   # These libraries aren't directly specified in setup.py as

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -5,10 +5,10 @@ channels:
   - defaults
 dependencies:
   - python>=3.10,<3.11
-  - geopandas>=0.9,<0.12
+  - geopandas>=0.9,<0.13
   - numba>=0.55.1,<0.56
   - pip>=22,<23
-  - pygeos>=0.10,<0.13
+  - pygeos>=0.10,<0.14
   - python-snappy>=0.6,<1
   - setuptools<66
   - sqlite>=3.36,<4


### PR DESCRIPTION
The dependabot doesn't bump conda environment versions for us, so these stale versions were taking precedence in some contexts.