### PR TITLE
Pin SQLAlchemy<2.0 and allow pip 23

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,10 @@ updates:
     labels:
       - dependencies
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: github-actions
     directory: /
     target-branch: dev
     schedule:
-      interval: daily
+      interval: weekly

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -5,7 +5,7 @@ channels:
   - defaults
 dependencies:
   # Used to set up the environment
-  - pip>=21,<23
+  - pip>=21,<24
   - wheel
   - python>=3.10,<3.11
   - setuptools<66

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - geopandas>=0.9,<0.13
-  - pip>=22,<23
+  - pip>=22,<24
   - python>=3.10,<3.11
   - python-snappy>=0.6,<1
   - setuptools<66

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "scikit-learn>=1.0,<1.3",
         "scipy>=1.6,<1.11",
         "Shapely>=2.0,<2.1",
-        "sqlalchemy>=1.4,<2.0.2",
+        "sqlalchemy>=1.4,<2",
         "timezonefinder>=5,<6.2",
         "xlsxwriter>=3,<3.1",
     ],

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - python>=3.10,<3.11
   - geopandas>=0.9,<0.13
   - numba>=0.55.1,<0.57
-  - pip>=22,<23
+  - pip>=22,<24
   - shapely>=2,<3
   - python-snappy>=0.6,<1
   - setuptools<66


### PR DESCRIPTION
# PR Overview

* Pin SQLAlchemy<2.0 as [pandas doesn't yet support it](https://github.com/pandas-dev/pandas/issues/40686)
* Also update conda environments to allow pip 23.
* See #2267

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [x] Make sure you've included good docstrings.
- [x] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [x] Include unit tests for new functions and classes.
- [x] Defensive data quality/sanity checks in analyses & data processing functions.
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [x] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
