### PR TITLE
Fix erroneous max row values in mcoe_test

### DIFF
--- a/test/validate/mcoe_test.py
+++ b/test/validate/mcoe_test.py
@@ -109,7 +109,7 @@ def test_no_null_rows_mcoe(pudl_out_mcoe, live_dbs, df_name, thresh):
         ("hr_by_gen", 557_819, 46_535),
         ("fuel_cost", 557_819, 46_535),
         ("capacity_factor", 604_594, 50_448),
-        ("mcoe", 1_077_537, 523_343),
+        ("mcoe", 604_642, 50_448),
     ],
 )
 def test_minmax_rows_mcoe(pudl_out_mcoe, live_dbs, monthly_rows, annual_rows, df_name):


### PR DESCRIPTION
I really don't know where I got those large values that were previously in there. But I glad it tripped a wire! Here's the updated version