### PR TITLE
Run integration & validation tests in parallel in the background.

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -32,16 +32,11 @@ function run_pudl_etl() {
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         $PUDL_SETTINGS_YML
-    # Run unit+integration tests and data validations in parallel in the background
-    # They each take ~1 hour on their own and have no interdependencies.
-    pytest \
+    && tox parallel -e unit,integration,validation --parallel-live \
+        -- \
         --gcs-cache-path=gs://internal-zenodo-cache.catalyst.coop \
         --etl-settings=$PUDL_SETTINGS_YML \
-        --live-dbs test/unit test/integration &
-    pytest \
-        --gcs-cache-path=gs://internal-zenodo-cache.catalyst.coop \
-        --etl-settings=$PUDL_SETTINGS_YML \
-        --live-dbs test/validate &
+        --live-dbs
 }
 
 function shutdown_vm() {

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -31,11 +31,17 @@ function run_pudl_etl() {
     && pudl_etl \
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
-        $PUDL_SETTINGS_YML \
-    && pytest \
+        $PUDL_SETTINGS_YML
+    # Run unit+integration tests and data validations in parallel in the background
+    # They each take ~1 hour on their own and have no interdependencies.
+    pytest \
         --gcs-cache-path=gs://internal-zenodo-cache.catalyst.coop \
         --etl-settings=$PUDL_SETTINGS_YML \
-        --live-dbs test
+        --live-dbs test/unit test/integration &
+    pytest \
+        --gcs-cache-path=gs://internal-zenodo-cache.catalyst.coop \
+        --etl-settings=$PUDL_SETTINGS_YML \
+        --live-dbs test/validate &
 }
 
 function shutdown_vm() {

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -32,7 +32,7 @@ function run_pudl_etl() {
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         $PUDL_SETTINGS_YML \
-    && tox parallel -e unit,integration,validation --parallel-live \
+    && tox run-parallel -e unit,integration,validation --parallel-live \
         -- \
         --gcs-cache-path=gs://internal-zenodo-cache.catalyst.coop \
         --etl-settings=$PUDL_SETTINGS_YML \

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -31,7 +31,7 @@ function run_pudl_etl() {
     && pudl_etl \
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
-        $PUDL_SETTINGS_YML
+        $PUDL_SETTINGS_YML \
     && tox parallel -e unit,integration,validation --parallel-live \
         -- \
         --gcs-cache-path=gs://internal-zenodo-cache.catalyst.coop \

--- a/docker/local_pudl_etl.sh
+++ b/docker/local_pudl_etl.sh
@@ -15,10 +15,11 @@ function run_pudl_etl() {
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         $PUDL_SETTINGS_YML \
-    && pytest \
+    && tox parallel -e unit,integration,validation --parallel-live \
+        -- \
         --gcs-cache-path=gs://internal-zenodo-cache.catalyst.coop \
         --etl-settings=$PUDL_SETTINGS_YML \
-        --live-dbs test
+        --live-dbs
 }
 
 # Run the ETL and save the logs.

--- a/docker/local_pudl_etl.sh
+++ b/docker/local_pudl_etl.sh
@@ -15,7 +15,7 @@ function run_pudl_etl() {
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         $PUDL_SETTINGS_YML \
-    && tox parallel -e unit,integration,validation --parallel-live \
+    && tox run-parallel -e unit,integration,validation --parallel-live \
         -- \
         --gcs-cache-path=gs://internal-zenodo-cache.catalyst.coop \
         --etl-settings=$PUDL_SETTINGS_YML \

--- a/tox.ini
+++ b/tox.ini
@@ -148,7 +148,7 @@ recreate = true
 extras =
     test
 commands =
-    pytest {tty:--color=yes} --live-dbs test/validate
+    pytest {tty:--color=yes} {posargs} --live-dbs test/validate
 
 [testenv:jupyter]
 description = Run all data validation tests. This requires a complete PUDL DB.


### PR DESCRIPTION
# PR Overview

I think we can shave an hour off of the nightly builds by running the unit+integration tests and the validation tests at the same time. Each of them takes about an hour on their own but they have no interdependency. I run them at the same time locally against a full DB whenever I'm trying to see if I broke something after a big change.

I'm not sure if just running them in the background is the right way to do this, but it seems like there should be *some* simple 2 line change that does it! If not these 2 lines, do you have other ideas @jdangerx?

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
