### PR TITLE
Fix balancing_authority_name update in cases where no ba_name_to_code_map()

### DIFF
--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -1100,6 +1100,20 @@ def fix_balancing_authority_codes_with_state(
     ba_name_to_code_map = map_balancing_authority_names_to_codes(plants)
     ba_name_to_code_map.reset_index(inplace=True)
 
+    if ba_name_to_code_map.empty:  # Prior to 2013
+        ba_name_fix = ["PacifiCorp - West", "PacifiCorp - East"]
+    else:
+        ba_name_fix = [
+            ba_name_to_code_map.loc[
+                ba_name_to_code_map.balancing_authority_code_eia == "PACW",
+                "balancing_authority_name_eia",
+            ].tolist()[0],
+            ba_name_to_code_map.loc[
+                ba_name_to_code_map.balancing_authority_code_eia == "PACE",
+                "balancing_authority_name_eia",
+            ].tolist()[0],
+        ]
+
     plants = plants.merge(
         plants_entity[["plant_id_eia", "state"]],  # only merge in state, drop later
         on=["plant_id_eia"],
@@ -1113,19 +1127,13 @@ def fix_balancing_authority_codes_with_state(
         BACodeFix(
             "PACE",
             "PACW",
-            ba_name_to_code_map.loc[
-                ba_name_to_code_map.balancing_authority_code_eia == "PACW",
-                "balancing_authority_name_eia",
-            ].tolist()[0],
+            ba_name_fix[0],
             ["OR", "CA"],
         ),
         BACodeFix(
             "PACW",
             "PACE",
-            ba_name_to_code_map.loc[
-                ba_name_to_code_map.balancing_authority_code_eia == "PACE",
-                "balancing_authority_name_eia",
-            ].tolist()[0],
+            ba_name_fix[1],
             ["UT"],
         ),
     ]

--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -1100,50 +1100,51 @@ def fix_balancing_authority_codes_with_state(
     ba_name_to_code_map = map_balancing_authority_names_to_codes(plants)
     ba_name_to_code_map.reset_index(inplace=True)
 
-    if ba_name_to_code_map.empty:  # Prior to 2013
-        ba_name_fix = ["PacifiCorp - West", "PacifiCorp - East"]
-    else:
-        ba_name_fix = [
-            ba_name_to_code_map.loc[
-                ba_name_to_code_map.balancing_authority_code_eia == "PACW",
-                "balancing_authority_name_eia",
-            ].tolist()[0],
-            ba_name_to_code_map.loc[
-                ba_name_to_code_map.balancing_authority_code_eia == "PACE",
-                "balancing_authority_name_eia",
-            ].tolist()[0],
-        ]
+    logger.info("Spot fixing incorrect PACW/PACE BA codes and names.")
 
-    plants = plants.merge(
-        plants_entity[["plant_id_eia", "state"]],  # only merge in state, drop later
-        on=["plant_id_eia"],
-        how="left",
-        validate="m:1",
-    )
-    BACodeFix = namedtuple(
-        "BACodeFix", ["ba_code_found", "ba_code_fix", "ba_name_fix", "states"]
-    )
-    fixes = [
-        BACodeFix(
-            "PACE",
-            "PACW",
-            ba_name_fix[0],
-            ["OR", "CA"],
-        ),
-        BACodeFix(
-            "PACW",
-            "PACE",
-            ba_name_fix[1],
-            ["UT"],
-        ),
-    ]
-    for fix in fixes:
-        plants.loc[
-            (plants.balancing_authority_code_eia == fix.ba_code_found)
-            & (plants.state.isin(fix.states)),
-            ["balancing_authority_code_eia", "balancing_authority_name_eia"],
-        ] = [fix.ba_code_fix, fix.ba_name_fix]
-    return plants.drop(columns=["state"])
+    if (
+        not ba_name_to_code_map.empty
+        and plants.balancing_authority_code_eia.isin(["PACW", "PACE"]).any()
+    ):
+        plants = plants.merge(
+            plants_entity[["plant_id_eia", "state"]],  # only merge in state, drop later
+            on=["plant_id_eia"],
+            how="left",
+            validate="m:1",
+        )
+        BACodeFix = namedtuple(
+            "BACodeFix", ["ba_code_found", "ba_code_fix", "ba_name_fix", "states"]
+        )
+        fixes = [
+            BACodeFix(
+                "PACE",
+                "PACW",
+                ba_name_to_code_map.loc[
+                    ba_name_to_code_map.balancing_authority_code_eia == "PACW",
+                    "balancing_authority_name_eia",
+                ].tolist()[0],
+                ["OR", "CA"],
+            ),
+            BACodeFix(
+                "PACW",
+                "PACE",
+                ba_name_to_code_map.loc[
+                    ba_name_to_code_map.balancing_authority_code_eia == "PACE",
+                    "balancing_authority_name_eia",
+                ].tolist()[0],
+                ["UT"],
+            ),
+        ]
+        for fix in fixes:
+            plants.loc[
+                (plants.balancing_authority_code_eia == fix.ba_code_found)
+                & (plants.state.isin(fix.states)),
+                ["balancing_authority_code_eia", "balancing_authority_name_eia"],
+            ] = [fix.ba_code_fix, fix.ba_name_fix]
+        return plants.drop(columns=["state"])
+
+    else:  # If no fixes to be made
+        return plants
 
 
 def transform(

--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -1100,12 +1100,14 @@ def fix_balancing_authority_codes_with_state(
     ba_name_to_code_map = map_balancing_authority_names_to_codes(plants)
     ba_name_to_code_map.reset_index(inplace=True)
 
-    logger.info("Spot fixing incorrect PACW/PACE BA codes and names.")
-
+    # Prior to 2013, there are no BA codes or names. Running a pre-2013 subset of data
+    # through the transform will thus return an empty ba_name_to_code_map.
     if (
         not ba_name_to_code_map.empty
         and plants.balancing_authority_code_eia.isin(["PACW", "PACE"]).any()
     ):
+        logger.info("Spot fixing incorrect PACW/PACE BA codes and names.")
+
         plants = plants.merge(
             plants_entity[["plant_id_eia", "state"]],  # only merge in state, drop later
             on=["plant_id_eia"],
@@ -1141,10 +1143,9 @@ def fix_balancing_authority_codes_with_state(
                 & (plants.state.isin(fix.states)),
                 ["balancing_authority_code_eia", "balancing_authority_name_eia"],
             ] = [fix.ba_code_fix, fix.ba_name_fix]
-        return plants.drop(columns=["state"])
+        plants = plants.drop(columns=["state"])
 
-    else:  # If no fixes to be made
-        return plants
+    return plants
 
 
 def transform(


### PR DESCRIPTION
This small PR patches a fix to the recently merged #2312 , which fails when there are no `balancing_authority_codes_eia` or `balancing_authority_names_eia` in the dataset (e.g. when a user selects a subset of data prior to 2013). I've added a few lines here to skip the fixes if these conditions are met. 

To test the functioning of this fix:
- test the ETL on a pre-2013 data subset, ensuring it does not break.
- test the ETL on 2013 data (the year in which the fix occurs), checking to see that the number of 'PACW' and 'PACE' `balancing_authority_codes` changes between the raw extracted data and the end of the ETL, and that names that are changed match the corresponding BA code for these records.

E.g.:
```
eia860_raw_dfs['plant']['balancing_authority_name_eia'].value_counts()[['PacifiCorp - East', 'PacifiCorp - West']]
out_dfs['plants_eia860']['balancing_authority_name_eia'].value_counts()[['PacifiCorp - East', 'PacifiCorp - West']]


plants = out_dfs['plants_eia860']

eia860_raw_dfs['plant'].loc[eia860_raw_dfs['plant'].balancing_authority_code_eia =="PACE",'balancing_authority_name_eia'].value_counts()
plants.loc[plants.balancing_authority_code_eia =="PACE",'balancing_authority_name_eia'].value_counts()

eia860_raw_dfs['plant'].loc[eia860_raw_dfs['plant'].balancing_authority_code_eia =="PACW",'balancing_authority_name_eia'].value_counts()
plants.loc[plants.balancing_authority_code_eia =="PACW",'balancing_authority_name_eia'].value_counts()
```

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [X] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [x] Make sure you've included good docstrings.
- [x] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
