### PR TITLE
add methods to `PudlTabl` so it can be serialized and de-serialized

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -42,6 +42,13 @@ Deprecations
   <https://www.github.com/catalyst-cooperative/pudl-archiver>`__ repository in
   :doc:`intro`, :doc:`dev/datastore`, and :doc:`dev/annual_updates`. See :pr:`2190`.
 
+Miscellaneous
+^^^^^^^^^^^^^
+
+* Added :meth:`pudl.output.pudltabl.PudlTabl.__getstate__` and
+  :meth:`pudl.output.pudltabl.PudlTabl.__setstate__` methods to allow
+  :class:`pudl.output.pudltabl.PudlTabl` to be serialized using :mod:`pickle`.
+
 .. _release-v2022.11.30:
 
 ---------------------------------------------------------------------------------------

--- a/src/pudl/output/pudltabl.py
+++ b/src/pudl/output/pudltabl.py
@@ -1214,11 +1214,12 @@ class PudlTabl:
     def __getstate__(self) -> dict:
         """Get current object state for pickle.
 
-        This method is run as part of pickling the object. It needs to return a dict
-        representing the object's current state with any un-serializable objects
-        converted to a form that can be serialized.
+        This method is run as part of pickling the object. It needs to return the
+        object's current state with any un-serializable objects converted to a form that
+        can be serialized. See :meth:`object.__getstate__` for further details on the
+        expected behavior of this method.
         """
-        return self.__dict__ | {
+        return self.__dict__.copy() | {
             # defaultdict may be serializable but lambdas are not, so it must go
             "_dfs": dict(self.__dict__["_dfs"]),
             # sqlalchemy engines are also a problem here, saving the URL should
@@ -1234,24 +1235,14 @@ class PudlTabl:
         """Restore the object's state from a dictionary.
 
         Args:
-            state: a dict of the object state to restore. This is effectively
-                the dict produced by :meth:`pudl.output.pudltabl.PudlTabl.__getstate__`.
+            state: the object state to restore. This is effectively the output of
+            :meth:`pudl.output.pudltabl.PudlTabl.__getstate__`.
 
         This method is run when the object is restored from a pickle. Anything
         that was changed in :meth:`pudl.output.pudltabl.PudlTabl.__getstate__` must be
         undone here. Another important detail is that ``__init__`` is not run when an
         object is de-serialized, so under some circumstances, setup that happened there
-        may also need to occur here. The pseudo-esque code below shows how this works.
-
-        .. code-block:: python
-
-            # open the pickle and read the object's state from it
-            with open(file) as pkl:
-                state = pkl.read_state()
-            # create an empty instance of PudlTabl
-            obj = PudlTabl.__new__(PudlTabl)
-            # restore the object's state
-            obj.__setstate__(state)
+        may also need to occur here.
         """
         try:
             pudl_engine = sa.create_engine(state["pudl_engine"])

--- a/src/pudl/output/pudltabl.py
+++ b/src/pudl/output/pudltabl.py
@@ -1234,15 +1234,15 @@ class PudlTabl:
     def __setstate__(self, state: dict) -> None:
         """Restore the object's state from a dictionary.
 
-        Args:
-            state: the object state to restore. This is effectively the output of
-            :meth:`pudl.output.pudltabl.PudlTabl.__getstate__`.
-
         This method is run when the object is restored from a pickle. Anything
         that was changed in :meth:`pudl.output.pudltabl.PudlTabl.__getstate__` must be
         undone here. Another important detail is that ``__init__`` is not run when an
         object is de-serialized, so under some circumstances, setup that happened there
         may also need to occur here.
+
+        Args:
+            state: the object state to restore. This is effectively the output
+                of :meth:`pudl.output.pudltabl.PudlTabl.__getstate__`.
         """
         try:
             pudl_engine = sa.create_engine(state["pudl_engine"])

--- a/src/pudl/output/pudltabl.py
+++ b/src/pudl/output/pudltabl.py
@@ -1224,8 +1224,8 @@ class PudlTabl:
             "_dfs": dict(self.__dict__["_dfs"]),
             # sqlalchemy engines are also a problem here, saving the URL should
             # provide enough of what is needed to recreate it, though that means the
-            # pickle is not portable, but any fix to that should probably happen
-            # on the other side
+            # pickle is not portable, but any fix to that will happen when the object
+            # is restored
             "pudl_engine": str(self.__dict__["pudl_engine"].url)
             .removeprefix("Engine(")
             .removesuffix(")"),
@@ -1237,8 +1237,8 @@ class PudlTabl:
         This method is run when the object is restored from a pickle. Anything
         that was changed in :meth:`pudl.output.pudltabl.PudlTabl.__getstate__` must be
         undone here. Another important detail is that ``__init__`` is not run when an
-        object is de-serialized, so under some circumstances, setup that happened there
-        may also need to occur here.
+        object is de-serialized, so any setup there that alters external state might
+        need to happen here as well.
 
         Args:
             state: the object state to restore. This is effectively the output
@@ -1246,15 +1246,20 @@ class PudlTabl:
         """
         try:
             pudl_engine = sa.create_engine(state["pudl_engine"])
-            # make sure that the URL for the engine from ``state`` is usable now, if
-            # it is for a local DB on a different computer, then we fall back to the
-            # PUDL default
+            # make sure that the URL for the engine from ``state`` is usable now
             pudl_engine.connect()
         except sa.exc.OperationalError:
+            # if the URL from ``state`` is not valid, e.g. because it is for a local
+            # DB on a different computer, create the engine from PUDL defaults
+
             from pudl.workspace.setup import get_defaults
 
-            # if the URL from ``state`` is not valid, create the engine from PUDL
-            # defaults
+            logger.warning(
+                "Unable to connect to the restored pudl_db URL %s. "
+                "Will use the default pudl_db %s instead.",
+                state["pudl_engine"],
+                get_defaults()["pudl_db"],
+            )
             pudl_engine = sa.create_engine(get_defaults()["pudl_db"])
 
         self.__dict__ = state | {

--- a/src/pudl/output/pudltabl.py
+++ b/src/pudl/output/pudltabl.py
@@ -1207,6 +1207,71 @@ class PudlTabl:
             self._dfs["epacamd_eia"] = pudl.output.epacems.epacamd_eia(self.pudl_engine)
         return self._dfs["epacamd_eia"]
 
+    ###########################################################################
+    # FOR PICKLING AND OTHER IO
+    ###########################################################################
+
+    def __getstate__(self) -> dict:
+        """Get current object state for pickle.
+
+        This method is run as part of pickling the object. It needs to return a dict
+        representing the object's current state with any un-serializable objects
+        converted to a form that can be serialized.
+        """
+        return self.__dict__ | {
+            # defaultdict may be serializable but lambdas are not, so it must go
+            "_dfs": dict(self.__dict__["_dfs"]),
+            # sqlalchemy engines are also a problem here, saving the URL should
+            # provide enough of what is needed to recreate it, though that means the
+            # pickle is not portable, but any fix to that should probably happen
+            # on the other side
+            "pudl_engine": str(self.__dict__["pudl_engine"].url)
+            .removeprefix("Engine(")
+            .removesuffix(")"),
+        }
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore the object's state from a dictionary.
+
+        Args:
+            state: a dict of the object state to restore. This is effectively
+                the dict produced by :meth:`pudl.output.pudltabl.PudlTabl.__getstate__`.
+
+        This method is run when the object is restored from a pickle. Anything
+        that was changed in :meth:`pudl.output.pudltabl.PudlTabl.__getstate__` must be
+        undone here. Another important detail is that ``__init__`` is not run when an
+        object is de-serialized, so under some circumstances, setup that happened there
+        may also need to occur here. The pseudo-esque code below shows how this works.
+
+        .. code-block:: python
+
+            # open the pickle and read the object's state from it
+            with open(file) as pkl:
+                state = pkl.read_state()
+            # create an empty instance of PudlTabl
+            obj = PudlTabl.__new__(PudlTabl)
+            # restore the object's state
+            obj.__setstate__(state)
+        """
+        try:
+            pudl_engine = sa.create_engine(state["pudl_engine"])
+            # make sure that the URL for the engine from ``state`` is usable now, if
+            # it is for a local DB on a different computer, then we fall back to the
+            # PUDL default
+            pudl_engine.connect()
+        except sa.exc.OperationalError:
+            from pudl.workspace.setup import get_defaults
+
+            # if the URL from ``state`` is not valid, create the engine from PUDL
+            # defaults
+            pudl_engine = sa.create_engine(get_defaults()["pudl_db"])
+
+        self.__dict__ = state | {
+            # recreate the defaultdict from the vanilla one from ``state``
+            "_dfs": defaultdict(lambda: None, state["_dfs"]),
+            "pudl_engine": pudl_engine,
+        }
+
 
 def get_table_meta(pudl_engine):
     """Grab the pudl sqlitie database table metadata."""

--- a/test/integration/output_test.py
+++ b/test/integration/output_test.py
@@ -273,30 +273,3 @@ def test_pudltabl_pickle(fast_out_annual):
 
     pd.testing.assert_frame_equal(restored._dfs["plants_eia860"], plants)
     assert set(restored.__dict__.keys()) == keys
-
-
-def test_pudltabl_datazip(fast_out_annual):
-    """Test that PudlTabl is serializable with DataZip.
-
-    If etoolbox is installed, test that PudlTabl can be serialized with DataZip.
-    """
-    dz = pytest.importorskip("etoolbox.datazip")
-    from io import BytesIO
-
-    plants = fast_out_annual.plants_eia860()
-    # just to make sure we keep all the parts
-    keys = set(fast_out_annual.__dict__.keys())
-    try:
-        # Have not tackled proper serialization of Datastore so
-        # DataZip knows to ignore it
-        keys.remove("ds")
-    except KeyError:
-        pass
-
-    # dump the object into a pickle stored in a buffer
-    dz.DataZip.dump(fast_out_annual, buffer := BytesIO())
-    # restore the object from the pickle in the buffer
-    restored = dz.DataZip.load(buffer)
-
-    pd.testing.assert_frame_equal(restored._dfs["plants_eia860"], plants)
-    assert set(restored.__dict__.keys()) == keys

--- a/test/integration/output_test.py
+++ b/test/integration/output_test.py
@@ -219,42 +219,7 @@ def test_plant_parts_eia_filled(fast_out_annual):
     fast_out_annual.plant_parts_eia()
 
 
-@pytest.fixture(scope="module")
-def fast_out_filled(pudl_engine, pudl_datastore_fixture):
-    """A PUDL output object for use in CI with net generation filled."""
-    return pudl.output.pudltabl.PudlTabl(
-        pudl_engine,
-        ds=pudl_datastore_fixture,
-        freq="MS",
-        fill_fuel_cost=True,
-        roll_fuel_cost=True,
-        fill_net_gen=True,
-    )
-
-
-@pytest.mark.parametrize(
-    "df_name,expected_nuke_fraction,tolerance",
-    [
-        ("gf_nuclear_eia923", 1.0, 0.001),
-        ("gf_nonuclear_eia923", 0.0, 0.0),
-        ("gf_eia923", 0.2, 0.02),
-        ("mcoe", 0.2, 0.02),
-    ],
-)
-def test_mcoe_filled(fast_out_filled, df_name, expected_nuke_fraction, tolerance):
-    """Test that the net generation allocation process is working.
-
-    In addition to running the allocation itself, make sure that the nuclear and non-
-    nuclear generation fractions are as we would expect after the net generation has
-    been allocated.
-    """
-    actual_nuke_fraction = nuke_gen_fraction(
-        fast_out_filled.__getattribute__(df_name)()
-    )
-    assert abs(actual_nuke_fraction - expected_nuke_fraction) <= tolerance
-
-
-def test_pudltabl_pickle(test_dir, fast_out_annual):
+def test_pudltabl_pickle(fast_out_annual):
     """Test that PudlTabl is serializable with pickle.
 
     Because pickle is insecure, bandit must be quieted for this test.
@@ -270,6 +235,33 @@ def test_pudltabl_pickle(test_dir, fast_out_annual):
     pickle.dump(fast_out_annual, buffer := BytesIO())
     # restore the object from the pickle in the buffer
     restored = pickle.loads(buffer.getvalue())  # nosec
+
+    pd.testing.assert_frame_equal(restored._dfs["plants_eia860"], plants)
+    assert set(restored.__dict__.keys()) == keys
+
+
+def test_pudltabl_datazip(fast_out_annual):
+    """Test that PudlTabl is serializable with DataZip.
+
+    If etoolbox is installed, test that PudlTabl can be serialized with DataZip.
+    """
+    dz = pytest.importorskip("etoolbox.datazip")
+    from io import BytesIO
+
+    plants = fast_out_annual.plants_eia860()
+    # just to make sure we keep all the parts
+    keys = set(fast_out_annual.__dict__.keys())
+    try:
+        # Have not tackled proper serialization of Datastore so
+        # DataZip knows to ignore it
+        keys.remove("ds")
+    except KeyError:
+        pass
+
+    # dump the object into a pickle stored in a buffer
+    dz.DataZip.dump(fast_out_annual, buffer := BytesIO())
+    # restore the object from the pickle in the buffer
+    restored = dz.DataZip.load(buffer)
 
     pd.testing.assert_frame_equal(restored._dfs["plants_eia860"], plants)
     assert set(restored.__dict__.keys()) == keys

--- a/test/integration/output_test.py
+++ b/test/integration/output_test.py
@@ -252,3 +252,24 @@ def test_mcoe_filled(fast_out_filled, df_name, expected_nuke_fraction, tolerance
         fast_out_filled.__getattribute__(df_name)()
     )
     assert abs(actual_nuke_fraction - expected_nuke_fraction) <= tolerance
+
+
+def test_pudltabl_pickle(test_dir, fast_out_annual):
+    """Test that PudlTabl is serializable with pickle.
+
+    Because pickle is insecure, bandit must be quieted for this test.
+    """
+    import pickle  # nosec
+    from io import BytesIO
+
+    plants = fast_out_annual.plants_eia860()
+    # just to make sure we keep all the parts
+    keys = set(fast_out_annual.__dict__.keys())
+
+    # dump the object into a pickle stored in a buffer
+    pickle.dump(fast_out_annual, buffer := BytesIO())
+    # restore the object from the pickle in the buffer
+    restored = pickle.loads(buffer.getvalue())  # nosec
+
+    pd.testing.assert_frame_equal(restored._dfs["plants_eia860"], plants)
+    assert set(restored.__dict__.keys()) == keys


### PR DESCRIPTION
## Motivation

The purpose of this PR is to enable `PudlTabl` to be serialized using `pickle`. In RMI's work with PUDL, we've often found it useful to save a copy of a `PudlTabl` before testing or running our data processing. This can save substantial amounts of time without jeopardizing validity because essentially all of our code is downstream of PUDL. The proposed changes here are a refined and generalized version of the solution we have used for a while now. In addition to being a more elegant solution than us subclassing or wrapping `PudlTabl`, it bring this functionality to all users, and the proposed tests should ensure that it continues to work properly.

## The changes

1. Two new methods for `PudlTabl`. A description of the default versions of these methods can be found [here](https://docs.python.org/3/library/pickle.html#pickle-inst), an example of how they might be modified in special cases is discussed [here](https://docs.python.org/3/library/pickle.html#pickle-state).
   1. `__getstate__` this converts the `PudlTabl` state into one that can be serialized with `pickle`. This is required because `pickle` doesn't like the `lambda` in the `self._dfs` `defaultdict` or `sa.Engine` so they need to be converted into form that `pickle` can deal with.
   2. `__setstate__` this takes the state as it was saved above and puts the pieces back into `PudlTabl` so a restored `PudlTabl` behaves the same as it would have before it was serialized. One important detail is that ``__init__`` is not run when an  object is de-serialized, so under some circumstances, setup that happened there may also need to occur here.

 2. Two new tests 
    1. `test_pudltabl_pickle` - this tests that we can take a `PudlTabl` with at least one df and that it can be pickled and restored from a pickle.
    2. `test_pudltabl_datazip` - this is similar to the previous but instead of using pickle, uses `DataZip` from our [`etoolbox`](https://github.com/RMI/etoolbox) which uses the same protocol as `pickle` (as far as I understand it). We generally use DataZip rather that pickle because it creates much more compact files because it uses `parquet` for dataframes and so is also more portable than pickle. It is here more as an example since I am not proposing to add a dependency to PUDL. Currently the test is skipped if `etoolbox` is not installed. Happy to remove it, chat about DataZip, or both.

## A few additional points

1. The current approach works and can accommodate the `Datastore` object because there is no issue with pickling the `__dict__` attribute of one of its instances. Not fully understanding how `Datastore` works, I think that's alright but am not confident of that. (`Datastore` does break `DataZip` so `DataZip` knows to exclude it, this has been fine for our purposes but would probably need to be addressed if you wanted to officially support `DataZip`. And to be clear, I am not here proposing that.)
2. My approach to saving the state of the `pudl_engine` is to save the URL, and on restoring, using `sa.create_engine` to create a new `sa.Engine` from the saved URL. This works fine. But then I thought, that will produce a `PudlTabl` that won't work properly if it is moved from the user/machine on which it was created. To fix this I added a check that tries connecting to the engine created from the saved URL, if that fails, we create an engine from the URL in `pudl.workspace.setup.get_defaults`. While that is probably convenient, it might cause weird problems I haven't thought of.
3. Both tests use the fixture `fast_out_annual`. This works totally fine when running the whole test suite but creating that fixture just to test serializing `PudlTabl` is overkill. For now this seemed like the better approach than creating another `PudlTabl`, especially since I wasn't sure what DB to connect it to so that it would work in GHA/CI land. If more work is required, especially as relates to the point below, it might be worth creating a minimal `PudlTabl` fixture for testing this functionality. Here I would request guidance on how to set it up so it plays nicely.
4. Again on the test, not fully understanding `Datastore` I'm not sure how to test that the restored one is functioning properly. For our current use case this isn't really a problem but could be for other users or in the future. I'd be happy to work on addressing this, though may request some guidance on how to think about `Datastore`.


## PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [x] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [x] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [x] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.