### PR TITLE
Use PUDL_INPUT not hard-coded data dir in datastore CLI

### DIFF
--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -534,7 +534,7 @@ def _get_pudl_in(args: dict) -> Path:
     if args.pudl_in:
         return Path(args.pudl_in)
     else:
-        return Path(pudl.workspace.setup.get_defaults()["pudl_in"])
+        return Path(pudl.workspace.setup.get_defaults()["PUDL_INPUT"])
 
 
 def _create_datastore(args: argparse.Namespace) -> Datastore:
@@ -542,7 +542,7 @@ def _create_datastore(args: argparse.Namespace) -> Datastore:
     # Configure how we want to obtain raw input data:
     ds_kwargs = dict(gcs_cache_path=args.gcs_cache_path, sandbox=args.sandbox)
     if not args.bypass_local_cache:
-        ds_kwargs["local_cache_path"] = _get_pudl_in(args) / "data"
+        ds_kwargs["local_cache_path"] = _get_pudl_in(args)
     return Datastore(**ds_kwargs)
 
 


### PR DESCRIPTION
# PR Overview

While debugging FERC 2 DBF extraction build failure I found a lingering hard-coded PUDL input directory in the datastore CLI and fixed it.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
