### PR TITLE
Make transform params stricter 2

### DIFF
--- a/src/pudl/transform/classes.py
+++ b/src/pudl/transform/classes.py
@@ -96,6 +96,7 @@ class TransformParams(BaseModel):
         """Prevent parameters from changing part way through."""
 
         allow_mutation = False
+        extra = "forbid"
 
 
 class MultiColumnTransformParams(TransformParams):

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -548,8 +548,8 @@ class Ferc1TableTransformParams(TableTransformParams):
     rename_columns_ferc1: RenameColumnsFerc1 = RenameColumnsFerc1(
         dbf=RenameColumns(),
         xbrl=RenameColumns(),
-        xbrl_instant=RenameColumns(),
-        xbrl_duration=RenameColumns(),
+        instant_xbrl=RenameColumns(),
+        duration_xbrl=RenameColumns(),
     )
     wide_to_tidy: WideToTidySourceFerc1 = WideToTidySourceFerc1(
         dbf=WideToTidy(), xbrl=WideToTidy()

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -540,11 +540,6 @@ class Ferc1TableTransformParams(TableTransformParams):
     :class:`pudl.transform.classes.AbstractTableTransformer` class.
     """
 
-    class Config:
-        """Only allow the known table transform params."""
-
-        extra = "forbid"
-
     rename_columns_ferc1: RenameColumnsFerc1 = RenameColumnsFerc1(
         dbf=RenameColumns(),
         xbrl=RenameColumns(),


### PR DESCRIPTION
Teeny tiny bb PR that adds the following code to the `TransformParams` class:
```
    class Config:
        """Only allow the known table transform params."""

        extra = "forbid"
```

And fixes a parameter name that was flip-flopped: 
- `xbrl_instant` and `xbrl_duration` were used as parameters in the `Ferc1TableTransformParams` class when the actual parameters defined in `RenameColumnsFerc1` are `instant_xbrl` and `duration_xbrl`. This PR flips them to reflect the `RenameColumnsFerc1` definition. 