### PR TITLE
Fix inconsistently reported leading zeros in EIA boiler id

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -43,6 +43,15 @@ Data Coverage
   :ref:`boilers_entity_eia` table now includes static boiler attributes. See issue
   :issue:`1162` & PR :pr:`2319`.
 
+Data Cleaning
+^^^^^^^^^^^^^
+
+* Removed inconsistently reported leading zeroes from numeric ``boiler_id`` values. This
+  affected a small number of records in any table referring to boilers, including
+  :ref:`boilers_entity_eia`, :ref:`boilers_eia860`, :ref:`boiler_fuel_eia923`,
+  :ref:`boiler_generator_assn_eia860` and the :ref:`epacamd_eia` crosswalk. It also had
+  some minor downstream effects on the MCOE outputs. See :issue:`2366` and :pr:`2367`.
+
 Analysis
 ^^^^^^^^
 

--- a/src/pudl/extract/eia860.py
+++ b/src/pudl/extract/eia860.py
@@ -40,10 +40,9 @@ class Extractor(excel.GenericExtractor):
             df["report_year"] = list(partition.values())[0]
         self.cols_added = ["report_year"]
         # Eventually we should probably make this a transform
-        if "generator_id" in df.columns:
-            df = remove_leading_zeros_from_numeric_strings(
-                df=df, col_name="generator_id"
-            )
+        for col in ["generator_id", "boiler_id"]:
+            if col in df.columns:
+                df = remove_leading_zeros_from_numeric_strings(df=df, col_name=col)
         df = self.add_data_maturity(df, page, **partition)
         return df
 

--- a/src/pudl/extract/eia860m.py
+++ b/src/pudl/extract/eia860m.py
@@ -47,10 +47,9 @@ class Extractor(excel.GenericExtractor):
         df = self.add_data_maturity(df, page, **partition)
         self.cols_added.append("report_year")
         # Eventually we should probably make this a transform
-        if "generator_id" in df.columns:
-            df = remove_leading_zeros_from_numeric_strings(
-                df=df, col_name="generator_id"
-            )
+        for col in ["generator_id", "boiler_id"]:
+            if col in df.columns:
+                df = remove_leading_zeros_from_numeric_strings(df=df, col_name=col)
         return df
 
     def extract(self, settings: Eia860Settings = Eia860Settings()):

--- a/src/pudl/extract/eia861.py
+++ b/src/pudl/extract/eia861.py
@@ -46,10 +46,9 @@ class Extractor(excel.GenericExtractor):
         )
         self.cols_added = []
         # Eventually we should probably make this a transform
-        if "generator_id" in df.columns:
-            df = remove_leading_zeros_from_numeric_strings(
-                df=df, col_name="generator_id"
-            )
+        for col in ["generator_id", "boiler_id"]:
+            if col in df.columns:
+                df = remove_leading_zeros_from_numeric_strings(df=df, col_name=col)
         df = self.add_data_maturity(df, page, **partition)
         return df
 

--- a/src/pudl/extract/eia923.py
+++ b/src/pudl/extract/eia923.py
@@ -41,10 +41,10 @@ class Extractor(excel.GenericExtractor):
         df = df.rename(columns=self._metadata.get_column_map(page, **partition))
         self.cols_added = []
         # Eventually we should probably make this a transform
-        if "generator_id" in df.columns:
-            df = remove_leading_zeros_from_numeric_strings(
-                df=df, col_name="generator_id"
-            )
+        for col in ["generator_id", "boiler_id"]:
+            if col in df.columns:
+                df = remove_leading_zeros_from_numeric_strings(df=df, col_name=col)
+        df = self.add_data_maturity(df, page, **partition)
         # the 2021 early release data had some ding dang "."'s and nulls in the year column
         if "report_year" in df.columns:
             mask = (df.report_year == ".") | df.report_year.isnull()

--- a/src/pudl/glue/epacamd_eia.py
+++ b/src/pudl/glue/epacamd_eia.py
@@ -112,6 +112,7 @@ def transform(
         .rename(columns=column_rename)
         .filter(list(column_rename.values()))
         .pipe(remove_leading_zeros_from_numeric_strings, col_name="generator_id")
+        .pipe(remove_leading_zeros_from_numeric_strings, col_name="boiler_id")
         .pipe(
             remove_leading_zeros_from_numeric_strings, col_name="emissions_unit_id_epa"
         )

--- a/src/pudl/settings.py
+++ b/src/pudl/settings.py
@@ -428,7 +428,7 @@ class DatasetsSettings(BaseModel):
         datasets_in_datastore_format = {
             name: setting
             for (name, setting) in datasets_settings.items()
-            if name in ds.get_known_datasets()
+            if name in ds.get_known_datasets() and setting is not None
         }
         # add the eia datasets that are nested inside of the eia settings
         if datasets_settings.get("eia", False):

--- a/test/validate/eia_test.py
+++ b/test/validate/eia_test.py
@@ -41,9 +41,9 @@ def test_no_null_cols_eia(pudl_out_eia, live_dbs, cols, df_name):
 @pytest.mark.parametrize(
     "df_name,raw_rows,monthly_rows,annual_rows",
     [
-        ("bf_eia923", 1_415_328, 1_415_328, 118_558),
-        ("bga_eia860", 129_869, 129_869, 129_869),
-        ("boil_eia860", 74_146, 74_146, 74_146),
+        ("bf_eia923", 1_415_040, 1_415_040, 118_534),
+        ("bga_eia860", 130_326, 130_326, 130_326),
+        ("boil_eia860", 74_090, 74_090, 74_090),
         ("frc_eia923", 597_000, 244_415, 24_065),
         ("gen_eia923", None, 5_171_497, 432_570),
         ("gens_eia860", 523_563, 523_563, 523_563),

--- a/test/validate/mcoe_test.py
+++ b/test/validate/mcoe_test.py
@@ -113,9 +113,9 @@ def test_no_null_rows_mcoe(pudl_out_mcoe, live_dbs, df_name, thresh):
 @pytest.mark.parametrize(
     "df_name,monthly_rows,annual_rows",
     [
-        ("hr_by_unit", 362_011, 30_309),
-        ("hr_by_gen", 554_665, 46_370),
-        ("fuel_cost", 554_665, 46_370),
+        ("hr_by_unit", 362_383, 30_340),
+        ("hr_by_gen", 555_121, 46_408),
+        ("fuel_cost", 555_121, 46_408),
         ("capacity_factor", 5_171_497, 432_570),
         ("mcoe", 5_171_881, 432_602),
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -121,6 +121,19 @@ extras =
 commands =
     pytest {tty:--color=yes}  {posargs} {[testenv]covargs} test/integration
 
+[testenv:minmax_rows]
+description = Check that all outputs have the expected number of rows.
+skip_install = false
+recreate = true
+extras =
+    test
+commands =
+    pytest {tty:--color=yes} --live-dbs \
+      test/validate/epacamd_eia_test.py::test_minmax_rows \
+      test/validate/ferc1_test.py::test_minmax_rows \
+      test/validate/eia_test.py::test_minmax_rows \
+      test/validate/mcoe_test.py::test_minmax_rows_mcoe
+
 [testenv:validate]
 description = Run all data validation tests. This requires a complete PUDL DB.
 skip_install = false


### PR DESCRIPTION
# PR Overview

See #2366 for a description of the problem.

This (Draft) PR simply applies the same solution to `boiler_id` that we were already applying to `generator_id` in the extract phase of the EIA 860, 860m, 861, and 923 data.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [x] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
- [x] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- ~Make sure you've included good docstrings.~
- ~Include unit tests for new functions and classes.~
- ~Defensive data quality/sanity checks in analyses & data processing functions.~

Closes #2366 