### PR TITLE
Configure dagster env vars from settings if not set already

### DIFF
--- a/src/pudl/cli.py
+++ b/src/pudl/cli.py
@@ -90,6 +90,12 @@ def main():
     etl_settings = EtlSettings.from_yaml(args.settings_file)
 
     if (not os.getenv("PUDL_OUT")) or (not os.getenv("PUDL_CACHE")):
+        logger.warning(
+            "PUDL will attempt to use legacy settings to derive paths."
+            "In the future this functionality will be deprecated in favor"
+            "of environment variables PUDL_OUT and PUDL_CACHE. For more"
+            "info see: https://catalystcoop-pudl.readthedocs.io/en/dev/dev/dev_setup.html"
+        )
         pudl_settings = pudl.workspace.setup.derive_paths(
             pudl_in=etl_settings.pudl_in, pudl_out=etl_settings.pudl_out
         )

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -29,6 +29,7 @@ from pandas._libs.missing import NAType
 
 import pudl.logging_helpers
 from pudl.metadata.fields import get_pudl_dtypes
+from pudl.workspace.setup import get_defaults
 
 sum_na = partial(pd.Series.sum, skipna=False)
 """A sum function that returns NA if the Series includes any NA values.
@@ -1589,7 +1590,7 @@ class EnvVar(Noneable):
         """
         if value is None:
             try:
-                return os.environ[self.env_var]
+                return os.environ.get(self.env_var, get_defaults()[self.env_var])
             except KeyError:
                 raise PostProcessingError(
                     f"Config value could not be found. Set the {self.env_var} environment variable or specify a value in dagster config."

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -1590,7 +1590,10 @@ class EnvVar(Noneable):
         """
         if value is None:
             try:
-                return os.environ.get(self.env_var, get_defaults()[self.env_var])
+                value = os.environ.get(self.env_var)
+
+                if not value:
+                    value = get_defaults()[self.env_var]
             except KeyError:
                 raise PostProcessingError(
                     f"Config value could not be found. Set the {self.env_var} environment variable or specify a value in dagster config."

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -30,6 +30,11 @@ def set_defaults(pudl_in, pudl_out, clobber=False):
     Returns:
         None
     """
+    logger.warning(
+        "pudl_settings is being depcrated in favor of environment"
+        "variables PUDL_OUTPUT and PUDL_CACHE. For more info"
+        "see: https://catalystcoop-pudl.readthedocs.io/en/dev/dev/dev_setup.html"
+    )
     settings_file = pathlib.Path.home() / ".pudl.yml"
     if settings_file.exists():
         if clobber:
@@ -54,6 +59,10 @@ def get_defaults():
         ``pudl_in`` and ``pudl_out`` defining their default PUDL workspace. If
         the ``$HOME/.pudl.yml`` file does not exist, set these paths to None.
     """
+    logger.warning(
+        "pudl_settings is being depcrated in favor of environment variables"
+        "PUDL_OUTPUT and PUDL_CACHE"
+    )
     settings_file = pathlib.Path.home() / ".pudl.yml"
 
     try:
@@ -95,6 +104,11 @@ def derive_paths(pudl_in, pudl_out):
         dict: A dictionary containing common PUDL settings, derived from those
             read out of the YAML file. Mostly paths for inputs & outputs.
     """
+    logger.warning(
+        "pudl_settings is being depcrated in favor of environment variables"
+        "PUDL_OUTPUT and PUDL_CACHE. For more info"
+        "see: https://catalystcoop-pudl.readthedocs.io/en/dev/dev/dev_setup.html"
+    )
     pudl_settings = {}
 
     # The only "inputs" are the datastore and example settings files:
@@ -111,6 +125,9 @@ def derive_paths(pudl_in, pudl_out):
     pudl_out = pathlib.Path(pudl_out).expanduser().resolve()
     pudl_settings["pudl_out"] = str(pudl_out)
     # One directory per output format:
+    logger.warning(
+        "sqlite and parquet directories are no longer being used. Make sure there is a single directory named 'output' at the root of your workspace. For more info see: https://catalystcoop-pudl.readthedocs.io/en/dev/dev/dev_setup.html"
+    )
     for fmt in ["sqlite", "parquet"]:
         pudl_settings[f"{fmt}_dir"] = str(pudl_out)
 

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -114,6 +114,10 @@ def derive_paths(pudl_in, pudl_out):
     for fmt in ["sqlite", "parquet"]:
         pudl_settings[f"{fmt}_dir"] = str(pudl_out)
 
+    # Mirror dagster env vars for ease of use
+    pudl_settings["PUDL_OUTPUT"] = pudl_settings["pudl_out"]
+    pudl_settings["PUDL_CACHE"] = pudl_settings["data_dir"]
+
     ferc1_db_file = pathlib.Path(pudl_settings["sqlite_dir"], "ferc1.sqlite")
     pudl_settings["ferc1_db"] = "sqlite:///" + str(ferc1_db_file.resolve())
 

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -67,7 +67,9 @@ def get_defaults():
     # Ensure that no matter what the user has put in this file, we get fully
     # specified absolute paths out when we read it:
     pudl_in = pathlib.Path(default_workspace["pudl_in"]).expanduser().resolve()
-    pudl_out = pathlib.Path(default_workspace["pudl_out"]).expanduser().resolve()
+    pudl_out = (
+        pathlib.Path(default_workspace["pudl_out"]).expanduser().resolve() / "output"
+    )
     return derive_paths(pudl_in, pudl_out)
 
 
@@ -110,7 +112,7 @@ def derive_paths(pudl_in, pudl_out):
     pudl_settings["pudl_out"] = str(pudl_out)
     # One directory per output format:
     for fmt in ["sqlite", "parquet"]:
-        pudl_settings[f"{fmt}_dir"] = str(pudl_out / fmt)
+        pudl_settings[f"{fmt}_dir"] = str(pudl_out)
 
     ferc1_db_file = pathlib.Path(pudl_settings["sqlite_dir"], "ferc1.sqlite")
     pudl_settings["ferc1_db"] = "sqlite:///" + str(ferc1_db_file.resolve())
@@ -205,10 +207,9 @@ def init(pudl_in, pudl_out, clobber=False):
     settings_pkg = "pudl.package_data.settings"
     deploy(settings_pkg, settings_dir, ignore_files, clobber=clobber)
 
-    # Make several output directories:
-    for fmt in ["sqlite", "parquet"]:
-        format_dir = pathlib.Path(pudl_settings["pudl_out"], fmt)
-        format_dir.mkdir(parents=True, exist_ok=True)
+    # Make output directory:
+    pudl_out = pathlib.Path(pudl_settings["pudl_out"]) / "output"
+    pudl_out.mkdir(parents=True, exist_ok=True)
 
 
 def deploy(pkg_path, deploy_dir, ignore_files, clobber=False):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -88,8 +88,8 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     """Make sure env vars are set before unit tests.
 
-    io_managers unit tests need these to be set, but they don't have to point top
-    anything meaningful.
+    io_managers unit tests need these to be set, but they don't have to point to
+    anything meaningful. They will be reset by the `pudl_env` fixture before being used.
     """
     os.environ["PUDL_OUTPUT"] = "~/"
     os.environ["DAGSTER_HOME"] = "~/"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,7 +10,6 @@ from pathlib import Path
 import pytest
 import yaml
 from dagster import build_init_resource_context, materialize_to_memory
-from dotenv import load_dotenv
 from ferc_xbrl_extractor import xbrl
 
 import pudl
@@ -87,8 +86,14 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
-    """Load dotenv before tests are run to set PUDL_OUTPUT and PUDL_CACHE."""
-    load_dotenv()
+    """Make sure env vars are set before unit tests.
+
+    io_managers unit tests need these to be set, but they don't have to point top
+    anything meaningful.
+    """
+    os.environ["PUDL_OUTPUT"] = "~/"
+    os.environ["DAGSTER_HOME"] = "~/"
+    os.environ["PUDL_CACHE"] = "~/"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This PR addresses #2301 by setting `PUDL_OUTPUT` and `PUDL_CACHE` from `pudl_settings` if these env vars are not already set.
