### PR TITLE
fix table name in record_id test

### DIFF
--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 non_unique_record_id_tables = [
     "plant_in_service_ferc1",
     "purchased_power_ferc1",
-    "electric_energy_account_sources_ferc1",
+    "electric_energy_sources_ferc1",
     "electric_energy_dispositions_ferc1",
 ]
 unique_record_tables = [


### PR DESCRIPTION
bb fix for the `electric_energy_sources_ferc1` table name change. it needed to be removed from the record_id valition test.