### PR TITLE
Simplify EPA CAMD EIA X-walk output to just read from DB.

### DIFF
--- a/src/pudl/output/epacems.py
+++ b/src/pudl/output/epacems.py
@@ -4,20 +4,9 @@ from itertools import product
 from pathlib import Path
 
 import dask.dataframe as dd
-import pandas as pd
-import sqlalchemy as sa
 
 import pudl
 from pudl.settings import EpaCemsSettings
-
-
-def epacamd_eia(pudl_engine: sa.engine.Engine) -> pd.DataFrame:
-    """Pull the EPACAMD-EIA Crosswalk table."""
-    pt = pudl.output.pudltabl.get_table_meta(pudl_engine)
-    crosswalk_tbl = pt["epacamd_eia"]
-    crosswalk_select = sa.sql.select(crosswalk_tbl)
-    crosswalk_df = pd.read_sql(crosswalk_select, pudl_engine)
-    return crosswalk_df
 
 
 def year_state_filter(

--- a/src/pudl/output/pudltabl.py
+++ b/src/pudl/output/pudltabl.py
@@ -1064,22 +1064,11 @@ class PudlTabl:
             )
         return self._dfs["ferc1_eia"]
 
-    def epacamd_eia(
-        self,
-        update: bool = False,
-    ) -> pd.DataFrame:
-        """Pull the EPACAMD-EIA Crosswalk Table.
-
-        Args:
-            update: If true, re-calculate the output dataframe, even if
-                a cached version exists.
-
-        Returns:
-            A denormalized table for interactive use.
-        """
-        if update or self._dfs["epacamd_eia"] is None:
-            self._dfs["epacamd_eia"] = pudl.output.epacems.epacamd_eia(self.pudl_engine)
-        return self._dfs["epacamd_eia"]
+    def epacamd_eia(self) -> pd.DataFrame:
+        """Read the EPACAMD-EIA Crosswalk from the PUDL DB."""
+        return pd.read_sql("epacamd_eia", self.pudl_engine).pipe(
+            apply_pudl_dtypes, group="glue"
+        )
 
     ###########################################################################
     # FOR PICKLING AND OTHER IO


### PR DESCRIPTION
# PR Overview

A minor simplification of access for the `epacamd_eia` table, since all we do is read it straight from the DB.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
