### PR TITLE
Dagster filter table schemas

### DIFF
--- a/src/pudl/cli.py
+++ b/src/pudl/cli.py
@@ -123,7 +123,7 @@ def main():
 
     etl_settings = EtlSettings.from_yaml(args.settings_file)
 
-    if (not os.getenv("PUDL_OUT")) or (not os.getenv("PUDL_CACHE")):
+    if (not os.getenv("PUDL_OUTPUT")) or (not os.getenv("PUDL_CACHE")):
         logger.warning(
             "PUDL will attempt to use legacy settings to derive paths."
             "In the future this functionality will be deprecated in favor"

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -153,7 +153,7 @@ def find_foreign_key_errors(dfs: dict[str, pd.DataFrame]) -> list[dict[str, Any]
     return errors
 
 
-def download_zip_url(url, save_path, chunk_size=128):
+def download_zip_url(url, save_path, chunk_size=128, timeout=9.05):
     """Download and save a Zipfile locally.
 
     Useful for acquiring and storing non-PUDL data locally.
@@ -162,6 +162,8 @@ def download_zip_url(url, save_path, chunk_size=128):
         url (str): The URL from which to download the Zipfile
         save_path (pathlib.Path): The location to save the file.
         chunk_size (int): Data chunk in bytes to use while downloading.
+        timeout (float): the amount of time we wait for the server to open a
+            connection. See https://requests.readthedocs.io/en/latest/user/advanced/#timeouts
 
     Returns:
         None
@@ -175,7 +177,7 @@ def download_zip_url(url, save_path, chunk_size=128):
         "Connection": "keep-alive",
         "Upgrade-Insecure-Requests": "1",
     }
-    r = requests.get(url, stream=True, headers=headers)
+    r = requests.get(url, stream=True, headers=headers, timeout=timeout)
     with save_path.open(mode="wb") as fd:
         for chunk in r.iter_content(chunk_size=chunk_size):
             fd.write(chunk)

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -531,7 +531,7 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
 
         sched_table_name = re.sub("_instant|_duration", "", table_name)
         with engine.connect() as con:
-            return pd.read_sql(  # nosec B608:hardcoded_sql_expressions
+            return pd.read_sql(
                 f"""
                 SELECT {table_name}.*, {id_table}.report_year FROM {table_name}
                 JOIN {id_table} ON {id_table}.filing_name = {table_name}.filing_name

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -371,7 +371,15 @@ class SQLiteIOManager(IOManager):
 def pudl_sqlite_io_manager(init_context) -> SQLiteIOManager:
     """Create a SQLiteManager dagster resource for the pudl database."""
     base_dir = init_context.resource_config["pudl_output_path"]
-    md = Package.from_resource_ids().to_sql()
+    md = Package.from_resource_ids(
+        excluded_etl_groups=(
+            "ferc714",
+            "static_eia_disabled",
+            "epacems",
+            "outputs",
+            "ferc1_disabled",
+        )
+    ).to_sql()
     return SQLiteIOManager(base_dir=base_dir, db_name="pudl", md=md)
 
 

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -533,10 +533,10 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
         with engine.connect() as con:
             return pd.read_sql(
                 f"""
-                    SELECT {table_name}.*, {id_table}.report_year FROM {table_name}
-                    JOIN {id_table} ON {id_table}.filing_name = {table_name}.filing_name
-                    WHERE {id_table}.report_year BETWEEN :min_year AND :max_year;
-                    """,
+                SELECT {table_name}.*, {id_table}.report_year FROM {table_name}
+                JOIN {id_table} ON {id_table}.filing_name = {table_name}.filing_name
+                WHERE {id_table}.report_year BETWEEN :min_year AND :max_year;
+                """,  # nosec: B608 - table names not supplied by user
                 con=con,
                 params={
                     "min_year": min(ferc1_settings.xbrl_years),

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -531,7 +531,7 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
 
         sched_table_name = re.sub("_instant|_duration", "", table_name)
         with engine.connect() as con:
-            return pd.read_sql(
+            return pd.read_sql(  # nosec B608:hardcoded_sql_expressions
                 f"""
                 SELECT {table_name}.*, {id_table}.report_year FROM {table_name}
                 JOIN {id_table} ON {id_table}.filing_name = {table_name}.filing_name

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1761,7 +1761,7 @@ class Package(Base):
         cls,
         resource_ids: tuple[str] = tuple(sorted(RESOURCE_METADATA)),
         resolve_foreign_keys: bool = False,
-        excluded_etl_groups: tuple[str] = None,
+        excluded_etl_groups: tuple[str] = (),
     ) -> "Package":
         """Construct a collection of Resources from PUDL identifiers (`resource.name`).
 

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1761,6 +1761,7 @@ class Package(Base):
         cls,
         resource_ids: tuple[str] = tuple(sorted(RESOURCE_METADATA)),
         resolve_foreign_keys: bool = False,
+        excluded_etl_groups: tuple[str] = None,
     ) -> "Package":
         """Construct a collection of Resources from PUDL identifiers (`resource.name`).
 
@@ -1777,6 +1778,8 @@ class Package(Base):
                 return value caching through lru_cache.
             resolve_foreign_keys: Whether to add resources as needed based on
                 foreign keys.
+            excluded_etl_groups: Collection of ETL groups used to filter resources
+                out of Package.
         """
         resources = [Resource.dict_from_id(x) for x in resource_ids]
         if resolve_foreign_keys:
@@ -1792,6 +1795,13 @@ class Package(Base):
                 i = len(resources)
                 if len(names) > i:
                     resources += [Resource.dict_from_id(x) for x in names[i:]]
+
+        if excluded_etl_groups:
+            resources = [
+                resource
+                for resource in resources
+                if resource["etl_group"] not in excluded_etl_groups
+            ]
 
         return cls(name="pudl", resources=resources)
 


### PR DESCRIPTION
This PR handles filtering tables out of the `pudl.sqlite` schema that should not be included, as discussed in #2294. It does this by adding the ability to exclude `etl_groups` when constructing a `Package`.
