### PR TITLE
Move `--no-sign-request` to the end of the command in the nightly_data_build docs

### DIFF
--- a/docs/dev/nightly_data_builds.rst
+++ b/docs/dev/nightly_data_builds.rst
@@ -178,14 +178,14 @@ the Unix ``cp`` command:
 
 .. code::
 
-   aws s3 cp --no-sign-request s3://intake.catalyst.coop/dev/pudl.sqlite ./
+   aws s3 cp s3://intake.catalyst.coop/dev/pudl.sqlite ./ --no-sign-request
 
 If you wanted to download all of the build outputs (more than 10GB!) you could use ``cp
 --recursive`` flag on the whole directory:
 
 .. code::
 
-   aws s3 cp --no-sign-request --recursive s3://intake.catalyst.coop/dev/ ./
+   aws s3 cp --recursive s3://intake.catalyst.coop/dev/ ./ --no-sign-request
 
 For more details on how to use ``aws`` in general see the
 `online documentation <https://docs.aws.amazon.com/cli/latest/reference/s3/>`__ or run:


### PR DESCRIPTION
# PR Overview

Very small docs change that puts the `--no-sign-request` flag at the end of the command in the `nightly_data_builds.rst` docs page. The command wasn't working with the flag at the beginning.

Went from:

```
aws s3 cp --no-sign-request s3://intake.catalyst.coop/dev/pudl.sqlite ./ 

aws s3 cp --no-sign-request --recursive s3://intake.catalyst.coop/dev/ ./
```
to:
```
aws s3 cp s3://intake.catalyst.coop/dev/pudl.sqlite ./ --no-sign-request

aws s3 cp --recursive s3://intake.catalyst.coop/dev/ ./ --no-sign-request

```

