### PR TITLE
Xbrl test speedups

### DIFF
--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -25,7 +25,7 @@ class FercXbrlDatastore:
         """Instantiate datastore wrapper for ferc1 resources."""
         self.datastore = datastore
 
-    def get_taxonomy(self, year: int, form: XbrlFormNumber):
+    def get_taxonomy(self, year: int, form: XbrlFormNumber) -> tuple[io.BytesIO, str]:
         """Returns the path to the taxonomy entry point within the an archive."""
         raw_archive = self.datastore.get_unique_resource(
             f"ferc{form.value}", year=year, data_format="XBRL"
@@ -57,12 +57,14 @@ class FercXbrlDatastore:
                     published = datetime.fromisoformat(info["published_parsed"])
 
                     if published > latest:
-                        latest_filing = f"{filing_id}.xbrl"
+                        latest = published
+                        latest_filing = filing_id
 
                 # Create in memory buffers with file data to be used in conversion
                 filings.append(
                     InstanceBuilder(
-                        io.BytesIO(archive.open(latest_filing).read()), filing_id
+                        io.BytesIO(archive.open(f"{latest_filing}.xbrl").read()),
+                        latest_filing,
                     )
                 )
 

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -37,7 +37,7 @@ class FercXbrlDatastore:
 
         return io.BytesIO(raw_archive), taxonomy_entry_point
 
-    def get_filings(self, year: int, form: XbrlFormNumber):
+    def get_filings(self, year: int, form: XbrlFormNumber) -> list[InstanceBuilder]:
         """Return list of filings from archive."""
         archive = self.datastore.get_zipfile_resource(
             f"ferc{form.value}", year=year, data_format="XBRL"

--- a/src/pudl/settings.py
+++ b/src/pudl/settings.py
@@ -517,7 +517,7 @@ class FercGenericXbrlToSqliteSettings(BaseSettings):
     """
 
     taxonomy: AnyHttpUrl
-    tables: list[int] | None = None
+    tables: list[str] | None = None
     years: list[int]
 
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -203,6 +203,9 @@ def ferc_xbrl(
         # Prep datastore
         datastore = FercXbrlDatastore(pudl_datastore_fixture)
 
+        # Set step size for subsetting
+        step_size = 5
+
         for form in XbrlFormNumber:
             raw_archive, taxonomy_entry_point = datastore.get_taxonomy(year, form)
 
@@ -211,15 +214,15 @@ def ferc_xbrl(
             form_settings = ferc_to_sqlite_settings.get_xbrl_dataset_settings(form)
 
             # Extract every fifth filing
-            filings_subset = datastore.get_filings(year, form)[::5]
+            filings_subset = datastore.get_filings(year, form)[::step_size]
             xbrl.extract(
-                datastore.get_filings(year, form)[::5],  # Take every 5th filing
+                filings_subset,
                 sqlite_engine,
                 raw_archive,
                 form.value,
                 requested_tables=form_settings.tables,
-                batch_size=len(filings_subset) // 5 + 1,
-                workers=5,
+                batch_size=len(filings_subset) // step_size + 1,
+                workers=step_size,
                 datapackage_path=pudl_settings_fixture[
                     f"ferc{form.value}_xbrl_datapackage"
                 ],

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,11 +10,13 @@ from pathlib import Path
 import pytest
 import sqlalchemy as sa
 import yaml
+from ferc_xbrl_extractor import xbrl
 
 import pudl
 from pudl.extract.ferc1 import extract_xbrl_metadata
+from pudl.extract.xbrl import FercXbrlDatastore, _get_sqlite_engine
 from pudl.output.pudltabl import PudlTabl
-from pudl.settings import DatasetsSettings, EtlSettings
+from pudl.settings import DatasetsSettings, EtlSettings, XbrlFormNumber
 
 logger = logging.getLogger(__name__)
 
@@ -184,27 +186,53 @@ def ferc1_dbf_sql_engine(
     return engine
 
 
-@pytest.fixture(scope="session", name="ferc1_engine_xbrl")
-def ferc1_xbrl_sql_engine(
+@pytest.fixture(scope="session")
+def ferc_xbrl(
     pudl_settings_fixture,
     live_dbs,
     ferc_to_sqlite_settings,
     pudl_datastore_fixture,
 ):
-    """Grab a connection to the FERC Form 1 DB clone.
+    """Extract XBRL filings and produce raw DB+metadata files.
 
-    If we are using the test database, we initialize it from scratch first. If we're
-    using the live database, then we just yield a conneciton to it.
+    Extracts a subset of filings for each form for the year 2021.
     """
     if not live_dbs:
-        pudl.extract.xbrl.xbrl2sqlite(
-            ferc_to_sqlite_settings=ferc_to_sqlite_settings,
-            pudl_settings=pudl_settings_fixture,
-            clobber=False,
-            datastore=pudl_datastore_fixture,
-            workers=5,
-            batch_size=20,
-        )
+        year = 2021
+
+        # Prep datastore
+        datastore = FercXbrlDatastore(pudl_datastore_fixture)
+
+        for form in XbrlFormNumber:
+            raw_archive, taxonomy_entry_point = datastore.get_taxonomy(year, form)
+
+            sqlite_engine = _get_sqlite_engine(form.value, pudl_settings_fixture, True)
+
+            form_settings = ferc_to_sqlite_settings.get_xbrl_dataset_settings(form)
+
+            # Extract every fifth filing
+            filings_subset = datastore.get_filings(year, form)[::5]
+            xbrl.extract(
+                datastore.get_filings(year, form)[::5],  # Take every 5th filing
+                sqlite_engine,
+                raw_archive,
+                form.value,
+                requested_tables=form_settings.tables,
+                batch_size=len(filings_subset) // 5 + 1,
+                workers=5,
+                datapackage_path=pudl_settings_fixture[
+                    f"ferc{form.value}_xbrl_datapackage"
+                ],
+                metadata_path=pudl_settings_fixture[
+                    f"ferc{form.value}_xbrl_taxonomy_metadata"
+                ],
+                archive_file_path=taxonomy_entry_point,
+            )
+
+
+@pytest.fixture(scope="session")
+def ferc1_engine_xbrl(pudl_settings_fixture, ferc_xbrl):
+    """Grab connection to raw FERC1 XBRL db."""
     engine = sa.create_engine(pudl_settings_fixture["ferc1_xbrl_db"])
     logger.info("FERC1 Engine: %s", engine)
     return engine

--- a/test/integration/datasette_metadata_test.py
+++ b/test/integration/datasette_metadata_test.py
@@ -12,7 +12,7 @@ from pudl.metadata.classes import DatasetteMetadata
 logger = logging.getLogger(__name__)
 
 
-def test_datasette_metadata_to_yml(pudl_settings_fixture, ferc1_engine_xbrl):
+def test_datasette_metadata_to_yml(pudl_settings_fixture, ferc_xbrl):
     """Test the ability to export metadata as YML for use with Datasette."""
     metadata_yml = Path(pudl_settings_fixture["pudl_out"], "metadata.yml")
     logger.info(f"Writing Datasette Metadata to {metadata_yml}")

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -179,8 +179,6 @@ def test_xbrl2sqlite(settings, forms, mocker):
         convert_form_mock.assert_not_called()
 
     for form in forms:
-        if form != XbrlFormNumber.FORM714:
-            continue
         convert_form_mock.assert_any_call(
             settings.get_xbrl_dataset_settings(form),
             form,

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -1,0 +1,122 @@
+"""Tests for xbrl extraction module."""
+import io
+import json
+from datetime import datetime, timedelta
+
+import pytest
+
+from pudl.extract.xbrl import FercXbrlDatastore
+from pudl.settings import XbrlFormNumber
+
+
+def test_ferc_xbrl_datastore_get_taxonomy(mocker):
+    """Test FercXbrlDatastore class."""
+    datastore_mock = mocker.MagicMock()
+    datastore_mock.get_unique_resource.return_value = b"Fake taxonomy data."
+
+    ferc_datastore = FercXbrlDatastore(datastore_mock)
+    raw_archive, taxonomy_entry_point = ferc_datastore.get_taxonomy(
+        2021, XbrlFormNumber.FORM1
+    )
+
+    # Check that get_unique_resource was called correctly
+    datastore_mock.get_unique_resource.assert_called_with(
+        "ferc1", year=2021, data_format="XBRL"
+    )
+
+    # Check return values
+    assert raw_archive.getvalue() == b"Fake taxonomy data."
+    assert (
+        taxonomy_entry_point
+        == "taxonomy/form1/2021-01-01/form/form1/form-1_2021-01-01.xsd"
+    )
+
+
+@pytest.mark.parametrize(
+    "file_map,selected_filings",
+    [
+        (
+            {
+                "rssfeed": io.StringIO(
+                    json.dumps(
+                        {
+                            "filer 1Q4": {
+                                "id1": {
+                                    "entry_id": "id1",
+                                    "title": "filer 1",
+                                    "download_url": "www.fake.url",
+                                    "published_parsed": str(datetime.now()),
+                                    "ferc_formname": "FercForm.FORM_1",
+                                    "ferc_year": 2021,
+                                    "ferc_period": "Q4",
+                                },
+                                "id2": {
+                                    "entry_id": "id2",
+                                    "title": "filer 1",
+                                    "download_url": "www.other_fake.url",
+                                    "published_parsed": str(
+                                        datetime.now() - timedelta(days=1)
+                                    ),
+                                    "ferc_formname": "FercForm.FORM_1",
+                                    "ferc_year": 2021,
+                                    "ferc_period": "Q4",
+                                },
+                            },
+                            "filer 2Q4": {
+                                "id3": {
+                                    "entry_id": "id3",
+                                    "title": "filer 2",
+                                    "download_url": "www.fake.url",
+                                    "published_parsed": str(
+                                        datetime.now() - timedelta(days=100)
+                                    ),
+                                    "ferc_formname": "FercForm.FORM_1",
+                                    "ferc_year": 2021,
+                                    "ferc_period": "Q4",
+                                },
+                                "id4": {
+                                    "entry_id": "id4",
+                                    "title": "filer 2",
+                                    "download_url": "www.fake.url",
+                                    "published_parsed": str(datetime.now()),
+                                    "ferc_formname": "FercForm.FORM_1",
+                                    "ferc_year": 2021,
+                                    "ferc_period": "Q4",
+                                },
+                            },
+                        }
+                    )
+                ),
+                "id1.xbrl": io.BytesIO(b"filer 1 fake filing."),
+                "id2.xbrl": io.BytesIO(b"filer 1 old filing (shouldn't be used)."),
+                "id3.xbrl": io.BytesIO(b"filer 2 old filing (shouldn't be used)."),
+                "id4.xbrl": io.BytesIO(b"filer 2 fake filing."),
+            },
+            {
+                "id1": b"filer 1 fake filing.",
+                "id4": b"filer 2 fake filing.",
+            },
+        ),
+    ],
+)
+def test_ferc_xbrl_datastore_get_filings(mocker, file_map, selected_filings):
+    """Test FercXbrlDatastore class."""
+    datastore_mock = mocker.MagicMock()
+
+    # Get mock of archive zipfile
+    archive_mock = datastore_mock.get_zipfile_resource.return_value
+    archive_mock.open.side_effect = file_map.get
+
+    # Call method
+    ferc_datastore = FercXbrlDatastore(datastore_mock)
+    filings = ferc_datastore.get_filings(2021, XbrlFormNumber.FORM1)
+
+    # Check that get_zipfile_resource was called correctly
+    datastore_mock.get_zipfile_resource.assert_called_with(
+        "ferc1", year=2021, data_format="XBRL"
+    )
+
+    # Loop through filings and verify the contents
+    for filing in filings:
+        assert filing.name in selected_filings
+        assert filing.file.getvalue() == selected_filings[filing.name]


### PR DESCRIPTION
# Overview
This PR speeds up/improves XBRL extraction testing. To do so, it uses a subset of the XBRL filings during integration testing. This dramatically reduces the time required to extract XBRL filings, and seems to reduce total runtime for the CI by ~10 minutes. This PR also adds several unit tests focused on the extraction and XBRL `datastore` object.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [x] Make sure you've included good docstrings.
- [x] Include unit tests for new functions and classes.
- [x] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
