### PR TITLE
Add encoding step to the transform step for the emissions_control_equ…

### DIFF
--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -860,6 +860,12 @@ def clean_emissions_control_equipment_eia860(
         "emission_control_equipment_cost",
     ] = 3200
 
+    emce_df = (
+        pudl.metadata.classes.Package.from_resource_ids()
+        .get_resource("emissions_control_equipment_eia860")
+        .encode(emce_df)
+    )
+
     return emce_df
 
 


### PR DESCRIPTION
Continuation of #2602.

The previous PR (above) adds `CS` to the listed of `ignored_codes` in the `CODE_METADATA` for `operational_status_eia`, but it didn't actually apply the encoder.

This PR applies the encoder to the transform step to the `emissions_control_equipment_eia860` table so the erroneous operational codes actually get converted to NA.

This should fix the build fail.