### PR TITLE
Address missing fuel ferc1 records

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,8 @@ setup(
     install_requires=[
         "addfips>=0.3.1,<0.4.0",
         "catalystcoop.dbfread>=3.0,<3.1",
-        "catalystcoop.ferc-xbrl-extractor==0.4.2",
+        # "catalystcoop.ferc-xbrl-extractor==0.4.2",
+        "catalystcoop.ferc-xbrl-extractor @ git+https://github.com/catalyst-cooperative/ferc-xbrl-extractor@dev",
         "coloredlogs>=15.0,<15.1",
         "dask>=2021.8,<2022.11.2",
         "datapackage>=1.11,<1.16",  # Transition datastore to use frictionless.

--- a/setup.py
+++ b/setup.py
@@ -49,8 +49,7 @@ setup(
     install_requires=[
         "addfips>=0.3.1,<0.4.0",
         "catalystcoop.dbfread>=3.0,<3.1",
-        # "catalystcoop.ferc-xbrl-extractor==0.4.2",
-        "catalystcoop.ferc-xbrl-extractor @ git+https://github.com/catalyst-cooperative/ferc-xbrl-extractor@dev",
+        "catalystcoop.ferc-xbrl-extractor==0.5.0",
         "coloredlogs>=15.0,<15.1",
         "dask>=2021.8,<2022.11.2",
         "datapackage>=1.11,<1.16",  # Transition datastore to use frictionless.

--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -63,8 +63,8 @@ def test_no_null_cols_ferc1(pudl_out_ferc1, live_dbs, cols, df_name):
 @pytest.mark.parametrize(
     "df_name,expected_rows",
     [
-        ("fbp_ferc1", 25_136),
-        ("fuel_ferc1", 48_280),
+        ("fbp_ferc1", 25_416),
+        ("fuel_ferc1", 48_821),
         ("plant_in_service_ferc1", 311_794),
         ("plants_all_ferc1", 54_276),
         ("plants_hydro_ferc1", 6_796),


### PR DESCRIPTION
For the moment this points at the `dev` branch of the `ferc-xbrl-extractor` repo, which fixes an issue with the XBRL to SQLite conversion that was affecting the `fuel_ferc1` table in particular.

* Updates the expected row counts for the `fuel_ferc1` and `fbp_ferc1` data validations.
* Adds some additional logging to the `Ferc1AbstractTableTransformer.merge_instant_and_duration_tables_xbrl()` method.
* Defensively uses a copy of the `fuel_ferc1` table in the transformation of the `plants_steam_ferc1` table just to be sure that the table isn't accidentally mutated in the process of the steam transform.

### Do not merge into `dev` until:
* [x] A full `tox -e nuke` has passed successfully locally (@zaneselvans is running it overnight)
* [x] https://github.com/catalyst-cooperative/ferc-xbrl-extractor/pull/35 has been merged and packaged for release by @zschira 
* [x] `setup.py` here in PUDL has been updated to point at the new version.