### PR TITLE
Rename check_pudl_fks to pudl_check_fks to align w/ other CLI names

### DIFF
--- a/docs/dev/run_the_etl.rst
+++ b/docs/dev/run_the_etl.rst
@@ -414,4 +414,4 @@ has been loaded into the database. To check the constraints, run:
 
 .. code-block:: console
 
-   $ check_pudl_fks
+   $ pudl_check_fks

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ setup(
             # See https://github.com/catalyst-cooperative/pudl/issues/1174
             # "pudl_territories = pudl.analysis.service_territory:main",
             "state_demand = pudl.analysis.state_demand:main",
-            "check_pudl_fks = pudl.etl.check_foreign_keys:main",
+            "pudl_check_fks = pudl.etl.check_foreign_keys:main",
         ]
     },
 )

--- a/src/pudl/etl/check_foreign_keys.py
+++ b/src/pudl/etl/check_foreign_keys.py
@@ -8,7 +8,7 @@ foreign key constraints.
 Foreign key constraings on ``pudl.sqlite`` are disabled so dagster can load tables
 into the database without a foreign key error being raised. However, foreign key
 constraints can be evaluated after all of the data has been loaded into the database.
-To check the constraints, run the ``check_pudl_fks`` cli command once the data
+To check the constraints, run the ``pudl_check_fks`` cli command once the data
 has been loaded into ``pudl.sqlite``.
 """
 import argparse


### PR DESCRIPTION
# PR Overview

Renamed `check_pudl_fks` to `pudl_check_fks` to follow the naming we've tried to have on our other CLI scripts (as suggested by @karldw waaaay back in #460).  We still don't do this on the commands with long names, but it's easy to do here.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
