### PR TITLE
WIP: Add `electric_plant_depreciation_changes_ferc1` into explosion

### DIFF
--- a/src/pudl/metadata/resources/ferc1.py
+++ b/src/pudl/metadata/resources/ferc1.py
@@ -182,7 +182,7 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "depreciation_type",
                 "plant_status",
                 "utility_type",
-                "utility_plant_value",
+                "dollar_value",
                 "record_id",
                 "balance",
                 "ferc_account",

--- a/src/pudl/transform/params/ferc1.py
+++ b/src/pudl/transform/params/ferc1.py
@@ -3876,22 +3876,22 @@ TRANSFORM_PARAMS = {
                     "row_seq": "row_seq",
                     "row_prvlg": "row_prvlg",
                     "report_prd": "report_prd",
-                    "total_cde": "total_utility_plant_value",
-                    "future_plant": "future_utility_plant_value",
-                    "leased_plant": "leased_utility_plant_value",
-                    "electric_plant": "in_service_utility_plant_value",
+                    "total_cde": "total_dollar_value",
+                    "future_plant": "future_dollar_value",
+                    "leased_plant": "leased_dollar_value",
+                    "electric_plant": "in_service_dollar_value",
                     "xbrl_factoid": "depreciation_type",
                 }
             },
             "instant_xbrl": {
                 "columns": {
-                    "accumulated_provision_for_depreciation_of_electric_utility_plant_ending_balance": "ending_balance_utility_plant_value",
-                    "accumulated_provision_for_depreciation_of_electric_utility_plant_starting_balance": "starting_balance_utility_plant_value",
+                    "accumulated_provision_for_depreciation_of_electric_utility_plant_ending_balance": "ending_balance_dollar_value",
+                    "accumulated_provision_for_depreciation_of_electric_utility_plant_starting_balance": "starting_balance_dollar_value",
                 }
             },
             "duration_xbrl": {
                 "columns": {
-                    xbrl_col: f"{xbrl_col}_utility_plant_value"
+                    xbrl_col: f"{xbrl_col}_dollar_value"
                     for xbrl_col in [
                         "book_cost_of_asset_retirement_costs",
                         "book_cost_of_retired_plant",
@@ -3931,7 +3931,7 @@ TRANSFORM_PARAMS = {
                     "depreciation_type",
                     "record_id",
                 ],
-                "value_types": ["utility_plant_value"],
+                "value_types": ["dollar_value"],
                 "expected_drop_cols": 2,
                 "stacked_column_name": "plant_status",
             },
@@ -3943,7 +3943,7 @@ TRANSFORM_PARAMS = {
                     "utility_type_axis",
                     "sched_table_name",
                 ],
-                "value_types": ["utility_plant_value"],
+                "value_types": ["dollar_value"],
                 "expected_drop_cols": 2,
                 "stacked_column_name": "depreciation_type",
             },
@@ -3959,6 +3959,11 @@ TRANSFORM_PARAMS = {
         },
         "unstack_balances_to_report_year_instant_xbrl": {
             "unstack_balances_to_report_year": True
+        },
+        "reconcile_table_calculations": {
+            "column_to_check": "dollar_value",
+            "calculation_tolerance": 0.4,
+            "subtotal_column": "depreciation_type",
         },
     },
     "electric_plant_depreciation_functional_ferc1": {


### PR DESCRIPTION
A sub-task of #2016. At present, we are missing `electric_plant_depreciation_changes_ferc1`, which is a sub-component of `balance_sheet_assets_ferc1`. This PR does the following:
- subclasses `process_xbrl_metadata()` to account for a non-standard renaming of the XBRL factoid provided in the FERC Instant XBRL data
- renames `utility_plant_value` to `dollar_value` to be consistent with other tables
- adds calculation and second-dimension calculation checks into the table processing
- adds one calculation into the metadata which is missing (`ending_balance`)

To do:
- [ ] Right now ~35% of calculations are off with no very obvious candidate. Fix this!

-->

# PR Overview

<!--

Include a short narrative summary of what's going on in the PR. This can be a bulleted list. You might want to include:

* What are you changing and why?
* Are there any known unsolved problems remaining in the PR?
* Is there anything that you want a reivewer to pay particular attention to?
* What kind of feedback are you looking for on the PR?

-->

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
