### PR TITLE
Add jobs for excluding EPA CEMS assets

### DIFF
--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -1,7 +1,14 @@
 """Dagster definitions for the PUDL ETL and Output tables."""
 import importlib
 
-from dagster import Definitions, define_asset_job, load_assets_from_modules
+from dagster import (
+    AssetKey,
+    AssetsDefinition,
+    AssetSelection,
+    Definitions,
+    define_asset_job,
+    load_assets_from_modules,
+)
 
 import pudl
 from pudl.io_managers import (
@@ -46,24 +53,73 @@ default_resources = {
     "epacems_io_manager": epacems_io_manager,
 }
 
+
+def create_non_cems_selection(all_asset: list[AssetsDefinition]) -> AssetSelection:
+    """Create a selection of assets excluding CEMS and all downstream assets.
+
+    Args:
+        all_assets: A list of asset definitions to remove CEMS assets from.
+
+    Returns:
+        An asset selection with all_assets assets excluding CEMS assets.
+    """
+    all_asset_keys = pudl.helpers.get_asset_keys(all_asset)
+    all_selection = AssetSelection.keys(*all_asset_keys)
+
+    cems_selection = AssetSelection.keys(AssetKey("hourly_emissions_epacems"))
+    return all_selection - cems_selection.downstream()
+
+
+def load_dataset_settings_from_file(setting_filename: str) -> dict:
+    """Load dataset settings from a settings file in `pudl.package_data.settings`.
+
+    Args:
+        setting_filename: name of settings file.
+
+    Returns:
+        Dictionary of dataset settings.
+    """
+    return EtlSettings.from_yaml(
+        importlib.resources.path("pudl.package_data.settings", setting_filename)
+    ).datasets.dict()
+
+
 defs = Definitions(
     assets=default_assets,
     resources=default_resources,
     jobs=[
-        define_asset_job(name="etl_full"),
+        define_asset_job(
+            name="etl_full", description="This job executes all years of all assets."
+        ),
+        define_asset_job(
+            name="etl_full_no_cems",
+            selection=create_non_cems_selection(default_assets),
+            description="This job executes all years of all assets except the "
+            "hourly_emissions_epacems asset and all assets downstream.",
+        ),
         define_asset_job(
             name="etl_fast",
             config={
                 "resources": {
                     "dataset_settings": {
-                        "config": EtlSettings.from_yaml(
-                            importlib.resources.path(
-                                "pudl.package_data.settings", "etl_fast.yml"
-                            )
-                        ).datasets.dict()
+                        "config": load_dataset_settings_from_file("etl_fast.yml")
                     }
                 }
             },
+            description="This job executes the most recent year of each asset.",
+        ),
+        define_asset_job(
+            name="etl_fast_no_cems",
+            selection=create_non_cems_selection(default_assets),
+            config={
+                "resources": {
+                    "dataset_settings": {
+                        "config": load_dataset_settings_from_file("etl_fast.yml")
+                    }
+                }
+            },
+            description="This job executes the most recent year of each asset except the "
+            "hourly_emissions_epacems asset and all assets downstream.",
         ),
     ],
 )

--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -54,7 +54,7 @@ default_resources = {
 }
 
 
-def create_non_cems_selection(all_asset: list[AssetsDefinition]) -> AssetSelection:
+def create_non_cems_selection(all_assets: list[AssetsDefinition]) -> AssetSelection:
     """Create a selection of assets excluding CEMS and all downstream assets.
 
     Args:
@@ -63,7 +63,7 @@ def create_non_cems_selection(all_asset: list[AssetsDefinition]) -> AssetSelecti
     Returns:
         An asset selection with all_assets assets excluding CEMS assets.
     """
-    all_asset_keys = pudl.helpers.get_asset_keys(all_asset)
+    all_asset_keys = pudl.helpers.get_asset_keys(all_assets)
     all_selection = AssetSelection.keys(*all_asset_keys)
 
     cems_selection = AssetSelection.keys(AssetKey("hourly_emissions_epacems"))
@@ -80,7 +80,9 @@ def load_dataset_settings_from_file(setting_filename: str) -> dict:
         Dictionary of dataset settings.
     """
     return EtlSettings.from_yaml(
-        importlib.resources.path("pudl.package_data.settings", setting_filename)
+        importlib.resources.path(
+            "pudl.package_data.settings", f"{setting_filename}.yml"
+        )
     ).datasets.dict()
 
 
@@ -102,7 +104,7 @@ defs = Definitions(
             config={
                 "resources": {
                     "dataset_settings": {
-                        "config": load_dataset_settings_from_file("etl_fast.yml")
+                        "config": load_dataset_settings_from_file("etl_fast")
                     }
                 }
             },
@@ -114,7 +116,7 @@ defs = Definitions(
             config={
                 "resources": {
                     "dataset_settings": {
-                        "config": load_dataset_settings_from_file("etl_fast.yml")
+                        "config": load_dataset_settings_from_file("etl_fast")
                     }
                 }
             },

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -23,7 +23,7 @@ import numpy as np
 import pandas as pd
 import requests
 import sqlalchemy as sa
-from dagster import Noneable
+from dagster import AssetKey, AssetsDefinition, Noneable, SourceAsset
 from dagster._config.errors import PostProcessingError
 from pandas._libs.missing import NAType
 
@@ -1599,3 +1599,27 @@ class EnvVar(Noneable):
                     f"Config value could not be found. Set the {self.env_var} environment variable or specify a value in dagster config."
                 )
         return value
+
+
+def get_asset_keys(
+    assets: list[AssetsDefinition], exclude_source_assets: bool = True
+) -> set[AssetKey]:
+    """Get a set of asset keys from a list of asset definitions.
+
+    Args:
+        assets: list of asset definitions.
+        exclude_source_assets: exclude SourceAssets in the returned list.
+                               Some selection operations don't require
+                               SourceAsset keys.
+
+    Returns:
+        A set of asset keys.
+    """
+    asset_keys = set()
+    for asset in assets:
+        if isinstance(asset, SourceAsset):
+            if not exclude_source_assets:
+                asset_keys = asset_keys.union(asset.key)
+        else:
+            asset_keys = asset_keys.union(asset.keys)
+    return asset_keys

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -1609,7 +1609,7 @@ def get_asset_keys(
     Args:
         assets: list of asset definitions.
         exclude_source_assets: exclude SourceAssets in the returned list.
-                               Some selection operations don't require
+                               Some selection operations don't allow
                                SourceAsset keys.
 
     Returns:

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -60,7 +60,7 @@ def get_defaults():
         the ``$HOME/.pudl.yml`` file does not exist, set these paths to None.
     """
     logger.warning(
-        "pudl_settings is being depcrated in favor of environment variables"
+        "pudl_settings is being depcrated in favor of environment variables "
         "PUDL_OUTPUT and PUDL_CACHE"
     )
     settings_file = pathlib.Path.home() / ".pudl.yml"
@@ -105,7 +105,7 @@ def derive_paths(pudl_in, pudl_out):
             read out of the YAML file. Mostly paths for inputs & outputs.
     """
     logger.warning(
-        "pudl_settings is being depcrated in favor of environment variables"
+        "pudl_settings is being depcrated in favor of environment variables "
         "PUDL_OUTPUT and PUDL_CACHE. For more info"
         "see: https://catalystcoop-pudl.readthedocs.io/en/dev/dev/dev_setup.html"
     )

--- a/test/unit/helpers_test.py
+++ b/test/unit/helpers_test.py
@@ -3,9 +3,11 @@
 import numpy as np
 import pandas as pd
 import pytest
+from dagster import AssetKey
 from pandas.testing import assert_frame_equal, assert_series_equal
 from pandas.tseries.offsets import BYearEnd
 
+import pudl
 from pudl.helpers import (
     convert_df_to_excel_file,
     convert_to_date,
@@ -612,3 +614,11 @@ def test_flatten_mix_types():
     """Test if :func:`flatten_list` can flatten an arbitraty list of ints."""
     list1a = ["1", 22, ["333", [4, "5"]], [[666]]]
     assert list(flatten_list(list1a)) == ["1", 22, "333", 4, "5", 666]
+
+
+def test_cems_selection():
+    """Test CEMS asset selection remove cems assets."""
+    cems_selection = pudl.etl.create_non_cems_selection(pudl.etl.default_assets)
+    assert AssetKey("hourly_emissions_epacems") not in cems_selection.resolve(
+        pudl.etl.default_assets
+    ), "hourly_emissions_epacems or downstream asset present in selection."


### PR DESCRIPTION
# PR Overview
I realized we often run the ETL without EPA CEMS so it doesn't take forever. I created two pre-configured jobs that select all assets excluding the `hourly_emissions_epacems` and downstream assets. 

I also made some changes in the `pudl_etl` cli command so users can specify a settings file without epacems. This feels a little janky because the epacems settings are still floating around in the dataset_settings resource even though the assets that depend on epacems settings aren't being used. At some point, it might make sense to remove the dataset_settings resource and just configure the extraction assets directly.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
