### PR TITLE
Fix income_statement_ferc1 utility_type categorization bug

### DIFF
--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -12,7 +12,7 @@ import importlib.resources
 import re
 from collections import namedtuple
 from collections.abc import Mapping
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 import numpy as np
 import pandas as pd
@@ -3117,7 +3117,7 @@ class IncomeStatementFerc1TableTransformer(Ferc1AbstractTableTransformer):
     table_id: TableIdFerc1 = TableIdFerc1.INCOME_STATEMENT_FERC1
     has_unique_record_ids: bool = False
 
-    def process_dbf(self, raw_dbf):
+    def process_dbf(self: Self, raw_dbf: pd.DataFrame) -> pd.DataFrame:
         """Drop incorrect row numbers from f1_incm_stmnt_2 before standard processing.
 
         In 2003, two rows were added to the ``f1_income_stmnt`` dbf table, which bumped
@@ -3150,6 +3150,23 @@ class IncomeStatementFerc1TableTransformer(Ferc1AbstractTableTransformer):
         )
         raw_dbf = super().process_dbf(raw_dbf)
         return raw_dbf
+
+    def transform_main(self: Self, df: pd.DataFrame) -> pd.DataFrame:
+        """Drop duplicate records from f1_income_stmnt.
+
+        Because net_utility_operating_income is reported on both page 1 and 2 of the
+        form, it ends up introducing a bunch of duplicated records, so we need to drop
+        one of them. Since the value is used in the calculations that are part of the
+        second page, we'll drop it from the first page.
+        """
+        df = super().transform_main(df)
+        df = df[
+            ~(
+                (df.record_id.str.startswith("f1_income_stmnt_"))
+                & (df.income_type == "net_utility_operating_income")
+            )
+        ]
+        return df
 
 
 class RetainedEarningsFerc1TableTransformer(Ferc1AbstractTableTransformer):

--- a/src/pudl/transform/params/ferc1.py
+++ b/src/pudl/transform/params/ferc1.py
@@ -3825,8 +3825,8 @@ TRANSFORM_PARAMS = {
             "utility_type": {
                 "categories": UTILITY_TYPE_CATEGORIES["categories"]
                 | {
-                    "total": {"total"},
-                    "other": {"other", "other_total", "ferc:OtherUtilityMember"},
+                    "total": {"total", "other_total"},
+                    "other": {"other", "ferc:OtherUtilityMember"},
                     "other1": {"other1"},
                     "other2": {"other2"},
                     "other3": {"other3"},


### PR DESCRIPTION
# PR Overview

* Fix categorization of `other_total` utility types in DBF data for the `income_statement_ferc1` table so that they end up being `total` rather than `other`.
* Drop the duplicated values of `net_utility_operating_income` that result from that value being reported on both page 1 and page 2 of the old DBF derived income statement form.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
