### PR TITLE
Add direct S3 nightly build download links to README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -181,31 +181,31 @@ Datasette:
   * `FERC-1 SQLite derived from DBF (1994-2020) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1.sqlite>`__
   * `FERC-1 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_xbrl.sqlite>`__
   * `FERC-1 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_xbrl_datapackage.json>`__
-  * `FERC-1 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_taxonomy_metadata.json>`__
+  * `FERC-1 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_xbrl_taxonomy_metadata.json>`__
 
 * Raw FERC Form 2:
 
   * `FERC-2 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc2_xbrl.sqlite>`__
   * `FERC-2 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc2_xbrl_datapackage.json>`__
-  * `FERC-2 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazoaws.com/dev/ferc2_taxonomy_metadata.json>`__
+  * `FERC-2 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazoaws.com/dev/ferc2_xbrl_taxonomy_metadata.json>`__
 
 * Raw FERC Form 6:
 
   * `FERC-6 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_xbrl.sqlite>`__
   * `FERC-6 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_xbrl_datapackage.json>`__
-  * `FERC-6 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_taxonomy_metadata.json>`__
+  * `FERC-6 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_xbrl_taxonomy_metadata.json>`__
 
 * Raw FERC Form 60:
 
   * `FERC-60 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_xbrl.sqlite>`__
   * `FERC-60 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_xbrl_datapackage.json>`__
-  * `FERC-60 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_taxonomy_metadata.json>`__
+  * `FERC-60 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_xbrl_taxonomy_metadata.json>`__
 
 * Raw FERC Form 714:
 
   * `FERC-714 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_xbrl.sqlite>`__
   * `FERC-714 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_xbrl_datapackage.json>`__
-  * `FERC-714 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_taxonomy_metadata.json>`__
+  * `FERC-714 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_xbrl_taxonomy_metadata.json>`__
 
 Contributing to PUDL
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -187,7 +187,7 @@ Datasette:
 
   * `FERC-2 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc2_xbrl.sqlite>`__
   * `FERC-2 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc2_xbrl_datapackage.json>`__
-  * `FERC-2 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazoaws.com/dev/ferc2_xbrl_taxonomy_metadata.json>`__
+  * `FERC-2 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc2_xbrl_taxonomy_metadata.json>`__
 
 * Raw FERC Form 6:
 

--- a/README.rst
+++ b/README.rst
@@ -202,6 +202,7 @@ Datasette:
   * `FERC-60 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_taxonomy_metadata.json>`__
 
 * Raw FERC Form 714:
+
   * `FERC-714 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_xbrl.sqlite>`__
   * `FERC-714 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_xbrl_datapackage.json>`__
   * `FERC-714 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_taxonomy_metadata.json>`__

--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,39 @@ This is by far the most involved way to access the data and isn't recommended fo
 most users. You should check out the Development section of the main `PUDL
 documentation <https://catalystcoop-pudl.readthedocs.io>`__ for more details.
 
+Nightly Data Builds
+^^^^^^^^^^^^^^^^^^^
+If you are less concerned with reproducibility and want the freshest possible data
+we also upload the outputs of our nightly builds to public S3 storage buckets. This
+data is produced by the `dev branch <https://github.com/catalyst-cooperative/pudl/tree/dev>`__,
+of PUDL, and is updated most weekday mornings. It is also the data used to populate
+Datasette:
+
+* `PUDL SQLite DB <http://intake.catalyst.coop.s3.amazonaws.com/dev/pudl.sqlite>`__
+* `EPA CEMS Hourly Emissions Parquet (1995-2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/hourly_emissions_epacems.parquet>`__
+* `Census DP1 SQLite DB (2010) <http://intake.catalyst.coop.s3.amazonaws.com/dev/censusdp1tract.sqlite>`__
+* Raw FERC Form 1:
+  * `FERC-1 SQLite derived from DBF (1994-2020) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1.sqlite>`__
+  * `FERC-1 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_xbrl.sqlite>`__
+  * `FERC-1 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_xbrl_datapackage.json>`__
+  * `FERC-1 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_taxonomy_metadata.json>`__
+* Raw FERC Form 2:
+  * `FERC-2 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc2_xbrl.sqlite>`__
+  * `FERC-2 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc2_xbrl_datapackage.json>`__
+  * `FERC-2 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazoaws.com/dev/ferc2_taxonomy_metadata.json>`__
+* Raw FERC Form 6:
+  * `FERC-6 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_xbrl.sqlite>`__
+  * `FERC-6 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_xbrl_datapackage.json>`__
+  * `FERC-6 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_taxonomy_metadata.json>`__
+* Raw FERC Form 60:
+  * `FERC-60 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_xbrl.sqlite>`__
+  * `FERC-60 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_xbrl_datapackage.json>`__
+  * `FERC-60 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_taxonomy_metadata.json>`__
+* Raw FERC Form 714:
+  * `FERC-714 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_xbrl.sqlite>`__
+  * `FERC-714 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_xbrl_datapackage.json>`__
+  * `FERC-714 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_taxonomy_metadata.json>`__
+
 Contributing to PUDL
 --------------------
 Find PUDL useful? Want to help make it better? There are lots of ways to help!

--- a/README.rst
+++ b/README.rst
@@ -175,23 +175,32 @@ Datasette:
 * `PUDL SQLite DB <http://intake.catalyst.coop.s3.amazonaws.com/dev/pudl.sqlite>`__
 * `EPA CEMS Hourly Emissions Parquet (1995-2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/hourly_emissions_epacems.parquet>`__
 * `Census DP1 SQLite DB (2010) <http://intake.catalyst.coop.s3.amazonaws.com/dev/censusdp1tract.sqlite>`__
+
 * Raw FERC Form 1:
+
   * `FERC-1 SQLite derived from DBF (1994-2020) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1.sqlite>`__
   * `FERC-1 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_xbrl.sqlite>`__
   * `FERC-1 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_xbrl_datapackage.json>`__
   * `FERC-1 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc1_taxonomy_metadata.json>`__
+
 * Raw FERC Form 2:
+
   * `FERC-2 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc2_xbrl.sqlite>`__
   * `FERC-2 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc2_xbrl_datapackage.json>`__
   * `FERC-2 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazoaws.com/dev/ferc2_taxonomy_metadata.json>`__
+
 * Raw FERC Form 6:
+
   * `FERC-6 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_xbrl.sqlite>`__
   * `FERC-6 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_xbrl_datapackage.json>`__
   * `FERC-6 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc6_taxonomy_metadata.json>`__
+
 * Raw FERC Form 60:
+
   * `FERC-60 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_xbrl.sqlite>`__
   * `FERC-60 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_xbrl_datapackage.json>`__
   * `FERC-60 XBRL Taxonomy Metadata as JSON (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc60_taxonomy_metadata.json>`__
+
 * Raw FERC Form 714:
   * `FERC-714 SQLite derived from XBRL (2021) <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_xbrl.sqlite>`__
   * `FERC-714 Datapackage (JSON) describing SQLite derived from XBRL <http://intake.catalyst.coop.s3.amazonaws.com/dev/ferc714_xbrl_datapackage.json>`__


### PR DESCRIPTION
# PR Overview

We have publicly available nightly build outputs in some S3 buckets! We should let our users download it if they want. This PR just adds some links to the README. We may want to add similar links to other places too, see #2196. But this at least gets them out publicly somewhere we can refer to!

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- ~[ ] Make sure you've included good docstrings.~
- ~[ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)~
- ~[ ] Include unit tests for new functions and classes.~
- ~[ ] Defensive data quality/sanity checks in analyses & data processing functions.~
- ~[ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.~
- ~[ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.~