### PR TITLE
Update row counts for dropped invalid plant names

### DIFF
--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -73,14 +73,14 @@ def test_no_null_cols_ferc1(pudl_out_ferc1, live_dbs, cols, df_name):
 @pytest.mark.parametrize(
     "df_name,expected_rows",
     [
-        ("fbp_ferc1", 25_416),
-        ("fuel_ferc1", 48_821),
+        ("fbp_ferc1", 25_414),
+        ("fuel_ferc1", 48_818),
         ("plant_in_service_ferc1", 311_794),
-        ("plants_all_ferc1", 54_276),
+        ("plants_all_ferc1", 54_275),
         ("plants_hydro_ferc1", 6_796),
         ("plants_pumped_storage_ferc1", 544),
         ("plants_small_ferc1", 16_235),
-        ("plants_steam_ferc1", 30_701),
+        ("plants_steam_ferc1", 30_700),
         ("pu_ferc1", 7_425),
         ("purchased_power_ferc1", 197_523),
     ],


### PR DESCRIPTION
The number of expected plant records changed slightly, as we are now excluding a few more invalid plant names (like "not applicable" or the string zero "0".