### PR TITLE
Resolve dev -> dagster merge fixes

### DIFF
--- a/devtools/materialize_asset.py
+++ b/devtools/materialize_asset.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python
+"""Materialize one asset & its upstream deps in-process so you can debug."""
+
+import argparse
+import importlib
+
+from dagster import AssetSelection, Definitions, define_asset_job
+
+from pudl import etl
+from pudl.settings import EtlSettings
+
+
+def _parse():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("asset_id")
+    return parser.parse_args()
+
+
+def main(asset_id):
+    """Entry point.
+
+    Defines dagster context like in etl/__init__.py - needs to be kept in sync.
+
+    Then creates a job with asset selection.
+    """
+    # TODO (daz/zach): maybe there's a way to do this directly with dagster cli?
+    defs = Definitions(
+        assets=etl.default_assets,
+        resources=etl.default_resources,
+        jobs=[
+            define_asset_job(
+                name="materialize_one",
+                selection=AssetSelection.keys(asset_id).upstream(),
+                config={
+                    "resources": {
+                        "dataset_settings": {
+                            "config": EtlSettings.from_yaml(
+                                importlib.resources.path(
+                                    "pudl.package_data.settings", "etl_fast.yml"
+                                )
+                            ).datasets.dict()
+                        }
+                    }
+                },
+            ),
+        ],
+    )
+    defs.get_job_def("materialize_one").execute_in_process()
+
+
+if __name__ == "__main__":
+    main(**vars(_parse()))

--- a/src/pudl/etl/static_assets.py
+++ b/src/pudl/etl/static_assets.py
@@ -6,11 +6,7 @@ from dagster import AssetOut, Output, multi_asset
 
 import pudl
 from pudl.metadata.classes import Package
-from pudl.metadata.dfs import (
-    FERC_ACCOUNTS,
-    FERC_DEPRECIATION_LINES,
-    POLITICAL_SUBDIVISIONS,
-)
+from pudl.metadata.dfs import FERC_ACCOUNTS, POLITICAL_SUBDIVISIONS
 
 logger = pudl.logging_helpers.get_logger(__name__)
 
@@ -86,17 +82,13 @@ def static_ferc1_tables():
     """Compile static tables for FERC1 for foriegn key constaints.
 
     This function grabs static encoded tables via :func:`_read_static_encoding_tables`
-    as well as two static tables that are non-encoded tables (``ferc_accounts`` and
-    ``ferc_depreciation_lines``).
+    as well as two static tables that are non-encoded tables (``ferc_accounts``).
     """
     static_table_dict = _read_static_encoding_tables("static_ferc1")
     static_table_dict.update(
         {
             "ferc_accounts": FERC_ACCOUNTS[
                 ["ferc_account_id", "ferc_account_description"]
-            ],
-            "ferc_depreciation_lines": FERC_DEPRECIATION_LINES[
-                ["line_id", "ferc_account_description"]
             ],
         }
     )

--- a/src/pudl/extract/eia860.py
+++ b/src/pudl/extract/eia860.py
@@ -60,13 +60,28 @@ class Extractor(excel.GenericExtractor):
 
 # TODO (bendnorman): Add this information to the metadata
 raw_table_names = (
+    "raw_boiler_cooling_eia860",
     "raw_boiler_generator_assn_eia860",
+    "raw_boiler_info_eia860",
+    "raw_boiler_mercury_eia860",
+    "raw_boiler_nox_eia860",
+    "raw_boiler_pm_eia860",
+    "raw_boiler_so2_eia860",
+    "raw_boiler_stack_flue_eia860",
+    "raw_cooling_equipment_eia860",
+    "raw_emission_control_strategies_eia860",
+    "raw_emissions_control_equipment_eia860",
+    "raw_fgd_equipment_eia860",
+    "raw_fgp_equipment_eia860",
     "raw_generator_eia860",
     "raw_generator_existing_eia860",
     "raw_generator_proposed_eia860",
     "raw_generator_retired_eia860",
+    "raw_multifuel_existing_eia860",
+    "raw_multifuel_retired_eia860",
     "raw_ownership_eia860",
     "raw_plant_eia860",
+    "raw_stack_flue_equipment_eia860",
     "raw_utility_eia860",
 )
 
@@ -104,12 +119,9 @@ def extract_eia860(context):
     eia860_raw_dfs = {
         "raw_" + table_name + "_eia860": df for table_name, df in eia860_raw_dfs.items()
     }
-
-    eia_raw_dfs = {}
-    eia_raw_dfs.update(eia860_raw_dfs)
-    eia_raw_dfs = dict(sorted(eia_raw_dfs.items()))
+    eia860_raw_dfs = dict(sorted(eia860_raw_dfs.items()))
 
     return (
         Output(output_name=table_name, value=df)
-        for table_name, df in eia_raw_dfs.items()
+        for table_name, df in eia860_raw_dfs.items()
     )

--- a/src/pudl/extract/eia923.py
+++ b/src/pudl/extract/eia923.py
@@ -123,11 +123,9 @@ def extract_eia923(context):
         "raw_" + table_name + "_eia923": df for table_name, df in eia923_raw_dfs.items()
     }
 
-    eia_raw_dfs = {}
-    eia_raw_dfs.update(eia923_raw_dfs)
-    eia_raw_dfs = dict(sorted(eia_raw_dfs.items()))
+    eia923_raw_dfs = dict(sorted(eia923_raw_dfs.items()))
 
     return (
         Output(output_name=table_name, value=df)
-        for table_name, df in eia_raw_dfs.items()
+        for table_name, df in eia923_raw_dfs.items()
     )

--- a/src/pudl/extract/ferc1.py
+++ b/src/pudl/extract/ferc1.py
@@ -1082,7 +1082,7 @@ def create_raw_ferc1_assets() -> list[SourceAsset]:
     # Create assets for the duration and instant tables
     xbrls = (v["xbrl"] for v in TABLE_NAME_MAP_FERC1.values())
     flattened_xbrls = chain.from_iterable(
-        x if isinstance(x, list) else [x] for x in dbfs
+        x if isinstance(x, list) else [x] for x in xbrls
     )
     xbrls_with_periods = chain.from_iterable(
         (f"{tn}_instant", f"{tn}_duration") for tn in flattened_xbrls

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -462,7 +462,7 @@ class FercDBFSQLiteIOManager(FercSQLiteIOManager):
                     "min_year": min(ferc1_settings.dbf_years),
                     "max_year": max(ferc1_settings.dbf_years),
                 },
-            )
+            ).assign(sched_table_name=table_name)
 
 
 @io_manager(
@@ -532,7 +532,7 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
                     "min_year": min(ferc1_settings.xbrl_years),
                     "max_year": max(ferc1_settings.xbrl_years),
                 },
-            )
+            ).assign(sched_table_name=table_name)
 
 
 @io_manager(

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -1,4 +1,5 @@
 """Dagster IO Managers."""
+import re
 from pathlib import Path
 from sqlite3 import sqlite_version
 
@@ -520,6 +521,7 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
 
         id_table = "identification_001_duration"
 
+        sched_table_name = re.sub("_instant|_duration", "", table_name)
         with engine.connect() as con:
             return pd.read_sql(
                 f"""
@@ -532,7 +534,7 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
                     "min_year": min(ferc1_settings.xbrl_years),
                     "max_year": max(ferc1_settings.xbrl_years),
                 },
-            ).assign(sched_table_name=table_name)
+            ).assign(sched_table_name=sched_table_name)
 
 
 @io_manager(

--- a/src/pudl/output/ferc1.py
+++ b/src/pudl/output/ferc1.py
@@ -1,6 +1,4 @@
 """Functions for pulling FERC Form 1 data out of the PUDL DB."""
-from typing import Literal
-
 import numpy as np
 import pandas as pd
 import sqlalchemy as sa

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -3815,7 +3815,7 @@ def ferc1_transform_asset_factory(
     """
     ins: Mapping[str, AssetIn] = {}
 
-    listify = lambda x: x if isinstance(x, list) else [x]
+    listify = lambda x: x if isinstance(x, list) else [x]  # noqa: E731
     dbf_tables = listify(TABLE_NAME_MAP_FERC1[table_name]["dbf"])
     xbrl_tables = listify(TABLE_NAME_MAP_FERC1[table_name]["xbrl"])
 
@@ -3849,12 +3849,16 @@ def ferc1_transform_asset_factory(
         else:
             transformer = tfr_class(xbrl_metadata_json=xbrl_metadata_json[table_name])
 
-        raw_dbf = pd.concat([df for key, df in kwargs if key.startswith("raw_dbf__")])
+        logger.info(f"{table_name} kwargs key: {kwargs.keys()}")
+
+        raw_dbf = pd.concat(
+            [df for key, df in kwargs.items() if key.startswith("raw_dbf__")]
+        )
         raw_xbrl_instant = pd.concat(
-            [df for key, df in kwargs if key.startswith("raw_xbrl_instant__")]
+            [df for key, df in kwargs.items() if key.startswith("raw_xbrl_instant__")]
         )
         raw_xbrl_duration = pd.concat(
-            [df for key, df in kwargs if key.startswith("raw_xbrl_duration__")]
+            [df for key, df in kwargs.items() if key.startswith("raw_xbrl_duration__")]
         )
         df = transformer.transform(
             raw_dbf=raw_dbf,
@@ -3880,12 +3884,23 @@ def create_ferc1_transform_assets() -> list[AssetsDefinition]:
         "plants_hydro_ferc1": PlantsHydroFerc1TableTransformer,
         "plant_in_service_ferc1": PlantInServiceFerc1TableTransformer,
         "plants_pumped_storage_ferc1": PlantsPumpedStorageFerc1TableTransformer,
+        "transmission_statistics_ferc1": TransmissionStatisticsFerc1TableTransformer,
         "purchased_power_ferc1": PurchasedPowerFerc1TableTransformer,
         "electric_energy_sources_ferc1": ElectricEnergySourcesFerc1TableTransformer,
         "electric_energy_dispositions_ferc1": ElectricEnergyDispositionsFerc1TableTransformer,
         "utility_plant_summary_ferc1": UtilityPlantSummaryFerc1TableTransformer,
+        "electric_opex_ferc1": ElectricOpexFerc1TableTransformer,
+        "balance_sheet_liabilities_ferc1": BalanceSheetLiabilitiesFerc1TableTransformer,
         "depreciation_amortization_summary_ferc1": DepreciationAmortizationSummaryFerc1TableTransformer,
         "balance_sheet_assets_ferc1": BalanceSheetAssetsFerc1TableTransformer,
+        "income_statement_ferc1": IncomeStatementFerc1TableTransformer,
+        "electric_plant_depreciation_changes_ferc1": ElectricPlantDepreciationChangesFerc1TableTransformer,
+        "electric_plant_depreciation_functional_ferc1": ElectricPlantDepreciationFunctionalFerc1TableTransformer,
+        "retained_earnings_ferc1": RetainedEarningsFerc1TableTransformer,
+        "electric_operating_revenues_ferc1": ElectricOperatingRevenuesFerc1TableTransformer,
+        "cash_flow_ferc1": CashFlowFerc1TableTransformer,
+        "electricity_sales_by_rate_schedule_ferc1": ElectricitySalesByRateScheduleFerc1TableTransformer,
+        "other_regulatory_liabilities_ferc1": OtherRegulatoryLiabilitiesFerc1,
     }
 
     assets = []

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -3849,8 +3849,6 @@ def ferc1_transform_asset_factory(
         else:
             transformer = tfr_class(xbrl_metadata_json=xbrl_metadata_json[table_name])
 
-        logger.info(f"{table_name} kwargs key: {kwargs.keys()}")
-
         raw_dbf = pd.concat(
             [df for key, df in kwargs.items() if key.startswith("raw_dbf__")]
         )

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -22,7 +22,7 @@ from ferc_xbrl_extractor import xbrl
 import pudl
 from pudl import resources
 from pudl.cli import get_etl_job
-from pudl.extract.ferc1 import extract_xbrl_metadata, xbrl_metadata_json
+from pudl.extract.ferc1 import xbrl_metadata_json
 from pudl.extract.xbrl import FercXbrlDatastore, _get_sqlite_engine
 from pudl.ferc_to_sqlite.cli import get_ferc_to_sqlite_job
 from pudl.io_managers import (

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -206,7 +206,6 @@ def test_convert_form(mocker):
 
     settings = FercGenericXbrlToSqliteSettings(
         taxonomy="https://www.fake.taxonomy.url",
-        tables=["table1", "table2"],
         years=[2020, 2021],
     )
 


### PR DESCRIPTION
# PR Overview

This PR resolves issues introduced in the dev -> dagster merge.

There are a couple of open issues:
- [x] Some tests in `xbrl_test.py` are breaking because they expect `xbrl2sqlite` to be a regular function, not a dagster op. @zschira you might know how to tackle this one.
- [ ] `['cash_flow_ferc1', 'electric_plant_depreciation_changes_ferc1', 'electricity_sales_by_rate_schedule_ferc1', 'plant_in_service_ferc1', 'retained_earnings_ferc1']` tables are failing because they have duplicate primary keys. I'm not sure where this bug was introduced. Might be out raw table concat logic, changes in the ferc1 transform classes that didn't get merged correctly or something in the xbrl extraction? 

**There are some changes in the database schema so I recommend deleting the pudl.sqlite files before debugging the ETL.** Bonus points if we can figure out how to compare the schema in the db and the schmea stored in the `pudl.metadata`.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
