### PR TITLE
Allow JupyterLab v4.0.0 in pudl-dev environment.

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -24,7 +24,7 @@ dependencies:
   # Jupyter notebook specific packages:
   - jupyter-resource-usage~=0.5.0
   - nbconvert>=6,<7
-  - jupyterlab~=3.2
+  - jupyterlab>=3.2,<4.1
 
   # Use pip to install the main PUDL repo / package for development:
   - pip:


### PR DESCRIPTION
# PR Overview

Updates the `pudl-dev` conda environment definition to allow the newly release Jupyter Lab 4.0.0.  I've been using it locally for several days and haven't run into any issues.  [Release notes here](https://jupyterlab.readthedocs.io/en/latest/getting_started/changelog.html#v4-0).

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
