### PR TITLE
Restructure data dictionary docs and add a class for etl_groups

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pkg_resources
 
-from pudl.metadata.classes import CodeMetadata, DataSource, Package
+from pudl.metadata.classes import CodeMetadata, DataSource, ETLGroup, Package
 from pudl.metadata.codes import CODE_METADATA
 from pudl.metadata.resources import RESOURCE_METADATA
 
@@ -153,10 +153,15 @@ def data_sources_metadata_to_rst(app):
     print("Exporting data source metadata to RST.")
     included_sources = ["eia860", "eia923", "ferc1", "epacems"]
     package = Package.from_resource_ids()
-    extra_etl_groups = {"eia860": ["entity_eia"], "ferc1": ["glue"]}
+    extra_etl_groups = {
+        "eia860": [ETLGroup.from_id("entity_eia")],
+        "ferc1": [ETLGroup.from_id("glue")],
+    }
     for name in included_sources:
         source = DataSource.from_id(name)
-        source_resources = [res for res in package.resources if res.etl_group == name]
+        source_resources = [
+            res for res in package.resources if res.etl_group == ETLGroup.from_id(name)
+        ]
         extra_resources = None
         if name in extra_etl_groups:
             # get resources for this source from extra etl groups

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,13 +138,13 @@ def data_dictionary_metadata_to_rst(app):
         resource.schema.fields = sorted(resource.schema.fields, key=lambda x: x.name)
     package.to_rst(
         docs_dir=DOCS_DIR,
-        path=DOCS_DIR / "data_dictionaries/pudl_db_fields.rst",
-        add_fields=True,
+        path=DOCS_DIR / "data_dictionaries/pudl_db.rst",
+        template="etl_group.rst.jinja",
     )
     package.to_rst(
         docs_dir=DOCS_DIR,
-        path=DOCS_DIR / "data_dictionaries/pudl_db.rst",
-        add_fields=False,
+        path=DOCS_DIR / "data_dictionaries/pudl_db_fields.rst",
+        template="package.rst.jinja",
     )
 
 
@@ -197,7 +197,7 @@ def static_dfs_to_rst(app):
 def cleanup_rsts(app, exception):
     """Remove generated RST files when the build is finished."""
     (DOCS_DIR / "data_dictionaries/pudl_db.rst").unlink()
-    (DOCS_DIR / "data_dictionaries/pudl_db_fields.rst").unlink()
+    # (DOCS_DIR / "data_dictionaries/pudl_db_fields.rst").unlink()
     (DOCS_DIR / "data_dictionaries/codes_and_labels.rst").unlink()
     (DOCS_DIR / "data_sources/eia860.rst").unlink()
     (DOCS_DIR / "data_sources/eia923.rst").unlink()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -136,7 +136,16 @@ def data_dictionary_metadata_to_rst(app):
     # Sort fields within each resource by name:
     for resource in package.resources:
         resource.schema.fields = sorted(resource.schema.fields, key=lambda x: x.name)
-    package.to_rst(docs_dir=DOCS_DIR, path=DOCS_DIR / "data_dictionaries/pudl_db.rst")
+    package.to_rst(
+        docs_dir=DOCS_DIR,
+        path=DOCS_DIR / "data_dictionaries/pudl_db_fields.rst",
+        add_fields=True,
+    )
+    package.to_rst(
+        docs_dir=DOCS_DIR,
+        path=DOCS_DIR / "data_dictionaries/pudl_db.rst",
+        add_fields=False,
+    )
 
 
 def data_sources_metadata_to_rst(app):
@@ -183,6 +192,7 @@ def static_dfs_to_rst(app):
 def cleanup_rsts(app, exception):
     """Remove generated RST files when the build is finished."""
     (DOCS_DIR / "data_dictionaries/pudl_db.rst").unlink()
+    (DOCS_DIR / "data_dictionaries/pudl_db_fields.rst").unlink()
     (DOCS_DIR / "data_dictionaries/codes_and_labels.rst").unlink()
     (DOCS_DIR / "data_sources/eia860.rst").unlink()
     (DOCS_DIR / "data_sources/eia923.rst").unlink()

--- a/docs/data_dictionaries/index.rst
+++ b/docs/data_dictionaries/index.rst
@@ -5,7 +5,7 @@ Data Dictionaries
 
 .. toctree::
    :caption: Data Processed & Cleaned by PUDL
-   :maxdepth: 1
+   :maxdepth: 2
 
    pudl_db
 

--- a/docs/templates/package.rst.jinja
+++ b/docs/templates/package.rst.jinja
@@ -7,30 +7,18 @@ PUDL Data Dictionary
 The following data tables have been cleaned and transformed by our ETL process.
 
 {% for group, resources in package.get_resource_by_etl_group().items() %}
-{{ package.get_etl_group()[group].title }}
--------------------------------------------------------------------------------
-
-{{ package.get_etl_group()[group].description }}
-
 {% for resource in resources %}
 
-{% if add_fields %}
 .. _{{ resource.name }}:
-{% endif %}
 
 {{ resource.name }}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 {{ resource.description | wordwrap(78) if resource.description else
 'No table description available.' }}
-{% if not add_fields %}
-:ref:`View Columns <{{ resource.name }}>`
-{% endif %}
 `Browse or query this table in Datasette. <https://data.catalyst.coop/pudl/{{ resource.name }}>`__
 
-{% if add_fields %}
 {% include 'resource.rst.jinja' %}
-{% endif %}
 
 {% endfor %}
 {% endfor %}

--- a/docs/templates/package.rst.jinja
+++ b/docs/templates/package.rst.jinja
@@ -1,3 +1,5 @@
+:orphan:
+
 ===============================================================================
 PUDL Data Dictionary
 ===============================================================================
@@ -10,14 +12,23 @@ The following data tables have been cleaned and transformed by our ETL process.
 
 {% for resource in resources %}
 
+{% if add_fields %}
 .. _{{ resource.name }}:
+{% endif %}
 
 {{ resource.name }}
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 {{ resource.description | wordwrap(78) if resource.description else
 'No table description available.' }}
+{% if not add_fields %}
+:ref:`View Columns <{{ resource.name }}>`
+{% endif %}
 `Browse or query this table in Datasette. <https://data.catalyst.coop/pudl/{{ resource.name }}>`__
+
+{% if add_fields %}
+{% include 'resource.rst.jinja' %}
+{% endif %}
 
 {% endfor %}
 {% endfor %}

--- a/docs/templates/package.rst.jinja
+++ b/docs/templates/package.rst.jinja
@@ -4,8 +4,20 @@ PUDL Data Dictionary
 
 The following data tables have been cleaned and transformed by our ETL process.
 
-{% for resource in package.resources %}
+{% for group, resources in package.get_resource_by_etl_group().items() %}
+{{ group }}
+-------------------------------------------------------------------------------
+
+{% for resource in resources %}
+
 .. _{{ resource.name }}:
 
-{% include 'resource.rst.jinja' %}
+{{ resource.name }}
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+{{ resource.description | wordwrap(78) if resource.description else
+'No table description available.' }}
+`Browse or query this table in Datasette. <https://data.catalyst.coop/pudl/{{ resource.name }}>`__
+
+{% endfor %}
 {% endfor %}

--- a/docs/templates/package.rst.jinja
+++ b/docs/templates/package.rst.jinja
@@ -7,8 +7,10 @@ PUDL Data Dictionary
 The following data tables have been cleaned and transformed by our ETL process.
 
 {% for group, resources in package.get_resource_by_etl_group().items() %}
-{{ group }}
+{{ package.get_etl_group()[group].title }}
 -------------------------------------------------------------------------------
+
+{{ package.get_etl_group()[group].description }}
 
 {% for resource in resources %}
 

--- a/docs/templates/resource.rst.jinja
+++ b/docs/templates/resource.rst.jinja
@@ -9,4 +9,5 @@
   * - {{ field.name }}
     - {{ field.type }}
     - {{ field.description if field.description else "N/A" }}
+
 {%- endfor %}

--- a/docs/templates/resource.rst.jinja
+++ b/docs/templates/resource.rst.jinja
@@ -1,11 +1,3 @@
--------------------------------------------------------------------------------
-{{ resource.name }}
--------------------------------------------------------------------------------
-
-{{ resource.description | wordwrap(78) if resource.description else
-'No table description available.' }}
-`Browse or query this table in Datasette. <https://data.catalyst.coop/pudl/{{ resource.name }}>`__
-
 .. list-table::
   :widths: auto
   :header-rows: 1

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1800,6 +1800,17 @@ class Package(Base):
         names = [resource.name for resource in self.resources]
         return self.resources[names.index(name)]
 
+    def get_resource_by_etl_group(self) -> dict[str, list[Resource]]:
+        """blah."""
+        resource_dict = {}
+        for etl_group in list(self.resources[0].__annotations__["etl_group"].__args__):
+            resource_dict[etl_group] = [
+                resource
+                for resource in self.resources
+                if resource.etl_group == etl_group
+            ]
+        return resource_dict
+
     def to_rst(self, docs_dir: DirectoryPath, path: str) -> None:
         """Output to an RST file."""
         template = _get_jinja_environment(docs_dir).get_template("package.rst.jinja")

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1826,10 +1826,10 @@ class Package(Base):
             ]
         return resource_dict
 
-    def to_rst(self, docs_dir: DirectoryPath, path: str, add_fields: bool) -> None:
+    def to_rst(self, docs_dir: DirectoryPath, path: str, template: str) -> None:
         """Output to an RST file."""
-        template = _get_jinja_environment(docs_dir).get_template("package.rst.jinja")
-        rendered = template.render(package=self, add_fields=add_fields)
+        template = _get_jinja_environment(docs_dir).get_template(template)
+        rendered = template.render(package=self)
         if path:
             Path(path).write_text(rendered)
         else:

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1811,10 +1811,10 @@ class Package(Base):
             ]
         return resource_dict
 
-    def to_rst(self, docs_dir: DirectoryPath, path: str) -> None:
+    def to_rst(self, docs_dir: DirectoryPath, path: str, add_fields: bool) -> None:
         """Output to an RST file."""
         template = _get_jinja_environment(docs_dir).get_template("package.rst.jinja")
-        rendered = template.render(package=self)
+        rendered = template.render(package=self, add_fields=add_fields)
         if path:
             Path(path).write_text(rendered)
         else:

--- a/src/pudl/metadata/constants.py
+++ b/src/pudl/metadata/constants.py
@@ -153,6 +153,83 @@ CONTRIBUTORS: dict[str, dict[str, str]] = {
 }
 """PUDL Contributors for attribution."""
 
+ETL_GROUPS: dict[str, dict[str, str]] = {
+    "eia860": {
+        "title": "EIA 860",
+        "description": """Tables derrived from the EIA Form 860. See our
+:doc:`../data_sources/eia860` page for more information.""",
+    },
+    "eia861": {
+        "title": "EIA 861",
+        "description": "Tables derrived from the EIA Form 861.",
+    },
+    "eia923": {
+        "title": "EIA 923",
+        "description": """Tables derrived from the EIA Form 923.  See our
+:doc:`../data_sources/eia923` page for more information.""",
+    },
+    "entity_eia": {
+        "title": "EIA Entity Tables",
+        "description": """EIA entity tables combine information reported in multiple EIA
+tables into a single source of truth. "Entities" (boilers, generators, plants and
+utilities) are referred to repeatedly throughout EIA resulting in data duplication and
+human-error. For example, one year a plant's latitude is ``55.339722`` and
+another year it's ``55.339725`` or in 860 a plant is called ``Barry`` but in 923 it's
+once referred to as ``Bary``. We use a "harvesting" process to extract this static (not
+changing on an annual basis) information, determine the true value, and rehome it in our
+entity tables. This reduces the amount of data we have to store and provides users with
+a master list of all entitiy types and their characteristics that are reported to a
+given source. Read more about our harvesting process in :mod:`pudl.transform.eia`.
+""",
+    },
+    "epacems": {
+        "title": "EPA CEMS",
+        "description": """Tables derrived from the EPA CEMS data. See our
+:doc:`../data_sources/epacems` page for more information""",
+    },
+    "ferc1": {
+        "title": "FERC Form 1",
+        "description": """Tables derrived from the FERC Form 1 tables. See our
+:doc:`../data_sources/ferc1` page for more information""",
+    },
+    "ferc1_disabled": {
+        "title": "FERC Form 1 disabled",
+        "description": "BLAH",
+    },
+    "ferc714": {
+        "title": "FERC Form 714",
+        "description": "Tables derrived from the FERC Form 714 tables",
+    },
+    "glue": {
+        "title": "Glue Tables",
+        "description": "Tables connecting information from multiple sources",
+    },
+    "outputs": {
+        "title": "Output Tables",
+        "description": "Blah",
+    },
+    "static_ferc1": {
+        "title": "Static FERC 1 Tables",
+        "description": "Blah",
+    },
+    "static_eia": {
+        "title": "Static EIA Tables",
+        "description": """Static EIA tables are like EIA entity tables in that they pull
+from multiple EIA tables, but their purpose is to elucidate encoded language. This is
+where acromyns are connected to their full spelling and descriptions.""",
+    },
+    "static_eia_disabled": {
+        "title": "Static EIA Tables (disabled)",
+        "description": "blah",
+    },
+    "eia_bulk_elec": {
+        "title": "EIA Bulk Electricity Tables",
+        "description": "Blah",
+    },
+    "static_pudl": {"title": "Static PUDL Tables", "description": "Blah"},
+}
+"""Table categorization by ETL group."""
+
 KEYWORDS: dict[str, list[str]] = {
     "electricity": [
         "electricity",

--- a/src/pudl/metadata/constants.py
+++ b/src/pudl/metadata/constants.py
@@ -154,20 +154,6 @@ CONTRIBUTORS: dict[str, dict[str, str]] = {
 """PUDL Contributors for attribution."""
 
 ETL_GROUPS: dict[str, dict[str, str]] = {
-    "eia860": {
-        "title": "EIA 860",
-        "description": """Tables derrived from the EIA Form 860. See our
-:doc:`../data_sources/eia860` page for more information.""",
-    },
-    "eia861": {
-        "title": "EIA 861",
-        "description": "Tables derrived from the EIA Form 861.",
-    },
-    "eia923": {
-        "title": "EIA 923",
-        "description": """Tables derrived from the EIA Form 923.  See our
-:doc:`../data_sources/eia923` page for more information.""",
-    },
     "entity_eia": {
         "title": "EIA Entity Tables",
         "description": """EIA entity tables combine information reported in multiple EIA
@@ -182,10 +168,42 @@ a master list of all entitiy types and their characteristics that are reported t
 given source. Read more about our harvesting process in :mod:`pudl.transform.eia`.
 """,
     },
+    "static_eia": {
+        "title": "EIA Static Tables",
+        "description": """Static EIA tables are like EIA entity tables in that they pull
+from multiple EIA tables, but their purpose is to elucidate encoded language. This is
+where acromyns are connected to their full spelling and descriptions.""",
+    },
+    "static_eia_disabled": {
+        "title": "EIA Static Tables (disabled)",
+        "description": "blah",
+    },
+    "eia860": {
+        "title": "EIA 860",
+        "description": """Tables derrived from the EIA Form 860. See our
+:doc:`../data_sources/eia860` page for more information.""",
+    },
+    "eia861": {
+        "title": "EIA 861",
+        "description": "Tables derrived from the EIA Form 861.",
+    },
+    "eia923": {
+        "title": "EIA 923",
+        "description": """Tables derrived from the EIA Form 923.  See our
+:doc:`../data_sources/eia923` page for more information.""",
+    },
+    "eia_bulk_elec": {
+        "title": "EIA Bulk Electricity Tables",
+        "description": "Blah",
+    },
     "epacems": {
         "title": "EPA CEMS",
         "description": """Tables derrived from the EPA CEMS data. See our
 :doc:`../data_sources/epacems` page for more information""",
+    },
+    "static_ferc1": {
+        "title": "FERC Form 1 Static Tables",
+        "description": "Blah",
     },
     "ferc1": {
         "title": "FERC Form 1",
@@ -206,24 +224,6 @@ given source. Read more about our harvesting process in :mod:`pudl.transform.eia
     },
     "outputs": {
         "title": "Output Tables",
-        "description": "Blah",
-    },
-    "static_ferc1": {
-        "title": "Static FERC 1 Tables",
-        "description": "Blah",
-    },
-    "static_eia": {
-        "title": "Static EIA Tables",
-        "description": """Static EIA tables are like EIA entity tables in that they pull
-from multiple EIA tables, but their purpose is to elucidate encoded language. This is
-where acromyns are connected to their full spelling and descriptions.""",
-    },
-    "static_eia_disabled": {
-        "title": "Static EIA Tables (disabled)",
-        "description": "blah",
-    },
-    "eia_bulk_elec": {
-        "title": "EIA Bulk Electricity Tables",
         "description": "Blah",
     },
     "static_pudl": {"title": "Static PUDL Tables", "description": "Blah"},

--- a/src/pudl/metadata/constants.py
+++ b/src/pudl/metadata/constants.py
@@ -172,11 +172,13 @@ given source. Read more about our harvesting process in :mod:`pudl.transform.eia
         "title": "EIA Static Tables",
         "description": """Static EIA tables are like EIA entity tables in that they pull
 from multiple EIA tables, but their purpose is to elucidate encoded language. This is
-where acromyns are connected to their full spelling and descriptions.""",
+where acromyns are connected to their full spelling and descriptions. These tables did
+not originate as raw EIA tables, rather they are created by us to link commonly used
+codes to important descriptors.""",
     },
     "static_eia_disabled": {
         "title": "EIA Static Tables (disabled)",
-        "description": "blah",
+        "description": "Disabled tables are no longer included in the PUDL DB.",
     },
     "eia860": {
         "title": "EIA 860",
@@ -203,7 +205,10 @@ where acromyns are connected to their full spelling and descriptions.""",
     },
     "static_ferc1": {
         "title": "FERC Form 1 Static Tables",
-        "description": "Blah",
+        "description": """Static FERC Form 1 tables elucidate encoded language. This is
+where acromyns are connected to their full spelling and descriptions. These tables did
+not originate as raw FERC Form 1 tables, rather they are created by us to link commonly
+used codes to important descriptors.""",
     },
     "ferc1": {
         "title": "FERC Form 1",
@@ -212,7 +217,7 @@ where acromyns are connected to their full spelling and descriptions.""",
     },
     "ferc1_disabled": {
         "title": "FERC Form 1 disabled",
-        "description": "BLAH",
+        "description": "Disabled tables are no longer included in the PUDL DB.",
     },
     "ferc714": {
         "title": "FERC Form 714",
@@ -226,7 +231,12 @@ where acromyns are connected to their full spelling and descriptions.""",
         "title": "Output Tables",
         "description": "Blah",
     },
-    "static_pudl": {"title": "Static PUDL Tables", "description": "Blah"},
+    "static_pudl": {
+        "title": "Static PUDL Tables",
+        "description": """Static PUDL tables elucidate encoded language. This is
+where acromyns are connected to their full spelling and descriptions. They're created
+to link commonly used codes to important descriptors.""",
+    },
 }
 """Table categorization by ETL group."""
 

--- a/test/unit/harvest_test.py
+++ b/test/unit/harvest_test.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from pudl.metadata.classes import Resource
+from pudl.metadata.classes import ETLGroup, Resource
 from pudl.metadata.helpers import most_frequent
 
 # ---- Helpers ---- #
@@ -35,6 +35,7 @@ STANDARD: dict[str, Any] = {
         ],
         "primary_key": ["i", "j"],
     },
+    "etl_group": ETLGroup.from_id("static_pudl"),
 }
 
 HARVEST: dict[str, Any] = {**STANDARD, "harvest": {"harvest": True}}
@@ -264,6 +265,7 @@ RESOURCES: list[dict[str, Any]] = [
             "fields": ["plant_id_eia", "state", "balancing_authority_code_eia"],
             "primary_key": ["plant_id_eia"],
         },
+        "etl_group": "eia860",
     },
     {
         "name": "generator_entity_eia860",
@@ -277,6 +279,7 @@ RESOURCES: list[dict[str, Any]] = [
             ],
             "primary_key": ["plant_id_eia", "generator_id"],
         },
+        "etl_group": "eia860",
     },
     {
         "name": "generators_eia860",
@@ -285,6 +288,7 @@ RESOURCES: list[dict[str, Any]] = [
             "fields": ["plant_id_eia", "generator_id", "report_year", "capacity_mw"],
             "primary_key": ["plant_id_eia", "generator_id", "report_year"],
         },
+        "etl_group": "eia860",
     },
     {
         "name": "utility_entity_eia",
@@ -293,6 +297,7 @@ RESOURCES: list[dict[str, Any]] = [
             "fields": ["utility_id_eia", "utility_name_eia"],
             "primary_key": ["utility_id_eia"],
         },
+        "etl_group": "entity_eia",
     },
     {
         "name": "utility_assn_eia",
@@ -301,6 +306,7 @@ RESOURCES: list[dict[str, Any]] = [
             "fields": ["utility_id_eia", "report_year", "state", "county"],
             "primary_key": ["utility_id_eia", "report_year", "state", "county"],
         },
+        "etl_group": "static_eia",
     },
     {
         "name": "generation_eia923",
@@ -314,6 +320,7 @@ RESOURCES: list[dict[str, Any]] = [
             ],
             "primary_key": ["plant_id_eia", "generator_id", "report_month"],
         },
+        "etl_group": "eia923",
     },
     {
         "name": "sales_eia861",
@@ -322,6 +329,7 @@ RESOURCES: list[dict[str, Any]] = [
             "fields": ["utility_id_eia", "report_year", "state", "county", "sales"],
             "primary_key": ["utility_id_eia", "report_year", "state", "county"],
         },
+        "etl_group": "eia861",
     },
     {
         "name": "boiler_generator_assn_eia860",
@@ -330,6 +338,7 @@ RESOURCES: list[dict[str, Any]] = [
             "fields": ["plant_id_eia", "generator_id", "report_year", "boiler_id"],
             "primary_key": ["plant_id_eia", "generator_id", "report_year", "boiler_id"],
         },
+        "etl_group": "eia860",
     },
 ]
 
@@ -338,6 +347,7 @@ for i, d in enumerate(RESOURCES):
     d["schema"]["fields"] = [
         {"name": name, "type": FIELD_DTYPES[name]} for name in d["schema"]["fields"]
     ]
+    d["etl_group"] = ETLGroup.from_id(d["etl_group"])
     RESOURCES[i] = Resource(**d)
 
 EXPECTED_DFS: dict[str, pd.DataFrame] = dict(


### PR DESCRIPTION
<!--

Making a PUDL Pull Request

Before making a PR you may want to check out our:

* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
* development process: https://catalystcoop-pudl.readthedocs.io/en/latest/dev/index.html

## PR Process Overview

* PRs have to get an approving review before merging into their development branch.
* Most PRs should be made against the `dev` branch, unless they are part of some larger ongoing refactoring, in which case there will be a persistent development branch for that work.
* It is much easier to do timely code reviews on smaller chunks of code. We try to keep PRs under 500 lines of code.
* Draft PRs are a good way to get early feedback on designs or several incremental commits that will add up to larger changes. If you want a review of a draft PR, make sure you contact the reviewer directly or mention their username in the PR comment, so they get a notification.
* How quickly we can review a PR will depend on how large and complex it is, and how busy we are, but ideally we strive to get an initial review done within a week. If there are going to be delays, we should at least comment on the PR to let you know the situation.
* If you believe you've addressed a reviewer's comments, respond with a brief note and mark the comment resolved. If further discussion is requried respond and do not resolve the comment.
* Before a PR is merged all reviewer comments should be resolved. If a reviewer doesn't feel that their comment has been sufficiently addressed, they may unresolve a comment.
* Be careful not to accidentally "start a review" when responding to comments! If this does happen, don't forget to submit the review you've started so the other PR participatns can see your comments (they are invisible to others if marked "Pending").
* In the period after an initial review when there is significant back-and-forth with the reviewer deciding what changes should actually be made, there should probably be daily interaction. If significant changes are required, it's usually best to request another review after those changes have been made.

Feel free to delete the commented-out parts of the template before submitting the PR.

-->

# PR Overview

This PR adds layers to the Data Dictionary documentation (and metadata) so that it's easier for users to see what data are available to them. We've had a series of conversations about how we structure, present, and view the final data products: 
- #2289 
- #1910 
- #1908

In #2289, Jesse suggested that we organize the PUDL tables by suffix. In looking at what kind of categorization we already had, I noticed the `etl_group` flag. This is part of the `class Resource` definition and spans the following categories: 

```
    "eia860",
    "eia861",
    "eia923",
    "entity_eia",
    "epacems",
    "ferc1",
    "ferc1_disabled",
    "ferc714",
    "glue",
    "outputs",
    "static_ferc1",
    "static_eia",
    "static_eia_disabled",
    "eia_bulk_elec",
    "static_pudl",
```

Previously, this was just a string Literal that was defined in the type hints. I turned it into a class of its own, `class ETLGroup` and a dictionary in constants `ETL_GROUPS` so that it would mirror the clear scope and definition of other, similar categories like contributors or licenses. Once I added definitions to all of the `etl_groups`, I pulled them into the metadata, using them to organize the flow of the Data Dictionaries Page. Instead of landing on a page with all the tables and all the columns in alphabetical order, you land on a page that shows you a list of tables by `etl_group` with a definition of each `etl_group`. When you click on a specific table it brings you to the page with the table and column definitions. 

My goal with these changes was to improve user experience while maintaining searchability / abundance. I wanted users to be able to *ctr F* through the page with allllll the column names if they wanted to see where else certain types of data pop up, but I also wanted them to be able to find something specific without having to do that. 

Ideally I would like to have a similar constant/class structure to include definitions for the SQL dbs themselves. This way we can pull and even higher-level description of what's what into the metadata and Datasette.

<!--

Include a short narrative summary of what's going on in the PR. This can be a bulleted list. You might want to include:

* What are you changing and why?
* Are there any known unsolved problems remaining in the PR?
* Is there anything that you want a reivewer to pay particular attention to?
* What kind of feedback are you looking for on the PR?

-->

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
