### PR TITLE
Teach Docker about new env vars & settings

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,10 +1,9 @@
 HOST_PUDL_IN=./pudl_in
 HOST_PUDL_OUT=./pudl_out
 CONTAINER_HOME=/home/catalyst
-CONTAINER_PUDL_IN=/home/catalyst/pudl_in
-CONTAINER_PUDL_OUT=/home/catalyst/pudl_out
-CONTAINER_DAGSTER_HOME=/home/catalyst/dagster_home
-DAGSTER_HOME=/home/catalyst/dagster_home
+PUDL_INPUT=/home/catalyst/pudl_work/data
+PUDL_OUTPUT=/home/catalyst/pudl_work/output
+DAGSTER_HOME=/home/catalyst/pudl_work/dagster_home
 CONDA_PREFIX=/home/catalyst/env
 PUDL_SETTINGS_YML=/home/catalyst/src/pudl/package_data/settings/etl_full.yml
 LOGFILE=/home/catalyst/pudl_out/pudl-etl.log

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,6 @@ RUN useradd -Ums /bin/bash catalyst
 
 ENV CONTAINER_HOME=/home/catalyst
 
-
 # Switch to being the catalyst user and go into the copied repo
 USER catalyst
 WORKDIR ${CONTAINER_HOME}
@@ -29,9 +28,11 @@ ENV CONDA_PREFIX=${CONTAINER_HOME}/env
 ENV PUDL_REPO=${CONTAINER_HOME}/pudl
 ENV CONDA_RUN="conda run --no-capture-output --prefix ${CONDA_PREFIX}"
 ENV PYTHON_VERSION="3.10"
-ENV CONTAINER_PUDL_IN=${CONTAINER_HOME}/pudl_in
-ENV CONTAINER_PUDL_OUT=${CONTAINER_HOME}/pudl_out
-ENV DAGSTER_HOME=${CONTAINER_HOME}/dagster_home
+
+ENV CONTAINER_PUDL_WORKSPACE=${CONTAINER_HOME}/pudl_work
+ENV PUDL_INPUT=${CONTAINER_PUDL_WORKSPACE}}/data
+ENV PUDL_OUTPUT=${CONTAINER_PUDL_WORKSPACE}}/output
+ENV DAGSTER_HOME=${CONTAINER_PUDL_WORKSPACE}}/dagster_home
 
 # Create a conda environment based on the specification in the repo
 COPY test/test-environment.yml test/test-environment.yml
@@ -48,11 +49,9 @@ COPY --chown=catalyst:catalyst . ${CONTAINER_HOME}
 RUN --mount=type=bind,source=.git,target=${PUDL_REPO}/.git \
     ${CONDA_RUN} pip install --no-cache-dir -e './[dev,doc,test,datasette]' && \
     # Create data input/output directories
-    mkdir ${CONTAINER_PUDL_IN} && mkdir ${CONTAINER_PUDL_OUT} && mkdir -p ${DAGSTER_HOME} && \
+    mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME} && \
     # Run the PUDL setup script so we know where to read and write data
-    ${CONDA_RUN} pudl_setup \
-    --pudl_in ${CONTAINER_PUDL_IN} \
-    --pudl_out ${CONTAINER_PUDL_OUT}
+    ${CONDA_RUN} pudl_setup
 
 
 # Run the unit tests:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,9 +30,12 @@ ENV CONDA_RUN="conda run --no-capture-output --prefix ${CONDA_PREFIX}"
 ENV PYTHON_VERSION="3.10"
 
 ENV CONTAINER_PUDL_WORKSPACE=${CONTAINER_HOME}/pudl_work
-ENV PUDL_INPUT=${CONTAINER_PUDL_WORKSPACE}}/data
-ENV PUDL_OUTPUT=${CONTAINER_PUDL_WORKSPACE}}/output
-ENV DAGSTER_HOME=${CONTAINER_PUDL_WORKSPACE}}/dagster_home
+ENV PUDL_INPUT=${CONTAINER_PUDL_WORKSPACE}/data
+ENV PUDL_OUTPUT=${CONTAINER_PUDL_WORKSPACE}/output
+ENV DAGSTER_HOME=${CONTAINER_PUDL_WORKSPACE}/dagster_home
+
+# Create data input/output directories
+RUN mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME}
 
 # Create a conda environment based on the specification in the repo
 COPY test/test-environment.yml test/test-environment.yml
@@ -41,6 +44,7 @@ RUN mamba create --copy --prefix ${CONDA_PREFIX} --yes python=${PYTHON_VERSION} 
     mamba env update --prefix ${CONDA_PREFIX} --file test/test-environment.yml && \
     conda clean -afy
 
+
 # Copy the cloned pudl repository into the user's home directory
 COPY --chown=catalyst:catalyst . ${CONTAINER_HOME}
 
@@ -48,8 +52,6 @@ COPY --chown=catalyst:catalyst . ${CONTAINER_HOME}
 # directory without copying it into the image.
 RUN --mount=type=bind,source=.git,target=${PUDL_REPO}/.git \
     ${CONDA_RUN} pip install --no-cache-dir -e './[dev,doc,test,datasette]' && \
-    # Create data input/output directories
-    mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME} && \
     # Run the PUDL setup script so we know where to read and write data
     ${CONDA_RUN} pudl_setup
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,15 +21,15 @@ services:
     volumes:
       - type: volume
         source: pudl-in
-        target: ${CONTAINER_PUDL_IN}
+        target: ${PUDL_INPUT}
         consistency: delegated
       - type: volume
         source: pudl-out
-        target: ${CONTAINER_PUDL_OUT}
+        target: ${PUDL_OUTPUT}
         consistency: delegated
       - type: volume
         source: dagster-home
-        target: ${CONTAINER_DAGSTER_HOME}
+        target: ${DAGSTER_HOME}
         consistency: delegated
     logging:
       driver: local

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -18,18 +18,10 @@ function authenticate_gcp() {
     gcloud config set project $GCP_BILLING_PROJECT
 }
 
-function bridge_settings() {
-    export PUDL_INPUT="${CONTAINER_PUDL_IN}/data"
-    export PUDL_OUTPUT=$CONTAINER_PUDL_OUT
-}
-
 function run_pudl_etl() {
     send_slack_msg ":large_yellow_circle: Deployment started for $ACTION_SHA-$GITHUB_REF :floppy_disk:"
     authenticate_gcp \
     && pudl_setup \
-        --pudl_in $CONTAINER_PUDL_IN \
-        --pudl_out $CONTAINER_PUDL_OUT \
-    && bridge_settings \
     && ferc_to_sqlite \
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \

--- a/docker/local_pudl_etl.sh
+++ b/docker/local_pudl_etl.sh
@@ -4,16 +4,8 @@
 
 set -x
 
-function bridge_settings() {
-    export PUDL_INPUT="${CONTAINER_PUDL_IN}/data"
-    export PUDL_OUTPUT=$CONTAINER_PUDL_OUT
-}
-
 function run_pudl_etl() {
     pudl_setup \
-        --pudl_in $CONTAINER_PUDL_IN \
-        --pudl_out $CONTAINER_PUDL_OUT \
-    && bridge_settings \
     && ferc_to_sqlite \
         --loglevel DEBUG \
         $PUDL_SETTINGS_YML \

--- a/src/pudl/workspace/setup_cli.py
+++ b/src/pudl/workspace/setup_cli.py
@@ -5,20 +5,13 @@ package, and copies several example settings files and Jupyter notebooks into
 it to get you started. If the command is run without any arguments, it will
 create this workspace in your current directory.
 
-The script will also create a file named .pudl.yml, describing the location of
-your PUDL workspace. The PUDL package will refer to this location in the future
-to know where it should look for raw data, where to put its outputs, etc. This
-file can be edited to change the default input and output directories if you
-wish. However, make sure those workspaces are set up using this script.
-
 It's also possible to specify different input and output directories, which is
 useful if you want to use a single PUDL data store (which may contain many GB
 of data) to support several different workspaces.  See the --pudl_in and
 --pudl_out options.
 
 By default the script will not overwrite existing files. If you want it to
-replace existing files (including your .pudl.yml file which defines your
-default PUDL workspace) use the --clobber option.
+replace existing files use the --clobber option.
 
 The directory structure set up for PUDL looks like this:
 
@@ -62,30 +55,19 @@ def initialize_parser():
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        "pudl_dir",
-        nargs="?",
-        default=pathlib.Path.cwd(),
-        help="""Directory where all the PUDL inputs and outputs should be
-        located. If unspecified, the current directory will be used. If pudl_in
-        or pudl_out are provided, they will be used instead of this directory
-        for their respective purposes.""",
-    )
-    parser.add_argument(
-        "--pudl_in",
+        "--pudl_input",
         "-i",
         type=str,
-        dest="pudl_in",
-        help="""Directory where the PUDL datastore should be located. This
-        will take precedence over pudl_dir if both are provided.""",
+        dest="pudl_input",
+        help="""Directory where the PUDL input data should be located.""",
     )
     parser.add_argument(
-        "--pudl_out",
+        "--pudl_output",
         "-o",
         type=str,
-        dest="pudl_out",
+        dest="pudl_output",
         help="""Directory where the PUDL outputs, notebooks, and example
-        settings files should be located. This value will take precedence over
-        pudl_dir if both are provided.""",
+        settings files should be located.""",
     )
     parser.add_argument(
         "--clobber",
@@ -120,33 +102,19 @@ def main():
         logfile=args.logfile, loglevel=args.loglevel
     )
 
-    if not args.pudl_in:
-        args.pudl_in = args.pudl_dir
-    if not args.pudl_out:
-        args.pudl_out = args.pudl_dir
+    if args.pudl_input:
+        pudl_in = pathlib.Path(args.pudl_in).expanduser().resolve()
+        if not pathlib.Path.is_dir(pudl_in):
+            raise FileNotFoundError(f"Directory not found: {pudl_in}")
 
-    # Given pudl_in and pudl_out, create a user settings file.
-    pudl_in = pathlib.Path(args.pudl_in).expanduser().resolve()
-    if not pathlib.Path.is_dir(pudl_in):
-        raise FileNotFoundError(f"Directory not found: {pudl_in}")
+    if args.pudl_output:
+        pudl_out = pathlib.Path(args.pudl_out).expanduser().resolve()
+        if not pathlib.Path.is_dir(pudl_out):
+            raise FileNotFoundError(f"Directory not found: {pudl_out}")
 
-    pudl_out = pathlib.Path(args.pudl_out).expanduser().resolve()
-    if not pathlib.Path.is_dir(pudl_out):
-        raise FileNotFoundError(f"Directory not found: {pudl_out}")
-
-    pudl_defaults_file = pathlib.Path.home() / ".pudl.yml"
-
-    # Only print out this information and do the defaults setting if that has
-    # been explicitly requested, or there are no defaults already:
-    if not pudl_defaults_file.exists() or args.clobber is True:
-        logger.info(f"Setting default pudl_in: {pudl_in}")
-        logger.info(f"Setting default pudl_out: {pudl_out}")
-        logger.info(
-            f"You can update these default values by editing {pudl_defaults_file}"
-        )
-        pudl.workspace.setup.set_defaults(pudl_in, pudl_out, clobber=args.clobber)
-
-    settings = pudl.workspace.setup.get_defaults()
+    settings = pudl.workspace.setup.get_defaults(
+        input_dir=args.pudl_input, output_dir=args.pudl_output
+    )
     pudl.workspace.setup.init(settings, clobber=args.clobber)
 
 


### PR DESCRIPTION
This uses the new `PUDL_INPUT`/`PUDL_OUTPUT` env vars to run the ETL in a container.

Things that want to use `pudl_settings` should get their `pudl_settings` dict from these env vars.

This also makes `pudl_setup` not make a `.pudl.yml` anymore - it just figures out where the directories are from the env vars, and then runs an initialization process. *If* you are a legacy user with a `~/.pudl.yml` and also no env vars, this should still work, because of how the configs are designed to override each other. But any new users will not even know about `~/.pudl.yml` at all.

This seems to not blow up immediately when I run `local_pudl_etl.sh` on my VM - so I'm putting the PR up for perusal.

It's probably worth re-writing some docs about pudl_setup to make clear that the `~/.pudl.yml` is really quite deprecated, but let's make sure this all works before we jump the gun there.

Nota bene: I ran into some errors where e.g. `ferc_to_sqlite` was asking me to `--clobber` the old DBs. This was because I ran with docker compose and the volumes were persistent - a `docker compose down -v` got rid of them. But that gets rid of the cached data if we need to do targeted debugging of just the `pytest` step. A thing to consider...