### PR TITLE
Fix job names in docs

### DIFF
--- a/docs/dev/run_the_etl.rst
+++ b/docs/dev/run_the_etl.rst
@@ -276,7 +276,7 @@ in the ``pudl.etl`` definition. Subsets of the ``pudl.etl`` asset graph
 are organized by asset groups. These groups are helfpul for visualizing and
 executing subsets of the asset graph.
 
-To execute the job, select ``fast_etl`` or ``full_etl`` and click "Materialize all".
+To execute the job, select ``etl_fast`` or ``etl_full`` and click "Materialize all".
 You can congifure which years to process by shift+clicking "Materialize all".
 Read the :ref:`resource_config` section to learn more.
 To view the status of the run, click the date next to "Latest run:".


### PR DESCRIPTION
# PR Overview
Running through the docs for the first time, and noticed that these names were slightly wrong; this is what they look like for me:
![Screenshot 2023-06-07 at 21 03 21](https://github.com/catalyst-cooperative/pudl/assets/6197628/8075b346-d704-4f77-96ff-c6c05d375f0e)

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
