### PR TITLE
Reorder PK of boilers_eia860 to group data like other tables

### DIFF
--- a/src/pudl/metadata/resources/eia860.py
+++ b/src/pudl/metadata/resources/eia860.py
@@ -8,8 +8,8 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         ),
         "schema": {
             "fields": [
-                "boiler_id",
                 "plant_id_eia",
+                "boiler_id",
                 "report_date",
                 "boiler_operating_date",
                 "boiler_status",
@@ -100,9 +100,9 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "standard_so2_percent_scrubbed",
                 "data_maturity",
             ],
-            "primary_key": ["boiler_id", "plant_id_eia", "report_date"],
+            "primary_key": ["plant_id_eia", "boiler_id", "report_date"],
             "foreign_key_rules": {
-                "fields": [["boiler_id", "plant_id_eia", "report_date"]],
+                "fields": [["plant_id_eia", "boiler_id", "report_date"]],
                 # TODO: Excluding monthly data tables since their report_date
                 # values don't match up with generators_eia860, which is annual,
                 # so non-january records violate the constraint.


### PR DESCRIPTION
# PR Overview

By default the data is ordered by primary key in the DB, and the current ordering means that all boilers with the same boiler ID are grouped together, rather than all boilers within a given plant being grouped together, as is the case with generator ID.  I think it's more likely that folks would like to see all the boilers that are part of a given plant, than all plants that happen to have a boiler with ID "A1". Check out [`boilers_eia860` on our Datasette](https://data.catalyst.coop/pudl/boilers_eia860) to see what it looks like now.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
