### PR TITLE
Bump allowed range of Dagster versions to >=1.1,<1.3

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -99,7 +99,7 @@ repos:
 
   # Check for known security vulnerabilities:
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.4
+    rev: 1.7.5
     hooks:
       - id: bandit
         args: ["--configfile", ".bandit.yml"]

--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,8 @@ setup(
         "catalystcoop.ferc-xbrl-extractor==0.8.1",
         "dask>=2021.8,<2023.3.1",
         "datapackage>=1.11,<1.16",  # Transition datastore to use frictionless.
-        "dagster~=1.1.13",
-        "dagit~=1.1.13",
+        "dagster>=1.1,<1.3",
+        "dagit>=1.1,<1.3",
         # "email-validator>=1.0.3",  # pydantic[email] dependency
         "fsspec>=2021.7,<2023.3.1",  # For caching datastore on GCS
         "gcsfs>=2021.7,<2023.3.1",  # For caching datastore on GCS

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -153,7 +153,7 @@ def find_foreign_key_errors(dfs: dict[str, pd.DataFrame]) -> list[dict[str, Any]
     return errors
 
 
-def download_zip_url(url, save_path, chunk_size=128):
+def download_zip_url(url, save_path, chunk_size=128, timeout=9.05):
     """Download and save a Zipfile locally.
 
     Useful for acquiring and storing non-PUDL data locally.
@@ -175,7 +175,7 @@ def download_zip_url(url, save_path, chunk_size=128):
         "Connection": "keep-alive",
         "Upgrade-Insecure-Requests": "1",
     }
-    r = requests.get(url, stream=True, headers=headers)
+    r = requests.get(url, stream=True, headers=headers, timeout=timeout)
     with save_path.open(mode="wb") as fd:
         for chunk in r.iter_content(chunk_size=chunk_size):
             fd.write(chunk)

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -528,7 +528,7 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
                     SELECT {table_name}.*, {id_table}.report_year FROM {table_name}
                     JOIN {id_table} ON {id_table}.filing_name = {table_name}.filing_name
                     WHERE {id_table}.report_year BETWEEN :min_year AND :max_year;
-                    """,
+                    """,  # nosec: B608
                 con=con,
                 params={
                     "min_year": min(ferc1_settings.xbrl_years),


### PR DESCRIPTION
# PR Overview

* I ran the full ETL locally with the new version of Dagster (it's so fast!) and it passed fine. I think it also makes the asset graph more readable.
* Also pulled in the `bandit` fixes.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
