### PR TITLE
Change FuelFix for nuclear from mmmbtu to mmbtu

### DIFF
--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -1597,7 +1597,7 @@ class FuelFerc1TableTransformer(Ferc1AbstractTableTransformer):
             # MW*days thermal to MWh thermal
             FuelFix("nuclear", "mwdth", "mwhth", 24.0),
             # Straight energy equivalence between BTU and MWh here:
-            FuelFix("nuclear", "mmmbtu", "mwhth", (1.0 / 3.412142)),
+            FuelFix("nuclear", "mmbtu", "mwhth", (1.0 / 3.412142)),
             FuelFix("nuclear", "btu", "mwhth", (1.0 / 3412142)),
             # Unclear if it's possible to convert heavy metal to heat reliably
             FuelFix("nuclear", "grams", "kg", (1.0 / 1000)),


### PR DESCRIPTION
When I was building a show-and-tell notebook for the Mines class I presented to, I noticed that there was a typo in the `FuelFix`s in the `standardize_physical_fuel_units`. Specifically, the fuel fix for nuclear was `FuelFix("nuclear", "mmmbtu", "mwhth", (1.0 / 3.412142)),` when it should have been `mmbtu` I removed the extra `m` here!