### PR TITLE
Cast resource filter values to lowercase

### DIFF
--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -27,7 +27,7 @@ class FercXbrlDatastore:
     def get_taxonomy(self, year: int, form: XbrlFormNumber) -> tuple[io.BytesIO, str]:
         """Returns the path to the taxonomy entry point within the an archive."""
         raw_archive = self.datastore.get_unique_resource(
-            f"ferc{form.value}", year=year, data_format="XBRL"
+            f"ferc{form.value}", year=year, data_format="xbrl"
         )
 
         # Construct path to taxonomy entry point within archive
@@ -39,7 +39,7 @@ class FercXbrlDatastore:
     def get_filings(self, year: int, form: XbrlFormNumber) -> list[InstanceBuilder]:
         """Return list of filings from archive."""
         archive = self.datastore.get_zipfile_resource(
-            f"ferc{form.value}", year=year, data_format="XBRL"
+            f"ferc{form.value}", year=year, data_format="xbrl"
         )
 
         # Load RSS feed metadata

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -85,7 +85,9 @@ class DatapackageDescriptor:
 
     def _matches(self, res: dict, **filters: Any):
         parts = res.get("parts", {})
-        return all(str(parts.get(k)) == str(v) for k, v in filters.items())
+        return all(
+            str(parts.get(k)).lower() == str(v).lower() for k, v in filters.items()
+        )
 
     def get_resources(
         self, name: str = None, **filters: Any

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -84,6 +84,11 @@ class DatapackageDescriptor:
             )
 
     def _matches(self, res: dict, **filters: Any):
+        for k, v in filters.items():
+            if str(v) != str(v).lower():
+                logger.warning(
+                    f"Resource filter values should be all lowercase: {k}={v}"
+                )
         parts = res.get("parts", {})
         return all(
             str(parts.get(k)).lower() == str(v).lower() for k, v in filters.items()

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -34,7 +34,7 @@ def test_ferc_xbrl_datastore_get_taxonomy(mocker):
 
     # Check that get_unique_resource was called correctly
     datastore_mock.get_unique_resource.assert_called_with(
-        "ferc1", year=2021, data_format="XBRL"
+        "ferc1", year=2021, data_format="xbrl"
     )
 
     # Check return values
@@ -126,7 +126,7 @@ def test_ferc_xbrl_datastore_get_filings(mocker, file_map, selected_filings):
 
     # Check that get_zipfile_resource was called correctly
     datastore_mock.get_zipfile_resource.assert_called_with(
-        "ferc1", year=2021, data_format="XBRL"
+        "ferc1", year=2021, data_format="xbrl"
     )
 
     # Loop through filings and verify the contents

--- a/test/unit/workspace/datastore_test.py
+++ b/test/unit/workspace/datastore_test.py
@@ -25,6 +25,11 @@ class TestDatapackageDescriptor(unittest.TestCase):
                 "path": "http://localhost/second",
                 "parts": {"color": "blue", "order": 2},
             },
+            {
+                "name": "mixed-case",
+                "path": "http://localhost/mixed",
+                "parts": {"upper": "UPPER", "lower": "lower", "mixed": "miXED"},
+            },
         ]
     }
 
@@ -55,6 +60,7 @@ class TestDatapackageDescriptor(unittest.TestCase):
             [
                 PudlResourceKey("epacems", "123", "first-red"),
                 PudlResourceKey("epacems", "123", "second-blue"),
+                PudlResourceKey("epacems", "123", "mixed-case"),
             ],
             list(self.descriptor.get_resources()),
         )
@@ -63,6 +69,19 @@ class TestDatapackageDescriptor(unittest.TestCase):
             list(self.descriptor.get_resources(color="red")),
         )
         self.assertEqual([], list(self.descriptor.get_resources(flavor="blueberry")))
+
+    def test_get_resources_filtering_case_insensitive(self):
+        """Verifies that values for the parts are treated case-insensitive."""
+        self.assertEqual(
+            [PudlResourceKey("epacems", "123", "mixed-case")],
+            list(self.descriptor.get_resources(upper="uppeR")),
+        )
+        self.assertEqual(
+            [PudlResourceKey("epacems", "123", "mixed-case")],
+            list(self.descriptor.get_resources(upper="uppeR", lower="Lower")),
+        )
+        # Lookups are, however, case-sensitive for the keys.
+        self.assertEqual([], list(self.descriptor.get_resources(Upper="UPPER")))
 
     def test_get_resources_by_name(self):
         """Verifies that get_resources() work when name is specified."""


### PR DESCRIPTION
This ensures that are filter values are cast to lowercase so there should not be any issues with incompatible cases used for things like `data_format=XBRL|dbf`.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
