### PR TITLE
Add oil well gas analysis bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,6 +36,16 @@ resource "google_storage_bucket" "tfstate" {
   }
 }
 
+resource "google_storage_bucket" "well_gas_pdfs" {
+  name          = "${random_id.bucket_prefix.hex}-catalyst-coop-well-gas-pdfs"
+  force_destroy = false
+  location      = "US"
+  storage_class = "STANDARD"
+  versioning {
+    enabled = true
+  }
+}
+
 module "gh_oidc" {
   source      = "terraform-google-modules/github-actions-runners/google//modules/gh-oidc"
   project_id  = var.project_id


### PR DESCRIPTION
Quick terraform change to make a bucket for the well gas analysis work 🏀 

In theory we could split the terraform across a bunch of repositories but I think we are a long way from needing to even split out beyond a single `main.tf` file, so I'm putting the config in our main repo for now.