### PR TITLE
Automatically clobber database if schema has changed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=[
         "addfips>=0.4,<0.5",
+        "alembic>=1.9.4<2",
         "catalystcoop.dbfread>=3.0,<3.1",
         "coloredlogs>=14.0,<15.1",  # Dagster requires 14.0
         "catalystcoop.ferc-xbrl-extractor==0.8.1",

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     setup_requires=["setuptools_scm"],
     install_requires=[
         "addfips>=0.4,<0.5",
-        "alembic>=1.9.4<2",
+        "alembic>=1.9.4,<2",
         "catalystcoop.dbfread>=3.0,<3.1",
         "coloredlogs>=14.0,<15.1",  # Dagster requires 14.0
         "catalystcoop.ferc-xbrl-extractor==0.8.1",

--- a/src/pudl/cli.py
+++ b/src/pudl/cli.py
@@ -71,6 +71,12 @@ def parse_command_line(argv):
         default=False,
         help="If set, output epacems year-state partitioned Parquet files",
     )
+    parser.add_argument(
+        "--clobber",
+        action="store_true",
+        default=False,
+        help="Remove the existing pudl.sqlite DB if the schema is different from what we expect.",
+    )
     arguments = parser.parse_args(argv[1:])
     return arguments
 
@@ -171,6 +177,7 @@ def main():
                         else "",
                     },
                 },
+                "pudl_sqlite_io_manager": {"config": {"clobber": args.clobber}},
             },
             "ops": {
                 "hourly_emissions_epacems": {

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -94,7 +94,7 @@ class SQLiteIOManager(IOManager):
         self,
         base_dir: str,
         db_name: str,
-        md: sa.MetaData = None,
+        md: sa.MetaData | None = None,
     ):
         """Init a SQLiteIOmanager.
 
@@ -119,9 +119,9 @@ class SQLiteIOManager(IOManager):
             )
 
         # If no metadata is specified, create an empty sqlalchemy metadata object.
+        if md is None:
+            md = sa.MetaData()
         self.md = md
-        if not self.md:
-            self.md = sa.MetaData()
 
         self.engine = self._setup_database()
 


### PR DESCRIPTION
Since we are instantiating one `pudl_sqlite_io_manager` per process, we need to make sure that they don't step on each others' toes when trying to clobber.

SQLite only allows one write transaction at a time, which is a convenient way to fix this, but the write transactions aren't implemented correctly in `pysqlite` - hence the workaround in this PR.

Currently the schemas aren't actually getting written, which is surprising! As in you can run the ETL and then open the `pudl.sqlite` via the `sqlite3` CLI tool to see an empty result after running `.schema.`