### PR TITLE
Update local cache when using `--gcs-cache-path`

### DIFF
--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -359,7 +359,11 @@ class Datastore:
                 continue
             if self._cache.contains(res):
                 logger.debug(f"Retrieved {res} from cache.")
-                yield (res, self._cache.get(res))
+                contents = self._cache.get(res)
+                if not self._cache.is_optimally_cached(res):
+                    logger.debug(f"{res} was not optimally cached yet, adding.")
+                    self._cache.add(res, contents)
+                yield (res, contents)
             elif not cached_only:
                 logger.debug(f"Retrieved {res} from zenodo.")
                 contents = self._zenodo_fetcher.get_resource(res)


### PR DESCRIPTION
Fixes #2315 (hopefully!)

While waiting for my CI to re-download everything because the cache is empty, I decided to jump in on this thing.

I cleared my data directory locally, ran integration tests with `--gcs-cache-path`, and watched as the local cache got populated, when it hadn't without this fix 😌 