### PR TITLE
fix `source_tables` definition

### DIFF
--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -69,11 +69,15 @@ def add_source_tables_to_xbrl_metadata(
             field["name"] for meta_list in table_meta.values() for field in meta_list
         ]
 
-    def extract_tables_to_fields(xbrl_meta: dict) -> dict[str : list[str]]:
-        """Compile a dictionary of table names (keys) to list of fields."""
+    def extract_tables_to_fields(raw_xbrl_metadata_json: dict) -> dict[str : list[str]]:
+        """Compile a dictionary of table names (keys) to list of fields.
+
+        Args:
+            raw_xbrl_metadata_json: dictionary of xbrl metadata.
+        """
         return {
             table_name: all_fields_in_table(table_meta)
-            for table_name, table_meta in xbrl_meta.items()
+            for table_name, table_meta in raw_xbrl_metadata_json.items()
         }
 
     def label_source_tables(calc_component: dict, tables_to_fields: str) -> dict:
@@ -91,18 +95,14 @@ def add_source_tables_to_xbrl_metadata(
 
     tables_to_fields = extract_tables_to_fields(raw_xbrl_metadata_json)
     # for each table loop through all of the calculations within each field
-    for table_name, table_meta in raw_xbrl_metadata_json.items():
+    for table_meta in raw_xbrl_metadata_json.values():
         for list_of_facts in table_meta.values():
             for xbrl_fact in list_of_facts:
                 # all facts have ``calculations``, but they are empty lists when null
                 for calc_component in xbrl_fact["calculations"]:
-                    # does the calc component show up in the table? if not, add a label
-                    if calc_component["name"] not in tables_to_fields[table_name]:
-                        calc_component = label_source_tables(
-                            calc_component, tables_to_fields
-                        )
-                    else:
-                        calc_component["source_tables"] = [table_name]
+                    calc_component = label_source_tables(
+                        calc_component, tables_to_fields
+                    )
     return raw_xbrl_metadata_json
 
 


### PR DESCRIPTION
# PR Overview
I was previously assuming that if a calculation component showed up in the source_table of the calculation, than i didn't need to check if that component also showed up in other tables.

That was wrong! There are instances like for factoid `utility_plant_and_construction_work_in_progress` which shows up in multiple tables and has calculations components like `construction_work_in_progress` that show up in multiple tables.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
