### PR TITLE
Add depreciation_amortization_summary_ferc1 to non-unique record ID's…

### DIFF
--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -25,6 +25,7 @@ non_unique_record_id_tables = [
     "utility_plant_summary_ferc1",
     "transmission_ferc1",
     "balance_sheet_assets_ferc1",
+    "depreciation_amortization_summary_ferc1",
 ]
 unique_record_tables = [
     t


### PR DESCRIPTION
Small PR to fix nightly builds failure caused by unique ID validation test.