### PR TITLE
Parameterize reconstructable jobs to set loglevel

### DIFF
--- a/src/pudl/cli.py
+++ b/src/pudl/cli.py
@@ -151,7 +151,7 @@ def main():
             "process_epacems": process_epacems,
         },
     )
-    execute_job(
+    result = execute_job(
         pudl_etl_reconstructable_job,
         instance=DagsterInstance.get(),
         run_config={
@@ -168,6 +168,12 @@ def main():
             }
         },
     )
+
+    # Workaround to reliably getting full stack trace
+    if not result.success:
+        for event in result.all_events:
+            if event.event_type_value == "STEP_FAILURE":
+                raise Exception(event.event_specific_data.error)
 
 
 if __name__ == "__main__":

--- a/src/pudl/convert/epacems_to_parquet.py
+++ b/src/pudl/convert/epacems_to_parquet.py
@@ -132,7 +132,7 @@ def main():
         "epacems_job_factory",
         reconstructable_kwargs={"loglevel": args.loglevel, "logfile": args.logfile},
     )
-    execute_job(
+    result = execute_job(
         epacems_reconstructable_job,
         instance=DagsterInstance.get(),
         run_config={
@@ -150,6 +150,12 @@ def main():
             }
         },
     )
+
+    # Workaround to reliably getting full stack trace
+    if not result.success:
+        for event in result.all_events:
+            if event.event_type_value == "STEP_FAILURE":
+                raise Exception(event.event_specific_data.error)
 
 
 if __name__ == "__main__":

--- a/src/pudl/convert/epacems_to_parquet.py
+++ b/src/pudl/convert/epacems_to_parquet.py
@@ -9,13 +9,15 @@ available on your system.
 """
 import argparse
 import sys
+from collections.abc import Callable
 
 from dagster import (
     DagsterInstance,
     Definitions,
+    JobDefinition,
+    build_reconstructable_job,
     define_asset_job,
     execute_job,
-    reconstructable,
 )
 from dotenv import load_dotenv
 
@@ -91,27 +93,47 @@ def parse_command_line(argv):
     return arguments
 
 
-def get_epacems_job():
-    """Create an epacems_job wrapped by to be wrapped by reconstructable."""
-    return Definitions(
-        assets=pudl.etl.default_assets,
-        resources=pudl.etl.default_resources,
-        jobs=[define_asset_job("epacems_job", selection="hourly_emissions_epacems")],
-    ).get_job_def("epacems_job")
+def epacems_job_factory(loglevel: str, logfile: str) -> Callable[[], JobDefinition]:
+    """Factory for parameterizing a reconstructable epacems job.
+
+    Args:
+        loglevel: The log level for the job's execution.
+        logfile: Path to a log file for the job's execution.
+
+    Returns:
+        The job definition to be executed.
+    """
+
+    def get_epacems_job():
+        """Create an epacems_job wrapped by to be wrapped by reconstructable."""
+        pudl.logging_helpers.configure_root_logger(logfile=logfile, loglevel=loglevel)
+        return Definitions(
+            assets=pudl.etl.default_assets,
+            resources=pudl.etl.default_resources,
+            jobs=[
+                define_asset_job("epacems_job", selection="hourly_emissions_epacems")
+            ],
+        ).get_job_def("epacems_job")
+
+    return get_epacems_job
 
 
 def main():
     """Convert zipped EPA CEMS Hourly data to Apache Parquet format."""
     load_dotenv()
     args = parse_command_line(sys.argv)
-
     # Display logged output from the PUDL package:
     pudl.logging_helpers.configure_root_logger(
         logfile=args.logfile, loglevel=args.loglevel
     )
 
+    epacems_reconstructable_job = build_reconstructable_job(
+        "pudl.convert.epacems_to_parquet",
+        "epacems_job_factory",
+        reconstructable_kwargs={"loglevel": args.loglevel, "logfile": args.logfile},
+    )
     execute_job(
-        reconstructable(get_epacems_job),
+        epacems_reconstructable_job,
         instance=DagsterInstance.get(),
         run_config={
             "resources": {

--- a/src/pudl/extract/ferc1.py
+++ b/src/pudl/extract/ferc1.py
@@ -635,7 +635,7 @@ def get_raw_df(
             default_value=None,
         ),
         "clobber": Field(
-            bool, description="Clobber existing ferc1 database.", default_value=True
+            bool, description="Clobber existing ferc1 database.", default_value=False
         ),
     },
     required_resource_keys={"ferc_to_sqlite_settings", "datastore"},

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -106,7 +106,7 @@ def _get_sqlite_engine(
             default_value=None,
         ),
         "clobber": Field(
-            bool, description="Clobber existing ferc1 database.", default_value=True
+            bool, description="Clobber existing ferc1 database.", default_value=False
         ),
         "workers": Field(
             Noneable(int),

--- a/src/pudl/ferc_to_sqlite/cli.py
+++ b/src/pudl/ferc_to_sqlite/cli.py
@@ -138,7 +138,7 @@ def main():  # noqa: C901
         reconstructable_kwargs={"loglevel": args.loglevel, "logfile": args.logfile},
     )
 
-    execute_job(
+    result = execute_job(
         ferc_to_sqlite_reconstructable_job,
         instance=DagsterInstance.get(),
         run_config={
@@ -170,6 +170,12 @@ def main():  # noqa: C901
         },
         raise_on_error=True,
     )
+
+    # Workaround to reliably getting full stack trace
+    if not result.success:
+        for event in result.all_events:
+            if event.event_type_value == "STEP_FAILURE":
+                raise Exception(event.event_specific_data.error)
 
 
 if __name__ == "__main__":

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,10 +14,10 @@ from ferc_xbrl_extractor import xbrl
 
 import pudl
 from pudl import resources
-from pudl.cli import get_etl_job
+from pudl.cli import pudl_etl_job_factory
 from pudl.extract.ferc1 import xbrl_metadata_json
 from pudl.extract.xbrl import FercXbrlDatastore, _get_sqlite_engine
-from pudl.ferc_to_sqlite.cli import get_ferc_to_sqlite_job
+from pudl.ferc_to_sqlite.cli import ferc_to_sqlite_job_factory
 from pudl.io_managers import (
     ferc1_dbf_sqlite_io_manager,
     ferc1_xbrl_sqlite_io_manager,
@@ -214,7 +214,7 @@ def ferc_to_sqlite(live_dbs, pudl_datastore_config, etl_settings):
     existing databases
     """
     if not live_dbs:
-        get_ferc_to_sqlite_job().execute_in_process(
+        ferc_to_sqlite_job_factory()().execute_in_process(
             run_config={
                 "resources": {
                     "ferc_to_sqlite_settings": {
@@ -321,7 +321,7 @@ def pudl_sql_io_manager(
     logger.info("setting up the pudl_engine fixture")
     if not live_dbs:
         # Run the ETL and generate a new PUDL SQLite DB for testing:
-        get_etl_job().execute_in_process(
+        pudl_etl_job_factory()().execute_in_process(
             run_config={
                 "resources": {
                     "dataset_settings": {


### PR DESCRIPTION
# PR Overview

I noticed the `--loglevel` flag wasn't working for the CLI commands that execute dagster jobs. I couldn't find anything in the documentation about set log levels when running jobs using `execute_job`. I played around with where to set the log level and for some reason, settings the log level in the job functions works. [`dagster.reconstructable()`](https://docs.dagster.io/_apidocs/execution#dagster.reconstructable) didn't let me parameterize the job function so I had to use this confusing function called [`dagster.build_reconstructable_job()`](https://docs.dagster.io/_apidocs/jobs#dagster.build_reconstructable_job). This is working but when there are failures **it occasionally will not show the full stack trace...** it just says an asset or op failed. I'm chatting with someone on the dagster slack to figure out what's going on here.

The logging and stack trace issues don't happen when using `execute_in_process()` or the `dagster job execute`cli commands. 

`build_reconstructable_job` and `reconstructable` are still experimental so we might not want to rely on them. Alternatives include 
- Calling `dagster job execute` from a python script which feels janky
- Use execute_in_process() but then we lose out on parallelism
- Set the default loglevel to DEBUG for now


# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
