### PR TITLE
bad shapely bad... (i mean bad us for not getting to these future war…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "Shapely!=1.8.3",  # Seems to have a bug or incompatibility
         "scipy>=1.6,<1.10",
         "Shapely!=1.8.3",  # Bug or incompatibility in upstream dependencies
+        "Shapely<2.0.0",
         "sqlalchemy>=1.4,<1.4.45",
         "timezonefinder>=5,<6.2",
         "xlsxwriter>=3,<3.1",


### PR DESCRIPTION
Shapely version 2.0.0 was giving me errors: 

```
FAILED test/unit/analysis/spatial_test.py::test_check_gdf[gdf5-ValueError-MultiPolygon contains Polygon geometries with zero area] - TypeError: 'MultiPolygon' object is not iterable
FAILED test/unit/analysis/spatial_test.py::test_polygonize - TypeError: 'GeometryCollection' object is not iterable
FAILED test/unit/analysis/spatial_test.py::test_explode - TypeError: 'MultiPolygon' object is not iterable
```

so I PINNED 📌 