### PR TITLE
Use FERC XBRL Extractor 0.8.2 to allow pandas 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ license = {file = "LICENSE.txt"}
 dependencies = [
     "addfips>=0.4,<0.5",
     "catalystcoop.dbfread>=3.0,<3.1",
-    "catalystcoop.ferc-xbrl-extractor==0.8.1",
+    "catalystcoop.ferc-xbrl-extractor==0.8.2",
     "coloredlogs>=14.0,<15.1",  # Dagster requires 14.0
     "dagit>=1.2.2,<1.3",  # 1.2.2 is first version to support Python 3.11
     "dagster>=1.2.2,<1.3",  # 1.2.2 is first version to support Python 3.11


### PR DESCRIPTION
# PR Overview

Update to v0.8.2 of our `ferc-xbrl-extractor` package, which allows (but does not require) pandas 2.0, in preparation for addressing #2394 / merging #2320.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
