### PR TITLE
Add more service accounts to Workload Identity Federation

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -17,6 +17,9 @@ jobs:
   build_and_deploy_pudl:
     name: Build Docker image, push to Docker Hub and deploy to a GCE VM
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule
         if: ${{ (github.event_name == 'schedule') }}
@@ -68,11 +71,11 @@ jobs:
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
 
-      # Authentication via credentials json
       - id: "auth"
         uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: "${{ secrets.DEPLOY_PUDL_SA_KEY }}"
+          workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
+          service_account: "deploy-pudl-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
 
       # Setup gcloud CLI
       - name: Set up Cloud SDK

--- a/.github/workflows/zenodo-cache-sync.yml
+++ b/.github/workflows/zenodo-cache-sync.yml
@@ -14,6 +14,9 @@ env:
 jobs:
   zenodo-cache-sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
     defaults:
@@ -55,7 +58,8 @@ jobs:
         id: gcloud-auth
         uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: "${{ secrets.ZENODO_CACHE_MANAGER_SA_KEY }}"
+          workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
+          service_account: "zenodo-cache-manager@catalyst-cooperative-pudl.iam.gserviceaccount.com"
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,9 +42,29 @@ module "gh_oidc" {
   pool_id     = "gh-actions-pool"
   provider_id = "gh-actions-provider"
   sa_mapping = {
-    "tox-pytest-github-action-service-account" = {
+    "pudl-tox-pytest-github-action-service-account" = {
       sa_name   = "projects/${var.project_id}/serviceAccounts/tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
-      attribute = "*"
+      attribute = "attribute.repository/catalyst-cooperative/pudl"
+    }
+    "pudl-deploy-pudl-github-action-service-account" = {
+      sa_name   = "projects/${var.project_id}/serviceAccounts/deploy-pudl-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+      attribute = "attribute.repository/catalyst-cooperative/pudl"
+    }
+    "pudl-zenodo-cache-manager-service-account" = {
+      sa_name   = "projects/${var.project_id}/serviceAccounts/zenodo-cache-manager@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+      attribute = "attribute.repository/catalyst-cooperative/pudl"
+    }
+    "pudl-usage-metrics-tox-pytest-github-action-service-account" = {
+      sa_name   = "projects/${var.project_id}/serviceAccounts/tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+      attribute = "attribute.repository/catalyst-cooperative/pudl-usage-metrics"
+    }
+    "pudl-catalog-tox-pytest-github-action-service-account" = {
+      sa_name   = "projects/${var.project_id}/serviceAccounts/tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+      attribute = "attribute.repository/catalyst-cooperative/pudl-catalog"
+    }
+    "gce-build-test-gce-github-action-test-service-account" = {
+      sa_name   = "projects/${var.project_id}/serviceAccounts/gce-github-action-test@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+      attribute = "attribute.repository/catalyst-cooperative/gce-build-test"
     }
   }
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -42,27 +42,27 @@ module "gh_oidc" {
   pool_id     = "gh-actions-pool"
   provider_id = "gh-actions-provider"
   sa_mapping = {
-    "pudl-tox-pytest-github-action-service-account" = {
+    "pudl-tox-pytest-github-action" = {
       sa_name   = "projects/${var.project_id}/serviceAccounts/tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
       attribute = "attribute.repository/catalyst-cooperative/pudl"
     }
-    "pudl-deploy-pudl-github-action-service-account" = {
+    "pudl-deploy-pudl-github-action" = {
       sa_name   = "projects/${var.project_id}/serviceAccounts/deploy-pudl-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
       attribute = "attribute.repository/catalyst-cooperative/pudl"
     }
-    "pudl-zenodo-cache-manager-service-account" = {
+    "pudl-zenodo-cache-manager" = {
       sa_name   = "projects/${var.project_id}/serviceAccounts/zenodo-cache-manager@catalyst-cooperative-pudl.iam.gserviceaccount.com"
       attribute = "attribute.repository/catalyst-cooperative/pudl"
     }
-    "pudl-usage-metrics-tox-pytest-github-action-service-account" = {
-      sa_name   = "projects/${var.project_id}/serviceAccounts/tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+    "pudl-usage-metrics-pudl-usage-metrics-etl" = {
+      sa_name   = "projects/${var.project_id}/serviceAccounts/pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
       attribute = "attribute.repository/catalyst-cooperative/pudl-usage-metrics"
     }
-    "pudl-catalog-tox-pytest-github-action-service-account" = {
+    "pudl-catalog-tox-pytest-github-action" = {
       sa_name   = "projects/${var.project_id}/serviceAccounts/tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
       attribute = "attribute.repository/catalyst-cooperative/pudl-catalog"
     }
-    "gce-build-test-gce-github-action-test-service-account" = {
+    "gce-build-test-gce-github-action-test" = {
       sa_name   = "projects/${var.project_id}/serviceAccounts/gce-github-action-test@catalyst-cooperative-pudl.iam.gserviceaccount.com"
       attribute = "attribute.repository/catalyst-cooperative/gce-build-test"
     }


### PR DESCRIPTION
# PR Overview

This adds a bunch of new service account associations to the WIF provider we set up earlier, so that other repos can also use WIF instead of credentials.

I've already run `terraform apply` here so the changes should be reflected within GCP already.

Note that the `build-deploy-pudl` and `zenodo-cache-sync` actions are triggered via `schedule` and `workload_dispatch`, so the versions on `main` are the ones that will run. Which means that they'll continue to use the old credentials jsons until this lands in `main`.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
