### PR TITLE
Fix rouge operational status codes causing foreign key failure

### DIFF
--- a/src/pudl/metadata/codes.py
+++ b/src/pudl/metadata/codes.py
@@ -943,6 +943,7 @@ CODE_METADATA: dict[str, dict[str, Any]] = {
             "(V) Under construction, more than 50 percent complete": "V",
             "BU": "SB",
         },
+        "ignored_codes": ["CS"],
     },
     "energy_sources_eia": {
         "df": pd.DataFrame(

--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -860,15 +860,6 @@ def clean_emissions_control_equipment_eia860(
         "emission_control_equipment_cost",
     ] = 3200
 
-    # Fix bad operational status code. Decided to fix it here instead of in the
-    # code_fixes portion of the CODE_METADATA because it felt more like a one-off
-    # rather than something that should be applied across the board. I determined that
-    # this was the right fix by looking at the operational_status_code for this
-    # emissions control unit in the surrounding yeras.
-    emce_df.loc[
-        emce_df["operational_status_code"] == "CS", "operational_status_code"
-    ] = "RE"
-
     return emce_df
 
 

--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -860,6 +860,15 @@ def clean_emissions_control_equipment_eia860(
         "emission_control_equipment_cost",
     ] = 3200
 
+    # Fix bad operational status code. Decided to fix it here instead of in the
+    # code_fixes portion of the CODE_METADATA because it felt more like a one-off
+    # rather than something that should be applied across the board. I determined that
+    # this was the right fix by looking at the operational_status_code for this
+    # emissions control unit in the surrounding yeras.
+    emce_df.loc[
+        emce_df["operational_status_code"] == "CS", "operational_status_code"
+    ] = "RE"
+
     return emce_df
 
 


### PR DESCRIPTION
Little fix for an operational status code value in the `emissions_control_equipment_eia860` table that was causing the nightly builds to fail. There was a value called "CS" for `plant_id_eia`: 2682, `particulate_control_id_eia` values 9 and 10 in 2016 that wasn't specified in the EIA's list of possible operational status codes. I looked at the operational status codes for the same plant and ids in 2015 and 2017 and both were "RE" so I changed it to RE. 

I made this change in the transform module rather than in the code_fixes part of the CODE_METADATA dictionary because it felt more like a one-off fix then something that should be applied across the board. I.e., I couldn't be sure that future instances of "CS" in the data should be automatically converted to RE.