### PR TITLE
Rename electric_opex_ferc1 table electric_operating_expenses_ferc1

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -33,7 +33,7 @@ Data Coverage
     :pr:`2119`.
   * :ref:`electric_plant_depreciation_functional_ferc1` see issue :issue:`1808` & PR
     :pr:`2183`
-  * :ref:`electric_opex_ferc1`, see issue :issue:`1817` & PR :pr:`2162`.
+  * :ref:`electric_operating_expenses_ferc1`, see issue :issue:`1817` & PR :pr:`2162`.
   * :ref:`retained_earnings_ferc1`, see issue :issue:`1811` & PR :pr:`2155`.
   * :ref:`cash_flow_ferc1`, see issue :issue:`1821` & PR :pr:`2184`
   * :ref:`electricity_sales_by_rate_schedule_ferc1`, see issue :issue:`1823` & PR

--- a/src/pudl/extract/ferc1.py
+++ b/src/pudl/extract/ferc1.py
@@ -131,7 +131,7 @@ TABLE_NAME_MAP_FERC1: dict[str, dict[str, str]] = {
         "dbf": "f1_xmssn_line",
         "xbrl": "transmission_line_statistics_422",
     },
-    "electric_opex_ferc1": {
+    "electric_operating_expenses_ferc1": {
         "dbf": "f1_elc_op_mnt_expn",
         "xbrl": "electric_operations_and_maintenance_expenses_320",
     },

--- a/src/pudl/metadata/resources/ferc1.py
+++ b/src/pudl/metadata/resources/ferc1.py
@@ -149,7 +149,7 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "etl_group": "ferc1",
         "field_namespace": "ferc1",
     },
-    "electric_opex_ferc1": {
+    "electric_operating_expenses_ferc1": {
         "description": (
             "Operating and maintenance costs associated with producing electricty, "
             "reported in Schedule 320 of FERC Form 1."

--- a/src/pudl/package_data/settings/etl_fast.yml
+++ b/src/pudl/package_data/settings/etl_fast.yml
@@ -132,7 +132,7 @@ datasets:
       - transmission_statistics_ferc1
       - electric_energy_sources_ferc1
       - electric_energy_dispositions_ferc1
-      - electric_opex_ferc1
+      - electric_operating_expenses_ferc1
       - utility_plant_summary_ferc1
       - balance_sheet_liabilities_ferc1
       - depreciation_amortization_summary_ferc1

--- a/src/pudl/package_data/settings/etl_full.yml
+++ b/src/pudl/package_data/settings/etl_full.yml
@@ -561,7 +561,7 @@ datasets:
       - electric_energy_sources_ferc1
       - electric_energy_dispositions_ferc1
       - utility_plant_summary_ferc1
-      - electric_opex_ferc1
+      - electric_operating_expenses_ferc1
       - balance_sheet_liabilities_ferc1
       - depreciation_amortization_summary_ferc1
       - balance_sheet_assets_ferc1

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -72,7 +72,7 @@ class TableIdFerc1(enum.Enum):
     ELECTRIC_ENERGY_SOURCES_FERC1 = "electric_energy_sources_ferc1"
     ELECTRIC_ENERGY_DISPOSITIONS_FERC1 = "electric_energy_dispositions_ferc1"
     UTILITY_PLANT_SUMMARY_FERC1 = "utility_plant_summary_ferc1"
-    ELECTRIC_OPEX_FERC1 = "electric_opex_ferc1"
+    ELECTRIC_OPERATING_EXPENSES_FERC1 = "electric_operating_expenses_ferc1"
     BALANCE_SHEET_LIABILITIES = "balance_sheet_liabilities_ferc1"
     DEPRECIATION_AMORTIZATION_SUMMARY_FERC1 = "depreciation_amortization_summary_ferc1"
     BALANCE_SHEET_ASSETS_FERC1 = "balance_sheet_assets_ferc1"
@@ -3480,10 +3480,10 @@ class ElectricPlantDepreciationFunctionalFerc1TableTransformer(
         return df
 
 
-class ElectricOpexFerc1TableTransformer(Ferc1AbstractTableTransformer):
-    """Transformer class for :ref:`electric_opex_ferc1` table."""
+class ElectricOperatingExpensesFerc1TableTransformer(Ferc1AbstractTableTransformer):
+    """Transformer class for :ref:`electric_operating_expenses_ferc1` table."""
 
-    table_id: TableIdFerc1 = TableIdFerc1.ELECTRIC_OPEX_FERC1
+    table_id: TableIdFerc1 = TableIdFerc1.ELECTRIC_OPERATING_EXPENSES_FERC1
     has_unique_record_ids: bool = False
 
     def targeted_drop_duplicates_dbf(self, raw_df: pd.DataFrame) -> pd.DataFrame:
@@ -3742,7 +3742,7 @@ def transform(
         "electric_energy_sources_ferc1": ElectricEnergySourcesFerc1TableTransformer,
         "electric_energy_dispositions_ferc1": ElectricEnergyDispositionsFerc1TableTransformer,
         "utility_plant_summary_ferc1": UtilityPlantSummaryFerc1TableTransformer,
-        "electric_opex_ferc1": ElectricOpexFerc1TableTransformer,
+        "electric_operating_expenses_ferc1": ElectricOperatingExpensesFerc1TableTransformer,
         "balance_sheet_liabilities_ferc1": BalanceSheetLiabilitiesFerc1TableTransformer,
         "depreciation_amortization_summary_ferc1": DepreciationAmortizationSummaryFerc1TableTransformer,
         "balance_sheet_assets_ferc1": BalanceSheetAssetsFerc1TableTransformer,

--- a/src/pudl/transform/params/ferc1.py
+++ b/src/pudl/transform/params/ferc1.py
@@ -4162,7 +4162,7 @@ TRANSFORM_PARAMS = {
             "on": "amount_type",
         },
     },
-    "electric_opex_ferc1": {
+    "electric_operating_expenses_ferc1": {
         "rename_columns_ferc1": {
             "dbf": {
                 "columns": {
@@ -4380,7 +4380,7 @@ TRANSFORM_PARAMS = {
         },
         "drop_duplicate_rows_dbf": {
             "data_columns": ["expense"],
-            "table_name": "electric_opex_ferc1",
+            "table_name": "electric_operating_expenses_ferc1",
         },
         "merge_xbrl_metadata": {
             "rename_columns": {"xbrl_factoid": "expense_type"},

--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -30,7 +30,7 @@ non_unique_record_id_tables = [
     "depreciation_amortization_summary_ferc1",
     "electric_plant_depreciation_changes_ferc1",
     "electric_plant_depreciation_functional_ferc1",
-    "electric_opex_ferc1",
+    "electric_operating_expenses_ferc1",
     "cash_flow_ferc1",
     "retained_earnings_ferc1",
     "electric_operating_revenues_ferc1",


### PR DESCRIPTION
# PR Overview

I made this name change because there's a directly analogous `electric_operating_revenues_ferc1` table that has also been integrated into PUDL, and the difference in naming made it less clear that they were a matched pair. We've also kept full names for pretty much all of the other FERC 1 tables.

This is a tiny lower priority thing, but it seemed better to get the name change in before we release a new version.

Closes #2370

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] ~Make sure you've included good docstrings.~
- [ ] ~For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)~
- [ ] ~Include unit tests for new functions and classes.~
- [ ] ~Defensive data quality/sanity checks in analyses & data processing functions.~
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
