### PR TITLE
Fix missing `generator_id` in epacamd_eia

### DIFF
--- a/src/pudl/analysis/epacamd_eia.py
+++ b/src/pudl/analysis/epacamd_eia.py
@@ -120,7 +120,7 @@ def _prep_for_networkx(crosswalk: pd.DataFrame) -> pd.DataFrame:
         by=["plant_id_eia", "emissions_unit_id_epa"]
     ).ngroup()
     # node IDs can't overlap so add (max + 1)
-    prepped["generator_id"] = (
+    prepped["generator_id_unique"] = (
         prepped.groupby(by=["plant_id_eia", "generator_id"]).ngroup()
         + prepped["combustor_id"].max()
         + 1
@@ -141,7 +141,7 @@ def _subplant_ids_from_prepped_crosswalk(prepped: pd.DataFrame) -> pd.DataFrame:
     graph = nx.from_pandas_edgelist(
         prepped,
         source="combustor_id",
-        target="generator_id",
+        target="generator_id_unique",
         edge_attr=True,
     )
     for i, node_set in enumerate(nx.connected_components(graph)):


### PR DESCRIPTION
In `epacamd_eia.py` when prepping the data for networkx, we created a new generator_id column that didn't have any overlapping id numbers. The problem was that this new unique id was assigned the same name as an existing column (`generator_id`), and this column was used as the target column in the network analysis. This was resulting in the final epacamd_eia crosswalk table missing a `generator_id` column. For our use in OGE, we need this crosswalk table to include the crosswalk to EIA generator ids.

To fix this, I just assigned the target column for the graph analysis a unique name that is different from the generator_id column.