### PR TITLE
add straggler dbf-only factoids into ferc1 table metadata

### DIFF
--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -2369,6 +2369,14 @@ class Ferc1AbstractTableTransformer(AbstractTableTransformer):
                     {
                         "calc_component_to_replace": {},
                         "calc_component_new": {
+                            "name": "unappropriated_undistributed_subsidiary_earnings_previous_year",
+                            "weight": 1.0,
+                            "source_tables": ["retained_earnings_ferc1"],
+                        },
+                    },
+                    {
+                        "calc_component_to_replace": {},
+                        "calc_component_new": {
                             "name": "equity_in_earnings_of_subsidiary_companies",
                             "weight": 1.0,
                             "source_tables": ["retained_earnings_ferc1"],
@@ -2392,6 +2400,14 @@ class Ferc1AbstractTableTransformer(AbstractTableTransformer):
                     },
                 ],
                 "unappropriated_retained_earnings": [
+                    {
+                        "calc_component_to_replace": {},
+                        "calc_component_new": {
+                            "name": "unappropriated_retained_earnings_previous_year",
+                            "weight": 1.0,
+                            "source_tables": ["retained_earnings_ferc1"],
+                        },
+                    },
                     {
                         "calc_component_to_replace": {},
                         "calc_component_new": {

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -5131,7 +5131,7 @@ class BalanceSheetLiabilitiesFerc1TableTransformer(Ferc1AbstractTableTransformer
             "ferc_account": [pd.NA],
             "xbrl_factoid_original": ["accumulated_deferred_income_taxes"],
             "intra_table_calc_flag": [True],
-            "row_type_xbrl": ["report_value"],
+            "row_type_xbrl": ["reported_value"],
         }
 
         new_facts = pd.DataFrame(facts_to_add).convert_dtypes()
@@ -5153,15 +5153,15 @@ class BalanceSheetAssetsFerc1TableTransformer(Ferc1AbstractTableTransformer):
         tbl_meta = super().process_xbrl_metadata(xbrl_metadata_json)
         facts_to_add = [
             {
-                "xbrl_factoid": dbf_onl_fact,
+                "xbrl_factoid": dbf_only_fact,
                 "calculations": "[]",
                 "balance": "credit",
                 "ferc_account": pd.NA,
-                "xbrl_factoid_original": dbf_onl_fact,
+                "xbrl_factoid_original": dbf_only_fact,
                 "intra_table_calc_flag": True,
-                "row_type_xbrl": "report_value",
+                "row_type_xbrl": "reported_value",
             }
-            for dbf_onl_fact in ["special_funds_all", "nuclear_fuel"]
+            for dbf_only_fact in ["special_funds_all", "nuclear_fuel"]
         ]
 
         new_facts = pd.DataFrame(facts_to_add).convert_dtypes()
@@ -5188,7 +5188,7 @@ class IncomeStatementFerc1TableTransformer(Ferc1AbstractTableTransformer):
             "ferc_account": [pd.NA],
             "xbrl_factoid_original": ["miscellaneous_deductions"],
             "intra_table_calc_flag": [True],
-            "row_type_xbrl": ["report_value"],
+            "row_type_xbrl": ["reported_value"],
         }
 
         new_facts = pd.DataFrame(facts_to_add).convert_dtypes()

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -2369,14 +2369,6 @@ class Ferc1AbstractTableTransformer(AbstractTableTransformer):
                     {
                         "calc_component_to_replace": {},
                         "calc_component_new": {
-                            "name": "unappropriated_undistributed_subsidiary_earnings_previous_year",
-                            "weight": 1.0,
-                            "source_tables": ["retained_earnings_ferc1"],
-                        },
-                    },
-                    {
-                        "calc_component_to_replace": {},
-                        "calc_component_new": {
                             "name": "equity_in_earnings_of_subsidiary_companies",
                             "weight": 1.0,
                             "source_tables": ["retained_earnings_ferc1"],
@@ -2400,14 +2392,6 @@ class Ferc1AbstractTableTransformer(AbstractTableTransformer):
                     },
                 ],
                 "unappropriated_retained_earnings": [
-                    {
-                        "calc_component_to_replace": {},
-                        "calc_component_new": {
-                            "name": "unappropriated_retained_earnings_previous_year",
-                            "weight": 1.0,
-                            "source_tables": ["retained_earnings_ferc1"],
-                        },
-                    },
                     {
                         "calc_component_to_replace": {},
                         "calc_component_new": {
@@ -5132,6 +5116,26 @@ class BalanceSheetLiabilitiesFerc1TableTransformer(Ferc1AbstractTableTransformer
 
     table_id: TableIdFerc1 = TableIdFerc1.BALANCE_SHEET_LIABILITIES
     has_unique_record_ids: bool = False
+
+    def process_xbrl_metadata(self, xbrl_metadata_json) -> pd.DataFrame:
+        """Perform default xbrl metadata processing plus adding a new xbrl_factoid.
+
+        Note: we should probably parameterize this and add it into the standard
+        :meth:`process_xbrl_metadata`.
+        """
+        tbl_meta = super().process_xbrl_metadata(xbrl_metadata_json)
+        facts_to_add = {
+            "xbrl_factoid": ["accumulated_deferred_income_taxes"],
+            "calculations": ["[]"],
+            "balance": ["credit"],
+            "ferc_account": [pd.NA],
+            "xbrl_factoid_original": ["accumulated_deferred_income_taxes"],
+            "intra_table_calc_flag": [True],
+            "row_type_xbrl": ["report_value"],
+        }
+
+        new_facts = pd.DataFrame(facts_to_add).convert_dtypes()
+        return pd.concat([tbl_meta, new_facts])
 
 
 class BalanceSheetAssetsFerc1TableTransformer(Ferc1AbstractTableTransformer):

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -5299,7 +5299,24 @@ class RetainedEarningsFerc1TableTransformer(Ferc1AbstractTableTransformer):
             "ferc_account",
         ] = "418.1"
 
-        return meta
+        facts_to_add = [
+            {
+                "xbrl_factoid": new_fact,
+                "calculations": "[]",
+                "balance": "credit",
+                "ferc_account": pd.NA,
+                "xbrl_factoid_original": new_fact,
+                "intra_table_calc_flag": True,
+                "row_type_xbrl": "reported_value",
+            }
+            for new_fact in [
+                "unappropriated_retained_earnings_previous_year",
+                "unappropriated_undistributed_subsidiary_earnings_previous_year",
+            ]
+        ]
+
+        new_facts = pd.DataFrame(facts_to_add).convert_dtypes()
+        return pd.concat([meta, new_facts])
 
     def process_dbf(self, raw_dbf: pd.DataFrame) -> pd.DataFrame:
         """Preform generic :meth:`process_dbf`, plus deal with duplicates.


### PR DESCRIPTION
# PR Overview
I started with just adding the dfb-only metadata fields into each table's metada doing it in a bespokey way. will probably parameterize this adding of these guys.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
