### PR TITLE
Remove tables from settings

### DIFF
--- a/src/pudl/cli.py
+++ b/src/pudl/cli.py
@@ -92,16 +92,7 @@ def main():
         run_config={
             "resources": {
                 "dataset_settings": {
-                    "config": EtlSettings.from_yaml(args.settings_file).datasets.dict(
-                        exclude={
-                            "ferc1": {"tables"},
-                            "eia": {
-                                "eia860": {"tables"},
-                                "eia923": {"tables"},
-                            },
-                            "epacems": {"tables"},
-                        }
-                    )
+                    "config": EtlSettings.from_yaml(args.settings_file).datasets.dict()
                 },
                 "datastore": {
                     "config": {

--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -59,16 +59,7 @@ defs = Definitions(
                     "dataset_settings": {
                         "config": EtlSettings.from_yaml(
                             importlib.resources.path(settings, "etl_fast.yml")
-                        ).datasets.dict(
-                            exclude={
-                                "ferc1": {"tables"},
-                                "eia": {
-                                    "eia860": {"tables"},
-                                    "eia923": {"tables"},
-                                },
-                                "epacems": {"tables"},
-                            }
-                        )
+                        ).datasets.dict()
                     }
                 }
             },

--- a/src/pudl/extract/ferc1.py
+++ b/src/pudl/extract/ferc1.py
@@ -484,7 +484,7 @@ def define_sqlite_db(
     Returns:
         None: the effects of the function are stored inside sqlite_meta
     """
-    for table in ferc1_to_sqlite_settings.tables:
+    for table in DBF_TABLES_FILENAMES.keys():
         add_sqlite_table(
             table_name=table,
             sqlite_meta=sqlite_meta,
@@ -626,7 +626,7 @@ def dbf2sqlite(context) -> None:
         ferc1_to_sqlite_settings=ferc1_to_sqlite_settings,
     )
 
-    for table in ferc1_to_sqlite_settings.tables:
+    for table in DBF_TABLES_FILENAMES.keys():
         logger.info(f"Pandas: reading {table} into a DataFrame.")
         new_df = get_raw_df(
             ferc1_dbf_ds, table, dbc_map, years=ferc1_to_sqlite_settings.years

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -185,7 +185,6 @@ def convert_form(
             sqlite_engine,
             raw_archive,
             form.value,
-            requested_tables=form_settings.tables,
             batch_size=batch_size,
             workers=workers,
             datapackage_path=datapackage_path,

--- a/src/pudl/ferc_to_sqlite/__init__.py
+++ b/src/pudl/ferc_to_sqlite/__init__.py
@@ -38,16 +38,7 @@ ferc_to_sqlite_fast = ferc_to_sqlite.to_job(
             "ferc_to_sqlite_settings": {
                 "config": EtlSettings.from_yaml(
                     importlib.resources.path(settings, "etl_fast.yml")
-                ).ferc_to_sqlite_settings.dict(
-                    exclude={
-                        "ferc1_dbf_to_sqlite_settings": {"tables"},
-                        "ferc1_xbrl_to_sqlite_settings": {"tables"},
-                        "ferc2_xbrl_to_sqlite_settings": {"tables"},
-                        "ferc6_xbrl_to_sqlite_settings": {"tables"},
-                        "ferc60_xbrl_to_sqlite_settings": {"tables"},
-                        "ferc714_xbrl_to_sqlite_settings": {"tables"},
-                    }
-                )
+                ).ferc_to_sqlite_settings.dict()
             }
         }
     },

--- a/src/pudl/ferc_to_sqlite/cli.py
+++ b/src/pudl/ferc_to_sqlite/cli.py
@@ -98,16 +98,7 @@ def main():  # noqa: C901
                 "ferc_to_sqlite_settings": {
                     "config": EtlSettings.from_yaml(
                         args.settings_file
-                    ).ferc_to_sqlite_settings.dict(
-                        exclude={
-                            "ferc1_dbf_to_sqlite_settings": {"tables"},
-                            "ferc1_xbrl_to_sqlite_settings": {"tables"},
-                            "ferc2_xbrl_to_sqlite_settings": {"tables"},
-                            "ferc6_xbrl_to_sqlite_settings": {"tables"},
-                            "ferc60_xbrl_to_sqlite_settings": {"tables"},
-                            "ferc714_xbrl_to_sqlite_settings": {"tables"},
-                        }
-                    )
+                    ).ferc_to_sqlite_settings.dict()
                 },
                 "datastore": {
                     "config": {

--- a/src/pudl/package_data/settings/etl_fast.yml
+++ b/src/pudl/package_data/settings/etl_fast.yml
@@ -6,55 +6,8 @@ ferc_to_sqlite_settings:
   ferc1_dbf_to_sqlite_settings:
     # What years of original FERC data should be cloned into the SQLite DB?
     years: [2020]
-    # A list of tables to be loaded into the local SQLite database. These are
-    # the table names as they appear in the 2015 FERC Form 1 database.
-    tables:
-      - f1_respondent_id
-      - f1_gnrt_plant
-      - f1_steam
-      - f1_fuel
-      - f1_plant_in_srvce
-      - f1_hydro
-      - f1_pumped_storage
-      - f1_purchased_pwr
-      - f1_elctrc_erg_acct
-      - f1_utltyplnt_smmry
-      - f1_xmssn_line
-      - f1_comp_balance_db
-      - f1_dacs_epda
-
   ferc1_xbrl_to_sqlite_settings:
     years: [2021]
-    # A list of tables to be loaded into the local SQLite database. These are
-    # the table names as created from the 2022 XBRL taxonomy.
-    tables:
-      - identification_001_duration
-      - identification_001_instant
-      - steam_electric_generating_plant_statistics_large_plants_402_duration
-      - steam_electric_generating_plant_statistics_large_plants_402_instant
-      - steam_electric_generating_plant_statistics_large_plants_fuel_statistics_402_duration
-      - steam_electric_generating_plant_statistics_large_plants_fuel_statistics_402_instant
-      - hydroelectric_generating_plant_statistics_large_plants_406_duration
-      - hydroelectric_generating_plant_statistics_large_plants_406_instant
-      - pumped_storage_generating_plant_statistics_large_plants_408_duration
-      - pumped_storage_generating_plant_statistics_large_plants_408_instant
-      - generating_plant_statistics_410_duration
-      - generating_plant_statistics_410_instant
-      - electric_plant_in_service_204_duration
-      - electric_plant_in_service_204_instant
-      - purchased_power_326_duration
-      - purchased_power_326_instant
-      - electric_energy_account_401a_duration
-      - electric_energy_account_401a_instant
-      - summary_of_utility_plant_and_accumulated_provisions_for_depreciation_amortization_and_depletion_200_duration
-      - summary_of_utility_plant_and_accumulated_provisions_for_depreciation_amortization_and_depletion_200_instant
-      - transmission_line_statistics_422_duration
-      - transmission_line_statistics_422_instant
-      - comparative_balance_sheet_assets_and_other_debits_110_duration
-      - comparative_balance_sheet_assets_and_other_debits_110_instant
-      - summary_of_depreciation_and_amortization_charges_section_a_336_duration
-      - summary_of_depreciation_and_amortization_charges_section_a_336_instant
-
   ferc2_xbrl_to_sqlite_settings:
     years: [2021]
   ferc6_xbrl_to_sqlite_settings:
@@ -75,37 +28,11 @@ description: >
 version: 0.1.0
 datasets:
   ferc1:
-    tables:
-      - fuel_ferc1 # requires plants_steam_ferc1 to load properly
-      - plants_steam_ferc1
-      - plants_small_ferc1
-      - plants_hydro_ferc1
-      - plants_pumped_storage_ferc1
-      - plant_in_service_ferc1
-      - purchased_power_ferc1
-      - transmission_ferc1
-      - electric_energy_sources_ferc1
-      - electric_energy_dispositions_ferc1
-      - utility_plant_summary_ferc1
-      - depreciation_amortization_summary_ferc1
-      - balance_sheet_assets_ferc1
     years: [2020, 2021]
   eia:
     eia923:
-      tables:
-        - generation_fuel_eia923
-        - boiler_fuel_eia923
-        - generation_eia923
-        - coalmine_eia923 # REQUIRES fuel_receipts_costs_eia923
-        - fuel_receipts_costs_eia923
       years: [2020, 2021]
     eia860:
-      tables:
-        - boiler_generator_assn_eia860
-        - utilities_eia860
-        - plants_eia860
-        - generators_eia860
-        - ownership_eia860
       years: [2020, 2021]
       eia860m: true
   epacems:

--- a/src/pudl/settings.py
+++ b/src/pudl/settings.py
@@ -640,9 +640,6 @@ def _convert_settings_to_dagster_config(d: dict) -> None:
     subclasses will default to include all working paritions if the partition value
     is None. Get the value type so dagster can do some basic type checking in the UI.
 
-    The `table` is not included in the dagster config because we are not supporting
-    processing a subset of tables.
-
     Args:
         d: dictionary of datasources and their parameters.
     """


### PR DESCRIPTION
# PR Overview
This PR removes tables from the settings models/yaml files, as discussed in #2272.

As @bendnorman mentioned in the PR linked above, it looks like we could use dagster's [multi-asset subsetting](https://docs.dagster.io/concepts/assets/multi-assets#subsetting-multi-assets) to allow us to select subsets of tables, but I'm not sure if it's worth the time/energy. Open to other's thoughts on this though. Perhaps it's something we could leave to the future if we have time.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`)
- [x] Include unit tests for new functions and classes.
- [x] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
