### PR TITLE
Add script to set DB schema before running ETL pipeline

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -21,6 +21,7 @@ function authenticate_gcp() {
 function run_pudl_etl() {
     send_slack_msg ":large_yellow_circle: Deployment started for $ACTION_SHA-$GITHUB_REF :floppy_disk:"
     authenticate_gcp \
+    && pudl_reset_db \
     && pudl_setup \
     && ferc_to_sqlite \
         --loglevel=DEBUG \

--- a/docker/local_pudl_etl.sh
+++ b/docker/local_pudl_etl.sh
@@ -6,6 +6,7 @@ set -x
 
 function run_pudl_etl() {
     pudl_setup \
+    && pudl_reset_db \
     && ferc_to_sqlite \
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \

--- a/docs/dev/run_the_etl.rst
+++ b/docs/dev/run_the_etl.rst
@@ -11,6 +11,14 @@ just want to use already processed data.
 
 These instructions assume you have already gone through the :ref:`dev_setup`.
 
+Database initialization
+-----------------------
+
+Before we run anything (and after we make changes to the database schema), we'll
+need to make sure that the schema in the database actually matches the schema
+in the code - run ``pudl_reset_db`` to delete whatever is already there and
+recreate the database with the right schema.
+
 Dagster
 -------
 PUDL uses `Dagster <https://dagster.io/>`__ to orchestrate its data pipelines. Dagster

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dynamic = ["version"]
 license = {file = "LICENSE.txt"}
 dependencies = [
     "addfips>=0.4,<0.5",
+    "alembic>=1.10.3,<1.11",
     "catalystcoop.dbfread>=3.0,<3.1",
     "catalystcoop.ferc-xbrl-extractor==0.8.2",
     "coloredlogs>=14.0,<15.1",  # Dagster requires 14.0
@@ -93,10 +94,11 @@ epacems_to_parquet = "pudl.convert.epacems_to_parquet:main"
 ferc_to_sqlite = "pudl.ferc_to_sqlite.cli:main"
 datasette_metadata_to_yml = "pudl.convert.datasette_metadata_to_yml:main"
 pudl_datastore = "pudl.workspace.datastore:main"
-pudl_etl = "pudl.cli:main"
+pudl_etl = "pudl.cli.etl:main"
 pudl_setup = "pudl.workspace.setup_cli:main"
 state_demand = "pudl.analysis.state_demand:main"
 pudl_check_fks = "pudl.etl.check_foreign_keys:main"
+pudl_reset_db = "pudl.cli.reset_db:main"
 # pudl_territories currently blows up memory usage to 100+ GB.
 # See https://github.com/catalyst-cooperative/pudl/issues/1174
 # pudl_territories = "pudl.analysis.service_territory:main"

--- a/src/pudl/__main__.py
+++ b/src/pudl/__main__.py
@@ -2,7 +2,7 @@
 
 import sys
 
-import pudl
+import pudl.cli
 
 if __name__ == "__main__":
-    sys.exit(pudl.cli.main())
+    sys.exit(pudl.cli.etl.main())

--- a/src/pudl/cli/__init__.py
+++ b/src/pudl/cli/__init__.py
@@ -1,0 +1,3 @@
+"""Holds various command-line interfaces for PUDL."""
+
+from . import etl, reset_db  # noqa: F401

--- a/src/pudl/cli/etl.py
+++ b/src/pudl/cli/etl.py
@@ -129,7 +129,7 @@ def main():
         dataset_settings_config["epacems"] = pudl.settings.EpaCemsSettings().dict()
 
     pudl_etl_reconstructable_job = build_reconstructable_job(
-        "pudl.cli",
+        "pudl.cli.etl",
         "pudl_etl_job_factory",
         reconstructable_kwargs={
             "loglevel": args.loglevel,

--- a/src/pudl/cli/reset_db.py
+++ b/src/pudl/cli/reset_db.py
@@ -1,0 +1,54 @@
+"""Reset the PUDL output DB to match the schema in pudl.metadata."""
+import argparse
+import pathlib
+
+import sqlalchemy as sa
+
+from pudl.metadata.classes import Package
+from pudl.workspace.setup import get_defaults
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(__doc__)
+    parser.add_argument(
+        "--sqlite-path", help="The path to the PUDL DB that you'd like to reset."
+    )
+    return parser.parse_args()
+
+
+def reset_db(
+    sqlite_path: str | None = None, metadata: sa.MetaData | None = None
+) -> None:
+    """Ensure empty SQLite DB at `sqlite_path` with schema `metadata`.
+
+    Args:
+        sqlite_path: the path to DB. Defaults to $PUDL_OUTPUT/pudl.sqlite
+        metadata: SQLAlchemy MetaData describing desired DB state. Defaults to
+            "all the tables defined in pudl.metadata".
+    """
+    if sqlite_path is None:
+        sqlite_path = pathlib.Path(get_defaults()["pudl_out"]) / "pudl.sqlite"
+
+    if metadata is None:
+        metadata = Package.from_resource_ids().to_sql()
+
+    # Check if a SQLite file already exists at the given path, and delete it if it does
+    if sqlite_path.exists():
+        sqlite_path.unlink()
+
+    # Use SQLAlchemy to create a new SQLite database at the given path
+    engine = sa.create_engine(f"sqlite:///{sqlite_path}")
+    conn = engine.connect()
+
+    # Use the metadata to initialize the table schema in the new database
+    metadata.create_all(conn)
+    conn.close()
+
+
+def main():
+    """Main entry-point: parse args and run DB reset logic."""
+    reset_db(**vars(_parse_args()))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -7,7 +7,7 @@ import dask.dataframe as dd
 import pandas as pd
 import pyarrow as pa
 import sqlalchemy as sa
-from alembic.autogenerate import compare_metadata
+from alembic.autogenerate.api import compare_metadata
 from alembic.migration import MigrationContext
 from dagster import (
     Field,
@@ -90,7 +90,7 @@ class SQLiteIOManager(IOManager):
         self,
         base_dir: str,
         db_name: str,
-        md: sa.MetaData = None,
+        md: sa.MetaData | None = None,
         timeout: float = 1_000.0,
     ):
         """Init a SQLiteIOmanager.
@@ -120,9 +120,9 @@ class SQLiteIOManager(IOManager):
             )
 
         # If no metadata is specified, create an empty sqlalchemy metadata object.
+        if md is None:
+            md = sa.MetaData()
         self.md = md
-        if not self.md:
-            self.md = sa.MetaData()
 
         self.engine = self._setup_database(timeout=timeout)
 
@@ -383,9 +383,9 @@ class PudlSQLiteIOManager(SQLiteIOManager):
 
     def __init__(
         self,
-        base_dir: str = None,
-        db_name: str = None,
-        package: Package = None,
+        base_dir: str,
+        db_name: str,
+        package: Package | None = None,
         timeout: float = 1_000.0,
     ):
         """Initialize PudlSQLiteIOManager.
@@ -414,7 +414,7 @@ class PudlSQLiteIOManager(SQLiteIOManager):
                 connection opens a transaction to modify the database, it will be locked
                 until that transaction is committed.
         """
-        if not package:
+        if package is None:
             package = Package.from_resource_ids()
         self.package = package
         md = self.package.to_sql()

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -428,11 +428,7 @@ class PudlSQLiteIOManager(SQLiteIOManager):
         metadata_diff = compare_metadata(existing_schema_context, self.md)
         if metadata_diff:
             logger.info(f"Metadata diff:\n\n{metadata_diff}")
-            raise RuntimeError(
-                "Database schema has changed, try running `alembic revision "
-                "--autogenerate -m 'Your change message'` then `alembic "
-                "upgrade`."
-            )
+            raise RuntimeError("Database schema has changed, run `pudl_reset_db`.")
 
     def _handle_str_output(self, context: OutputContext, query: str):
         """Execute a sql query on the database.

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,7 @@ from ferc_xbrl_extractor import xbrl
 import pudl
 from pudl import resources
 from pudl.cli.etl import pudl_etl_job_factory
+from pudl.cli.reset_db import reset_db
 from pudl.extract.ferc1 import xbrl_metadata_json
 from pudl.extract.xbrl import FercXbrlDatastore, _get_sqlite_engine
 from pudl.ferc_to_sqlite.cli import ferc_to_sqlite_job_factory
@@ -298,6 +299,7 @@ def pudl_sql_io_manager(
     """
     logger.info("setting up the pudl_engine fixture")
     if not live_dbs:
+        reset_db()
         # Run the ETL and generate a new PUDL SQLite DB for testing:
         pudl_etl_job_factory()().execute_in_process(
             run_config={

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -14,7 +14,7 @@ from ferc_xbrl_extractor import xbrl
 
 import pudl
 from pudl import resources
-from pudl.cli import pudl_etl_job_factory
+from pudl.cli.etl import pudl_etl_job_factory
 from pudl.extract.ferc1 import xbrl_metadata_json
 from pudl.extract.xbrl import FercXbrlDatastore, _get_sqlite_engine
 from pudl.ferc_to_sqlite.cli import ferc_to_sqlite_job_factory

--- a/test/unit/io_managers_test.py
+++ b/test/unit/io_managers_test.py
@@ -4,6 +4,7 @@ import pytest
 from dagster import AssetKey, build_input_context, build_output_context
 from sqlalchemy.exc import IntegrityError, OperationalError
 
+from pudl.cli.reset_db import reset_db
 from pudl.io_managers import (
     ForeignKeyError,
     ForeignKeyErrors,
@@ -199,6 +200,7 @@ def test_missing_schema_error(sqlite_io_manager_fixture):
 @pytest.fixture
 def pudl_sqlite_io_manager_fixture(tmp_path, test_pkg):
     """Create a SQLiteIOManager fixture with a PUDL database schema."""
+    reset_db(tmp_path / "pudl.sqlite", test_pkg.to_sql())
     return PudlSQLiteIOManager(base_dir=tmp_path, db_name="pudl", package=test_pkg)
 
 

--- a/test/unit/reset_db_test.py
+++ b/test/unit/reset_db_test.py
@@ -1,0 +1,49 @@
+import sqlalchemy as sa
+
+from pudl.cli import reset_db
+
+
+def test_reset_db_no_preexisting(tmp_path):
+    sqlite_path = tmp_path / "test_db.sqlite"
+
+    # Define the metadata for the test database
+    metadata = sa.MetaData()
+    sa.Table("foo", metadata, sa.Column("bar", sa.Integer))
+
+    reset_db.reset_db(sqlite_path=sqlite_path, metadata=metadata)
+
+    engine = sa.create_engine(f"sqlite:///{sqlite_path}")
+    reflected_metadata = sa.MetaData()
+    reflected_metadata.reflect(bind=engine)
+
+    assert len(metadata.tables) == len(reflected_metadata.tables)
+    assert "foo" in reflected_metadata.tables
+    assert len(metadata.tables["foo"].columns) == len(
+        reflected_metadata.tables["foo"].columns
+    )
+    assert "bar" in reflected_metadata.tables["foo"].columns
+
+
+def test_reset_db_clobbers_preexisting(tmp_path):
+    sqlite_path = tmp_path / "test_db.sqlite"
+
+    # initial schema - we'll overwrite this later
+    metadata = sa.MetaData()
+    sa.Table("foo", metadata, sa.Column("bar", sa.Integer))
+    reset_db.reset_db(sqlite_path=sqlite_path, metadata=metadata)
+
+    # actual schema
+    metadata = sa.MetaData()
+    sa.Table("foo", metadata, sa.Column("baz", sa.Integer))
+    reset_db.reset_db(sqlite_path=sqlite_path, metadata=metadata)
+
+    engine = sa.create_engine(f"sqlite:///{sqlite_path}")
+    reflected_metadata = sa.MetaData()
+    reflected_metadata.reflect(bind=engine)
+
+    assert len(metadata.tables) == len(reflected_metadata.tables)
+    assert "foo" in reflected_metadata.tables
+    assert len(metadata.tables["foo"].columns) == len(
+        reflected_metadata.tables["foo"].columns
+    )
+    assert "baz" in reflected_metadata.tables["foo"].columns

--- a/tox.ini
+++ b/tox.ini
@@ -229,7 +229,7 @@ commands =
     {[testenv:integration]commands}
     bash -c 'rm -f tox-nuke.log'
     bash -c 'coverage run --append src/pudl/convert/ferc_to_sqlite.py --logfile tox-nuke.log --clobber src/pudl/package_data/settings/etl_full.yml'
-    bash -c 'coverage run --append src/pudl/cli.py --logfile tox-nuke.log --clobber src/pudl/package_data/settings/etl_full.yml'
+    bash -c 'coverage run --append src/pudl/cli/etl.py --logfile tox-nuke.log --clobber src/pudl/package_data/settings/etl_full.yml'
     pytest {tty:--color=yes} --live-dbs {posargs} {[testenv]covargs} \
       --etl-settings src/pudl/package_data/settings/etl_full.yml \
       test/integration


### PR DESCRIPTION
Closes #2377 

This makes it so that we don't start with a completely empty DB, we start with one that has the same schema as whatever is written in our `pudl.metadata` package.

This sidesteps the various concurrency issues with trying to make sure the schema is correct *within* the DAG run.

In the future, we might want to use migrations, or have some sort of non-concurrent setup op in the DAG, but for now this will provide a decent UX and hopefully get around the flakiness we've been seeing with the nightly builds (see #2469).

We decided to not use `alembic` for the migrations because of the slightly more complicated UX, but I think using it for diffing schemas is fine and I trust them more than I trust myself, to catch the various edge cases of "does this database setup look right?"

