### PR TITLE
fix ferc1 record_id validation errors

### DIFF
--- a/src/pudl/metadata/resources/ferc1.py
+++ b/src/pudl/metadata/resources/ferc1.py
@@ -56,7 +56,7 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
         },
         "sources": ["ferc1"],
-        "etl_group": "ferc1",
+        "etl_group": "ferc1_disabled",
         "field_namespace": "ferc1",
     },
     "ferc_accounts": {

--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -14,8 +14,13 @@ from pudl.metadata.classes import DataSource
 logger = logging.getLogger(__name__)
 
 # These are tables for which individual records have been sliced up and
-# turned into columns -- so there's no universally unique record ID:
-non_unique_record_id_tables = ["plant_in_service_ferc1", "purchased_power_ferc1"]
+# turned into columns -- so there's no universally unique record ID. But we should
+# parameterize the has_unique_record_ids class attributes in the FERC classes
+non_unique_record_id_tables = [
+    "plant_in_service_ferc1",
+    "purchased_power_ferc1",
+    "electric_energy_account_sources_ferc1",
+]
 unique_record_tables = [
     t
     for t in DataSource.from_id("ferc1").get_resource_ids()


### PR DESCRIPTION
we have one validation ferc1 test to check whether the record_id is unique, which doesn't apply to any of the column-> row reshaped tables. so we have to tell it to ignore those. + i added the shell of a table into the resources before it was ready so i disabled that one. we should use the transform params to find the tables to do this check on without having to enumerate each of these non-unique record_id tables

## PR Checklist

Before requesting a review of your pull request, please make sure you've done the
following:

* [x] Merge the most recent version of `dev` (or the appropriate upstream branch) into
      your branch and resolved any merge conflicts. You may need to do this several
      times over the course of a PR as `dev` changes frequently.
* [ ] Verify that all of the CI checks on your PR are passing. See
      [Running Tests with Tox](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
      for details on how to run the full test suite locally if you need to debug a
      particular failure.
* [ ] Ensure that the docstrings for any new modules, classes, functions, or methods are
      descriptive enough for developers and users to understand your code.
* [ ] If you expanded data coverage or changed the outputs, ensure that the full
      [data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
      pass locally on a fresh DB.
* [ ] If you've added new functions or classes, ensure that they have at least basic
      unit tests.
* [ ] If you've added new analyses, make sure they include defensive sanity checks that
      will catch unexpected data issues.
* [ ] Update the
      [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html)
      to reflect your changes. Make sure to reference the PR and any related issues.
* [x] Do your own review of the PR. Add comments highlighting areas where you have
      questions you'd like reviewers to answer, known issues, solutions you're
      unsatisfied with, or other things that deserve special attention from the
      reviewer.
