### PR TITLE
Merge two 'head' migrations together

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,6 +35,7 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
+        exclude: migrations/.*
 
   # Format the code
   - repo: https://github.com/psf/black
@@ -42,6 +43,7 @@ repos:
     hooks:
       - id: black
         language_version: python3.11
+        exclude: migrations/.*
 
   # Format docstrings
   - repo: https://github.com/PyCQA/docformatter
@@ -49,6 +51,7 @@ repos:
     hooks:
       - id: docformatter
         args: ["--in-place", "--config", "tox.ini"]
+        exclude: migrations/.*
 
   # Remove f-string prefix when there's nothing in the string to format.
   - repo: https://github.com/dannysepler/rm_unneeded_f_str
@@ -85,6 +88,7 @@ repos:
     hooks:
       - id: flake8
         args: [--config, tox.ini]
+        exclude: migrations/.*
         additional_dependencies:
           - flake8-docstrings
           - flake8-colors

--- a/migrations/versions/9ab4befcc33a_merge_migrations.py
+++ b/migrations/versions/9ab4befcc33a_merge_migrations.py
@@ -1,0 +1,24 @@
+"""Merge migrations
+
+Revision ID: 9ab4befcc33a
+Revises: 91358c4810b5, e878ec83ceb5
+Create Date: 2023-05-22 11:08:29.071908
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '9ab4befcc33a'
+down_revision = ('91358c4810b5', 'e878ec83ceb5')
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/tox.ini
+++ b/tox.ini
@@ -328,6 +328,7 @@ extend-exclude =
     ./build,
     ./venv,
     .ipynb_checkpoints,
+    ./migrations,
 # We have a backlog of complex functions being skipped with noqa: C901
 max-complexity = 10
 format = %(cyan)s%(path)s%(reset)s:%(green)s%(row)-4d%(reset)s %(red)s%(bold)s%(code)s%(reset)s %(text)s


### PR DESCRIPTION
This PR merges together two `alembic` migrations to address the current failure in the nightly builds. It also instructs several pre-commit hooks to ignore any files in the `migrations/` directory. It's probably best to leave the auto-generated files here alone.