### PR TITLE
Fix "Make a PR" link in nightly build success message

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -66,7 +66,7 @@ function notify_slack() {
     # Notify pudl-builds slack channel of deployment status
     if [ $1 = "success" ]; then
         message=":large_green_circle: :sunglasses: :unicorn_face: :rainbow: The deployment succeeded!! :partygritty: :database_parrot: :blob-dance: :large_green_circle:\n\n "
-        message+='Make a PR for `${GITHUB_REF}` into `main`: https://github.com/catalyst-cooperative/pudl/compare/main...${GITHUB_REF}\n\n'
+        message+="Make a PR for \`${GITHUB_REF}\` into \`main\`: https://github.com/catalyst-cooperative/pudl/compare/main...${GITHUB_REF}\n\n"
     elif [ $1 = "failure" ]; then
         message=":large_red_square: Oh bummer the deployment failed ::fiiiiine: :sob: :cry_spin:\n\n "
     else

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -66,7 +66,7 @@ function notify_slack() {
     # Notify pudl-builds slack channel of deployment status
     if [ $1 = "success" ]; then
         message=":large_green_circle: :sunglasses: :unicorn_face: :rainbow: The deployment succeeded!! :partygritty: :database_parrot: :blob-dance: :large_green_circle:\n\n "
-        message+="Make a PR for \`${GITHUB_REF}\` into \`main\`: https://github.com/catalyst-cooperative/pudl/compare/main...${GITHUB_REF}\n\n"
+        message+="<https://github.com/catalyst-cooperative/pudl/compare/main...${GITHUB_REF}|Make a PR for \`${GITHUB_REF}\` into \`main\`!>\n\n"
     elif [ $1 = "failure" ]; then
         message=":large_red_square: Oh bummer the deployment failed ::fiiiiine: :sob: :cry_spin:\n\n "
     else


### PR DESCRIPTION
This should make our nightly build slack posts not look silly anymore.

We should merge this as a post-dagster-merge fix to `dev` I think. Not worth the extra hour of waiting for CI before the dagster merge.