### PR TITLE
Fix Alembic migration diversions in dev

### DIFF
--- a/migrations/versions/e608f95a3b78_drop_amount_from_retained_earnings.py
+++ b/migrations/versions/e608f95a3b78_drop_amount_from_retained_earnings.py
@@ -1,8 +1,8 @@
-"""Remove amount column from retained earnings
+"""drop amount from retained earnings
 
-Revision ID: cd70aa9ce4e9
-Revises: 88d9201ae4c4
-Create Date: 2023-06-13 09:18:41.174833
+Revision ID: e608f95a3b78
+Revises: 3c458b36094e
+Create Date: 2023-06-19 09:04:49.591285
 
 """
 from alembic import op
@@ -10,8 +10,8 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'cd70aa9ce4e9'
-down_revision = '88d9201ae4c4'
+revision = 'e608f95a3b78'
+down_revision = '3c458b36094e'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Looks like we simultaneously pushed two different alembic migration histories into dev and broke the nightly build. Let's fix it!

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
