### PR TITLE
Use Workload Identity Federation in GH Actions

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -62,6 +62,7 @@ jobs:
 
       - name: Set default gcp credentials
         id: gcloud-auth
+        continue-on-error: true
         uses: "google-github-actions/auth@v1"
         with:
           workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -66,13 +66,11 @@ jobs:
         with:
           workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
           service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
-          export_environment_variables: true
+          create_credentials_file: true
 
       - name: Run PyTest with Tox against GCS cache (internal PRs)
         run: |
           tox -- --gcs-cache-path gs://zenodo-cache.catalyst.coop
-        env:
-          CLOUDSDK_BILLING_QUOTA_PROJECT: ${{ steps.gcloud-auth.outputs.project_id }}
         if: ${{ steps.gcloud-auth.outcome == 'success' }}
 
       - name: Run PyTest with Tox against Zenodo (external PRs)

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -71,6 +71,8 @@ jobs:
       - name: Run PyTest with Tox
         run: |
           tox -- --gcs-cache-path gs://zenodo-cache.catalyst.coop
+        env:
+          CLOUDSDK_BILLING_QUOTA_PROJECT: ${{ steps.gcloud-auth.outputs.project_id }
 
       - name: Log post-test Zenodo datastore contents
         run: find ~/pudl-work/data/

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -61,7 +61,8 @@ jobs:
         id: gcloud-auth
         uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: "${{ secrets.TOX_PYTEST_SA_KEY }}"
+          workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
+          service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
 
       - name: Run PyTest with Tox
         run: |

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -6,6 +6,9 @@ on: [push, pull_request]
 jobs:
   ci-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
     defaults:

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -92,6 +92,7 @@ jobs:
     steps:
       - name: Inform the Codemonkeys
         uses: 8398a7/action-slack@v3
+        continue-on-error: true
         with:
           status: custom
           fields: workflow,job,commit,repo,ref,author,took

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
           service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+          export_environment_variables: true
 
       - name: Run PyTest with Tox
         run: |

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -68,11 +68,17 @@ jobs:
           service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
           export_environment_variables: true
 
-      - name: Run PyTest with Tox
+      - name: Run PyTest with Tox against GCS cache (internal PRs)
         run: |
           tox -- --gcs-cache-path gs://zenodo-cache.catalyst.coop
         env:
-          CLOUDSDK_BILLING_QUOTA_PROJECT: ${{ steps.gcloud-auth.outputs.project_id }
+          CLOUDSDK_BILLING_QUOTA_PROJECT: ${{ steps.gcloud-auth.outputs.project_id }}
+        if: ${{ steps.gcloud-auth.outcome == 'success' }}
+
+      - name: Run PyTest with Tox against Zenodo (external PRs)
+        run: |
+          tox
+        if: ${{ steps.gcloud-auth.outcome == 'failure' }}
 
       - name: Log post-test Zenodo datastore contents
         run: find ~/pudl-work/data/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ notebooks/*.pkl.gz
 
 **.tfstate
 **.tfstate.*
+terraform/.terraform/*

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ commit.txt
 devtools/profiles/
 notebooks/*.pkl.gz
 **/.~lock*#
+
+**.tfstate
+**.tfstate.*

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -18,3 +18,4 @@ Development
   data_guidelines
   packaging
   nightly_data_builds
+  infrastructure_as_code

--- a/docs/dev/infrastructure_as_code.rst
+++ b/docs/dev/infrastructure_as_code.rst
@@ -1,0 +1,39 @@
+===============================================================================
+Infrastructure as Code
+===============================================================================
+
+-------------------------------------------------------------------------------
+Overview
+-------------------------------------------------------------------------------
+
+We use `terraform <https://developer.hashicorp.com/terraform>`__ to manage some
+of our infrastructure. It lets us repeat infrastructure setup tasks without
+having to rely on individual developers clicking the right buttons in the right
+order.
+
+-------------------------------------------------------------------------------
+Setup
+-------------------------------------------------------------------------------
+
+1. Install terraform with the `official docs
+   <https://developer.hashicorp.com/terraform/downloads>`__
+
+2. Make sure you're authenticated to GCP for `*application* usage
+   <https://cloud.google.com/docs/authentication/application-default-credentials>`__,
+   not just normal gcloud usage: ``gcloud auth application-default login``
+
+-------------------------------------------------------------------------------
+Development
+-------------------------------------------------------------------------------
+
+Just put things into ``main.tf`` for now. You might want to check out the `GCP
+tutorial
+<https://developer.hashicorp.com/terraform/tutorials/gcp-get-started>`__ or the
+`GCP provider docs
+<https://registry.terraform.io/providers/hashicorp/google/latest/docs>`__.
+
+Run:
+
+1. ``tf init`` so you get the GCP provider. You only need to do this the first time.
+2. ``tf plan`` to see what is going to happen.
+3. ``tf apply`` to make changes to infrastructure.

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -302,10 +302,10 @@ class Datastore:
                 self._cache.add_cache_layer(
                     resource_cache.GoogleCloudStorageCache(gcs_cache_path)
                 )
-            except DefaultCredentialsError:
+            except (DefaultCredentialsError, OSError) as e:
                 logger.info(
                     f"Unable to obtain credentials for GCS Cache at {gcs_cache_path}. "
-                    "Falling back to Zenodo if necessary."
+                    f"Falling back to Zenodo if necessary. Error was: {e}"
                 )
                 pass
 

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,61 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "4.51.0"
+  constraints = ">= 3.64.0, 4.51.0, < 5.0.0"
+  hashes = [
+    "h1:8lpgWoonXz+Y2kM4h/UZEe6W/WZwaga6bhfwmb11grA=",
+    "zh:001bf7478e495d497ffd4054453c97ab4dd3e6a24d46496d51d4c8094e95b2b1",
+    "zh:19db72113552dd295854a99840e85678d421312708e8329a35787fff1baeed8b",
+    "zh:42c3e629ace225a2cb6cf87b8fabeaf1c56ac8eca6a77b9e3fc489f3cc0a9db5",
+    "zh:50b930755c4b1f8a01c430d8f688ea79de0b0198c87511baa3a783e360d7e624",
+    "zh:5acd67f0aafff5ad59e179543cccd1ffd48d69b98af0228506403b8d8193b340",
+    "zh:70128d57b4b4bf07df941172e6af15c4eda8396af5cc2b0128c906983c7b7fad",
+    "zh:7905fac0ba2becf0e97edfcd4224e57466b04f960f36a3ec654a0a3c2ffececb",
+    "zh:79b4cc760305cd77c1ff841f789184f808b8052e8f4faa5cb8d518e4c13beb22",
+    "zh:c7aebd7d7dd2b29de28e382500d36fae8b4d8a192cf05e41ea29c66f1251acfc",
+    "zh:d8b4494b13ef5af65d3afedf05bf7565918f1e31ad68ae0df81f5c3b12baf519",
+    "zh:e6e68ef6881bc3312db50c9fd761f226f34d7834b64f90d96616b7ca6b1daf34",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "4.51.0"
+  constraints = ">= 3.64.0, < 5.0.0"
+  hashes = [
+    "h1:IKpYgud4esNWarue1f/1/sGgvJPLONQ7WSbL2h5PVYk=",
+    "zh:1533c31173b4789415e90cf68bace4e2443f7e3b2e45d81030cf2b9d552c1408",
+    "zh:1bae9b52367718a4e334b797655325709e2ef6f6289f1fb3605fc1bf2a303a69",
+    "zh:3c0cbf3916471a11c3094753ff8d0c622e0a9c90d9ce61c88cc9b65808a5958f",
+    "zh:5967fd1813193101eebc53d22e5ec90388439dd2fea557a0470194b0acc69bad",
+    "zh:67dc7a06d6ce97cbc56e8bd542de479bc3de23dfed1f7212014c7c4a97708af2",
+    "zh:72dc56612d386cb022150d53bb5ff0a50fc2fe63b4d7ed1ea18d509250b2c093",
+    "zh:8757dfd226e91c00595318ca87c8fbf36add746ae7d2b86120709c7ebde3d949",
+    "zh:b1c28197e1a74af768a1fd6c4e828a493fce0e663e4806e7f30448b73f4a68bd",
+    "zh:b4a07979901d1be45169b519f615022b18cde4658fbcda52c4039c181c7e5793",
+    "zh:b85ac442a95b57e632ff8470938d34b3bf0efe40dfec893e2538da7de93b3ea5",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fe818cfe3ab69e15178b4c4e8915eda0fd0e33e5fd49408aa2541c2c1a46a8bf",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.4.3"
+  hashes = [
+    "h1:saZR+mhthL0OZl4SyHXZraxyaBNVMxiZzks78nWcZ2o=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,4 +1,8 @@
 terraform {
+  backend "gcs" {
+    bucket = "f3441e415e6e5e7d-bucket-tfstate"
+    prefix = "terraform/state"
+  }
   required_providers {
     google = {
       source  = "hashicorp/google"
@@ -16,6 +20,20 @@ provider "google" {
   project = var.project_id
   region  = "us-east1"
   zone    = "us-east1-c"
+}
+
+resource "random_id" "bucket_prefix" {
+  byte_length = 8
+}
+
+resource "google_storage_bucket" "tfstate" {
+  name          = "${random_id.bucket_prefix.hex}-bucket-tfstate"
+  force_destroy = false
+  location      = "US"
+  storage_class = "STANDARD"
+  versioning {
+    enabled = true
+  }
 }
 
 module "gh_oidc" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.51.0"
+    }
+  }
+}
+
+variable "project_id" {
+  type    = string
+  default = "catalyst-cooperative-pudl"
+}
+
+provider "google" {
+  project = var.project_id
+  region  = "us-east1"
+  zone    = "us-east1-c"
+}
+
+module "gh_oidc" {
+  source      = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
+  project_id  = var.project_id
+  pool_id     = "gh-actions-pool"
+  provider_id = "gh-actions-provider"
+  sa_mapping = {
+    "tox-pytest-github-action-service-account" = {
+      sa_name   = "projects/${var.project_id}/serviceAccounts/tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+      attribute = "*"
+    }
+  }
+}


### PR DESCRIPTION
Our GH actions GCloud authentication is broken for workflows that originate in forks - this is because repo-level secrets don't get passed into those runners by default. I guess that makes sense, and we probably shouldn't let people access our secrets just by pushing some malicious actions.

However! We can set up Workload Identity Federation, I think, which should avoid that problem - so here's a crack at that.

CI now passes for external PRs too: https://github.com/catalyst-cooperative/pudl/pull/2261

Separately, I took the opportunity to set these bits of infrastructure up through Terraform.

TODO:
* [ ] get the tox-pytest service account working through WIF
* [ ] get the zenodo-cache-manager service account working through WIF too.