### PR TITLE
Breakpoints in Dagster

### DIFF
--- a/devtools/materialize_asset.py
+++ b/devtools/materialize_asset.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python
+"""Materialize one asset & its upstream deps in-process so you can debug."""
+
+import argparse
+import importlib
+
+from dagster import AssetSelection, Definitions, define_asset_job
+
+from pudl import etl
+from pudl.settings import EtlSettings
+
+
+def _parse():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("asset_id")
+    return parser.parse_args()
+
+
+def main(asset_id):
+    """Entry point.
+
+    Defines dagster context like in etl/__init__.py - needs to be kept in sync.
+
+    Then creates a job with asset selection.
+    """
+    # TODO (daz/zach): maybe there's a way to do this directly with dagster cli?
+    defs = Definitions(
+        assets=etl.default_assets,
+        resources=etl.default_resources,
+        jobs=[
+            define_asset_job(
+                name="materialize_one",
+                selection=AssetSelection.keys(asset_id).upstream(),
+                config={
+                    "resources": {
+                        "dataset_settings": {
+                            "config": EtlSettings.from_yaml(
+                                importlib.resources.path(
+                                    "pudl.package_data.settings", "etl_fast.yml"
+                                )
+                            ).datasets.dict()
+                        }
+                    }
+                },
+            ),
+        ],
+    )
+    defs.get_job_def("materialize_one").execute_in_process()
+
+
+if __name__ == "__main__":
+    main(**vars(_parse()))


### PR DESCRIPTION
This is a small devtool to help us add breakpoints to code that runs in Dagster. Maybe there's a way to do this natively in the dagster CLI, but it was faster to write this code than search through the docs more.

Relates to #2318 and #2294 .