### PR TITLE
Fix google auth error in tox-pytest

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
           service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
-          create_credentials_file: true
 
       - name: Run PyTest with Tox against GCS cache (internal PRs)
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -11,9 +11,12 @@ allowlist_externals =
 envdir = {toxinidir}/.env_tox
 passenv =
     CI
+    CLOUDSDK_*
     CONDA_PREFIX
     GITHUB_*
-    GOOGLE_APPLICATION_CREDENTIALS
+    GOOGLE_*
+    GCLOUD_*
+    GCP_*
     HOME
     SQLALCHEMY_WARN_20
 covargs = --cov={envsitepackagesdir}/pudl --cov-append --cov-report=xml


### PR DESCRIPTION
As we saw in #2224, [our datastores were still failing to connect to Google](https://github.com/catalyst-cooperative/pudl/actions/runs/4185969563/jobs/7253799219) because of

```
Unable to obtain credentials for GCS Cache at gs://zenodo-cache.catalyst.coop. Falling back to Zenodo if necessary. Error was: Project was not passed and could not be determined from the environment.
```

It turns out that we had not run the proper Google-related environment variables into the tox environments - this fixes that and also removes the credential file itself - why go to all the effort of WIF if you're just gonna dump the creds back to disk anyways, eh?