### PR TITLE
Adding EIA 176 to sources.py

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -46,6 +46,8 @@ Miscellaneous
 ^^^^^^^^^^^^^
 * Apply start and end dates to ferc1 data in :class:`pudl.output.pudltabl.PudlTabl`.
   See :pr:`2238` & :issue:`274`.
+* Add generic spot fix method to transform process, to manually rescue FERC1 records.
+  See :pr:`2254` & :issue:`1980`.
 
 .. _release-v2022.11.30:
 

--- a/notebooks/work-in-progress/ferc1-etl-spot-fix-debug.ipynb
+++ b/notebooks/work-in-progress/ferc1-etl-spot-fix-debug.ipynb
@@ -1,0 +1,9050 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "3deb7c75-179c-439f-b30c-beca40e9cecf",
+   "metadata": {},
+   "source": [
+    "# Working with the FERC Form 1 Extract / Transform\n",
+    "This notebook steps through PUDL's extract and transform steps for FERC Form 1 to make it easier to test and add new years of data, or new tables from the various spreadsheets that haven't been integrated yet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 233,
+   "id": "1fa9ca56-b2c8-4bae-8ba3-ee9050b0ef86",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 3\n",
+    "import pudl\n",
+    "import logging\n",
+    "import sys\n",
+    "from pathlib import Path\n",
+    "import pandas as pd\n",
+    "pd.options.display.max_columns = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 234,
+   "id": "e21fea69-9d14-48d6-b0c9-149c37844e95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logger = logging.getLogger()\n",
+    "logger.setLevel(logging.INFO)\n",
+    "handler = logging.StreamHandler(stream=sys.stdout)\n",
+    "formatter = logging.Formatter('%(message)s')\n",
+    "handler.setFormatter(formatter)\n",
+    "logger.handlers = [handler]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 235,
+   "id": "4a6e60d7-49e6-447c-a523-f88987c28086",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pudl_settings = pudl.workspace.setup.get_defaults()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0bac7d3-bb44-4e20-bd02-67afdd4412af",
+   "metadata": {},
+   "source": [
+    "## Pick the tables you want to load"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 236,
+   "id": "bd17e444-c01d-41e6-a6ea-68244daf0fbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# tables = [\n",
+    "#     \"balance_sheet_assets_ferc1\",\n",
+    "#     \"balance_sheet_liabilities_ferc1\",\n",
+    "#     \"depreciation_amortization_summary_ferc1\",\n",
+    "#     \"electric_energy_dispositions_ferc1\",\n",
+    "#     \"electric_energy_sources_ferc1\",\n",
+    "#     \"electric_opex_ferc1\",\n",
+    "#     \"electric_plant_depreciation_changes_ferc1\",\n",
+    "#     \"fuel_ferc1\",\n",
+    "#     \"income_statement_ferc1\",\n",
+    "#     \"plants_hydro_ferc1\",\n",
+    "#     \"plants_pumped_storage_ferc1\",\n",
+    "#     \"plants_small_ferc1\",\n",
+    "#     \"plants_steam_ferc1\",\n",
+    "#     \"plant_in_service_ferc1\",\n",
+    "#     \"purchased_power_ferc1\",\n",
+    "#     \"retained_earnings_ferc1\",\n",
+    "#     \"transmission_statistics_ferc1\",\n",
+    "#     \"utility_plant_summary_ferc1\",\n",
+    "#     \"electricity_sales_by_rate_schedule_ferc1\"\n",
+    "# ]\n",
+    "\n",
+    "#tables = [\"electricity_sales_by_rate_schedule_ferc1\", \"income_statement_ferc1\", \"balance_sheet_assets_ferc1\"]\n",
+    "tables = [\"plants_steam_ferc1\", \"fuel_ferc1\"]\n",
+    "\n",
+    "#table = \"electricity_sales_by_rate_schedule_ferc1\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 237,
+   "id": "451cb78d-d4c0-47a7-9eef-193f54cfc06d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ferc1_settings = pudl.settings.Ferc1Settings(tables=tables)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14145b03-fb79-46a6-a0e6-82da0c549d66",
+   "metadata": {},
+   "source": [
+    "## Extract DBF and XBRL Data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40a748a6-02c1-4f64-9b05-7b4a9d6fce9e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Extract old FERC form 1 data from DBF (2020 -)\n",
+    "ferc1_dbf_raw_dfs = pudl.extract.ferc1.extract_dbf(\n",
+    "    ferc1_settings=ferc1_settings, pudl_settings=pudl_settings\n",
+    ")\n",
+    "# Extract new FERC form 1 data from XBRL (2021 + )\n",
+    "ferc1_xbrl_raw_dfs = pudl.extract.ferc1.extract_xbrl(\n",
+    "    ferc1_settings=ferc1_settings, pudl_settings=pudl_settings\n",
+    ")\n",
+    "# Extract XBRL metadata\n",
+    "xbrl_metadata_json_dict = pudl.extract.ferc1.extract_xbrl_metadata(\n",
+    "    ferc1_settings=ferc1_settings, pudl_settings=pudl_settings\n",
+    ")\n",
+    "#xbrl_metadata_json_dict = {table: pudl.extract.ferc1.extract_xbrl_metadata(ferc1_settings, pudl_settings)[table] for table in tables}\n",
+    "xbrl_metadata_json_dict = pudl.extract.ferc1.extract_xbrl_metadata(\n",
+    "    ferc1_settings=ferc1_settings, pudl_settings=pudl_settings\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3be13154-c0c7-4df8-974d-4740bb2cd200",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ferc1_xbrl_raw_dfs[table]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78271302-5323-4a4e-a208-256824a59ca4",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Transform FERC 1 Tables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "96ecacb3-439f-49f2-b2f9-00fc16b93d24",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true,
+     "source_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from pudl.transform.ferc1 import *\n",
+    "from pudl.transform.params import *\n",
+    "\n",
+    "transformers = [\n",
+    "    bsa := BalanceSheetAssetsFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"balance_sheet_assets_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    bsl := BalanceSheetLiabilitiesFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"balance_sheet_liabilities_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    das := DepreciationAmortizationSummaryFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"depreciation_amortization_summary_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    eed := ElectricEnergyDispositionsFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_energy_dispositions_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    ees := ElectricEnergySourcesFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_energy_sources_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    eo := ElectricOpexFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_opex_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    epdc := ElectricPlantDepreciationChangesFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_plant_depreciation_changes_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    ff := FuelFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"fuel_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    ins := IncomeStatementFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"income_statement_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    ph := PlantsHydroFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_hydro_ferc1\"], \n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    pps := PlantsPumpedStorageFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_pumped_storage_ferc1\"], \n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    psm := PlantsSmallFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_small_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    pst := PlantsSteamFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_steam_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    pis := PlantInServiceFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plant_in_service_ferc1\"], \n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    pp := PurchasedPowerFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"purchased_power_ferc1\"], \n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    re := RetainedEarningsFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"retained_earnings_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    ts := TransmissionStatisticsFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"transmission_statistics_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    ups := UtilityPlantSummaryFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"utility_plant_summary_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    ),\n",
+    "    esbrs := ElectricitySalesByRateScheduleFerc1TableTransformer(\n",
+    "    #xbrl_metadata_json=xbrl_metadata_json_dict[\"electricity_sales_by_rate_schedule_ferc1\"],\n",
+    "    cache_dfs=True, \n",
+    "    clear_cached_dfs=False\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 257,
+   "id": "7dbf2af1-5da0-4c8d-98ec-4e27b3e1bc5d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:04:53 [    INFO] catalystcoop.pudl.transform.ferc1:896 fuel_ferc1: Processing XBRL metadata.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Processing XBRL metadata.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:04:53 [    INFO] catalystcoop.pudl.transform.ferc1:896 plants_steam_ferc1: Processing XBRL metadata.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Processing XBRL metadata.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pudl.transform.ferc1 import *\n",
+    "from pudl.transform.params import *\n",
+    "\n",
+    "ff = FuelFerc1TableTransformer(\n",
+    "    xbrl_metadata_json=xbrl_metadata_json_dict[\"fuel_ferc1\"],\n",
+    "    cache_dfs=True, \n",
+    "    clear_cached_dfs=False\n",
+    ")\n",
+    "\n",
+    "pst = PlantsSteamFerc1TableTransformer(\n",
+    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_steam_ferc1\"],\n",
+    "        cache_dfs=True, \n",
+    "        clear_cached_dfs=False\n",
+    "    )\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b514045-1045-4b90-821e-c521e0f12190",
+   "metadata": {},
+   "source": [
+    "### Transform Individual Tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 258,
+   "id": "d594beab-7c93-47e3-acb4-b18ef6d3b16e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pick one table to transform\n",
+    "TRANSFORMER = ff\n",
+    "table = TRANSFORMER.table_id.value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 259,
+   "id": "d94d688e-c4cd-443e-9058-c7dfe9fb0882",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1056 fuel_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1255 fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1159 fuel_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 15 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 15 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1267 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1218 fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1242 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1663 fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1667 fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+     ]
+    }
+   ],
+   "source": [
+    "#for transformer in transformers:\n",
+    "\n",
+    "bb = TRANSFORMER.process_xbrl(\n",
+    "    raw_xbrl_instant=ferc1_xbrl_raw_dfs[table][\"instant\"],\n",
+    "    raw_xbrl_duration=ferc1_xbrl_raw_dfs[table][\"duration\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 260,
+   "id": "53bd3f6a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.ferc1:1003 plants_steam_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.ferc1:1056 plants_steam_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.ferc1:1255 plants_steam_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.ferc1:1159 plants_steam_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 43 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Attempting to rename 43 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:53 [ WARNING] catalystcoop.pudl.transform.classes:1203 plants_steam_ferc1: Attempting to rename columns which are not present in the dataframe.\n",
+      "Missing columns: {'net_continuous_plant_capability', 'net_peak_demand_on_plant', 'maintenance_of_boiler_plant_steam_power_generation', 'year_plant_originally_constructed', 'net_generation_excluding_plant_use', 'plant_average_number_of_employees', 'plant_hours_connected_to_load', 'electric_expenses_steam_power_generation', 'miscellaneous_steam_power_expenses', 'net_continuous_plant_capability_not_limited_by_condenser_water', 'maintenance_of_electric_plant_steam_power_generation', 'plant_name', 'asset_retirement_costs_steam_production', 'coolants_and_water', 'cost_per_kilowatt_of_installed_capacity', 'plant_construction_type', 'expenses_per_net_kilowatt_hour', 'maintenance_supervision_and_engineering_steam_power_generation', 'power_production_expenses_steam_power', 'steam_expenses_steam_power_generation', 'allowances', 'maintenance_of_miscellaneous_steam_plant', 'net_continuous_plant_capability_limited_by_condenser_water', 'year_last_unit_of_plant_installed', 'date', 'cost_of_structures_and_improvements_steam_production', 'cost_of_plant', 'cost_of_land_and_land_rights_steam_production', 'steam_transferred_credit', 'installed_capacity_of_plant', 'rents_steam_power_generation', 'order_number', 'maintenance_of_structures_steam_power_generation', 'operation_supervision_and_engineering_expense', 'cost_of_equipment_steam_production', 'steam_from_other_sources', 'fuel_steam_power_generation', 'plant_kind'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Attempting to rename columns which are not present in the dataframe.\n",
+      "Missing columns: {'net_continuous_plant_capability', 'net_peak_demand_on_plant', 'maintenance_of_boiler_plant_steam_power_generation', 'year_plant_originally_constructed', 'net_generation_excluding_plant_use', 'plant_average_number_of_employees', 'plant_hours_connected_to_load', 'electric_expenses_steam_power_generation', 'miscellaneous_steam_power_expenses', 'net_continuous_plant_capability_not_limited_by_condenser_water', 'maintenance_of_electric_plant_steam_power_generation', 'plant_name', 'asset_retirement_costs_steam_production', 'coolants_and_water', 'cost_per_kilowatt_of_installed_capacity', 'plant_construction_type', 'expenses_per_net_kilowatt_hour', 'maintenance_supervision_and_engineering_steam_power_generation', 'power_production_expenses_steam_power', 'steam_expenses_steam_power_generation', 'allowances', 'maintenance_of_miscellaneous_steam_plant', 'net_continuous_plant_capability_limited_by_condenser_water', 'year_last_unit_of_plant_installed', 'date', 'cost_of_structures_and_improvements_steam_production', 'cost_of_plant', 'cost_of_land_and_land_rights_steam_production', 'steam_transferred_credit', 'installed_capacity_of_plant', 'rents_steam_power_generation', 'order_number', 'maintenance_of_structures_steam_power_generation', 'operation_supervision_and_engineering_expense', 'cost_of_equipment_steam_production', 'steam_from_other_sources', 'fuel_steam_power_generation', 'plant_kind'}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:06:53 [ WARNING] catalystcoop.pudl.transform.ferc1:1387 plants_steam_ferc1: Found 500 duplicate record_ids: \n",
+      "['steam_electric_generating_plant_statistics_large_plants_402_2021_c008999_baxter_wilson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008999_gerald_andrus'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008999_independence'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001330_unit_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001330_units_13'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000906_fort_martin'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000906_harrison'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_glenwood_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_port_jefferson_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_northport_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_ef_barrett_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_far_rockaway_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_ef_barrett_gt'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003184_rockport_total_aeg'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003184_rockport_total_plant'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000620_jim_bridger'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000620_boardman'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000620_valmy'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000532_rockport_total_im'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000532_rockport_total_plant'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001444__clover'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001444__louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001444__marsh_run'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_laramie_river_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_craig_station_units_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_craig_station_units_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_craig_station_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_craig_station_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000538_mitchellwpco_share'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000538_mitchell_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004995_big_cajun_2_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004995_ninemile_6'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004995_roy_s_nelson_6'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004995_waterford_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001315_petersburg'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001315_harding_street'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001315_harding_street'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001315_harding_street_gas_turb'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_lieberman'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_lieberman'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_knox_lee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_knox_lee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_wilkes'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_wilkes'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_welsh'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_welsh'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_flint_creek_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_flint_creek_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_pirkey_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_pirkey_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_dolet_hills_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_dolet_hills_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_turk_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_turk_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000555_ew_brown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000555_ghent'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000555_trimble_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000555_brown_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_encogen'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_ferndale'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_whitehorn'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_frederickson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_fredonia_12'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_fredonia_34'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001132_beaver'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_west_campus'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_west_campus'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001218_san_juan'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001218_four_corners_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_allen'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_belews_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_belews_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_catawba'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_cliffside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_cliffside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_lee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_lincoln'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_marshall'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_marshall'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_mcguire'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_millcreek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_oconee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_rockingham'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_big_stone'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_big_stone'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_coyote'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_coyote'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_neal'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_colstrip_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_dggs'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008998_white_bluff'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008998_independence'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001775_sooner'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001775_muskogee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001775_river_valley'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_bay_front'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_bay_front'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_french_island_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_french_island_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_wheaton'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_manatee__steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_lauderdale'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_ft_myers__gas'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_cape_canaveral'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_ft_myers'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_manatee__cc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_martin_34'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_martin_8'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_riviera'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_sanford'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_turkey_point'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_west_county_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_port_everglades'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_ft_myers__simple_cycle'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_okeechobee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_lauderdale__simple_cycle'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_martin_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_desoto_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_space_coast_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_manatee_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_citrus_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_babcock_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_coral_farms_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_horizon_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_wildflower_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_blue_cypress_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_hammock_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_interstate_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_loggerhead_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_indian_river_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_barefoot_bay_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_pioneer_trail_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_sunshine_gateway_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_miamidade_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_northern_preserve_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_sweetbay_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_twin_lakes_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_babcock_preserve_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_cattle_ranch_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_blue_heron_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_okeechobee_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_hibiscus_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_echo_river_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_southfork_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_rodeo_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_magnolia_springs_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_egret_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_pelican_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_lakeside_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_nassau_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_palm_bay_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_union_springs_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_trailside_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_orange_blossom_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_sabal_palm_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_discovery_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_willow_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_fort_drum_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000533_mitchellkepco_share'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000533_mitchell_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_asheville_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_asheville_gas_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_asheville_cc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_brunswick'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_darlington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_hf_lee_gas_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_hb_robinson_nuclear'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_harris'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_lv_sutton_gas_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_mayo'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_roxboro'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_smith_energy_complex'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_wayne_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_roy_s_nelson_6'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_big_cajun_2_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_sabine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_montgomery_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_hardin_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_walter_scott_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_walter_scott_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_neal_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_neal_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_neal_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_neal_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_ottumwa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_ottumwa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_river_hills'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_river_hills'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_sycamore'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_sycamore'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_pleasant_hill'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_pleasant_hill'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_electrifarm'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_electrifarm'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_merl_parr'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_merl_parr'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_moline'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_moline'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_coralville'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_coralville'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_quadcities'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_quadcities'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_greater_des_moines_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_greater_des_moines_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_walter_scott_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_walter_scott_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_altavista'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_chesterfield'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_clover'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_darbytown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_gordonsville'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_gravel_neck'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_ladysmith'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_mount_storm'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_mount_storm'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_remington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_southampton'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_yorktown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_yorktown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_possum_point_com_cyc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_polyester'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_elizabeth_river_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_chesterfield_com_cyc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_bear_garden'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_virginia_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_virginia_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000379_kettle_falls'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000379_colstrip'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_crystal_river_north'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_hines'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_bartow_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_debary'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_intercession_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_suwannee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_tulsa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_riverside_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_riverside_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_northeastern_12'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_northeastern_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_northeastern_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_comanche'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_weleetka'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001555_daniel__steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_gordan_evans_ctf'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_hutchinson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_hutchinson_wdiesel'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_jeffrey_jec'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_lawrence'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000553_mill_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000553_trimble_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_jeffrey_energy_ctr_8'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_greenwood'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_lake_road__steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_lake_road__steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_lake_road__gas_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_iatan_1_18'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_iatan_2_18'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_wilmarth'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_wilmarth'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_a_s_king'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_a_s_king'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_blue_lake'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_blue_lake'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_sherburne_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_inver_hills'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_angus_anson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_angus_anson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001288_coyote'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001288_big_stone'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001288_hoot_lake'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001288_solway'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_bowen'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_mcintosh_retired'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_scherer'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_mcdonough_no_46'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_mcdonough_no_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_mcintosh_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_hammond_retired'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_warner_robins'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_wansley'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000045_gibson_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000045_prairie_state'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000291_east_bend'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000291_woodsdale_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_labadie'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_sioux'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_rush_island'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_meramec'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_venice_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_meramec_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_kinmundy'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_rio_grande'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_rio_grande_unit_9'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_newman'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_montana'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_copper'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001454_wygen_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001454_cheyenne_prairie_42'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001454_cheyenne_prairie'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_concord'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_elm_road'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_germantown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_paris'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_rothschild'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_south_oak_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000388_humboldt_gen_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_cholla_1_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_cholla_1_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_cholla_3_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_cholla_3_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_four_corners_4_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_four_corners_5_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_1_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_2_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_3_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_4_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_5_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_6_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_campbell_1_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_karn_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_karn_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_karn_3__4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_campbell_3_ceco'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000542_michigan_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000542_rm_schahfer_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_cayuga'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_cayuga_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_edwardsport_igcc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_gallagher'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_gibson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000116_big_bend_24'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000116_polk_2_cc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003646_williams'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003646_williams'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_rm_heskett'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_rm_heskett'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_rm_heskett'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_miles_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_big_stone'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_glendive'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_coyote'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_lewis__clark'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_lewis__clark'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_ab_brown_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_fb_culley_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_warrick_unit_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_ab_brown_turbine_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_broadway_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_broadway_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_riverton_101112'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_stateline_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_iatan_12'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_plum_point'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001245__hunter_ii_dgt_share'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001245__bonanza_dgt_share'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000134_east_river_67'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001421_ben_french_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001421_neil_simpson_unit_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_plant_x'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_plant_x'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_tolk'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_tolk'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_jones_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_jones_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_harrington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_harrington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_hawthorn_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_iatan_1_70'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_iatan_2_5471'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_wolf_creek_47'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_lacygne_1_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_lacygne_1_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_lacygne_2_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000530_amos'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000530_mountaineer'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000622_kyger_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_belle_river_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_belle_river_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_belle_river_dte81'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_belle_river_dte81'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_fermi_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_monroe'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_monroe'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_greenwood_ec'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_greenwood_ec'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_st_clair_pp'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_st_clair_pp'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_trenton_channel_pp'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_trenton_channel_pp'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_northeast_peaker'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_st_clair_peaker'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_urquhart'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_wateree'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_mcmeekin'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_cope'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_cope'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_parr_combined'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_hagood_combined'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_urquhart_combined_14'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_urquhart_combined_cycle'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_coit_combined'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_williams_combined'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_jasper'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_columbia_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_cherokee_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_cherokee_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_hayden'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_hayden'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_pawnee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_fort_lupton'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_fruita'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_blue_spruce'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_cherokee_5_6__7'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_comanche'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_craig'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_craig'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_valmont_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_alamosa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001673_boswell'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001673_hibbard'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001673_hibbard'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_blue_indigo'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_blue_springs'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_cotton_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_gulf_clean_energy_center_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_gulf_clean_energy_center_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_gulf_clean_energy_center_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_daniel'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_pea_ridge'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_scherer'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c011304_0'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_edgewater_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_edgewater_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_columbia'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_columbia'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_neenah'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_neenah'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_s_fond_du_lac'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_s_fond_du_lac'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_sheboygan_falls'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_sheboygan_falls'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_west_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_west_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_forward_wind'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_forward_wind'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_cedar_ridge'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_cedar_ridge'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_kossuth'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_kossuth'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_bent_tree'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_bent_tree'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001609_valmy_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000447_rodemacher_unit_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000447_dolet_hills_power'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000447_madison_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000447_madison_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_prairie_creek_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_burlington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_burlington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_lansing_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_emery'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_ottumwa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_george_neal_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_george_neal_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_wolf_creek_47'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_gordon_evans_wdiesel'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_lacygne_1_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_lacygne_2_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_jeffrey_20'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_colstrip'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_craig'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_dave_johnston'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hayden'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hunter_unit_no_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hunter_unit_no_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hunter_unit_no_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hunter__total_plant'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_huntington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_jim_bridger'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_naughton'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_wyodak'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000500_columbia'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000500_de_pere_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000500_weston'].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Found 500 duplicate record_ids: \n",
+      "['steam_electric_generating_plant_statistics_large_plants_402_2021_c008999_baxter_wilson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008999_gerald_andrus'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008999_independence'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001330_unit_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001330_units_13'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000906_fort_martin'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000906_harrison'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_glenwood_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_port_jefferson_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_northport_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_ef_barrett_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_far_rockaway_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001322_ef_barrett_gt'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003184_rockport_total_aeg'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003184_rockport_total_plant'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000620_jim_bridger'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000620_boardman'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000620_valmy'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000532_rockport_total_im'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000532_rockport_total_plant'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001444__clover'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001444__louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001444__marsh_run'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_laramie_river_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_craig_station_units_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_craig_station_units_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_craig_station_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003836_craig_station_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000538_mitchellwpco_share'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000538_mitchell_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004995_big_cajun_2_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004995_ninemile_6'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004995_roy_s_nelson_6'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004995_waterford_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001315_petersburg'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001315_harding_street'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001315_harding_street'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001315_harding_street_gas_turb'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_lieberman'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_lieberman'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_knox_lee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_knox_lee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_wilkes'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_wilkes'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_welsh'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_welsh'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_flint_creek_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_flint_creek_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_pirkey_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_pirkey_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_dolet_hills_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_dolet_hills_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_turk_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000537_turk_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000555_ew_brown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000555_ghent'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000555_trimble_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000555_brown_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_encogen'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_ferndale'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_whitehorn'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_frederickson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_fredonia_12'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000171_fredonia_34'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001132_beaver'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_columbia_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_west_campus'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002498_west_campus'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001218_san_juan'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001218_four_corners_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_allen'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_belews_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_belews_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_catawba'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_cliffside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_cliffside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_lee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_lincoln'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_marshall'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_marshall'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_mcguire'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_millcreek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_oconee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000290_rockingham'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_big_stone'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_big_stone'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_coyote'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_coyote'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_neal'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_colstrip_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001789_dggs'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008998_white_bluff'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008998_independence'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001775_sooner'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001775_muskogee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001775_river_valley'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_bay_front'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_bay_front'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_french_island_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_french_island_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000823_wheaton'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_manatee__steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_lauderdale'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_ft_myers__gas'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_cape_canaveral'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_ft_myers'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_manatee__cc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_martin_34'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_martin_8'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_riviera'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_sanford'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_turkey_point'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_west_county_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_port_everglades'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_ft_myers__simple_cycle'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_okeechobee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_lauderdale__simple_cycle'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_martin_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_desoto_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_space_coast_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_manatee_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_citrus_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_babcock_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_coral_farms_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_horizon_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_wildflower_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_blue_cypress_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_hammock_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_interstate_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_loggerhead_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_indian_river_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_barefoot_bay_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_pioneer_trail_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_sunshine_gateway_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_miamidade_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_northern_preserve_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_sweetbay_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_twin_lakes_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_babcock_preserve_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_cattle_ranch_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_blue_heron_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_okeechobee_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_hibiscus_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_echo_river_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_southfork_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_rodeo_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_magnolia_springs_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_egret_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_pelican_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_lakeside_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_nassau_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_palm_bay_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_union_springs_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_trailside_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_orange_blossom_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_sabal_palm_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_discovery_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_willow_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001030_fort_drum_solar_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000533_mitchellkepco_share'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000533_mitchell_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_asheville_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_asheville_gas_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_asheville_cc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_brunswick'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_darlington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_hf_lee_gas_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_hb_robinson_nuclear'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_harris'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_lv_sutton_gas_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_mayo'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_roxboro'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_smith_energy_complex'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000135_wayne_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_roy_s_nelson_6'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_big_cajun_2_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_sabine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_montgomery_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000851_hardin_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_walter_scott_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_walter_scott_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_neal_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_neal_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_neal_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_neal_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_ottumwa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_ottumwa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_river_hills'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_river_hills'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_sycamore'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_sycamore'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_pleasant_hill'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_pleasant_hill'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_electrifarm'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_electrifarm'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_merl_parr'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_merl_parr'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_moline'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_moline'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_coralville'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_coralville'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_quadcities'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_quadcities'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_greater_des_moines_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_greater_des_moines_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_walter_scott_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001143_walter_scott_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_altavista'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_chesterfield'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_clover'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_darbytown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_gordonsville'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_gravel_neck'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_ladysmith'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_mount_storm'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_mount_storm'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_remington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_southampton'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_yorktown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_yorktown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_possum_point_com_cyc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_polyester'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_elizabeth_river_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_chesterfield_com_cyc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_bear_garden'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_virginia_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000196_virginia_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000379_kettle_falls'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000379_colstrip'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_crystal_river_north'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_hines'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_bartow_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_debary'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_intercession_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000136_suwannee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_tulsa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_riverside_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_riverside_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_northeastern_12'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_northeastern_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_northeastern_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_comanche'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000536_weleetka'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001555_daniel__steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_gordan_evans_ctf'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_hutchinson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_hutchinson_wdiesel'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_jeffrey_jec'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000772_lawrence'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000553_mill_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000553_trimble_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_jeffrey_energy_ctr_8'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_greenwood'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_lake_road__steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_lake_road__steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_lake_road__gas_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_iatan_1_18'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001182_iatan_2_18'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_wilmarth'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_wilmarth'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_a_s_king'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_a_s_king'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_blue_lake'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_blue_lake'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_sherburne_county'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_inver_hills'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_angus_anson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000824_angus_anson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001288_coyote'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001288_big_stone'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001288_hoot_lake'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001288_solway'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_bowen'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_mcintosh_retired'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_scherer'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_mcdonough_no_46'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_mcdonough_no_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_mcintosh_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_hammond_retired'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_warner_robins'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001553_wansley'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000045_gibson_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000045_prairie_state'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000291_east_bend'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000291_woodsdale_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_labadie'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_sioux'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_rush_island'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_meramec'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_venice_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_meramec_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000744_kinmundy'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_rio_grande'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_rio_grande_unit_9'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_newman'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_montana'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000465_copper'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001454_wygen_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001454_cheyenne_prairie_42'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001454_cheyenne_prairie'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_concord'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_elm_road'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_germantown'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_paris'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_rothschild'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001316_south_oak_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000388_humboldt_gen_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_cholla_1_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_cholla_1_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_cholla_3_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_cholla_3_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_four_corners_4_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_four_corners_5_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_1_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_2_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_3_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_4_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_5_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001436_yucca_6_comb_turbine'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_campbell_1_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_karn_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_karn_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_karn_3__4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000191_campbell_3_ceco'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000542_michigan_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000542_rm_schahfer_steam'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_cayuga'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_cayuga_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_edwardsport_igcc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_gallagher'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000289_gibson'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000116_big_bend_24'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000116_polk_2_cc'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003646_williams'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c003646_williams'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_rm_heskett'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_rm_heskett'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_rm_heskett'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_miles_city'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_big_stone'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_glendive'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_coyote'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_lewis__clark'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c002045_lewis__clark'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_ab_brown_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_fb_culley_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_warrick_unit_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_ab_brown_turbine_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_broadway_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001009_broadway_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_riverton_101112'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_stateline_ct'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_iatan_12'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001130_plum_point'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001245__hunter_ii_dgt_share'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001245__bonanza_dgt_share'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000134_east_river_67'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001421_ben_french_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001421_neil_simpson_unit_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_plant_x'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_plant_x'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_tolk'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_tolk'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_jones_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_jones_station'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_harrington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000825_harrington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_hawthorn_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_iatan_1_70'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_iatan_2_5471'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_wolf_creek_47'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_lacygne_1_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_lacygne_1_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001181_lacygne_2_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000530_amos'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000530_mountaineer'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000622_kyger_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_belle_river_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_belle_river_total'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_belle_river_dte81'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_belle_river_dte81'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_fermi_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_monroe'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_monroe'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_greenwood_ec'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_greenwood_ec'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_st_clair_pp'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_st_clair_pp'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_trenton_channel_pp'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_trenton_channel_pp'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_northeast_peaker'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000415_st_clair_peaker'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_urquhart'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_wateree'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_mcmeekin'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_cope'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_cope'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_parr_combined'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_hagood_combined'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_urquhart_combined_14'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_urquhart_combined_cycle'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_coit_combined'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_williams_combined'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_jasper'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000241_columbia_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_cherokee_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_cherokee_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_hayden'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_hayden'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_pawnee'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_fort_lupton'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_fruita'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_blue_spruce'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_cherokee_5_6__7'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_comanche'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_craig'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_craig'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_valmont_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000822_alamosa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001673_boswell'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001673_hibbard'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001673_hibbard'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_blue_indigo'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_blue_springs'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_cotton_creek'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_gulf_clean_energy_center_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_gulf_clean_energy_center_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_gulf_clean_energy_center_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_daniel'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_pea_ridge'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001554_scherer'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c011304_0'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_edgewater_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_edgewater_5'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_columbia'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_columbia'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_neenah'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_neenah'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_s_fond_du_lac'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_s_fond_du_lac'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_sheboygan_falls'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_sheboygan_falls'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_west_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_west_riverside'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_forward_wind'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_forward_wind'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_cedar_ridge'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_cedar_ridge'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_kossuth'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_kossuth'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_bent_tree'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_bent_tree'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000691_'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001609_valmy_1__2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000447_rodemacher_unit_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000447_dolet_hills_power'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000447_madison_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000447_madison_unit_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_prairie_creek_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_louisa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_burlington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_burlington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_lansing_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_emery'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_ottumwa'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_george_neal_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000692_george_neal_4'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_wolf_creek_47'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_gordon_evans_wdiesel'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_lacygne_1_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_lacygne_2_50'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c004044_jeffrey_20'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_colstrip'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_craig'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_dave_johnston'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hayden'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hunter_unit_no_1'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hunter_unit_no_2'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hunter_unit_no_3'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_hunter__total_plant'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_huntington'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_jim_bridger'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_naughton'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c001646_wyodak'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000500_columbia'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000500_de_pere_energy_center'\n",
+      " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c000500_weston'].\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Process steam\n",
+    "TRANSFORMER = pst\n",
+    "#print(TRANSFORMER)\n",
+    "#table = TRANSFORMER.table_id.value\n",
+    "\n",
+    "steam = TRANSFORMER.process_xbrl(\n",
+    "    raw_xbrl_instant=ferc1_xbrl_raw_dfs[table][\"instant\"],\n",
+    "    raw_xbrl_duration=ferc1_xbrl_raw_dfs[table][\"duration\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 261,
+   "id": "30ddcac0-3379-4239-a268-7b510937a4b6",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>utility_id_ferc1_xbrl</th>\n",
+       "      <th>start_date</th>\n",
+       "      <th>end_date</th>\n",
+       "      <th>fuel_kind_axis</th>\n",
+       "      <th>plant_name_ferc1</th>\n",
+       "      <th>average_cost_of_fuel_burned_per_kilowatt_hour_net_generation</th>\n",
+       "      <th>average_cost_of_fuel_per_unit_burned</th>\n",
+       "      <th>average_cost_of_fuel_burned_per_million_british_thermal_unit</th>\n",
+       "      <th>fuel_burned_average_heat_content</th>\n",
+       "      <th>fuel_kind</th>\n",
+       "      <th>average_british_thermal_unit_per_kilowatt_hour_net_generation</th>\n",
+       "      <th>quantity_of_fuel_burned</th>\n",
+       "      <th>fuel_unit</th>\n",
+       "      <th>average_cost_of_fuel_per_unit_as_delivered</th>\n",
+       "      <th>report_year</th>\n",
+       "      <th>record_id</th>\n",
+       "      <th>utility_id_ferc1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1180</th>\n",
+       "      <td>C011304</td>\n",
+       "      <td>2021-01-01</td>\n",
+       "      <td>2021-12-31</td>\n",
+       "      <td>COAL</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.027</td>\n",
+       "      <td>53.876</td>\n",
+       "      <td>236.732</td>\n",
+       "      <td>11517.0</td>\n",
+       "      <td>COAL</td>\n",
+       "      <td>10800.0</td>\n",
+       "      <td>2357771.0</td>\n",
+       "      <td>T</td>\n",
+       "      <td>59.736</td>\n",
+       "      <td>2021</td>\n",
+       "      <td>steam_electric_generating_plant_statistics_lar...</td>\n",
+       "      <td>444</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1181</th>\n",
+       "      <td>C011304</td>\n",
+       "      <td>2021-01-01</td>\n",
+       "      <td>2021-12-31</td>\n",
+       "      <td>OIL</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>2.167</td>\n",
+       "      <td>1367.210</td>\n",
+       "      <td>136000.0</td>\n",
+       "      <td>OIL</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>844331.0</td>\n",
+       "      <td>bbl</td>\n",
+       "      <td>2.276</td>\n",
+       "      <td>2021</td>\n",
+       "      <td>steam_electric_generating_plant_statistics_lar...</td>\n",
+       "      <td>444</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1231</th>\n",
+       "      <td>C000447</td>\n",
+       "      <td>2021-01-01</td>\n",
+       "      <td>2021-12-31</td>\n",
+       "      <td>Gas</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Gas</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>Mcf</td>\n",
+       "      <td>0.000</td>\n",
+       "      <td>2021</td>\n",
+       "      <td>steam_electric_generating_plant_statistics_lar...</td>\n",
+       "      <td>185</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     utility_id_ferc1_xbrl start_date   end_date fuel_kind_axis plant_name_ferc1  average_cost_of_fuel_burned_per_kilowatt_hour_net_generation  average_cost_of_fuel_per_unit_burned  average_cost_of_fuel_burned_per_million_british_thermal_unit  fuel_burned_average_heat_content fuel_kind  average_british_thermal_unit_per_kilowatt_hour_net_generation  quantity_of_fuel_burned fuel_unit  average_cost_of_fuel_per_unit_as_delivered  report_year                                          record_id  utility_id_ferc1\n",
+       "1180               C011304 2021-01-01 2021-12-31           COAL                0                                              0.027                                           53.876                                            236.732                                      11517.0      COAL                                            10800.0                            2357771.0         T                                      59.736         2021  steam_electric_generating_plant_statistics_lar...               444\n",
+       "1181               C011304 2021-01-01 2021-12-31            OIL                0                                              0.000                                            2.167                                           1367.210                                     136000.0       OIL                                                0.0                             844331.0       bbl                                       2.276         2021  steam_electric_generating_plant_statistics_lar...               444\n",
+       "1231               C000447 2021-01-01 2021-12-31            Gas                0                                              0.000                                            0.000                                              0.000                                          NaN       Gas                                                0.0                                  NaN       Mcf                                       0.000         2021  steam_electric_generating_plant_statistics_lar...               185"
+      ]
+     },
+     "execution_count": 261,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# View missing plant names\n",
+    "steam[steam['plant_name_ferc1'] == \"0\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d030e249-3858-4650-ba2c-8ef62316db37",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### Transform Step-by-Step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 262,
+   "id": "3c5f3389-58c8-40db-b71a-e74a1d4c8c09",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:02 [    INFO] catalystcoop.pudl.transform.ferc1:982 plants_steam_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:02 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 43 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Attempting to rename 43 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1003 plants_steam_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1056 plants_steam_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1255 plants_steam_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1165 plants_steam_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1176 plants_steam_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 43 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Attempting to rename 43 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:819 plants_steam_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    }
+   ],
+   "source": [
+    "start = TRANSFORMER.transform_start(\n",
+    "    raw_dbf=ferc1_dbf_raw_dfs[TRANSFORMER.table_id.value],\n",
+    "    raw_xbrl_instant=ferc1_xbrl_raw_dfs[TRANSFORMER.table_id.value][\"instant\"],\n",
+    "    raw_xbrl_duration=ferc1_xbrl_raw_dfs[TRANSFORMER.table_id.value][\"duration\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 263,
+   "id": "93ea54d5-f503-4d20-92e0-885588563b46",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>utility_id_ferc1_dbf</th>\n",
+       "      <th>report_year</th>\n",
+       "      <th>plant_name_ferc1</th>\n",
+       "      <th>plant_type</th>\n",
+       "      <th>construction_type</th>\n",
+       "      <th>construction_year</th>\n",
+       "      <th>installation_year</th>\n",
+       "      <th>capacity_mw</th>\n",
+       "      <th>peak_demand_mw</th>\n",
+       "      <th>plant_hours_connected_while_generating</th>\n",
+       "      <th>plant_capability_mw</th>\n",
+       "      <th>not_water_limited_capacity_mw</th>\n",
+       "      <th>water_limited_capacity_mw</th>\n",
+       "      <th>avg_num_employees</th>\n",
+       "      <th>net_generation_kwh</th>\n",
+       "      <th>capex_land</th>\n",
+       "      <th>capex_structures</th>\n",
+       "      <th>capex_equipment</th>\n",
+       "      <th>capex_total</th>\n",
+       "      <th>capex_per_kw</th>\n",
+       "      <th>opex_operations</th>\n",
+       "      <th>opex_fuel</th>\n",
+       "      <th>opex_coolants</th>\n",
+       "      <th>opex_steam</th>\n",
+       "      <th>opex_steam_other</th>\n",
+       "      <th>opex_transfer</th>\n",
+       "      <th>opex_electric</th>\n",
+       "      <th>opex_misc_power</th>\n",
+       "      <th>opex_rents</th>\n",
+       "      <th>opex_allowances</th>\n",
+       "      <th>opex_engineering</th>\n",
+       "      <th>opex_structures</th>\n",
+       "      <th>opex_boiler</th>\n",
+       "      <th>opex_plants</th>\n",
+       "      <th>opex_misc_steam</th>\n",
+       "      <th>opex_production_total</th>\n",
+       "      <th>opex_per_kwh</th>\n",
+       "      <th>asset_retirement_cost</th>\n",
+       "      <th>record_id</th>\n",
+       "      <th>utility_id_ferc1</th>\n",
+       "      <th>utility_id_ferc1_xbrl</th>\n",
+       "      <th>date</th>\n",
+       "      <th>start_date</th>\n",
+       "      <th>end_date</th>\n",
+       "      <th>plant_name</th>\n",
+       "      <th>order_number</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>9645</th>\n",
+       "      <td>72.0</td>\n",
+       "      <td>1999</td>\n",
+       "      <td></td>\n",
+       "      <td>Steam</td>\n",
+       "      <td>Conventional</td>\n",
+       "      <td>1955</td>\n",
+       "      <td>1956</td>\n",
+       "      <td>1303.56</td>\n",
+       "      <td>1327.0</td>\n",
+       "      <td>8760.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1284.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>390.0</td>\n",
+       "      <td>8.531868e+09</td>\n",
+       "      <td>673317.0</td>\n",
+       "      <td>64561620.0</td>\n",
+       "      <td>322548092.0</td>\n",
+       "      <td>387783029.0</td>\n",
+       "      <td>297.48</td>\n",
+       "      <td>1154409.0</td>\n",
+       "      <td>107221337.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>4377325.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>2030686.0</td>\n",
+       "      <td>4309783.0</td>\n",
+       "      <td>2400.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>425959.0</td>\n",
+       "      <td>1277712.0</td>\n",
+       "      <td>11216023.0</td>\n",
+       "      <td>2529112.0</td>\n",
+       "      <td>709251.0</td>\n",
+       "      <td>135253997.0</td>\n",
+       "      <td>0.0159</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>f1_steam_1999_12_72_0_1</td>\n",
+       "      <td>409</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      utility_id_ferc1_dbf  report_year plant_name_ferc1 plant_type construction_type construction_year installation_year  capacity_mw  peak_demand_mw  plant_hours_connected_while_generating  plant_capability_mw  not_water_limited_capacity_mw  water_limited_capacity_mw  avg_num_employees  net_generation_kwh  capex_land  capex_structures  capex_equipment  capex_total  capex_per_kw  opex_operations    opex_fuel  opex_coolants  opex_steam  opex_steam_other  opex_transfer  opex_electric  opex_misc_power  opex_rents  opex_allowances  opex_engineering  opex_structures  opex_boiler  opex_plants  opex_misc_steam  opex_production_total  opex_per_kwh  asset_retirement_cost                record_id  utility_id_ferc1 utility_id_ferc1_xbrl date start_date end_date plant_name  order_number\n",
+       "9645                  72.0         1999                       Steam      Conventional              1955              1956      1303.56          1327.0                                  8760.0                  NaN                         1284.0                        NaN              390.0        8.531868e+09    673317.0        64561620.0      322548092.0  387783029.0        297.48        1154409.0  107221337.0            NaN   4377325.0               NaN            NaN      2030686.0        4309783.0      2400.0              NaN          425959.0        1277712.0   11216023.0    2529112.0         709251.0            135253997.0        0.0159                    NaN  f1_steam_1999_12_72_0_1               409                   NaN  NaN        NaT      NaT        NaN           NaN"
+      ]
+     },
+     "execution_count": 263,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "start[start['record_id']=='f1_steam_1999_12_72_0_1']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 264,
+   "id": "8c0b3926",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:12 [    INFO] catalystcoop.pudl.transform.ferc1:982 fuel_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:12 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 17 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 17 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:13 [ WARNING] catalystcoop.pudl.transform.ferc1:1387 fuel_ferc1: Found 1 duplicate record_ids: \n",
+      "['f1_fuel_2000_12_24_3_1'].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Found 1 duplicate record_ids: \n",
+      "['f1_fuel_2000_12_24_3_1'].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:13 [    INFO] catalystcoop.pudl.transform.classes:1267 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:13 [    INFO] catalystcoop.pudl.transform.classes:1218 fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:14 [    INFO] catalystcoop.pudl.transform.classes:1242 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:14 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:14 [    INFO] catalystcoop.pudl.transform.ferc1:1056 fuel_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:14 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1255 fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1159 fuel_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 15 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 15 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1267 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1218 fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1242 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1663 fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1667 fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:819 fuel_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1320 fuel_ferc1: Spot fixing missing values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Spot fixing missing values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1296 fuel_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:823 68.7% of records (107454 rows) contain only {0, '', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "68.7% of records (107454 rows) contain only {0, '', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:823 0.4% of records (217 rows) contain only {'', '-', 'must 123', 'must 456', nan, '0', 'ant1-3', 'elk 1-3', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.4% of records (217 rows) contain only {'', '-', 'must 123', 'must 456', nan, '0', 'ant1-3', 'elk 1-3', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1737 fuel_ferc1: Dropping 0/48841rows representing plant-level all-fuel totals.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping 0/48841rows representing plant-level all-fuel totals.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1283 fuel_ferc1: Correcting inferred non-standard column units.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Correcting inferred non-standard column units.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 181/10820 (1.67%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "181/10820 (1.67%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 860/15769 (5.45%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "860/15769 (5.45%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 643/17623 (3.65%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "643/17623 (3.65%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 1367/10820 (12.63%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1367/10820 (12.63%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 2071/15769 (13.13%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2071/15769 (13.13%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 8083/17623 (45.87%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8083/17623 (45.87%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1327 fuel_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Transform fuel table for use in \n",
+    "\n",
+    "TRANSFORMERF = ff\n",
+    "tablef = TRANSFORMERF.table_id.value\n",
+    "\n",
+    "fuel = TRANSFORMERF.transform(\n",
+    "    raw_dbf=ferc1_dbf_raw_dfs[TRANSFORMERF.table_id.value],\n",
+    "    raw_xbrl_instant=ferc1_xbrl_raw_dfs[TRANSFORMERF.table_id.value][\"instant\"],\n",
+    "    raw_xbrl_duration=ferc1_xbrl_raw_dfs[TRANSFORMERF.table_id.value][\"duration\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 266,
+   "id": "9aa10b65-9200-42c4-8c02-745228b46b7f",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1218 plants_steam_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1242 plants_steam_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1267 plants_steam_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1229 plants_steam_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1256 plants_steam_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1309 plants_steam_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1320 plants_steam_ferc1: Spot fixing missing values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing missing values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Spot fixing some values\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1296 plants_steam_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:29 [    INFO] catalystcoop.pudl.transform.classes:823 41.7% of records (22039 rows) contain only {0, '', nan, 'none', '0', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "41.7% of records (22039 rows) contain only {0, '', nan, 'none', '0', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:29 [    INFO] catalystcoop.pudl.transform.classes:823 0.2% of records (71 rows) contain only {'', '-', nan, '0', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.2% of records (71 rows) contain only {'', '-', nan, '0', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:09:29 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:399 Identifying distinct large FERC plants for ID assignment.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Identifying distinct large FERC plants for ID assignment.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:02 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:432 Successfully associated 22900 of 30710 (74.57%) FERC Form 1 plant records with multi-year plant entities.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully associated 22900 of 30710 (74.57%) FERC Form 1 plant records with multi-year plant entities.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:02 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:445 Assigning IDs to multi-year FERC plant entities.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Assigning IDs to multi-year FERC plant entities.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:09 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:462 Identified 4949 orphaned FERC plant records. Adding orphans to list of plant entities.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Identified 4949 orphaned FERC plant records. Adding orphans to list of plant entities.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:14 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:484 Successfully Identified 2079 multi-year plant entities.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully Identified 2079 multi-year plant entities.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1994 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1994 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1995 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1995 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1996 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1996 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1998 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1998 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1999 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1999 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2000 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2000 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2001 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2001 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2002 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2002 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2003 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2003 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2004 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2004 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2005 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2005 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2006 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2006 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2007 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2007 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2008 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2008 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2009 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2009 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2010 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2010 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2011 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2011 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2012 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2012 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2013 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2013 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2014 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2014 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2015 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2015 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2016 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2016 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2017 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2017 2 times in plant_id_ferc1=345\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1995 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1995 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1996 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1996 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1997 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1997 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1998 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1998 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1999 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1999 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2000 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2000 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2001 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2001 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2002 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2002 2 times in plant_id_ferc1=368\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2008 2 times in plant_id_ferc1=680\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2008 2 times in plant_id_ferc1=680\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2005 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2005 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2006 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2006 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2007 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2007 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2008 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2008 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2009 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2009 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2010 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2010 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2011 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2011 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2012 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2012 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2013 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2013 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2014 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2014 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2015 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2015 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2016 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2016 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2017 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2017 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2018 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2018 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2019 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2019 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2020 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2020 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2021 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2021 2 times in plant_id_ferc1=888\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1995 2 times in plant_id_ferc1=1094\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=1995 2 times in plant_id_ferc1=1094\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2000 2 times in plant_id_ferc1=1186\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2000 2 times in plant_id_ferc1=1186\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2019 2 times in plant_id_ferc1=1281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2019 2 times in plant_id_ferc1=1281\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2020 2 times in plant_id_ferc1=1281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2020 2 times in plant_id_ferc1=1281\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2021 2 times in plant_id_ferc1=1281\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2021 2 times in plant_id_ferc1=1281\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2004 2 times in plant_id_ferc1=1567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2004 2 times in plant_id_ferc1=1567\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2005 2 times in plant_id_ferc1=1567\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found report_year=2005 2 times in plant_id_ferc1=1567\n"
+     ]
+    }
+   ],
+   "source": [
+    "main = TRANSFORMER.transform_main(\n",
+    "    start, transformed_fuel = fuel\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 269,
+   "id": "f640e3ce",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>utility_id_ferc1_dbf</th>\n",
+       "      <th>report_year</th>\n",
+       "      <th>capacity_mw</th>\n",
+       "      <th>peak_demand_mw</th>\n",
+       "      <th>plant_hours_connected_while_generating</th>\n",
+       "      <th>plant_capability_mw</th>\n",
+       "      <th>not_water_limited_capacity_mw</th>\n",
+       "      <th>water_limited_capacity_mw</th>\n",
+       "      <th>avg_num_employees</th>\n",
+       "      <th>capex_land</th>\n",
+       "      <th>capex_structures</th>\n",
+       "      <th>capex_equipment</th>\n",
+       "      <th>capex_total</th>\n",
+       "      <th>opex_operations</th>\n",
+       "      <th>opex_fuel</th>\n",
+       "      <th>opex_coolants</th>\n",
+       "      <th>opex_steam</th>\n",
+       "      <th>opex_steam_other</th>\n",
+       "      <th>opex_transfer</th>\n",
+       "      <th>opex_electric</th>\n",
+       "      <th>opex_misc_power</th>\n",
+       "      <th>opex_rents</th>\n",
+       "      <th>opex_allowances</th>\n",
+       "      <th>opex_engineering</th>\n",
+       "      <th>opex_structures</th>\n",
+       "      <th>opex_boiler</th>\n",
+       "      <th>opex_plants</th>\n",
+       "      <th>opex_misc_steam</th>\n",
+       "      <th>opex_production_total</th>\n",
+       "      <th>asset_retirement_cost</th>\n",
+       "      <th>record_id</th>\n",
+       "      <th>utility_id_ferc1</th>\n",
+       "      <th>utility_id_ferc1_xbrl</th>\n",
+       "      <th>date</th>\n",
+       "      <th>start_date</th>\n",
+       "      <th>end_date</th>\n",
+       "      <th>plant_name</th>\n",
+       "      <th>order_number</th>\n",
+       "      <th>plant_name_ferc1</th>\n",
+       "      <th>construction_type</th>\n",
+       "      <th>plant_type</th>\n",
+       "      <th>capex_per_mw</th>\n",
+       "      <th>opex_per_mwh</th>\n",
+       "      <th>net_generation_mwh</th>\n",
+       "      <th>construction_year</th>\n",
+       "      <th>installation_year</th>\n",
+       "      <th>plant_id_ferc1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>6370</th>\n",
+       "      <td>64.0</td>\n",
+       "      <td>1998</td>\n",
+       "      <td>349.0</td>\n",
+       "      <td>313.0</td>\n",
+       "      <td>4649.0</td>\n",
+       "      <td>295.0</td>\n",
+       "      <td>295.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>30484465.0</td>\n",
+       "      <td>176340418.0</td>\n",
+       "      <td>206824883.0</td>\n",
+       "      <td>145058.0</td>\n",
+       "      <td>21212847.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1429184.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>212211.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>141832.0</td>\n",
+       "      <td>149465.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>699439.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>23990036.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>f1_steam_1998_12_64_0_1</td>\n",
+       "      <td>253</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaT</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>hardee power station</td>\n",
+       "      <td>outdoor</td>\n",
+       "      <td>combustion_turbine</td>\n",
+       "      <td>592621.4</td>\n",
+       "      <td>26.2</td>\n",
+       "      <td>916579.0</td>\n",
+       "      <td>1992.0</td>\n",
+       "      <td>1992.0</td>\n",
+       "      <td>249</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      utility_id_ferc1_dbf  report_year  capacity_mw  peak_demand_mw  plant_hours_connected_while_generating  plant_capability_mw  not_water_limited_capacity_mw  water_limited_capacity_mw  avg_num_employees  capex_land  capex_structures  capex_equipment  capex_total  opex_operations   opex_fuel  opex_coolants  opex_steam  opex_steam_other  opex_transfer  opex_electric  opex_misc_power  opex_rents  opex_allowances  opex_engineering  opex_structures  opex_boiler  opex_plants  opex_misc_steam  opex_production_total  asset_retirement_cost                record_id  utility_id_ferc1 utility_id_ferc1_xbrl date start_date end_date plant_name  order_number      plant_name_ferc1 construction_type          plant_type  capex_per_mw  opex_per_mwh  net_generation_mwh  construction_year  installation_year  plant_id_ferc1\n",
+       "6370                  64.0         1998        349.0           313.0                                  4649.0                295.0                          295.0                        NaN                NaN         NaN        30484465.0      176340418.0  206824883.0         145058.0  21212847.0            NaN         NaN               NaN            NaN      1429184.0              NaN    212211.0              NaN          141832.0         149465.0          NaN     699439.0              NaN             23990036.0                    NaN  f1_steam_1998_12_64_0_1               253                   NaN  NaN        NaT      NaT        NaN           NaN  hardee power station           outdoor  combustion_turbine      592621.4          26.2            916579.0             1992.0             1992.0             249"
+      ]
+     },
+     "execution_count": 269,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Test it works!\n",
+    "main[main['record_id'].str.contains('f1_steam_1999_12_72_0_1')] #clifty creek\n",
+    "main[main['record_id'].str.contains('f1_steam_1998_12_64_0_1')] #hardee power station\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 203,
+   "id": "0ad46a20",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "14375    TEST\n",
+       "Name: plant_name_ferc1, dtype: object"
+      ]
+     },
+     "execution_count": 203,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "start.loc[start['record_id']==\"f1_steam_2001_12_204_0_1\", 'plant_name_ferc1'] = \"TEST\"\n",
+    "start.loc[start['record_id']==\"f1_steam_2001_12_204_0_1\", 'plant_name_ferc1']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 213,
+   "id": "b3df553d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "       utility_id_ferc1_dbf  report_year plant_name_ferc1 plant_type construction_type construction_year installation_year  capacity_mw  peak_demand_mw  plant_hours_connected_while_generating  plant_capability_mw  not_water_limited_capacity_mw  water_limited_capacity_mw  avg_num_employees  net_generation_kwh  capex_land  capex_structures  capex_equipment  capex_total  capex_per_kw  opex_operations  opex_fuel  opex_coolants  opex_steam  opex_steam_other  opex_transfer  opex_electric  opex_misc_power  opex_rents  opex_allowances  opex_engineering  opex_structures  opex_boiler  opex_plants  opex_misc_steam  opex_production_total  opex_per_kwh  asset_retirement_cost                 record_id  utility_id_ferc1 utility_id_ferc1_xbrl date start_date end_date plant_name  order_number\n",
+      "11185                 204.0         2000         seabrook    Nuclear   Fully contained              1990              1990         26.0            25.0                                   150.0                  NaN                           25.0                       25.0              790.0         172206194.0         NaN          250647.0         587142.0     837789.0       32.2227         493970.0   791329.0        48581.0    481644.0               NaN            NaN        18081.0         676363.0         NaN              NaN          272584.0          70920.0     397851.0     458895.0          18550.0              3728768.0        0.0217                    NaN  f1_steam_2000_12_204_0_1                47                   NaN  NaN        NaT      NaT        NaN           NaN\n",
+      "14375                 204.0         2001         seabrook    Nuclear   Fully Contained              1990              1990         26.0            25.0                                   102.0                  NaN                           25.0                       25.0              797.0         188961475.0         NaN          442518.0         695791.0    1138309.0       43.7811         533771.0   834728.0        49059.0    404999.0               NaN            NaN         2277.0         639325.0         NaN              NaN          247171.0          63760.0     185490.0     194578.0          11078.0              3166236.0        0.0168                    NaN  f1_steam_2001_12_204_0_1                47                   NaN  NaN        NaT      NaT        NaN         100.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = start\n",
+    "for i in SpotFixValues['spot_fix']:\n",
+    "    idcol = list(i.keys())[0] # Get name of identifying column\n",
+    "    \n",
+    "    if idcol in list(df.columns): # For each row to be spot-fixed\n",
+    "        for key in i['fixes']: # For each fix\n",
+    "            if key in list(df.columns):\n",
+    "                df.loc[df[idcol]==i[idcol], key] = i['fixes'][key] # Manually update value\n",
+    "    else:\n",
+    "        # Could log error here\n",
+    "        pass\n",
+    "\n",
+    "print(df.loc[df['plant_name_ferc1']=='seabrook'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37597634",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def spot_fix_values(self, df: pd.DataFrame, params: SpotFixValues) -> pd.DataFrame:\n",
+    "        \"\"\"Manually fix one-off singular missing values.\n",
+    "\n",
+    "        With our new ferc1 transform process we are less intense about dropping records.\n",
+    "        Because of that, a fair amount of records have \"\" or 0 as a plant name. \n",
+    "        Most of these records have no other data points in them and thus can be dropped.\n",
+    "        But some of them actually have some information. Manual investigation of some\n",
+    "        of these records led to some pretty easy identification of plant names. This\n",
+    "        function takes a dictionary of these fixes and applies them to the dataframe.\n",
+    "\n",
+    "        There are probably plenty of other spot fixes one could add here.\n",
+    "\n",
+    "        Params:\n",
+    "            df: Pre-processed, concatenated XBRL and DBF data.\n",
+    "            params: an instance of :class:`SpotFixValues`\n",
+    "\n",
+    "        Returns:\n",
+    "            The same input DataFrame but with some spot fixes corrected.\n",
+    "        \"\"\"\n",
+    "        logger.info(f\"{self.table_id.value}: Spot fixing some values\")\n",
+    "        \n",
+    "        \n",
+    "        # Define rows and columns to change\n",
+    "        for i in params:\n",
+    "            idcol = list(i.keys())[0] # Get name of identifying column\n",
+    "    \n",
+    "            if idcol in list(df.columns): # For each row to be spot-fixed\n",
+    "                for key in i['fixes']: # For each fix\n",
+    "                    if key in list(df.columns):\n",
+    "                        df.loc[df[idcol]==i[idcol], key] = i['fixes'][key] # Manually update value\n",
+    "            else:\n",
+    "                # Could log error here\n",
+    "                pass\n",
+    "\n",
+    "        return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "id": "e4e1e202-a6b0-4fb9-b9cc-eccbc2e3b813",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-31 10:20:15 [    INFO] catalystcoop.pudl.transform.classes:1264 plants_steam_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_steam_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "ename": "KeyError",
+     "evalue": "'record_id_ferc1'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "File \u001b[0;32m~/mambaforge/envs/pudl-dev/lib/python3.10/site-packages/pandas/core/indexes/base.py:3802\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key, method, tolerance)\u001b[0m\n\u001b[1;32m   3801\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m-> 3802\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_engine\u001b[39m.\u001b[39;49mget_loc(casted_key)\n\u001b[1;32m   3803\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m \u001b[39mas\u001b[39;00m err:\n",
+      "File \u001b[0;32m~/mambaforge/envs/pudl-dev/lib/python3.10/site-packages/pandas/_libs/index.pyx:138\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32m~/mambaforge/envs/pudl-dev/lib/python3.10/site-packages/pandas/_libs/index.pyx:165\u001b[0m, in \u001b[0;36mpandas._libs.index.IndexEngine.get_loc\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:5745\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "File \u001b[0;32mpandas/_libs/hashtable_class_helper.pxi:5753\u001b[0m, in \u001b[0;36mpandas._libs.hashtable.PyObjectHashTable.get_item\u001b[0;34m()\u001b[0m\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'record_id_ferc1'",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[97], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m end \u001b[39m=\u001b[39m TRANSFORMER\u001b[39m.\u001b[39mtransform_end(\n\u001b[1;32m      2\u001b[0m     main\n\u001b[1;32m      3\u001b[0m )\n\u001b[0;32m----> 4\u001b[0m end[end[\u001b[39m'\u001b[39;49m\u001b[39mrecord_id_ferc1\u001b[39;49m\u001b[39m'\u001b[39;49m]\u001b[39m==\u001b[39m\u001b[39m'\u001b[39m\u001b[39mf1_steam_2014_12_276_0_1\u001b[39m\u001b[39m'\u001b[39m]\n",
+      "File \u001b[0;32m~/mambaforge/envs/pudl-dev/lib/python3.10/site-packages/pandas/core/frame.py:3807\u001b[0m, in \u001b[0;36mDataFrame.__getitem__\u001b[0;34m(self, key)\u001b[0m\n\u001b[1;32m   3805\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mcolumns\u001b[39m.\u001b[39mnlevels \u001b[39m>\u001b[39m \u001b[39m1\u001b[39m:\n\u001b[1;32m   3806\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_getitem_multilevel(key)\n\u001b[0;32m-> 3807\u001b[0m indexer \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mcolumns\u001b[39m.\u001b[39;49mget_loc(key)\n\u001b[1;32m   3808\u001b[0m \u001b[39mif\u001b[39;00m is_integer(indexer):\n\u001b[1;32m   3809\u001b[0m     indexer \u001b[39m=\u001b[39m [indexer]\n",
+      "File \u001b[0;32m~/mambaforge/envs/pudl-dev/lib/python3.10/site-packages/pandas/core/indexes/base.py:3804\u001b[0m, in \u001b[0;36mIndex.get_loc\u001b[0;34m(self, key, method, tolerance)\u001b[0m\n\u001b[1;32m   3802\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_engine\u001b[39m.\u001b[39mget_loc(casted_key)\n\u001b[1;32m   3803\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m \u001b[39mas\u001b[39;00m err:\n\u001b[0;32m-> 3804\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mKeyError\u001b[39;00m(key) \u001b[39mfrom\u001b[39;00m \u001b[39merr\u001b[39;00m\n\u001b[1;32m   3805\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mTypeError\u001b[39;00m:\n\u001b[1;32m   3806\u001b[0m     \u001b[39m# If we have a listlike key, _check_indexing_error will raise\u001b[39;00m\n\u001b[1;32m   3807\u001b[0m     \u001b[39m#  InvalidIndexError. Otherwise we fall through and re-raise\u001b[39;00m\n\u001b[1;32m   3808\u001b[0m     \u001b[39m#  the TypeError.\u001b[39;00m\n\u001b[1;32m   3809\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_check_indexing_error(key)\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'record_id_ferc1'"
+     ]
+    }
+   ],
+   "source": [
+    "end = TRANSFORMER.transform_end(\n",
+    "    main\n",
+    ")\n",
+    "end[end['record_id']=='f1_steam_2014_12_276_0_1']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "id": "d9956d84",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>record_id</th>\n",
+       "      <th>utility_id_ferc1</th>\n",
+       "      <th>report_year</th>\n",
+       "      <th>plant_id_ferc1</th>\n",
+       "      <th>plant_name_ferc1</th>\n",
+       "      <th>plant_type</th>\n",
+       "      <th>construction_type</th>\n",
+       "      <th>construction_year</th>\n",
+       "      <th>installation_year</th>\n",
+       "      <th>capacity_mw</th>\n",
+       "      <th>peak_demand_mw</th>\n",
+       "      <th>plant_hours_connected_while_generating</th>\n",
+       "      <th>plant_capability_mw</th>\n",
+       "      <th>water_limited_capacity_mw</th>\n",
+       "      <th>not_water_limited_capacity_mw</th>\n",
+       "      <th>avg_num_employees</th>\n",
+       "      <th>net_generation_mwh</th>\n",
+       "      <th>capex_land</th>\n",
+       "      <th>capex_structures</th>\n",
+       "      <th>capex_equipment</th>\n",
+       "      <th>capex_total</th>\n",
+       "      <th>capex_per_mw</th>\n",
+       "      <th>opex_operations</th>\n",
+       "      <th>opex_fuel</th>\n",
+       "      <th>opex_coolants</th>\n",
+       "      <th>opex_steam</th>\n",
+       "      <th>opex_steam_other</th>\n",
+       "      <th>opex_transfer</th>\n",
+       "      <th>opex_electric</th>\n",
+       "      <th>opex_misc_power</th>\n",
+       "      <th>opex_rents</th>\n",
+       "      <th>opex_allowances</th>\n",
+       "      <th>opex_engineering</th>\n",
+       "      <th>opex_structures</th>\n",
+       "      <th>opex_boiler</th>\n",
+       "      <th>opex_plants</th>\n",
+       "      <th>opex_misc_steam</th>\n",
+       "      <th>opex_production_total</th>\n",
+       "      <th>opex_per_mwh</th>\n",
+       "      <th>asset_retirement_cost</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [record_id, utility_id_ferc1, report_year, plant_id_ferc1, plant_name_ferc1, plant_type, construction_type, construction_year, installation_year, capacity_mw, peak_demand_mw, plant_hours_connected_while_generating, plant_capability_mw, water_limited_capacity_mw, not_water_limited_capacity_mw, avg_num_employees, net_generation_mwh, capex_land, capex_structures, capex_equipment, capex_total, capex_per_mw, opex_operations, opex_fuel, opex_coolants, opex_steam, opex_steam_other, opex_transfer, opex_electric, opex_misc_power, opex_rents, opex_allowances, opex_engineering, opex_structures, opex_boiler, opex_plants, opex_misc_steam, opex_production_total, opex_per_mwh, asset_retirement_cost]\n",
+       "Index: []"
+      ]
+     },
+     "execution_count": 104,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "end[end['plant_name_ferc1']=='0']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a6b2ad2b-57e3-49bd-ba83-8a68f6c06b17",
+   "metadata": {},
+   "source": [
+    "#### Transform All Steps Together"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "87e11c18-f6a1-49b0-92d5-b9ebc38fe920",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:05 [    INFO] catalystcoop.pudl.transform.ferc1:981 fuel_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:06 [    INFO] catalystcoop.pudl.transform.classes:1144 fuel_ferc1: Attempting to rename 17 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 17 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:06 [ WARNING] catalystcoop.pudl.transform.ferc1:1386 fuel_ferc1: Found 1 duplicate record_ids: \n",
+      "['f1_fuel_2000_12_24_3_1'].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Found 1 duplicate record_ids: \n",
+      "['f1_fuel_2000_12_24_3_1'].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:06 [    INFO] catalystcoop.pudl.transform.classes:1217 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:06 [    INFO] catalystcoop.pudl.transform.classes:1168 fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1192 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1144 fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.ferc1:1055 fuel_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1144 fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.ferc1:1254 fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.ferc1:1158 fuel_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1144 fuel_ferc1: Attempting to rename 15 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 15 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1217 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1168 fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1192 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.ferc1:1658 fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.ferc1:1662 fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.ferc1:819 fuel_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1246 fuel_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:823 68.7% of records (107454 rows) contain only {0, nan, '', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "68.7% of records (107454 rows) contain only {0, nan, '', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:823 0.4% of records (217 rows) contain only {'', nan, 'elk 1-3', '-', 'must 123', 'ant1-3', 'not applicable', 'must 456', '0', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.4% of records (217 rows) contain only {'', nan, 'elk 1-3', '-', 'must 123', 'ant1-3', 'not applicable', 'must 456', '0', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.ferc1:1732 fuel_ferc1: Dropping 0/48841rows representing plant-level all-fuel totals.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping 0/48841rows representing plant-level all-fuel totals.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1233 fuel_ferc1: Correcting inferred non-standard column units.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Correcting inferred non-standard column units.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:719 181/10820 (1.67%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "181/10820 (1.67%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:719 860/15769 (5.45%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "860/15769 (5.45%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:719 643/17623 (3.65%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "643/17623 (3.65%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:719 1367/10820 (12.63%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1367/10820 (12.63%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:719 2071/15769 (13.13%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2071/15769 (13.13%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:719 8083/17623 (45.87%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8083/17623 (45.87%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 11:07:07 [    INFO] catalystcoop.pudl.transform.classes:1264 fuel_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    }
+   ],
+   "source": [
+    "full = TRANSFORMER.transform(\n",
+    "    raw_dbf=ferc1_dbf_raw_dfs[TRANSFORMER.table_id.value],\n",
+    "    raw_xbrl_instant=ferc1_xbrl_raw_dfs[TRANSFORMER.table_id.value][\"instant\"],\n",
+    "    raw_xbrl_duration=ferc1_xbrl_raw_dfs[TRANSFORMER.table_id.value][\"duration\"]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "4a17f61f-fde7-4217-ae58-b72ff46d1837",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "48841"
+      ]
+     },
+     "execution_count": 65,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(full)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e795f853-a752-44a6-86ac-644baf291f9b",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Transform All Tables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "08da1d39-6272-435f-8241-8b3879078393",
+   "metadata": {
+    "collapsed": true,
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:15 [    INFO] catalystcoop.pudl.transform.ferc1:1072 balance_sheet_assets_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:15 [    INFO] catalystcoop.pudl.transform.ferc1:1135 balance_sheet_assets_ferc1: After selection only annual records, we have 40.6% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: After selection only annual records, we have 40.6% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:15 [    INFO] catalystcoop.pudl.transform.ferc1:348 Aligning row numbers from DBF row to XBRL map for ['f1_comp_balance_db']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aligning row numbers from DBF row to XBRL map for ['f1_comp_balance_db']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:15 [    INFO] catalystcoop.pudl.transform.classes:1144 balance_sheet_assets_ferc1: Attempting to rename 10 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Attempting to rename 10 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:1062 balance_sheet_assets_ferc1: Dropping rows where primary key and data columns are duplicated.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Dropping rows where primary key and data columns are duplicated.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/austensharpe/Desktop/Repos/pudl/src/pudl/transform/ferc1.py:298: FutureWarning: In a future version, `df.iloc[:, i] = newvals` will attempt to set the values inplace instead of always setting a new array. To retain the old behavior, use either `df[df.columns[i]] = newvals` or, if columns are non-unique, `df.isetitem(i, newvals)`\n",
+      "  dupes_w_possible_unique_data.loc[\n",
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:328 Dropped 2761 duplicate records: 1.2% of total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dropped 2761 duplicate records: 1.2% of total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:1093 balance_sheet_assets_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1144 balance_sheet_assets_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:1147 balance_sheet_assets_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:1269 balance_sheet_assets_ferc1: No XBRL duration table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: No XBRL duration table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:1185 balance_sheet_assets_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1144 balance_sheet_assets_ferc1: Attempting to rename 3 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Attempting to rename 3 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:910 balance_sheet_assets_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1168 balance_sheet_assets_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1192 balance_sheet_assets_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1217 balance_sheet_assets_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1179 balance_sheet_assets_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1206 balance_sheet_assets_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1259 balance_sheet_assets_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1246 balance_sheet_assets_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:1032 balance_sheet_assets_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1264 balance_sheet_assets_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_assets_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:1072 balance_sheet_liabilities_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:1135 balance_sheet_liabilities_ferc1: After selection only annual records, we have 39.1% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: After selection only annual records, we have 39.1% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.ferc1:348 Aligning row numbers from DBF row to XBRL map for ['f1_bal_sheet_cr']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aligning row numbers from DBF row to XBRL map for ['f1_bal_sheet_cr']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:16 [    INFO] catalystcoop.pudl.transform.classes:1144 balance_sheet_liabilities_ferc1: Attempting to rename 12 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Attempting to rename 12 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:1062 balance_sheet_liabilities_ferc1: Dropping rows where primary key and data columns are duplicated.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Dropping rows where primary key and data columns are duplicated.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/austensharpe/Desktop/Repos/pudl/src/pudl/transform/ferc1.py:298: FutureWarning: In a future version, `df.iloc[:, i] = newvals` will attempt to set the values inplace instead of always setting a new array. To retain the old behavior, use either `df[df.columns[i]] = newvals` or, if columns are non-unique, `df.isetitem(i, newvals)`\n",
+      "  dupes_w_possible_unique_data.loc[\n",
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:328 Dropped 1311 duplicate records: 0.7% of total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dropped 1311 duplicate records: 0.7% of total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:1093 balance_sheet_liabilities_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1144 balance_sheet_liabilities_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:1147 balance_sheet_liabilities_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [ WARNING] catalystcoop.pudl.transform.ferc1:520 Dropping unexpected years: [2019]\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dropping unexpected years: [2019]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:1269 balance_sheet_liabilities_ferc1: No XBRL duration table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: No XBRL duration table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:1185 balance_sheet_liabilities_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1144 balance_sheet_liabilities_ferc1: Attempting to rename 3 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Attempting to rename 3 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:910 balance_sheet_liabilities_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1168 balance_sheet_liabilities_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1192 balance_sheet_liabilities_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1217 balance_sheet_liabilities_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1179 balance_sheet_liabilities_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1206 balance_sheet_liabilities_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1259 balance_sheet_liabilities_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1246 balance_sheet_liabilities_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:1032 balance_sheet_liabilities_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1264 balance_sheet_liabilities_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "balance_sheet_liabilities_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:1072 depreciation_amortization_summary_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.ferc1:348 Aligning row numbers from DBF row to XBRL map for ['f1_dacs_epda']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aligning row numbers from DBF row to XBRL map for ['f1_dacs_epda']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:17 [    INFO] catalystcoop.pudl.transform.classes:1144 depreciation_amortization_summary_ferc1: Attempting to rename 13 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Attempting to rename 13 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1185 depreciation_amortization_summary_ferc1: applying wide_to_tidy for dbf\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: applying wide_to_tidy for dbf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1093 depreciation_amortization_summary_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 depreciation_amortization_summary_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1147 depreciation_amortization_summary_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 depreciation_amortization_summary_ferc1: Attempting to rename 6 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Attempting to rename 6 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1374 depreciation_amortization_summary_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1266 depreciation_amortization_summary_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1185 depreciation_amortization_summary_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 depreciation_amortization_summary_ferc1: Attempting to rename 3 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Attempting to rename 3 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:910 depreciation_amortization_summary_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1168 depreciation_amortization_summary_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1192 depreciation_amortization_summary_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1217 depreciation_amortization_summary_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1179 depreciation_amortization_summary_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1206 depreciation_amortization_summary_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1259 depreciation_amortization_summary_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1246 depreciation_amortization_summary_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:3348 depreciation_amortization_summary_ferc1: merging metadata\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: merging metadata\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1264 depreciation_amortization_summary_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "depreciation_amortization_summary_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1072 electric_energy_dispositions_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:348 Aligning row numbers from DBF row to XBRL map for ['f1_elctrc_erg_acct']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aligning row numbers from DBF row to XBRL map for ['f1_elctrc_erg_acct']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_energy_dispositions_ferc1: Attempting to rename 10 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Attempting to rename 10 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1093 electric_energy_dispositions_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_energy_dispositions_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1147 electric_energy_dispositions_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_energy_dispositions_ferc1: Attempting to rename 8 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Attempting to rename 8 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1374 electric_energy_dispositions_ferc1: After selection of dates based on the report year, we have 58.7% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: After selection of dates based on the report year, we have 58.7% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1266 electric_energy_dispositions_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1185 electric_energy_dispositions_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_energy_dispositions_ferc1: Attempting to rename 4 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Attempting to rename 4 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:910 electric_energy_dispositions_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1168 electric_energy_dispositions_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1192 electric_energy_dispositions_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1217 electric_energy_dispositions_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1179 electric_energy_dispositions_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1206 electric_energy_dispositions_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1259 electric_energy_dispositions_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1246 electric_energy_dispositions_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:823 65.7% of records (46625 rows) contain only {'', <NA>, nan} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "65.7% of records (46625 rows) contain only {'', <NA>, nan} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1032 electric_energy_dispositions_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1264 electric_energy_dispositions_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_dispositions_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1072 electric_energy_sources_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:348 Aligning row numbers from DBF row to XBRL map for ['f1_elctrc_erg_acct']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aligning row numbers from DBF row to XBRL map for ['f1_elctrc_erg_acct']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_energy_sources_ferc1: Attempting to rename 10 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Attempting to rename 10 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1093 electric_energy_sources_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_energy_sources_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1147 electric_energy_sources_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_energy_sources_ferc1: Attempting to rename 17 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Attempting to rename 17 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1374 electric_energy_sources_ferc1: After selection of dates based on the report year, we have 58.7% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: After selection of dates based on the report year, we have 58.7% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1266 electric_energy_sources_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.ferc1:1185 electric_energy_sources_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:18 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_energy_sources_ferc1: Attempting to rename 4 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Attempting to rename 4 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.ferc1:910 electric_energy_sources_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:1168 electric_energy_sources_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:1192 electric_energy_sources_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:1217 electric_energy_sources_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:1179 electric_energy_sources_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:1206 electric_energy_sources_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:1259 electric_energy_sources_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:1246 electric_energy_sources_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:823 52.2% of records (37927 rows) contain only {'', <NA>, nan} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "52.2% of records (37927 rows) contain only {'', <NA>, nan} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.ferc1:1032 electric_energy_sources_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:1264 electric_energy_sources_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_energy_sources_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.ferc1:3495 Heyyyy dropping that one row\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Heyyyy dropping that one row\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.ferc1:1072 electric_opex_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.ferc1:348 Aligning row numbers from DBF row to XBRL map for ['f1_elc_op_mnt_expn']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aligning row numbers from DBF row to XBRL map for ['f1_elc_op_mnt_expn']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:19 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_opex_ferc1: Attempting to rename 9 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Attempting to rename 9 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:1062 electric_opex_ferc1: Dropping rows where primary key and data columns are duplicated.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Dropping rows where primary key and data columns are duplicated.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/austensharpe/Desktop/Repos/pudl/src/pudl/transform/ferc1.py:298: FutureWarning: In a future version, `df.iloc[:, i] = newvals` will attempt to set the values inplace instead of always setting a new array. To retain the old behavior, use either `df[df.columns[i]] = newvals` or, if columns are non-unique, `df.isetitem(i, newvals)`\n",
+      "  dupes_w_possible_unique_data.loc[\n",
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:328 Dropped 103 duplicate records: 0.0% of total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dropped 103 duplicate records: 0.0% of total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:1093 electric_opex_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_opex_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:1147 electric_opex_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_opex_ferc1: Attempting to rename 171 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Attempting to rename 171 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:1374 electric_opex_ferc1: After selection of dates based on the report year, we have 50.5% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: After selection of dates based on the report year, we have 50.5% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:1266 electric_opex_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:1185 electric_opex_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_opex_ferc1: Attempting to rename 3 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Attempting to rename 3 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:910 electric_opex_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1168 electric_opex_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1192 electric_opex_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1217 electric_opex_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1179 electric_opex_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1206 electric_opex_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1259 electric_opex_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1246 electric_opex_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:1032 electric_opex_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.classes:1264 electric_opex_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_opex_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:21 [    INFO] catalystcoop.pudl.transform.ferc1:1072 electric_plant_depreciation_changes_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:348 Aligning row numbers from DBF row to XBRL map for ['f1_accumdepr_prvsn']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aligning row numbers from DBF row to XBRL map for ['f1_accumdepr_prvsn']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_plant_depreciation_changes_ferc1: Attempting to rename 12 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Attempting to rename 12 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:1185 electric_plant_depreciation_changes_ferc1: applying wide_to_tidy for dbf\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: applying wide_to_tidy for dbf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:1093 electric_plant_depreciation_changes_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:1147 electric_plant_depreciation_changes_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_plant_depreciation_changes_ferc1: Attempting to rename 2 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Attempting to rename 2 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_plant_depreciation_changes_ferc1: Attempting to rename 13 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Attempting to rename 13 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:1374 electric_plant_depreciation_changes_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:1272 electric_plant_depreciation_changes_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:1309 electric_plant_depreciation_changes_ferc1: Combining XBRL instant & duration tables using CONCATENATION.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Combining XBRL instant & duration tables using CONCATENATION.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:1185 electric_plant_depreciation_changes_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1144 electric_plant_depreciation_changes_ferc1: Attempting to rename 4 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Attempting to rename 4 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:967 electric_plant_depreciation_changes_ferc1: Selecting DBF rows with desired values in depreciation_type.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Selecting DBF rows with desired values in depreciation_type.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:910 electric_plant_depreciation_changes_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1168 electric_plant_depreciation_changes_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1192 electric_plant_depreciation_changes_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1217 electric_plant_depreciation_changes_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1179 electric_plant_depreciation_changes_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1206 electric_plant_depreciation_changes_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1259 electric_plant_depreciation_changes_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1246 electric_plant_depreciation_changes_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.ferc1:1032 electric_plant_depreciation_changes_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:22 [    INFO] catalystcoop.pudl.transform.classes:1264 electric_plant_depreciation_changes_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "electric_plant_depreciation_changes_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:23 [    INFO] catalystcoop.pudl.transform.ferc1:1072 fuel_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:23 [    INFO] catalystcoop.pudl.transform.classes:1144 fuel_ferc1: Attempting to rename 17 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 17 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:23 [ WARNING] catalystcoop.pudl.transform.ferc1:1497 fuel_ferc1: Found 1 duplicate record_ids: \n",
+      "['f1_fuel_2000_12_24_3_1'].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Found 1 duplicate record_ids: \n",
+      "['f1_fuel_2000_12_24_3_1'].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:23 [    INFO] catalystcoop.pudl.transform.classes:1217 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:23 [    INFO] catalystcoop.pudl.transform.classes:1168 fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:1192 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:1144 fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.ferc1:1147 fuel_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:1144 fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.ferc1:1374 fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.ferc1:1266 fuel_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:1144 fuel_ferc1: Attempting to rename 15 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Attempting to rename 15 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:1217 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:1168 fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:1192 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.ferc1:1772 fuel_ferc1: Aggregating 36 rows with duplicate primary keys out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Aggregating 36 rows with duplicate primary keys out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.ferc1:1776 fuel_ferc1: Dropping 92 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping 92 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.ferc1:910 fuel_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:1246 fuel_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:823 68.7% of records (107471 rows) contain only {0, '', <NA>, nan} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "68.7% of records (107471 rows) contain only {0, '', <NA>, nan} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:823 0.4% of records (217 rows) contain only {'', 'ant1-3', '0', 'must 456', nan, '-', 'must 123', 'not applicable', 'elk 1-3', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.4% of records (217 rows) contain only {'', 'ant1-3', '0', 'must 456', nan, '-', 'must 123', 'not applicable', 'elk 1-3', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.ferc1:1846 fuel_ferc1: Dropping 0/48818rows representing plant-level all-fuel totals.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Dropping 0/48818rows representing plant-level all-fuel totals.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:1233 fuel_ferc1: Correcting inferred non-standard column units.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Correcting inferred non-standard column units.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:719 181/10820 (1.67%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "181/10820 (1.67%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:24 [    INFO] catalystcoop.pudl.transform.classes:719 860/15769 (5.45%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "860/15769 (5.45%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:719 643/17623 (3.65%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "643/17623 (3.65%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==coal.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:719 1367/10820 (12.63%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1367/10820 (12.63%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==gas.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:719 2071/15769 (13.13%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2071/15769 (13.13%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==oil.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:719 8083/17623 (45.87%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "8083/17623 (45.87%) of records could not be corrected and were set to NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:1264 fuel_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.ferc1:3135 Dropped 150 records (0.0% oftotal) records from 2003 from the f1_incm_stmnt_2 DBF table that have known incorrect row numbers.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dropped 150 records (0.0% oftotal) records from 2003 from the f1_incm_stmnt_2 DBF table that have known incorrect row numbers.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.ferc1:1072 income_statement_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.ferc1:1135 income_statement_ferc1: After selection only annual records, we have 38.9% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: After selection only annual records, we have 38.9% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.ferc1:348 Aligning row numbers from DBF row to XBRL map for ['f1_income_stmnt', 'f1_incm_stmnt_2']\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Aligning row numbers from DBF row to XBRL map for ['f1_income_stmnt', 'f1_incm_stmnt_2']\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:25 [    INFO] catalystcoop.pudl.transform.classes:1144 income_statement_ferc1: Attempting to rename 16 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Attempting to rename 16 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:26 [    INFO] catalystcoop.pudl.transform.ferc1:1185 income_statement_ferc1: applying wide_to_tidy for dbf\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: applying wide_to_tidy for dbf\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:27 [    INFO] catalystcoop.pudl.transform.ferc1:1062 income_statement_ferc1: Dropping rows where primary key and data columns are duplicated.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Dropping rows where primary key and data columns are duplicated.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/austensharpe/Desktop/Repos/pudl/src/pudl/transform/ferc1.py:298: FutureWarning: In a future version, `df.iloc[:, i] = newvals` will attempt to set the values inplace instead of always setting a new array. To retain the old behavior, use either `df[df.columns[i]] = newvals` or, if columns are non-unique, `df.isetitem(i, newvals)`\n",
+      "  dupes_w_possible_unique_data.loc[\n",
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.ferc1:328 Dropped 45624 duplicate records: 2.2% of total rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Dropped 45624 duplicate records: 2.2% of total rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.ferc1:1093 income_statement_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.classes:1144 income_statement_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.ferc1:1147 income_statement_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.classes:1144 income_statement_ferc1: Attempting to rename 68 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Attempting to rename 68 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.ferc1:1374 income_statement_ferc1: After selection of dates based on the report year, we have 51.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: After selection of dates based on the report year, we have 51.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.ferc1:1266 income_statement_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: No XBRL instant table found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.ferc1:1185 income_statement_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: applying wide_to_tidy for xbrl\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.classes:1144 income_statement_ferc1: Attempting to rename 4 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Attempting to rename 4 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.ferc1:910 income_statement_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.classes:1168 income_statement_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:28 [    INFO] catalystcoop.pudl.transform.classes:1192 income_statement_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1217 income_statement_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1179 income_statement_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Stripping non-numeric values from [].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1206 income_statement_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1259 income_statement_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1246 income_statement_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:823 84.2% of records (1697454 rows) contain only {'', <NA>, nan} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "84.2% of records (1697454 rows) contain only {'', <NA>, nan} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.ferc1:1032 income_statement_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Merging metadata\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1264 income_statement_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "income_statement_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.ferc1:1072 plants_hydro_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_hydro_ferc1: Attempting to rename 41 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Attempting to rename 41 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.ferc1:1093 plants_hydro_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_hydro_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.ferc1:1147 plants_hydro_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_hydro_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.ferc1:1374 plants_hydro_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.ferc1:1272 plants_hydro_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.ferc1:1291 plants_hydro_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_hydro_ferc1: Attempting to rename 41 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Attempting to rename 41 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.ferc1:910 plants_hydro_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1168 plants_hydro_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1192 plants_hydro_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1217 plants_hydro_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1179 plants_hydro_ferc1: Stripping non-numeric values from ['project_num'].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Stripping non-numeric values from ['project_num'].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1206 plants_hydro_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1259 plants_hydro_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:1246 plants_hydro_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:29 [    INFO] catalystcoop.pudl.transform.classes:823 60.5% of records (10440 rows) contain only {0, '', 'none', '—', '0', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "60.5% of records (10440 rows) contain only {0, '', 'none', '—', '0', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:823 0.4% of records (30 rows) contain only {'', '0', nan, '-', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.4% of records (30 rows) contain only {'', '0', nan, '-', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1264 plants_hydro_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_hydro_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1072 plants_pumped_storage_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_pumped_storage_ferc1: Attempting to rename 45 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Attempting to rename 45 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1093 plants_pumped_storage_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_pumped_storage_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1147 plants_pumped_storage_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_pumped_storage_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1374 plants_pumped_storage_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1272 plants_pumped_storage_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1291 plants_pumped_storage_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_pumped_storage_ferc1: Attempting to rename 46 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Attempting to rename 46 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:910 plants_pumped_storage_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1168 plants_pumped_storage_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1192 plants_pumped_storage_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1217 plants_pumped_storage_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1179 plants_pumped_storage_ferc1: Stripping non-numeric values from ['project_num'].\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Stripping non-numeric values from ['project_num'].\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1206 plants_pumped_storage_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1259 plants_pumped_storage_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Replacing specified values with NA.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1246 plants_pumped_storage_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:823 89.1% of records (5636 rows) contain only {0, '', 'none', '—', '0', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "89.1% of records (5636 rows) contain only {0, '', 'none', '—', '0', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:823 21.0% of records (145 rows) contain only {'', '0', nan, '-', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "21.0% of records (145 rows) contain only {'', '0', nan, '-', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1264 plants_pumped_storage_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_pumped_storage_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1072 plants_small_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Processing DBF data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_small_ferc1: Attempting to rename 19 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Attempting to rename 19 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1093 plants_small_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Processing XBRL data pre-concatenation.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_small_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1147 plants_small_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Unstacking balances to the report years.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_small_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Attempting to rename 0 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1374 plants_small_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1272 plants_small_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Both XBRL instant & duration tables found.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:1291 plants_small_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1144 plants_small_ferc1: Attempting to rename 20 columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Attempting to rename 20 columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:910 plants_small_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Concatenating DBF + XBRL dataframes.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1168 plants_small_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Normalizing freeform string columns.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1206 plants_small_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Nullifying outlying values.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.classes:1217 plants_small_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Converting units and renaming columns accordingly.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:2199 plants_small_ferc1: Extracting FERC license from plant name\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Extracting FERC license from plant name\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:2439 plants_small_ferc1: Labeling header rows\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Labeling header rows\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:2585 plants_small_ferc1: Labeling total rows\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Labeling total rows\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:30 [    INFO] catalystcoop.pudl.transform.ferc1:2555 plants_small_ferc1: Labeling notes rows\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Labeling notes rows\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/austensharpe/Desktop/Repos/pudl/src/pudl/transform/ferc1.py:2559: FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.\n",
+      "To preserve the previous behavior, use\n",
+      "\n",
+      "\t>>> .groupby(..., group_keys=False)\n",
+      "\n",
+      "To adopt the future behavior and silence this warning, use \n",
+      "\n",
+      "\t>>> .groupby(..., group_keys=True)\n",
+      "  return util_groups.apply(lambda x: self._label_note_rows_group(x))\n",
+      "2023-01-27 16:22:36 [    INFO] catalystcoop.pudl.transform.ferc1:2754 plants_small_ferc1: Forward filling header fuel and plant types\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Forward filling header fuel and plant types\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:36 [    INFO] catalystcoop.pudl.transform.ferc1:2872 plants_small_ferc1: Getting fuel type (hydro) from plant name\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Getting fuel type (hydro) from plant name\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:36 [    INFO] catalystcoop.pudl.transform.classes:1192 plants_small_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:36 [ WARNING] catalystcoop.pudl.transform.classes:466 fuel_type_from_header: Found 31 uncategorized values: {'miscellaneous other power generation expense', 'steam plant', 'internal combustion: (emergency standby', 'auke bay internal combustion', 'neal shoals-hydro license', 'auke bay internal combustion:', 'other-leased:', 'renewables:', 'lemon creek internal combustion', 'lemon creek internal combustion:', 'internal combustion auxiliary', 'renewables', 'international combustion', 'other production:', 'lewiston canal facilities:', 'combined cycle plant:', 'combustion turbine', 'interal combustion:', 'steam:', 'other general ops supervision & engineering', 'internal conbustion:', 'steam heating plant', 'internal combustion peaking units', 'other:', 'manufactured gas plant remediation project', 'other / internal combustion :', 'wind - solar', 'waste water removal cost', 'internal combustion :', 'internal combustion-diesel', nan}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "fuel_type_from_header: Found 31 uncategorized values: {'miscellaneous other power generation expense', 'steam plant', 'internal combustion: (emergency standby', 'auke bay internal combustion', 'neal shoals-hydro license', 'auke bay internal combustion:', 'other-leased:', 'renewables:', 'lemon creek internal combustion', 'lemon creek internal combustion:', 'internal combustion auxiliary', 'renewables', 'international combustion', 'other production:', 'lewiston canal facilities:', 'combined cycle plant:', 'combustion turbine', 'interal combustion:', 'steam:', 'other general ops supervision & engineering', 'internal conbustion:', 'steam heating plant', 'internal combustion peaking units', 'other:', 'manufactured gas plant remediation project', 'other / internal combustion :', 'wind - solar', 'waste water removal cost', 'internal combustion :', 'internal combustion-diesel', nan}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:36 [ WARNING] catalystcoop.pudl.transform.classes:466 plant_type_from_header: Found 14 uncategorized values: {'landfill:', 'miscellaneous other power generation expense', 'renewables:', 'dinner lake gas', 'manufactured gas plant remediation project', 'wind - solar', 'other-leased:', 'lewiston canal facilities:', 'other:', 'waste water removal cost', 'renewables', 'other general ops supervision & engineering', 'other production:', nan}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plant_type_from_header: Found 14 uncategorized values: {'landfill:', 'miscellaneous other power generation expense', 'renewables:', 'dinner lake gas', 'manufactured gas plant remediation project', 'wind - solar', 'other-leased:', 'lewiston canal facilities:', 'other:', 'waste water removal cost', 'renewables', 'other general ops supervision & engineering', 'other production:', nan}\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:36 [    INFO] catalystcoop.pudl.transform.ferc1:2807 plants_small_ferc1: Filling NA and 'other' fuel and plant types with header info\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Filling NA and 'other' fuel and plant types with header info\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:36 [    INFO] catalystcoop.pudl.transform.ferc1:2846 Added fuel types to 6590 plant rows (40%). Added plant types to 11389 plant rows (69%).\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Added fuel types to 6590 plant rows (40%). Added plant types to 11389 plant rows (69%).\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:36 [    INFO] catalystcoop.pudl.transform.ferc1:2955 plants_small_ferc1: Mapping notes and ferc license from notes rows\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Mapping notes and ferc license from notes rows\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/austensharpe/Desktop/Repos/pudl/src/pudl/transform/ferc1.py:3002: FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.\n",
+      "To preserve the previous behavior, use\n",
+      "\n",
+      "\t>>> .groupby(..., group_keys=False)\n",
+      "\n",
+      "To adopt the future behavior and silence this warning, use \n",
+      "\n",
+      "\t>>> .groupby(..., group_keys=True)\n",
+      "  sg_notes = groups.apply(lambda x: associate_notes_with_values_group(x))\n",
+      "2023-01-27 16:22:38 [    INFO] catalystcoop.pudl.transform.ferc1:3009 Mapped 734 notes to plant rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Mapped 734 notes to plant rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:38 [    INFO] catalystcoop.pudl.transform.ferc1:3031 plants_small_ferc1: Spot fixing some rows\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Spot fixing some rows\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:38 [    INFO] catalystcoop.pudl.transform.classes:1246 plants_small_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Dropping remaining invalid rows.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:38 [    INFO] catalystcoop.pudl.transform.classes:823 20.0% of records (4257 rows) contain only {'note', 'header'} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20.0% of records (4257 rows) contain only {'note', 'header'} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:38 [    INFO] catalystcoop.pudl.transform.classes:823 4.2% of records (715 rows) contain only {0, '', 'none', '0', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.2% of records (715 rows) contain only {0, '', 'none', '0', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:38 [    INFO] catalystcoop.pudl.transform.classes:823 0.4% of records (67 rows) contain only {'', '0', nan, '-', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.4% of records (67 rows) contain only {'', '0', nan, '-', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-01-27 16:22:38 [    INFO] catalystcoop.pudl.transform.classes:1264 plants_small_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "plants_small_ferc1: Enforcing database schema on dataframe.\n"
+     ]
+    },
+    {
+     "ename": "TypeError",
+     "evalue": "PlantsSteamFerc1TableTransformer.transform() missing 1 required positional argument: 'transformed_fuel'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[8], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m transformed_tables \u001b[38;5;241m=\u001b[39m {}\n\u001b[1;32m      3\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m transformer \u001b[38;5;129;01min\u001b[39;00m transformers:\n\u001b[0;32m----> 4\u001b[0m     transformed_tables[transformer\u001b[38;5;241m.\u001b[39mtable_id\u001b[38;5;241m.\u001b[39mvalue] \u001b[38;5;241m=\u001b[39m \u001b[43mtransformer\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtransform\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m      5\u001b[0m \u001b[43m        \u001b[49m\u001b[43mraw_dbf\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mferc1_dbf_raw_dfs\u001b[49m\u001b[43m[\u001b[49m\u001b[43mtransformer\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtable_id\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalue\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      6\u001b[0m \u001b[43m        \u001b[49m\u001b[43mraw_xbrl_instant\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mferc1_xbrl_raw_dfs\u001b[49m\u001b[43m[\u001b[49m\u001b[43mtransformer\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtable_id\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalue\u001b[49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43minstant\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m      7\u001b[0m \u001b[43m        \u001b[49m\u001b[43mraw_xbrl_duration\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mferc1_xbrl_raw_dfs\u001b[49m\u001b[43m[\u001b[49m\u001b[43mtransformer\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mtable_id\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mvalue\u001b[49m\u001b[43m]\u001b[49m\u001b[43m[\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mduration\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m]\u001b[49m\n\u001b[1;32m      8\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n",
+      "\u001b[0;31mTypeError\u001b[0m: PlantsSteamFerc1TableTransformer.transform() missing 1 required positional argument: 'transformed_fuel'"
+     ]
+    }
+   ],
+   "source": [
+    "transformed_tables = {}\n",
+    "\n",
+    "for transformer in transformers:\n",
+    "    transformed_tables[transformer.table_id.value] = transformer.transform(\n",
+    "        raw_dbf=ferc1_dbf_raw_dfs[transformer.table_id.value],\n",
+    "        raw_xbrl_instant=ferc1_xbrl_raw_dfs[transformer.table_id.value][\"instant\"],\n",
+    "        raw_xbrl_duration=ferc1_xbrl_raw_dfs[transformer.table_id.value][\"duration\"]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8b9f7bf-b434-4e8c-a0ec-cbc75faa9187",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "transformed_table"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e88afef9-a6d2-4f3e-b255-4dbbf6817d5d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pudl-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "6e19b88aa386627e1cb51efb7fffa4d1c93b7b6266d71ad8fe17b8bdfe58c332"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/work-in-progress/ferc1-etl-spot-fix-debug.ipynb
+++ b/notebooks/work-in-progress/ferc1-etl-spot-fix-debug.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 233,
+   "execution_count": 33,
    "id": "1fa9ca56-b2c8-4bae-8ba3-ee9050b0ef86",
    "metadata": {},
    "outputs": [
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 234,
+   "execution_count": 34,
    "id": "e21fea69-9d14-48d6-b0c9-149c37844e95",
    "metadata": {},
    "outputs": [],
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 235,
+   "execution_count": 35,
    "id": "4a6e60d7-49e6-447c-a523-f88987c28086",
    "metadata": {},
    "outputs": [],
@@ -70,7 +70,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 236,
+   "execution_count": 36,
    "id": "bd17e444-c01d-41e6-a6ea-68244daf0fbc",
    "metadata": {},
    "outputs": [],
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 237,
+   "execution_count": 37,
    "id": "451cb78d-d4c0-47a7-9eef-193f54cfc06d",
    "metadata": {},
    "outputs": [],
@@ -123,12 +123,125 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "40a748a6-02c1-4f64-9b05-7b4a9d6fce9e",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-01 09:25:12 [    INFO] catalystcoop.pudl.extract.ferc1:763 Converting extracted FERC Form 1 table fuel_ferc1 into a pandas DataFrame from DBF table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Converting extracted FERC Form 1 table fuel_ferc1 into a pandas DataFrame from DBF table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-01 09:25:25 [    INFO] catalystcoop.pudl.extract.ferc1:763 Converting extracted FERC Form 1 table plants_steam_ferc1 into a pandas DataFrame from DBF table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Converting extracted FERC Form 1 table plants_steam_ferc1 into a pandas DataFrame from DBF table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-01 09:25:26 [    INFO] catalystcoop.pudl.extract.ferc1:824 Converting extracted FERC Form 1 table fuel_ferc1 into a pandas DataFrame from XBRL table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Converting extracted FERC Form 1 table fuel_ferc1 into a pandas DataFrame from XBRL table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-01 09:25:27 [    INFO] catalystcoop.pudl.extract.ferc1:824 Converting extracted FERC Form 1 table plants_steam_ferc1 into a pandas DataFrame from XBRL table.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Converting extracted FERC Form 1 table plants_steam_ferc1 into a pandas DataFrame from XBRL table.\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-01 09:25:28 [    INFO] catalystcoop.pudl.extract.ferc1:940 Reading XBRL Taxonomy metadata for FERC Form 1 table fuel_ferc1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading XBRL Taxonomy metadata for FERC Form 1 table fuel_ferc1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-01 09:25:28 [    INFO] catalystcoop.pudl.extract.ferc1:940 Reading XBRL Taxonomy metadata for FERC Form 1 table plants_steam_ferc1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading XBRL Taxonomy metadata for FERC Form 1 table plants_steam_ferc1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.extract.ferc1:940 Reading XBRL Taxonomy metadata for FERC Form 1 table fuel_ferc1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading XBRL Taxonomy metadata for FERC Form 1 table fuel_ferc1\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.extract.ferc1:940 Reading XBRL Taxonomy metadata for FERC Form 1 table plants_steam_ferc1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Reading XBRL Taxonomy metadata for FERC Form 1 table plants_steam_ferc1\n"
+     ]
+    }
+   ],
    "source": [
     "# Extract old FERC form 1 data from DBF (2020 -)\n",
     "ferc1_dbf_raw_dfs = pudl.extract.ferc1.extract_dbf(\n",
@@ -150,14 +263,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "id": "3be13154-c0c7-4df8-974d-4740bb2cd200",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "ferc1_xbrl_raw_dfs[table]"
+    "# ferc1_xbrl_raw_dfs[table]"
    ]
   },
   {
@@ -172,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "id": "96ecacb3-439f-49f2-b2f9-00fc16b93d24",
    "metadata": {
     "collapsed": true,
@@ -184,111 +297,111 @@
    },
    "outputs": [],
    "source": [
-    "from pudl.transform.ferc1 import *\n",
-    "from pudl.transform.params import *\n",
+    "# from pudl.transform.ferc1 import *\n",
+    "# from pudl.transform.params import *\n",
     "\n",
-    "transformers = [\n",
-    "    bsa := BalanceSheetAssetsFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"balance_sheet_assets_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    bsl := BalanceSheetLiabilitiesFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"balance_sheet_liabilities_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    das := DepreciationAmortizationSummaryFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"depreciation_amortization_summary_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    eed := ElectricEnergyDispositionsFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_energy_dispositions_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    ees := ElectricEnergySourcesFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_energy_sources_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    eo := ElectricOpexFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_opex_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    epdc := ElectricPlantDepreciationChangesFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_plant_depreciation_changes_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    ff := FuelFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"fuel_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    ins := IncomeStatementFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"income_statement_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    ph := PlantsHydroFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_hydro_ferc1\"], \n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    pps := PlantsPumpedStorageFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_pumped_storage_ferc1\"], \n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    psm := PlantsSmallFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_small_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    pst := PlantsSteamFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_steam_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    pis := PlantInServiceFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"plant_in_service_ferc1\"], \n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    pp := PurchasedPowerFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"purchased_power_ferc1\"], \n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    re := RetainedEarningsFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"retained_earnings_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    ts := TransmissionStatisticsFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"transmission_statistics_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    ups := UtilityPlantSummaryFerc1TableTransformer(\n",
-    "        xbrl_metadata_json=xbrl_metadata_json_dict[\"utility_plant_summary_ferc1\"],\n",
-    "        cache_dfs=True, \n",
-    "        clear_cached_dfs=False\n",
-    "    ),\n",
-    "    esbrs := ElectricitySalesByRateScheduleFerc1TableTransformer(\n",
-    "    #xbrl_metadata_json=xbrl_metadata_json_dict[\"electricity_sales_by_rate_schedule_ferc1\"],\n",
-    "    cache_dfs=True, \n",
-    "    clear_cached_dfs=False\n",
-    "    ),\n",
-    "]"
+    "# transformers = [\n",
+    "#     bsa := BalanceSheetAssetsFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"balance_sheet_assets_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     bsl := BalanceSheetLiabilitiesFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"balance_sheet_liabilities_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     das := DepreciationAmortizationSummaryFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"depreciation_amortization_summary_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     eed := ElectricEnergyDispositionsFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_energy_dispositions_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     ees := ElectricEnergySourcesFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_energy_sources_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     eo := ElectricOpexFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_opex_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     epdc := ElectricPlantDepreciationChangesFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"electric_plant_depreciation_changes_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     ff := FuelFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"fuel_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     ins := IncomeStatementFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"income_statement_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     ph := PlantsHydroFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_hydro_ferc1\"], \n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     pps := PlantsPumpedStorageFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_pumped_storage_ferc1\"], \n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     psm := PlantsSmallFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_small_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     pst := PlantsSteamFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"plants_steam_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     pis := PlantInServiceFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"plant_in_service_ferc1\"], \n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     pp := PurchasedPowerFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"purchased_power_ferc1\"], \n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     re := RetainedEarningsFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"retained_earnings_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     ts := TransmissionStatisticsFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"transmission_statistics_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     ups := UtilityPlantSummaryFerc1TableTransformer(\n",
+    "#         xbrl_metadata_json=xbrl_metadata_json_dict[\"utility_plant_summary_ferc1\"],\n",
+    "#         cache_dfs=True, \n",
+    "#         clear_cached_dfs=False\n",
+    "#     ),\n",
+    "#     esbrs := ElectricitySalesByRateScheduleFerc1TableTransformer(\n",
+    "#     #xbrl_metadata_json=xbrl_metadata_json_dict[\"electricity_sales_by_rate_schedule_ferc1\"],\n",
+    "#     cache_dfs=True, \n",
+    "#     clear_cached_dfs=False\n",
+    "#     ),\n",
+    "# ]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 257,
+   "execution_count": 41,
    "id": "7dbf2af1-5da0-4c8d-98ec-4e27b3e1bc5d",
    "metadata": {
     "tags": []
@@ -298,7 +411,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:04:53 [    INFO] catalystcoop.pudl.transform.ferc1:896 fuel_ferc1: Processing XBRL metadata.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:896 fuel_ferc1: Processing XBRL metadata.\n"
      ]
     },
     {
@@ -312,7 +425,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:04:53 [    INFO] catalystcoop.pudl.transform.ferc1:896 plants_steam_ferc1: Processing XBRL metadata.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:896 plants_steam_ferc1: Processing XBRL metadata.\n"
      ]
     },
     {
@@ -351,7 +464,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 258,
+   "execution_count": 42,
    "id": "d594beab-7c93-47e3-acb4-b18ef6d3b16e",
    "metadata": {},
    "outputs": [],
@@ -363,7 +476,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 259,
+   "execution_count": 43,
    "id": "d94d688e-c4cd-443e-9058-c7dfe9fb0882",
    "metadata": {
     "tags": []
@@ -373,7 +486,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 0 columns.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1197 fuel_ferc1: Attempting to rename 0 columns.\n"
      ]
     },
     {
@@ -387,7 +500,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1056 fuel_ferc1: Unstacking balances to the report years.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:1056 fuel_ferc1: Unstacking balances to the report years.\n"
      ]
     },
     {
@@ -401,7 +514,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 0 columns.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1197 fuel_ferc1: Attempting to rename 0 columns.\n"
      ]
     },
     {
@@ -415,7 +528,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1255 fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:1255 fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
      ]
     },
     {
@@ -429,7 +542,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1159 fuel_ferc1: No XBRL instant table found.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:1159 fuel_ferc1: No XBRL instant table found.\n"
      ]
     },
     {
@@ -443,7 +556,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 15 columns.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1197 fuel_ferc1: Attempting to rename 15 columns.\n"
      ]
     },
     {
@@ -457,7 +570,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1267 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1270 fuel_ferc1: Converting units and renaming columns accordingly.\n"
      ]
     },
     {
@@ -471,7 +584,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1218 fuel_ferc1: Normalizing freeform string columns.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1221 fuel_ferc1: Normalizing freeform string columns.\n"
      ]
     },
     {
@@ -485,7 +598,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.classes:1242 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1245 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
      ]
     },
     {
@@ -499,7 +612,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1663 fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:1663 fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
      ]
     },
     {
@@ -513,7 +626,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:49 [    INFO] catalystcoop.pudl.transform.ferc1:1667 fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:1667 fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
      ]
     },
     {
@@ -535,7 +648,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 260,
+   "execution_count": 44,
    "id": "53bd3f6a",
    "metadata": {},
    "outputs": [
@@ -543,7 +656,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.ferc1:1003 plants_steam_ferc1: Processing XBRL data pre-concatenation.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:1003 plants_steam_ferc1: Processing XBRL data pre-concatenation.\n"
      ]
     },
     {
@@ -557,7 +670,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 0 columns.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1197 plants_steam_ferc1: Attempting to rename 0 columns.\n"
      ]
     },
     {
@@ -571,7 +684,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.ferc1:1056 plants_steam_ferc1: Unstacking balances to the report years.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:1056 plants_steam_ferc1: Unstacking balances to the report years.\n"
      ]
     },
     {
@@ -585,7 +698,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 0 columns.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1197 plants_steam_ferc1: Attempting to rename 0 columns.\n"
      ]
     },
     {
@@ -599,7 +712,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.ferc1:1255 plants_steam_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:1255 plants_steam_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
      ]
     },
     {
@@ -613,7 +726,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.ferc1:1159 plants_steam_ferc1: No XBRL instant table found.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:1159 plants_steam_ferc1: No XBRL instant table found.\n"
      ]
     },
     {
@@ -627,7 +740,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:53 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 43 columns.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1197 plants_steam_ferc1: Attempting to rename 43 columns.\n"
      ]
     },
     {
@@ -641,8 +754,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:53 [ WARNING] catalystcoop.pudl.transform.classes:1203 plants_steam_ferc1: Attempting to rename columns which are not present in the dataframe.\n",
-      "Missing columns: {'net_continuous_plant_capability', 'net_peak_demand_on_plant', 'maintenance_of_boiler_plant_steam_power_generation', 'year_plant_originally_constructed', 'net_generation_excluding_plant_use', 'plant_average_number_of_employees', 'plant_hours_connected_to_load', 'electric_expenses_steam_power_generation', 'miscellaneous_steam_power_expenses', 'net_continuous_plant_capability_not_limited_by_condenser_water', 'maintenance_of_electric_plant_steam_power_generation', 'plant_name', 'asset_retirement_costs_steam_production', 'coolants_and_water', 'cost_per_kilowatt_of_installed_capacity', 'plant_construction_type', 'expenses_per_net_kilowatt_hour', 'maintenance_supervision_and_engineering_steam_power_generation', 'power_production_expenses_steam_power', 'steam_expenses_steam_power_generation', 'allowances', 'maintenance_of_miscellaneous_steam_plant', 'net_continuous_plant_capability_limited_by_condenser_water', 'year_last_unit_of_plant_installed', 'date', 'cost_of_structures_and_improvements_steam_production', 'cost_of_plant', 'cost_of_land_and_land_rights_steam_production', 'steam_transferred_credit', 'installed_capacity_of_plant', 'rents_steam_power_generation', 'order_number', 'maintenance_of_structures_steam_power_generation', 'operation_supervision_and_engineering_expense', 'cost_of_equipment_steam_production', 'steam_from_other_sources', 'fuel_steam_power_generation', 'plant_kind'}\n"
+      "2023-02-01 09:25:29 [ WARNING] catalystcoop.pudl.transform.classes:1206 plants_steam_ferc1: Attempting to rename columns which are not present in the dataframe.\n",
+      "Missing columns: {'net_continuous_plant_capability_limited_by_condenser_water', 'plant_hours_connected_to_load', 'expenses_per_net_kilowatt_hour', 'fuel_steam_power_generation', 'electric_expenses_steam_power_generation', 'power_production_expenses_steam_power', 'installed_capacity_of_plant', 'cost_of_equipment_steam_production', 'rents_steam_power_generation', 'coolants_and_water', 'net_continuous_plant_capability', 'year_last_unit_of_plant_installed', 'asset_retirement_costs_steam_production', 'plant_average_number_of_employees', 'maintenance_supervision_and_engineering_steam_power_generation', 'cost_of_structures_and_improvements_steam_production', 'cost_per_kilowatt_of_installed_capacity', 'steam_expenses_steam_power_generation', 'net_continuous_plant_capability_not_limited_by_condenser_water', 'cost_of_plant', 'plant_construction_type', 'allowances', 'steam_from_other_sources', 'steam_transferred_credit', 'maintenance_of_electric_plant_steam_power_generation', 'miscellaneous_steam_power_expenses', 'year_plant_originally_constructed', 'plant_name', 'maintenance_of_miscellaneous_steam_plant', 'net_generation_excluding_plant_use', 'net_peak_demand_on_plant', 'cost_of_land_and_land_rights_steam_production', 'plant_kind', 'operation_supervision_and_engineering_expense', 'maintenance_of_structures_steam_power_generation', 'order_number', 'maintenance_of_boiler_plant_steam_power_generation', 'date'}\n"
      ]
     },
     {
@@ -650,14 +763,14 @@
      "output_type": "stream",
      "text": [
       "plants_steam_ferc1: Attempting to rename columns which are not present in the dataframe.\n",
-      "Missing columns: {'net_continuous_plant_capability', 'net_peak_demand_on_plant', 'maintenance_of_boiler_plant_steam_power_generation', 'year_plant_originally_constructed', 'net_generation_excluding_plant_use', 'plant_average_number_of_employees', 'plant_hours_connected_to_load', 'electric_expenses_steam_power_generation', 'miscellaneous_steam_power_expenses', 'net_continuous_plant_capability_not_limited_by_condenser_water', 'maintenance_of_electric_plant_steam_power_generation', 'plant_name', 'asset_retirement_costs_steam_production', 'coolants_and_water', 'cost_per_kilowatt_of_installed_capacity', 'plant_construction_type', 'expenses_per_net_kilowatt_hour', 'maintenance_supervision_and_engineering_steam_power_generation', 'power_production_expenses_steam_power', 'steam_expenses_steam_power_generation', 'allowances', 'maintenance_of_miscellaneous_steam_plant', 'net_continuous_plant_capability_limited_by_condenser_water', 'year_last_unit_of_plant_installed', 'date', 'cost_of_structures_and_improvements_steam_production', 'cost_of_plant', 'cost_of_land_and_land_rights_steam_production', 'steam_transferred_credit', 'installed_capacity_of_plant', 'rents_steam_power_generation', 'order_number', 'maintenance_of_structures_steam_power_generation', 'operation_supervision_and_engineering_expense', 'cost_of_equipment_steam_production', 'steam_from_other_sources', 'fuel_steam_power_generation', 'plant_kind'}\n"
+      "Missing columns: {'net_continuous_plant_capability_limited_by_condenser_water', 'plant_hours_connected_to_load', 'expenses_per_net_kilowatt_hour', 'fuel_steam_power_generation', 'electric_expenses_steam_power_generation', 'power_production_expenses_steam_power', 'installed_capacity_of_plant', 'cost_of_equipment_steam_production', 'rents_steam_power_generation', 'coolants_and_water', 'net_continuous_plant_capability', 'year_last_unit_of_plant_installed', 'asset_retirement_costs_steam_production', 'plant_average_number_of_employees', 'maintenance_supervision_and_engineering_steam_power_generation', 'cost_of_structures_and_improvements_steam_production', 'cost_per_kilowatt_of_installed_capacity', 'steam_expenses_steam_power_generation', 'net_continuous_plant_capability_not_limited_by_condenser_water', 'cost_of_plant', 'plant_construction_type', 'allowances', 'steam_from_other_sources', 'steam_transferred_credit', 'maintenance_of_electric_plant_steam_power_generation', 'miscellaneous_steam_power_expenses', 'year_plant_originally_constructed', 'plant_name', 'maintenance_of_miscellaneous_steam_plant', 'net_generation_excluding_plant_use', 'net_peak_demand_on_plant', 'cost_of_land_and_land_rights_steam_production', 'plant_kind', 'operation_supervision_and_engineering_expense', 'maintenance_of_structures_steam_power_generation', 'order_number', 'maintenance_of_boiler_plant_steam_power_generation', 'date'}\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:06:53 [ WARNING] catalystcoop.pudl.transform.ferc1:1387 plants_steam_ferc1: Found 500 duplicate record_ids: \n",
+      "2023-02-01 09:25:29 [ WARNING] catalystcoop.pudl.transform.ferc1:1387 plants_steam_ferc1: Found 500 duplicate record_ids: \n",
       "['steam_electric_generating_plant_statistics_large_plants_402_2021_c008999_baxter_wilson'\n",
       " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008999_gerald_andrus'\n",
       " 'steam_electric_generating_plant_statistics_large_plants_402_2021_c008999_independence'\n",
@@ -1682,7 +1795,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 261,
+   "execution_count": 45,
    "id": "30ddcac0-3379-4239-a268-7b510937a4b6",
    "metadata": {
     "collapsed": true,
@@ -1804,7 +1917,7 @@
        "1231               C000447 2021-01-01 2021-12-31            Gas                0                                              0.000                                            0.000                                              0.000                                          NaN       Gas                                                0.0                                  NaN       Mcf                                       0.000         2021  steam_electric_generating_plant_statistics_lar...               185"
       ]
      },
-     "execution_count": 261,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1826,7 +1939,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 262,
+   "execution_count": 46,
    "id": "3c5f3389-58c8-40db-b71a-e74a1d4c8c09",
    "metadata": {
     "tags": []
@@ -1836,7 +1949,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:02 [    INFO] catalystcoop.pudl.transform.ferc1:982 plants_steam_ferc1: Processing DBF data pre-concatenation.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.ferc1:982 plants_steam_ferc1: Processing DBF data pre-concatenation.\n"
      ]
     },
     {
@@ -1850,7 +1963,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:02 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 43 columns.\n"
+      "2023-02-01 09:25:29 [    INFO] catalystcoop.pudl.transform.classes:1197 plants_steam_ferc1: Attempting to rename 43 columns.\n"
      ]
     },
     {
@@ -1864,7 +1977,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1003 plants_steam_ferc1: Processing XBRL data pre-concatenation.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.ferc1:1003 plants_steam_ferc1: Processing XBRL data pre-concatenation.\n"
      ]
     },
     {
@@ -1878,7 +1991,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 0 columns.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.classes:1197 plants_steam_ferc1: Attempting to rename 0 columns.\n"
      ]
     },
     {
@@ -1892,7 +2005,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1056 plants_steam_ferc1: Unstacking balances to the report years.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.ferc1:1056 plants_steam_ferc1: Unstacking balances to the report years.\n"
      ]
     },
     {
@@ -1906,7 +2019,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 0 columns.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.classes:1197 plants_steam_ferc1: Attempting to rename 0 columns.\n"
      ]
     },
     {
@@ -1920,7 +2033,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1255 plants_steam_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.ferc1:1255 plants_steam_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
      ]
     },
     {
@@ -1934,7 +2047,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1165 plants_steam_ferc1: Both XBRL instant & duration tables found.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.ferc1:1165 plants_steam_ferc1: Both XBRL instant & duration tables found.\n"
      ]
     },
     {
@@ -1948,7 +2061,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:1176 plants_steam_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.ferc1:1176 plants_steam_ferc1: Combining XBRL instant & duration tables using RIGHT-MERGE.\n"
      ]
     },
     {
@@ -1962,7 +2075,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.classes:1194 plants_steam_ferc1: Attempting to rename 43 columns.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.classes:1197 plants_steam_ferc1: Attempting to rename 43 columns.\n"
      ]
     },
     {
@@ -1976,7 +2089,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:03 [    INFO] catalystcoop.pudl.transform.ferc1:819 plants_steam_ferc1: Concatenating DBF + XBRL dataframes.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.ferc1:819 plants_steam_ferc1: Concatenating DBF + XBRL dataframes.\n"
      ]
     },
     {
@@ -1997,7 +2110,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 263,
+   "execution_count": 47,
    "id": "93ea54d5-f503-4d20-92e0-885588563b46",
    "metadata": {},
    "outputs": [
@@ -2129,7 +2242,7 @@
        "9645                  72.0         1999                       Steam      Conventional              1955              1956      1303.56          1327.0                                  8760.0                  NaN                         1284.0                        NaN              390.0        8.531868e+09    673317.0        64561620.0      322548092.0  387783029.0        297.48        1154409.0  107221337.0            NaN   4377325.0               NaN            NaN      2030686.0        4309783.0      2400.0              NaN          425959.0        1277712.0   11216023.0    2529112.0         709251.0            135253997.0        0.0159                    NaN  f1_steam_1999_12_72_0_1               409                   NaN  NaN        NaT      NaT        NaN           NaN"
       ]
      },
-     "execution_count": 263,
+     "execution_count": 47,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2140,7 +2253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 264,
+   "execution_count": 48,
    "id": "8c0b3926",
    "metadata": {},
    "outputs": [
@@ -2148,7 +2261,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:12 [    INFO] catalystcoop.pudl.transform.ferc1:982 fuel_ferc1: Processing DBF data pre-concatenation.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.ferc1:982 fuel_ferc1: Processing DBF data pre-concatenation.\n"
      ]
     },
     {
@@ -2162,7 +2275,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:12 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 17 columns.\n"
+      "2023-02-01 09:25:30 [    INFO] catalystcoop.pudl.transform.classes:1197 fuel_ferc1: Attempting to rename 17 columns.\n"
      ]
     },
     {
@@ -2176,7 +2289,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:13 [ WARNING] catalystcoop.pudl.transform.ferc1:1387 fuel_ferc1: Found 1 duplicate record_ids: \n",
+      "2023-02-01 09:25:31 [ WARNING] catalystcoop.pudl.transform.ferc1:1387 fuel_ferc1: Found 1 duplicate record_ids: \n",
       "['f1_fuel_2000_12_24_3_1'].\n"
      ]
     },
@@ -2192,7 +2305,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:13 [    INFO] catalystcoop.pudl.transform.classes:1267 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+      "2023-02-01 09:25:31 [    INFO] catalystcoop.pudl.transform.classes:1270 fuel_ferc1: Converting units and renaming columns accordingly.\n"
      ]
     },
     {
@@ -2206,7 +2319,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:13 [    INFO] catalystcoop.pudl.transform.classes:1218 fuel_ferc1: Normalizing freeform string columns.\n"
+      "2023-02-01 09:25:31 [    INFO] catalystcoop.pudl.transform.classes:1221 fuel_ferc1: Normalizing freeform string columns.\n"
      ]
     },
     {
@@ -2220,7 +2333,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:14 [    INFO] catalystcoop.pudl.transform.classes:1242 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+      "2023-02-01 09:25:32 [    INFO] catalystcoop.pudl.transform.classes:1245 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
      ]
     },
     {
@@ -2234,7 +2347,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:14 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 0 columns.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1197 fuel_ferc1: Attempting to rename 0 columns.\n"
      ]
     },
     {
@@ -2248,7 +2361,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:14 [    INFO] catalystcoop.pudl.transform.ferc1:1056 fuel_ferc1: Unstacking balances to the report years.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.ferc1:1056 fuel_ferc1: Unstacking balances to the report years.\n"
      ]
     },
     {
@@ -2262,7 +2375,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:14 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 0 columns.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1197 fuel_ferc1: Attempting to rename 0 columns.\n"
      ]
     },
     {
@@ -2276,7 +2389,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1255 fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.ferc1:1255 fuel_ferc1: After selection of dates based on the report year, we have 100.0% of the original table.\n"
      ]
     },
     {
@@ -2290,7 +2403,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1159 fuel_ferc1: No XBRL instant table found.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.ferc1:1159 fuel_ferc1: No XBRL instant table found.\n"
      ]
     },
     {
@@ -2304,7 +2417,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1194 fuel_ferc1: Attempting to rename 15 columns.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1197 fuel_ferc1: Attempting to rename 15 columns.\n"
      ]
     },
     {
@@ -2318,7 +2431,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1267 fuel_ferc1: Converting units and renaming columns accordingly.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1270 fuel_ferc1: Converting units and renaming columns accordingly.\n"
      ]
     },
     {
@@ -2332,7 +2445,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1218 fuel_ferc1: Normalizing freeform string columns.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1221 fuel_ferc1: Normalizing freeform string columns.\n"
      ]
     },
     {
@@ -2346,7 +2459,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1242 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1245 fuel_ferc1: Categorizing string columns using a controlled vocabulary.\n"
      ]
     },
     {
@@ -2360,7 +2473,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1663 fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.ferc1:1663 fuel_ferc1: Aggregating 30 rows with duplicate primary keys out of 1312 total rows.\n"
      ]
     },
     {
@@ -2374,7 +2487,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1667 fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.ferc1:1667 fuel_ferc1: Dropping 98 records with inconsistent fuel units preventing aggregation out of 1312 total rows.\n"
      ]
     },
     {
@@ -2388,7 +2501,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:819 fuel_ferc1: Concatenating DBF + XBRL dataframes.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.ferc1:819 fuel_ferc1: Concatenating DBF + XBRL dataframes.\n"
      ]
     },
     {
@@ -2402,7 +2515,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1320 fuel_ferc1: Spot fixing missing values.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1323 fuel_ferc1: Spot fixing missing values.\n"
      ]
     },
     {
@@ -2416,7 +2529,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1296 fuel_ferc1: Dropping remaining invalid rows.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1299 fuel_ferc1: Dropping remaining invalid rows.\n"
      ]
     },
     {
@@ -2430,7 +2543,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:823 68.7% of records (107454 rows) contain only {0, '', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:823 68.7% of records (107454 rows) contain only {0, '', nan, <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
      ]
     },
     {
@@ -2444,21 +2557,21 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:823 0.4% of records (217 rows) contain only {'', '-', 'must 123', 'must 456', nan, '0', 'ant1-3', 'elk 1-3', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:823 0.4% of records (217 rows) contain only {'', '-', <NA>, nan, 'must 123', '0', 'elk 1-3', 'ant1-3', 'not applicable', 'must 456'} values in required columns. Dropped these 💩💩💩 records.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.4% of records (217 rows) contain only {'', '-', 'must 123', 'must 456', nan, '0', 'ant1-3', 'elk 1-3', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+      "0.4% of records (217 rows) contain only {'', '-', <NA>, nan, 'must 123', '0', 'elk 1-3', 'ant1-3', 'not applicable', 'must 456'} values in required columns. Dropped these 💩💩💩 records.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.ferc1:1737 fuel_ferc1: Dropping 0/48841rows representing plant-level all-fuel totals.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.ferc1:1737 fuel_ferc1: Dropping 0/48841rows representing plant-level all-fuel totals.\n"
      ]
     },
     {
@@ -2472,7 +2585,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1283 fuel_ferc1: Correcting inferred non-standard column units.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1286 fuel_ferc1: Correcting inferred non-standard column units.\n"
      ]
     },
     {
@@ -2486,7 +2599,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==coal.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==coal.\n"
      ]
     },
     {
@@ -2500,7 +2613,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 181/10820 (1.67%) of records could not be corrected and were set to NA.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:719 181/10820 (1.67%) of records could not be corrected and were set to NA.\n"
      ]
     },
     {
@@ -2514,7 +2627,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==gas.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==gas.\n"
      ]
     },
     {
@@ -2528,7 +2641,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 860/15769 (5.45%) of records could not be corrected and were set to NA.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:719 860/15769 (5.45%) of records could not be corrected and were set to NA.\n"
      ]
     },
     {
@@ -2542,7 +2655,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==oil.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_mmbtu_per_unit where fuel_type_code_pudl==oil.\n"
      ]
     },
     {
@@ -2556,7 +2669,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 643/17623 (3.65%) of records could not be corrected and were set to NA.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:719 643/17623 (3.65%) of records could not be corrected and were set to NA.\n"
      ]
     },
     {
@@ -2570,7 +2683,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==coal.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==coal.\n"
      ]
     },
     {
@@ -2584,7 +2697,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 1367/10820 (12.63%) of records could not be corrected and were set to NA.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:719 1367/10820 (12.63%) of records could not be corrected and were set to NA.\n"
      ]
     },
     {
@@ -2598,7 +2711,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==gas.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==gas.\n"
      ]
     },
     {
@@ -2612,7 +2725,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 2071/15769 (13.13%) of records could not be corrected and were set to NA.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:719 2071/15769 (13.13%) of records could not be corrected and were set to NA.\n"
      ]
     },
     {
@@ -2626,7 +2739,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==oil.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:698 Correcting units of fuel_cost_per_mmbtu where fuel_type_code_pudl==oil.\n"
      ]
     },
     {
@@ -2640,7 +2753,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:719 8083/17623 (45.87%) of records could not be corrected and were set to NA.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:719 8083/17623 (45.87%) of records could not be corrected and were set to NA.\n"
      ]
     },
     {
@@ -2654,7 +2767,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:07:15 [    INFO] catalystcoop.pudl.transform.classes:1327 fuel_ferc1: Enforcing database schema on dataframe.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1330 fuel_ferc1: Enforcing database schema on dataframe.\n"
      ]
     },
     {
@@ -2680,7 +2793,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 266,
+   "execution_count": 49,
    "id": "9aa10b65-9200-42c4-8c02-745228b46b7f",
    "metadata": {
     "collapsed": true,
@@ -2694,91 +2807,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1218 plants_steam_ferc1: Normalizing freeform string columns.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Normalizing freeform string columns.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1242 plants_steam_ferc1: Categorizing string columns using a controlled vocabulary.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Categorizing string columns using a controlled vocabulary.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1267 plants_steam_ferc1: Converting units and renaming columns accordingly.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Converting units and renaming columns accordingly.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1229 plants_steam_ferc1: Stripping non-numeric values from [].\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Stripping non-numeric values from [].\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1256 plants_steam_ferc1: Nullifying outlying values.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Nullifying outlying values.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1309 plants_steam_ferc1: Replacing specified values with NA.\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Replacing specified values with NA.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1320 plants_steam_ferc1: Spot fixing missing values.\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1323 plants_steam_ferc1: Spot fixing missing values.\n"
      ]
     },
     {
@@ -2792,147 +2821,91 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+      "2023-02-01 09:25:33 [    INFO] catalystcoop.pudl.transform.classes:1221 plants_steam_ferc1: Normalizing freeform string columns.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
+      "plants_steam_ferc1: Normalizing freeform string columns.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+      "2023-02-01 09:25:34 [    INFO] catalystcoop.pudl.transform.classes:1245 plants_steam_ferc1: Categorizing string columns using a controlled vocabulary.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
+      "plants_steam_ferc1: Categorizing string columns using a controlled vocabulary.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+      "2023-02-01 09:25:34 [    INFO] catalystcoop.pudl.transform.classes:1270 plants_steam_ferc1: Converting units and renaming columns accordingly.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
+      "plants_steam_ferc1: Converting units and renaming columns accordingly.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+      "2023-02-01 09:25:34 [    INFO] catalystcoop.pudl.transform.classes:1232 plants_steam_ferc1: Stripping non-numeric values from [].\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
+      "plants_steam_ferc1: Stripping non-numeric values from [].\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+      "2023-02-01 09:25:34 [    INFO] catalystcoop.pudl.transform.classes:1259 plants_steam_ferc1: Nullifying outlying values.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
+      "plants_steam_ferc1: Nullifying outlying values.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
+      "2023-02-01 09:25:34 [    INFO] catalystcoop.pudl.transform.classes:1312 plants_steam_ferc1: Replacing specified values with NA.\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
+      "plants_steam_ferc1: Replacing specified values with NA.\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:886 plants_steam_ferc1: Spot fixing some values\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "plants_steam_ferc1: Spot fixing some values\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "2023-01-31 16:09:28 [    INFO] catalystcoop.pudl.transform.classes:1296 plants_steam_ferc1: Dropping remaining invalid rows.\n"
+      "2023-02-01 09:25:34 [    INFO] catalystcoop.pudl.transform.classes:1299 plants_steam_ferc1: Dropping remaining invalid rows.\n"
      ]
     },
     {
@@ -2946,7 +2919,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:29 [    INFO] catalystcoop.pudl.transform.classes:823 41.7% of records (22039 rows) contain only {0, '', nan, 'none', '0', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+      "2023-02-01 09:25:34 [    INFO] catalystcoop.pudl.transform.classes:823 41.7% of records (22039 rows) contain only {0, '', nan, 'none', '0', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
      ]
     },
     {
@@ -2960,7 +2933,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:29 [    INFO] catalystcoop.pudl.transform.classes:823 0.2% of records (71 rows) contain only {'', '-', nan, '0', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
+      "2023-02-01 09:25:34 [    INFO] catalystcoop.pudl.transform.classes:823 0.2% of records (71 rows) contain only {'', '-', nan, '0', 'not applicable', <NA>} values in required columns. Dropped these 💩💩💩 records.\n"
      ]
     },
     {
@@ -2974,7 +2947,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:09:29 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:399 Identifying distinct large FERC plants for ID assignment.\n"
+      "2023-02-01 09:25:34 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:399 Identifying distinct large FERC plants for ID assignment.\n"
      ]
     },
     {
@@ -2988,7 +2961,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:02 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:432 Successfully associated 22900 of 30710 (74.57%) FERC Form 1 plant records with multi-year plant entities.\n"
+      "2023-02-01 09:40:00 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:432 Successfully associated 22900 of 30710 (74.57%) FERC Form 1 plant records with multi-year plant entities.\n"
      ]
     },
     {
@@ -3002,7 +2975,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:02 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:445 Assigning IDs to multi-year FERC plant entities.\n"
+      "2023-02-01 09:40:00 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:445 Assigning IDs to multi-year FERC plant entities.\n"
      ]
     },
     {
@@ -3016,7 +2989,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:09 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:462 Identified 4949 orphaned FERC plant records. Adding orphans to list of plant entities.\n"
+      "2023-02-01 09:40:09 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:462 Identified 4949 orphaned FERC plant records. Adding orphans to list of plant entities.\n"
      ]
     },
     {
@@ -3030,7 +3003,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:14 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:484 Successfully Identified 2079 multi-year plant entities.\n"
+      "2023-02-01 09:40:14 [    INFO] catalystcoop.pudl.analysis.classify_plants_ferc1:484 Successfully Identified 2079 multi-year plant entities.\n"
      ]
     },
     {
@@ -3044,7 +3017,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1994 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1994 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3058,7 +3031,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1995 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1995 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3072,7 +3045,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1996 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1996 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3086,7 +3059,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1998 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1998 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3100,7 +3073,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1999 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1999 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3114,7 +3087,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2000 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2000 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3128,7 +3101,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2001 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2001 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3142,7 +3115,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2002 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2002 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3156,7 +3129,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2003 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2003 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3170,7 +3143,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2004 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2004 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3184,7 +3157,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2005 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2005 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3198,7 +3171,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2006 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2006 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3212,7 +3185,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2007 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2007 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3226,7 +3199,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2008 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2008 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3240,7 +3213,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2009 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2009 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3254,7 +3227,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2010 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2010 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3268,7 +3241,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2011 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2011 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3282,7 +3255,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2012 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2012 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3296,7 +3269,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2013 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2013 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3310,7 +3283,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2014 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2014 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3324,7 +3297,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2015 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2015 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3338,7 +3311,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2016 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2016 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3352,7 +3325,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2017 2 times in plant_id_ferc1=345\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2017 2 times in plant_id_ferc1=345\n"
      ]
     },
     {
@@ -3366,7 +3339,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1995 2 times in plant_id_ferc1=368\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1995 2 times in plant_id_ferc1=368\n"
      ]
     },
     {
@@ -3380,7 +3353,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1996 2 times in plant_id_ferc1=368\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1996 2 times in plant_id_ferc1=368\n"
      ]
     },
     {
@@ -3394,7 +3367,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1997 2 times in plant_id_ferc1=368\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1997 2 times in plant_id_ferc1=368\n"
      ]
     },
     {
@@ -3408,7 +3381,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1998 2 times in plant_id_ferc1=368\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1998 2 times in plant_id_ferc1=368\n"
      ]
     },
     {
@@ -3422,7 +3395,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1999 2 times in plant_id_ferc1=368\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1999 2 times in plant_id_ferc1=368\n"
      ]
     },
     {
@@ -3436,7 +3409,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2000 2 times in plant_id_ferc1=368\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2000 2 times in plant_id_ferc1=368\n"
      ]
     },
     {
@@ -3450,7 +3423,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2001 2 times in plant_id_ferc1=368\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2001 2 times in plant_id_ferc1=368\n"
      ]
     },
     {
@@ -3464,7 +3437,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2002 2 times in plant_id_ferc1=368\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2002 2 times in plant_id_ferc1=368\n"
      ]
     },
     {
@@ -3478,7 +3451,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2008 2 times in plant_id_ferc1=680\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2008 2 times in plant_id_ferc1=680\n"
      ]
     },
     {
@@ -3492,7 +3465,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2005 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2005 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3506,7 +3479,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2006 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2006 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3520,7 +3493,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2007 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2007 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3534,7 +3507,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2008 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2008 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3548,7 +3521,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2009 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2009 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3562,7 +3535,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2010 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2010 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3576,7 +3549,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2011 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2011 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3590,7 +3563,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2012 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2012 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3604,7 +3577,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2013 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2013 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3618,7 +3591,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2014 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2014 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3632,7 +3605,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2015 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2015 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3646,7 +3619,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2016 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2016 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3660,7 +3633,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2017 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2017 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3674,7 +3647,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2018 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2018 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3688,7 +3661,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2019 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2019 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3702,7 +3675,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2020 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2020 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3716,7 +3689,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2021 2 times in plant_id_ferc1=888\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2021 2 times in plant_id_ferc1=888\n"
      ]
     },
     {
@@ -3730,7 +3703,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1995 2 times in plant_id_ferc1=1094\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=1995 2 times in plant_id_ferc1=1094\n"
      ]
     },
     {
@@ -3744,7 +3717,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2000 2 times in plant_id_ferc1=1186\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2000 2 times in plant_id_ferc1=1186\n"
      ]
     },
     {
@@ -3758,7 +3731,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2019 2 times in plant_id_ferc1=1281\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2019 2 times in plant_id_ferc1=1281\n"
      ]
     },
     {
@@ -3772,7 +3745,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2020 2 times in plant_id_ferc1=1281\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2020 2 times in plant_id_ferc1=1281\n"
      ]
     },
     {
@@ -3786,7 +3759,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2021 2 times in plant_id_ferc1=1281\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2021 2 times in plant_id_ferc1=1281\n"
      ]
     },
     {
@@ -3800,7 +3773,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2004 2 times in plant_id_ferc1=1567\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2004 2 times in plant_id_ferc1=1567\n"
      ]
     },
     {
@@ -3814,7 +3787,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023-01-31 16:28:26 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2005 2 times in plant_id_ferc1=1567\n"
+      "2023-02-01 09:40:28 [   ERROR] catalystcoop.pudl.analysis.classify_plants_ferc1:594 Found report_year=2005 2 times in plant_id_ferc1=1567\n"
      ]
     },
     {
@@ -3833,7 +3806,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 269,
+   "execution_count": 50,
    "id": "f640e3ce",
    "metadata": {},
    "outputs": [
@@ -3909,65 +3882,65 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>6370</th>\n",
-       "      <td>64.0</td>\n",
-       "      <td>1998</td>\n",
-       "      <td>349.0</td>\n",
-       "      <td>313.0</td>\n",
-       "      <td>4649.0</td>\n",
-       "      <td>295.0</td>\n",
-       "      <td>295.0</td>\n",
+       "      <th>10230</th>\n",
+       "      <td>204.0</td>\n",
+       "      <td>2001</td>\n",
+       "      <td>26.0</td>\n",
+       "      <td>25.0</td>\n",
+       "      <td>102.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>25.0</td>\n",
+       "      <td>25.0</td>\n",
+       "      <td>797.0</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>442518.0</td>\n",
+       "      <td>695791.0</td>\n",
+       "      <td>1138309.0</td>\n",
+       "      <td>533771.0</td>\n",
+       "      <td>834728.0</td>\n",
+       "      <td>49059.0</td>\n",
+       "      <td>404999.0</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>30484465.0</td>\n",
-       "      <td>176340418.0</td>\n",
-       "      <td>206824883.0</td>\n",
-       "      <td>145058.0</td>\n",
-       "      <td>21212847.0</td>\n",
+       "      <td>2277.0</td>\n",
+       "      <td>639325.0</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
+       "      <td>247171.0</td>\n",
+       "      <td>63760.0</td>\n",
+       "      <td>185490.0</td>\n",
+       "      <td>194578.0</td>\n",
+       "      <td>11078.0</td>\n",
+       "      <td>3166236.0</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>1429184.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>212211.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>141832.0</td>\n",
-       "      <td>149465.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>699439.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>23990036.0</td>\n",
-       "      <td>NaN</td>\n",
-       "      <td>f1_steam_1998_12_64_0_1</td>\n",
-       "      <td>253</td>\n",
+       "      <td>f1_steam_2001_12_204_0_1</td>\n",
+       "      <td>47</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaT</td>\n",
        "      <td>NaT</td>\n",
        "      <td>NaN</td>\n",
        "      <td>NaN</td>\n",
-       "      <td>hardee power station</td>\n",
-       "      <td>outdoor</td>\n",
-       "      <td>combustion_turbine</td>\n",
-       "      <td>592621.4</td>\n",
-       "      <td>26.2</td>\n",
-       "      <td>916579.0</td>\n",
-       "      <td>1992.0</td>\n",
-       "      <td>1992.0</td>\n",
-       "      <td>249</td>\n",
+       "      <td>seabrook</td>\n",
+       "      <td>conventional</td>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>43781.1</td>\n",
+       "      <td>16.8</td>\n",
+       "      <td>188961.475</td>\n",
+       "      <td>1990.0</td>\n",
+       "      <td>1990.0</td>\n",
+       "      <td>3848</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "      utility_id_ferc1_dbf  report_year  capacity_mw  peak_demand_mw  plant_hours_connected_while_generating  plant_capability_mw  not_water_limited_capacity_mw  water_limited_capacity_mw  avg_num_employees  capex_land  capex_structures  capex_equipment  capex_total  opex_operations   opex_fuel  opex_coolants  opex_steam  opex_steam_other  opex_transfer  opex_electric  opex_misc_power  opex_rents  opex_allowances  opex_engineering  opex_structures  opex_boiler  opex_plants  opex_misc_steam  opex_production_total  asset_retirement_cost                record_id  utility_id_ferc1 utility_id_ferc1_xbrl date start_date end_date plant_name  order_number      plant_name_ferc1 construction_type          plant_type  capex_per_mw  opex_per_mwh  net_generation_mwh  construction_year  installation_year  plant_id_ferc1\n",
-       "6370                  64.0         1998        349.0           313.0                                  4649.0                295.0                          295.0                        NaN                NaN         NaN        30484465.0      176340418.0  206824883.0         145058.0  21212847.0            NaN         NaN               NaN            NaN      1429184.0              NaN    212211.0              NaN          141832.0         149465.0          NaN     699439.0              NaN             23990036.0                    NaN  f1_steam_1998_12_64_0_1               253                   NaN  NaN        NaT      NaT        NaN           NaN  hardee power station           outdoor  combustion_turbine      592621.4          26.2            916579.0             1992.0             1992.0             249"
+       "       utility_id_ferc1_dbf  report_year  capacity_mw  peak_demand_mw  plant_hours_connected_while_generating  plant_capability_mw  not_water_limited_capacity_mw  water_limited_capacity_mw  avg_num_employees  capex_land  capex_structures  capex_equipment  capex_total  opex_operations  opex_fuel  opex_coolants  opex_steam  opex_steam_other  opex_transfer  opex_electric  opex_misc_power  opex_rents  opex_allowances  opex_engineering  opex_structures  opex_boiler  opex_plants  opex_misc_steam  opex_production_total  asset_retirement_cost                 record_id  utility_id_ferc1 utility_id_ferc1_xbrl date start_date end_date plant_name  order_number plant_name_ferc1 construction_type plant_type  capex_per_mw  opex_per_mwh  net_generation_mwh  construction_year  installation_year  plant_id_ferc1\n",
+       "10230                 204.0         2001         26.0            25.0                                   102.0                  NaN                           25.0                       25.0              797.0         NaN          442518.0         695791.0    1138309.0         533771.0   834728.0        49059.0    404999.0               NaN            NaN         2277.0         639325.0         NaN              NaN          247171.0          63760.0     185490.0     194578.0          11078.0              3166236.0                    NaN  f1_steam_2001_12_204_0_1                47                   NaN  NaN        NaT      NaT        NaN           NaN         seabrook      conventional    nuclear       43781.1          16.8          188961.475             1990.0             1990.0            3848"
       ]
      },
-     "execution_count": 269,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3975,7 +3948,8 @@
    "source": [
     "# Test it works!\n",
     "main[main['record_id'].str.contains('f1_steam_1999_12_72_0_1')] #clifty creek\n",
-    "main[main['record_id'].str.contains('f1_steam_1998_12_64_0_1')] #hardee power station\n"
+    "#main[main['record_id'].str.contains('f1_steam_1998_12_64_0_1')] #hardee power station\n",
+    "main[main['record_id'].str.contains('f1_steam_2001_12_204_0_1')] # seabrook\n"
    ]
   },
   {

--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -21,6 +21,45 @@ SOURCES: dict[str, Any] = {
         "license_raw": LICENSES["us-govt"],
         "license_pudl": LICENSES["cc-by-4.0"],
     },
+    "eia176": {
+        "title": "EIA Form 176",
+        "path": "https://www.eia.gov/naturalgas/ngqs/all_ng_data.zip",
+        "description": (
+            "The EIA Form 176, also known as the Annual Report of Natural and "
+            "Supplemental Gas Supply and Disposition, describes the origins, suppliers, "
+            "and disposition of natural gas on a yearly and state by state basis."
+        ),
+        "source_file_dict": {
+            "respondents": (
+                "Interstate natural gas pipeline companies; intrastate natural gas "
+                "pipeline companies; natural gas distribution companies; underground "
+                "natural gas storage (UNG) operators; synthetic natural gas plant "
+                "operators; field, well, or processing plant operators that deliver "
+                "natural gas directly to consumers (including their own industrial "
+                "facilities) other than for lease or plant use or processing; "
+                "field, well, or processing plant operators that transport gas to, "
+                "across, or from a State border through field or gathering facilities; "
+                "liquefied natural gas (LNG) storage operators."
+            ),
+            "source_format": "Microsoft Excel (.xls/.xlsx)",
+        },
+        "field_namespace": "eia",
+        "contributors": [CONTRIBUTORS["catalyst-cooperative"]],
+        "keywords": sorted(
+            set(
+                [
+                    "eia176",
+                    "form 176",
+                ]
+                + KEYWORDS["eia"]
+                + KEYWORDS["us_govt"]
+                + KEYWORDS["fuels"]
+                + KEYWORDS["environment"]
+            )
+        ),
+        "license_raw": LICENSES["us-govt"],
+        "license_pudl": LICENSES["cc-by-4.0"],
+    },
     "eia860": {
         "title": "EIA Form 860",
         "path": "https://www.eia.gov/electricity/data/eia860",

--- a/src/pudl/transform/classes.py
+++ b/src/pudl/transform/classes.py
@@ -860,8 +860,10 @@ class SpotFixes(TransformParams):
     """Parameters that replace certain values with a manual corrected value."""
 
     record_col: str | None = None
+    """The column used to identify a record."""
     record_id: str | None = None
-    fixes: dict[str, Any]  # TO DECIDE - could also restrict to just string updates.
+    """The value in that column used to identify 1+ records to spot fix."""
+    fixes: dict[str, str | int | float | bool]
     """A dictionary of the column to replace and the value to replace with."""
 
 
@@ -874,8 +876,6 @@ def spot_fix_values(self, df: pd.DataFrame, params: SpotFixes) -> pd.DataFrame:
     of these records led to some pretty easy identification of plant names. This
     function takes a dictionary of these fixes and applies them to the dataframe.
 
-    There are probably plenty of other spot fixes one could add here.
-
     Params:
         df: Pre-processed, concatenated XBRL and DBF data.
         params: an instance of :class:`SpotFixes`
@@ -883,8 +883,6 @@ def spot_fix_values(self, df: pd.DataFrame, params: SpotFixes) -> pd.DataFrame:
     Returns:
         The same input DataFrame but with some spot fixes corrected.
     """
-    logger.info(f"{self.table_id.value}: Spot fixing some values")
-
     # The default SpotFixValues() instance has no effect:
     if params.record_id is None or params.record_col is None:
         return df

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -831,13 +831,13 @@ class Ferc1AbstractTableTransformer(AbstractTableTransformer):
             derived from the raw DBF and/or XBRL inputs.
         """
         df = (
-            self.normalize_strings(df)
+            self.spot_fix_values(df)
+            .pipe(self.normalize_strings)
             .pipe(self.categorize_strings)
             .pipe(self.convert_units)
             .pipe(self.strip_non_numeric_values)
             .pipe(self.nullify_outliers)
             .pipe(self.replace_with_na)
-            .pipe(self.spot_fix_values)
             .pipe(self.drop_invalid_rows)
             .pipe(
                 pudl.metadata.classes.Package.from_resource_ids()
@@ -2036,7 +2036,8 @@ class PlantsSmallFerc1TableTransformer(Ferc1AbstractTableTransformer):
             derived from the raw DBF and/or XBRL inputs.
         """
         df = (
-            self.normalize_strings(df)
+            self.spot_fix_values(df)
+            .pipe(self.normalize_strings)
             .pipe(self.nullify_outliers)
             .pipe(self.convert_units)
             .pipe(self.extract_ferc1_license)
@@ -2047,7 +2048,6 @@ class PlantsSmallFerc1TableTransformer(Ferc1AbstractTableTransformer):
             .pipe(self.map_header_fuel_and_plant_types)
             .pipe(self.associate_notes_with_values)
             .pipe(self.spot_fix_rows)
-            .pipe(self.spot_fix_values)
             .pipe(self.drop_invalid_rows)
             # Now remove the row_type columns because we've already moved totals to a
             # different column

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -837,6 +837,7 @@ class Ferc1AbstractTableTransformer(AbstractTableTransformer):
             .pipe(self.strip_non_numeric_values)
             .pipe(self.nullify_outliers)
             .pipe(self.replace_with_na)
+            .pipe(self.spot_fix_values)
             .pipe(self.drop_invalid_rows)
             .pipe(
                 pudl.metadata.classes.Package.from_resource_ids()
@@ -1492,7 +1493,11 @@ class FuelFerc1TableTransformer(Ferc1AbstractTableTransformer):
             A single transformed table concatenating multiple years of cleaned data
             derived from the raw DBF and/or XBRL inputs.
         """
-        return self.drop_invalid_rows(df).pipe(self.correct_units)
+        return (
+            self.spot_fix_values(df)
+            .pipe(self.drop_invalid_rows)
+            .pipe(self.correct_units)
+        )
 
     @cache_df(key="dbf")
     def process_dbf(self, raw_dbf: pd.DataFrame) -> pd.DataFrame:
@@ -2042,6 +2047,7 @@ class PlantsSmallFerc1TableTransformer(Ferc1AbstractTableTransformer):
             .pipe(self.map_header_fuel_and_plant_types)
             .pipe(self.associate_notes_with_values)
             .pipe(self.spot_fix_rows)
+            .pipe(self.spot_fix_values)
             .pipe(self.drop_invalid_rows)
             # Now remove the row_type columns because we've already moved totals to a
             # different column

--- a/src/pudl/transform/params/ferc1.py
+++ b/src/pudl/transform/params/ferc1.py
@@ -2359,6 +2359,58 @@ TRANSFORM_PARAMS = {
             "opex_per_kwh": PERKWH_TO_PERMWH,
             "net_generation_kwh": KWH_TO_MWH,
         },
+        "spot_fix_values": [
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_1999_12_72_0_1",
+                "fixes": {"plant_name_ferc1": "clifty creek"},
+            },
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_2010_12_306_0_1",
+                "fixes": {"plant_name_ferc1": "harrison county"},
+            },
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_1997_12_230_0_1",
+                "fixes": {"plant_name_ferc1": "hermiston generating"},
+            },
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_1998_12_64_0_1",
+                "fixes": {"plant_name_ferc1": "hardee power station"},
+            },
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_2015_12_276_0_1",
+                "fixes": {"plant_name_ferc1": "state line"},
+            },
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_2014_12_276_0_1",
+                "fixes": {"plant_name_ferc1": "state line"},
+            },
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_2003_12_62_2_3",
+                "fixes": {"plant_name_ferc1": "pea ridge"},
+            },
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_2003_12_62_2_2",
+                "fixes": {"plant_name_ferc1": "smith"},
+            },
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_2000_12_204_0_1",
+                "fixes": {"plant_name_ferc1": "seabrook"},
+            },
+            {
+                "record_col": "record_id",
+                "record_id": "f1_steam_2001_12_204_0_1",
+                "fixes": {"plant_name_ferc1": "seabrook"},
+            },
+        ],
         "drop_invalid_rows": [
             {
                 "invalid_values": [0, "0", pd.NA, np.nan, "", "none"],


### PR DESCRIPTION
This is a small PR, which is a necessary dependency for [https://github.com/catalyst-cooperative/pudl-archiver/pull/50](an EIA 176 archiver PR) in the pudl-archiver repo. This updates `sources.py` to include EIA 176. An example of a sample Zenodo upload based on this metadata can be found [here](https://sandbox.zenodo.org/record/1155188). The reviewer should review both PRs concurrently.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
