### PR TITLE
Remove refs to 2i2c JupyterHub. Move nightly build links to data access page

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,7 @@ resources and everyone in between!
 How do I access the data?
 -------------------------
 
-There are four main ways to access PUDL outputs. For more details you'll want
+There are several ways to access PUDL outputs. For more details you'll want
 to check out `the complete documentation
 <https://catalystcoop-pudl.readthedocs.io>`__, but here's a quick overview:
 
@@ -138,20 +138,6 @@ The `PUDL Examples repository <https://github.com/catalyst-cooperative/pudl-exam
 has more detailed instructions on how to work with the Zenodo data archive and Docker
 image.
 
-JupyterHub
-^^^^^^^^^^
-Do you want to use Python and Jupyter Notebooks to access the data but aren't
-comfortable setting up Docker? We are working with `2i2c <https://2i2c.org>`__ to host
-a JupyterHub that has the same software and data as the Docker container and Zenodo
-archive mentioned above, but running in the cloud.
-
-* `Request an account <https://forms.gle/TN3GuE2e2mnWoFC4A>`__
-* `Log in to the JupyterHub <https://bit.ly/pudl-examples-01>`__
-
-**Note:** you'll only have 4-6GB of RAM and 1 CPU to work with on the JupyterHub, so
-if you need more computing power, you may need to set PUDL up on your own computer.
-Eventually we hope to offer scalable computing resources on the JupyterHub as well.
-
 The PUDL Development Environment
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 If you're more familiar with the Python data science stack and are comfortable working
@@ -161,53 +147,22 @@ full data processing pipeline yourself, tweak the underlying source code, and (w
 make contributions back to the project.
 
 This is by far the most involved way to access the data and isn't recommended for
-most users. You should check out the `Development section <https://catalystcoop-pudl.readthedocs.io/en/latest/dev/dev_setup.html>`__ of the main `PUDL
-documentation <https://catalystcoop-pudl.readthedocs.io>`__ for more details.
+most users. You should check out the `Development section <https://catalystcoop-pudl.readthedocs.io/en/latest/dev/dev_setup.html>`__
+of the main `PUDL documentation <https://catalystcoop-pudl.readthedocs.io>`__ for more
+details.
 
 Nightly Data Builds
 ^^^^^^^^^^^^^^^^^^^
 If you are less concerned with reproducibility and want the freshest possible data
-we also upload the outputs of our nightly builds to public S3 storage buckets. This
-data is produced by the `dev branch <https://github.com/catalyst-cooperative/pudl/tree/dev>`__,
-of PUDL, and is updated most weekday mornings. It is also the data used to populate
-Datasette:
+we automatically upload the outputs of our nightly builds to public S3 storage buckets
+as part of the `AWS Open Data Registry
+<https://registry.opendata.aws/catalyst-cooperative-pudl/>`__.  This data is based on
+the `dev branch <https://github.com/catalyst-cooperative/pudl/tree/dev>`__, of PUDL, and
+is updated most weekday mornings. It is also the data used to populate Datasette.
 
-* `PUDL SQLite DB <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/pudl.sqlite>`__
-* `EPA CEMS Hourly Emissions Parquet (1995-2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/hourly_emissions_epacems.parquet>`__
-* `Census DP1 SQLite DB (2010) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/censusdp1tract.sqlite>`__
-
-* Raw FERC Form 1:
-
-  * `FERC-1 SQLite derived from DBF (1994-2020) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc1.sqlite>`__
-  * `FERC-1 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc1_xbrl.sqlite>`__
-  * `FERC-1 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc1_xbrl_datapackage.json>`__
-  * `FERC-1 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc1_xbrl_taxonomy_metadata.json>`__
-
-* Raw FERC Form 2:
-
-  * `FERC-2 SQLite derived from DBF (1996-2020) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc2.sqlite>`__
-  * `FERC-2 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc2_xbrl.sqlite>`__
-  * `FERC-2 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc2_xbrl_datapackage.json>`__
-  * `FERC-2 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc2_xbrl_taxonomy_metadata.json>`__
-
-* Raw FERC Form 6:
-
-  * `FERC-6 SQLite derived from DBF (2000-2020) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc6.sqlite>`__
-  * `FERC-6 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc6_xbrl.sqlite>`__
-  * `FERC-6 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc6_xbrl_datapackage.json>`__
-  * `FERC-6 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc6_xbrl_taxonomy_metadata.json>`__
-
-* Raw FERC Form 60:
-
-  * `FERC-60 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc60_xbrl.sqlite>`__
-  * `FERC-60 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc60_xbrl_datapackage.json>`__
-  * `FERC-60 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc60_xbrl_taxonomy_metadata.json>`__
-
-* Raw FERC Form 714:
-
-  * `FERC-714 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc714_xbrl.sqlite>`__
-  * `FERC-714 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc714_xbrl_datapackage.json>`__
-  * `FERC-714 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc714_xbrl_taxonomy_metadata.json>`__
+The nightly build outputs can be accessed using the AWS CLI, the S3 API, or downloaded
+directly via the web. See `Accessing Nightly Builds <https://catalystcoop-pudl.readthedocs.io/en/latest/data_access.html#access-nightly-builds>`__
+for links to the individual SQLite, JSON, and Apache Parquet outputs.
 
 Contributing to PUDL
 --------------------

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -30,16 +30,15 @@ which one is right for you and your use case.
        Select data to download as CSVs for local analysis in spreadsheets.
        Create sharable links to a particular selection of data.
        Access PUDL data via a REST API.
+   * - :ref:`access-nightly-builds`
+     - Cloud Developer, Database User, Beta Tester
+     - Get the freshest data that has passed all data validations, updated most weekday
+       mornings. Fast downloads from AWS S3 storage buckets.
    * - :ref:`access-zenodo`
      - Researcher, Database User, Notebook Analyst
      - Use a stable, citable, fully processed version of the PUDL on your own computer.
        Use PUDL in Jupyer Notebooks running in a stable, archived Docker container.
        Access the SQLite DB and Parquet files directly using any toolset.
-   * - :ref:`access-jupyterhub`
-     - New Python User, Notebook Analyst
-     - Work through the PUDL example notebooks without any downloads or setup.
-       Perform your own notebook-based analyses using PUDL data and limited
-       computational resources.
    * - :ref:`access-development`
      - Python Developer, Data Wrangler
      - Run the PUDL data processing pipeline on your own computer.
@@ -66,6 +65,60 @@ Note that only data that has been fully integrated into the SQLite databases are
 available here. Currently this includes `the core PUDL database
 <https://data.catalyst.coop/pudl>`__ and our concatenation of `all historical FERC
 Form 1 databases <https://data.catalyst.coop/ferc1>`__.
+
+.. _access-nightly-builds:
+
+---------------------------------------------------------------------------------------
+Nightly Builds
+---------------------------------------------------------------------------------------
+
+Every night we attempt to process all of the data that's part of PUDL using the most
+recent version of the `dev branch
+<https://github.com/catalyst-cooperative/pudl/tree/dev>`__. If the ETL succeeds and the
+resulting outputs pass all of the data validation tests we've defined, the outputs are
+automatically uploaded to the `AWS Open Data Registry
+<https://registry.opendata.aws/catalyst-cooperative-pudl/>`__, and used to deploy a new
+version of Datasette (see above). These nightly build outputs can be accessed using the
+AWS CLI, or programmatically via the S3 API. They can also be downloaded directly over
+HTTPS using the following links:
+
+* `PUDL SQLite DB <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/pudl.sqlite>`__
+* `EPA CEMS Hourly Emissions Parquet (1995-2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/hourly_emissions_epacems.parquet>`__
+* `Census DP1 SQLite DB (2010) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/censusdp1tract.sqlite>`__
+
+* Raw FERC Form 1:
+
+  * `FERC-1 SQLite derived from DBF (1994-2020) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc1.sqlite>`__
+  * `FERC-1 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc1_xbrl.sqlite>`__
+  * `FERC-1 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc1_xbrl_datapackage.json>`__
+  * `FERC-1 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc1_xbrl_taxonomy_metadata.json>`__
+
+* Raw FERC Form 2:
+
+  * `FERC-2 SQLite derived from DBF (1996-2020) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc2.sqlite>`__
+  * `FERC-2 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc2_xbrl.sqlite>`__
+  * `FERC-2 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc2_xbrl_datapackage.json>`__
+  * `FERC-2 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc2_xbrl_taxonomy_metadata.json>`__
+
+* Raw FERC Form 6:
+
+  * `FERC-6 SQLite derived from DBF (2000-2020) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc6.sqlite>`__
+  * `FERC-6 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc6_xbrl.sqlite>`__
+  * `FERC-6 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc6_xbrl_datapackage.json>`__
+  * `FERC-6 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc6_xbrl_taxonomy_metadata.json>`__
+
+* Raw FERC Form 60:
+
+  * `FERC-60 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc60_xbrl.sqlite>`__
+  * `FERC-60 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc60_xbrl_datapackage.json>`__
+  * `FERC-60 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc60_xbrl_taxonomy_metadata.json>`__
+
+* Raw FERC Form 714:
+
+  * `FERC-714 SQLite derived from XBRL (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc714_xbrl.sqlite>`__
+  * `FERC-714 Datapackage (JSON) describing SQLite derived from XBRL <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc714_xbrl_datapackage.json>`__
+  * `FERC-714 XBRL Taxonomy Metadata as JSON (2021) <https://s3.us-west-2.amazonaws.com/intake.catalyst.coop/dev/ferc714_xbrl_taxonomy_metadata.json>`__
+
 
 .. _access-zenodo:
 
@@ -97,31 +150,6 @@ products in `the Catalyst Cooperative Community on Zenodo
    .. code-block:: console
 
       $ docker pull catalystcoop/pudl-jupyter:latest
-
-.. _access-jupyterhub:
-
----------------------------------------------------------------------------------------
-JupyterHub
----------------------------------------------------------------------------------------
-
-We've set up a `JupyterHub <https://jupyter.org/hub>`__ in collaboration with
-`2i2c.org <https://2i2c.org>`__ to provide access to all of the processed PUDL
-data and the software environment required to work with it. You don't have to
-download or install anything to use it, but we do need to create an account for you.
-
-* Request an account by submitting `this form <https://forms.gle/TN3GuE2e2mnWoFC4A>`__.
-* Once we've created an account for you
-  `follow this link <https://bit.ly/pudl-examples-01>`__ to log in and open up the first
-  example notebook on the JupyterHub.
-* You can create your own notebooks and upload, save, and download modest amounts of
-  data on the hub.
-
-We can only offer a small amount of memory (4-6GB) and processing power (1 CPU) per
-user on the JupyterHub for free. If you need to work with lots of data or do
-computationally intensive analysis, you may want to look into using the
-:ref:`access-zenodo` option on your own computer. The JupyterHub uses exactly the
-same data and software environment as the Zenodo Archives. Eventually we also want to
-offer paid access to the JupyterHub with plenty of computing power.
 
 .. _access-development:
 


### PR DESCRIPTION
# PR Overview

We're [decommissioning the 2i2c JupyterHub](https://github.com/2i2c-org/infrastructure/issues/2607#issuecomment-1577249036) so we need to remove references to it from our documentation.

The PR also moves the increasingly long list of nightly build output links to the Data Access page.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
