### PR TITLE
Fix apparent typos in FERC 1 rename params.

### DIFF
--- a/src/pudl/transform/params/ferc1.py
+++ b/src/pudl/transform/params/ferc1.py
@@ -3204,8 +3204,8 @@ TRANSFORM_PARAMS = {
                     # detail of accum deprish
                     # in service
                     "in_srvce_depr": "depreciation_utility_plant_in_service_ending_balance",
-                    "amrtzd_dplt_nglr": "amortization_and_depletion_of_producing_natural_gas_land_and_land_rightsutility_plant_in_service_ending_balance",
-                    "amrtzd_ugrndstrg": "amortization_of_underground_storage_land_and_land_rightsutility_plant_in_service_ending_balance",
+                    "amrtzd_dplt_nglr": "amortization_and_depletion_of_producing_natural_gas_land_and_land_rights_utility_plant_in_service_ending_balance",
+                    "amrtzd_ugrndstrg": "amortization_of_underground_storage_land_and_land_rights_utility_plant_in_service_ending_balance",
                     "amrtz_utlty_plnt": "amortization_of_other_utility_plant_utility_plant_in_service_ending_balance",
                     "tot_in_service": "depreciation_amortization_and_depletion_utility_plant_in_service_ending_balance",
                     # leased to others
@@ -3246,7 +3246,7 @@ TRANSFORM_PARAMS = {
                         "depreciation_utility_plant_held_for_future_use",
                         "abandonment_of_leases",
                         "utility_plant_net",
-                        "amortization_and_depletion_of_producing_natural_gas_land_and_land_rightsutility_plant_in_service",
+                        "amortization_and_depletion_of_producing_natural_gas_land_and_land_rights_utility_plant_in_service",
                         "amortization_utility_plant_held_for_future_use",
                         "amortization_and_depletion_utility_plant_leased_to_others",
                         "accumulated_provision_for_depreciation_amortization_and_depletion_of_plant_utility",
@@ -3255,7 +3255,7 @@ TRANSFORM_PARAMS = {
                         "utility_plant_leased_to_others",
                         "utility_plant_held_for_future_use",
                         "amortization_of_other_utility_plant_utility_plant_in_service",
-                        "amortization_of_underground_storage_land_and_land_rightsutility_plant_in_service",
+                        "amortization_of_underground_storage_land_and_land_rights_utility_plant_in_service",
                         "utility_plant_in_service_completed_construction_not_classified",
                         "utility_plant_in_service_plant_purchased_or_sold",
                         "construction_work_in_progress",

--- a/src/pudl/transform/params/ferc1.py
+++ b/src/pudl/transform/params/ferc1.py
@@ -3246,7 +3246,6 @@ TRANSFORM_PARAMS = {
                         "depreciation_utility_plant_held_for_future_use",
                         "abandonment_of_leases",
                         "utility_plant_net",
-                        "amortization_and_depletion_of_producing_natural_gas_land_and_land_rights_utility_plant_in_service",
                         "amortization_utility_plant_held_for_future_use",
                         "amortization_and_depletion_utility_plant_leased_to_others",
                         "accumulated_provision_for_depreciation_amortization_and_depletion_of_plant_utility",
@@ -3261,6 +3260,10 @@ TRANSFORM_PARAMS = {
                         "construction_work_in_progress",
                         "utility_plant_in_service_experimental_plant_unclassified",
                     ]
+                }
+                | {
+                    "amortization_and_depletion_of_producing_natural_gas_land_and_land_rightsutility_plant_in_service": "amortization_and_depletion_of_producing_natural_gas_land_and_land_rights_utility_plant_in_service_ending_balance",
+                    "amortization_of_underground_storage_land_and_land_rightsutility_plant_in_service": "amortization_of_underground_storage_land_and_land_rights_utility_plant_in_service_ending_balance",
                 }
             },
         },


### PR DESCRIPTION
# PR Overview

A few of the column renames in the `utility_plant_summary_ferc1` table appear to have had some cut-and-paste or search-and-replace typos in them, resulting in missing underscores between components of the name.  Unless there's some unusual reason we need not to have those underscores?

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
