### PR TITLE
Add GCP region/zone env var to nightly build scripts

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -99,6 +99,7 @@ jobs:
             --container-env GITHUB_REF=${{ env.GITHUB_REF }} \
             --container-env SLACK_TOKEN=${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }} \
             --container-env GCE_INSTANCE=${{ env.GCE_INSTANCE }} \
+            --container-env GCE_INSTANCE_ZONE=${{ env.GCE_INSTANCE_ZONE }} \
             --container-env GCP_BILLING_PROJECT=${{ secrets.GCP_BILLING_PROJECT }}
 
       # Start the VM

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -58,7 +58,7 @@ function shutdown_vm() {
         "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
         -H "Metadata-Flavor: Google" | jq -r '.access_token'`
 
-    curl -X POST -H "Content-Length: 0" -H "Authorization: Bearer ${ACCESS_TOKEN}" https://compute.googleapis.com/compute/v1/projects/catalyst-cooperative-pudl/zones/us-central1-a/instances/$GCE_INSTANCE/stop
+    curl -X POST -H "Content-Length: 0" -H "Authorization: Bearer ${ACCESS_TOKEN}" https://compute.googleapis.com/compute/v1/projects/catalyst-cooperative-pudl/zones/$GCE_INSTANCE_ZONE/instances/$GCE_INSTANCE/stop
 }
 
 function copy_outputs_to_intake_bucket() {


### PR DESCRIPTION
The most recent nightly build failed to shut down the VM because the region was hardcoded in the API request that shuts down the VM at the end of the nightly builds. This PR passes the GCE_INSTANCE_ZONE env var to the container on the VM.

## PR Checklist

Before requesting a review of your pull request, please make sure you've done the
following:

* [ ] Merge the most recent version of `dev` (or the appropriate upstream branch) into
      your branch and resolved any merge conflicts. You may need to do this several
      times over the course of a PR as `dev` changes frequently.
* [ ] Verify that all of the CI checks on your PR are passing. See
      [Running Tests with Tox](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
      for details on how to run the full test suite locally if you need to debug a
      particular failure.
* [ ] Ensure that the docstrings for any new modules, classes, functions, or methods are
      descriptive enough for developers and users to understand your code.
* [ ] If you expanded data coverage or changed the outputs, ensure that the full
      [data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
      pass locally on a fresh DB.
* [ ] If you've added new functions or classes, ensure that they have at least basic
      unit tests.
* [ ] If you've added new analyses, make sure they include defensive sanity checks that
      will catch unexpected data issues.
* [ ] Update the
      [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html)
      to reflect your changes. Make sure to reference the PR and any related issues.
* [ ] Do your own review of the PR. Add comments highlighting areas where you have
      questions you'd like reviewers to answer, known issues, solutions you're
      unsatisfied with, or other things that deserve special attention from the
      reviewer.
