### PR TITLE
Revert crosswalk to 2018

### DIFF
--- a/src/pudl/etl/glue_assets.py
+++ b/src/pudl/etl/glue_assets.py
@@ -61,8 +61,8 @@ def raw_epacamd_eia(context) -> pd.DataFrame:
     """Extract the EPACAMD-EIA Crosswalk from the Datastore."""
     logger.info("Extracting the EPACAMD-EIA crosswalk from Zenodo")
     ds = context.resources.datastore
-    with ds.get_zipfile_resource("epacamd_eia", name="epacamd_eia_2021.zip").open(
-        "camd-eia-crosswalk-2021-main/epa_eia_crosswalk.csv"
+    with ds.get_zipfile_resource("epacamd_eia", name="epacamd_eia_2018.zip").open(
+        "camd-eia-crosswalk-master/epa_eia_crosswalk.csv"
     ) as f:
         return pd.read_csv(f)
 


### PR DESCRIPTION
Revert EPA-EIA crosswalk to 2018 version until we decide how to handle 2021 version in #2580.