### PR TITLE
Make nightly build message a little cleaner.

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -72,7 +72,7 @@ function notify_slack() {
     # Notify pudl-builds slack channel of deployment status
     if [ $1 = "success" ]; then
         message=":large_green_circle: :sunglasses: :unicorn_face: :rainbow: The deployment succeeded!! :partygritty: :database_parrot: :blob-dance: :large_green_circle:\n\n "
-        message+="[Make a PR for ${GITHUB_REF} into `main`](https://github.com/catalyst-cooperative/pudl/compare/main...${GITHUB_REF})"
+        message+='Make a PR for `${GITHUB_REF}` into `main`: https://github.com/catalyst-cooperative/pudl/compare/main...${GITHUB_REF}\n\n'
     elif [ $1 = "failure" ]; then
         message=":large_red_square: Oh bummer the deployment failed ::fiiiiine: :sob: :cry_spin:\n\n "
     else


### PR DESCRIPTION
I forgot to do this before merging the nightly build stuff. But this is the easiest way for us to "make PRs into `main` from `dev` when nightly builds pass." Anything more than this requires pushing GH access into the ETL VM, etc.