### PR TITLE
Add release notes explaning FERC 1 metadata cleanup

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -170,6 +170,9 @@ Data Cleaning
 * The :ref:`boiler_fuel_eia923` table now includes the ``prime_mover_code`` column. This
   column was previously incorrectly being associated with boilers in the
   :ref:`boilers_entity_eia` table. See issue :issue:`2349` & PR :pr:`2362`.
+* Added "correction" records to many FERC Form 1 tables where the reported totals do not
+  match the outcomes of calculations specified in XBRL metadata (even after cleaning up
+  the often incorrect calculation specifications!). See :issue:`2957` and :pr:`2620`.
 
 Analysis
 ^^^^^^^^


### PR DESCRIPTION
# PR Overview

@cmgosnell & @e-belfer I noticed that we haven't really been documenting our cleanup of the FERC 1 metadata / calculations in the release notes, which seems like it'll be helpful.  I added a note about adding the correction records, if y'all want to add your own notes about what you've done and the issues / PRs that would be great!

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
