### PR TITLE
Fix duplicated components in balance sheet liabilities FERC1 table

### DIFF
--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -2596,6 +2596,32 @@ class Ferc1AbstractTableTransformer(AbstractTableTransformer):
                         },
                     },
                 ],
+                "current_and_accrued_liabilities": [
+                    {
+                        "calc_component_to_replace": {
+                            "name": "long_term_portion_of_derivative_instrument_liabilities",
+                            "weight": 1.0,
+                            "source_tables": ["balance_sheet_liabilities_ferc1"],
+                        },
+                        "calc_component_new": {
+                            "name": "less_long_term_portion_of_derivative_instrument_liabilities",
+                            "weight": -1.0,
+                            "source_tables": ["balance_sheet_liabilities_ferc1"],
+                        },
+                    },
+                    {
+                        "calc_component_to_replace": {
+                            "name": "long_term_portion_of_derivative_instrument_liabilities_hedges",
+                            "weight": 1.0,
+                            "source_tables": ["balance_sheet_liabilities_ferc1"],
+                        },
+                        "calc_component_new": {
+                            "name": "less_long_term_portion_of_derivative_instrument_liabilities_hedges",
+                            "weight": -1.0,
+                            "source_tables": ["balance_sheet_liabilities_ferc1"],
+                        },
+                    },
+                ],
             },
             "retained_earnings_ferc1": {
                 "appropriated_retained_earnings_including_reserve_amortization": [
@@ -5379,13 +5405,56 @@ class BalanceSheetLiabilitiesFerc1TableTransformer(Ferc1AbstractTableTransformer
     table_id: TableIdFerc1 = TableIdFerc1.BALANCE_SHEET_LIABILITIES
     has_unique_record_ids: bool = False
 
+    @cache_df(key="main")
+    def transform_main(self: Self, df: pd.DataFrame) -> pd.DataFrame:
+        """Duplicate data that appears in multiple distinct calculations.
+
+        There is a one case in which exactly the same data values are referenced in
+        multiple calculations which can't be resolved by choosing one of the
+        referenced values as the canonical location for that data. In order to preserve
+        all of the calculation structure, we need to duplicate those records in the
+        data, the metadata, and the calculation specifications.  Here we duplicate the
+        data and associated it with newly defined facts, which we will also add to
+        the metadata and calculations.
+        """
+        df = super().transform_main(df)
+        facts_to_duplicate = [
+            "long_term_portion_of_derivative_instrument_liabilities",
+            "long_term_portion_of_derivative_instrument_liabilities_hedges",
+        ]
+        new_data = (
+            df[df.liability_type.isin(facts_to_duplicate)]
+            .copy()
+            .assign(liability_type=lambda x: "less_" + x.liability_type)
+        )
+
+        return pd.concat([df, new_data])
+
+    @cache_df(key="process_xbrl_metadata")
     def process_xbrl_metadata(self, xbrl_metadata_json) -> pd.DataFrame:
-        """Perform default xbrl metadata processing plus adding a new xbrl_factoid.
+        """Perform default xbrl metadata processing plus adding new xbrl_factoids.
+
+        We add two new factoids which are defined (by PUDL) only for the DBF data, and
+        also duplicate and redefine several factoids which are referenced in multiple
+        calculations and need to be distinguishable from each other.
 
         Note: we should probably parameterize this and add it into the standard
         :meth:`process_xbrl_metadata`.
         """
         tbl_meta = super().process_xbrl_metadata(xbrl_metadata_json)
+        facts_to_duplicate = [
+            "long_term_portion_of_derivative_instrument_liabilities",
+            "long_term_portion_of_derivative_instrument_liabilities_hedges",
+        ]
+        duplicated_facts = (
+            tbl_meta[tbl_meta.xbrl_factoid.isin(facts_to_duplicate)]
+            .copy()
+            .assign(
+                xbrl_factoid=lambda x: "less_" + x.xbrl_factoid,
+                xbrl_factoid_original=lambda x: "less_" + x.xbrl_factoid_original,
+                balance="credit",
+            )
+        )
         facts_to_add = {
             "xbrl_factoid": ["accumulated_deferred_income_taxes"],
             "calculations": ["[]"],
@@ -5397,7 +5466,7 @@ class BalanceSheetLiabilitiesFerc1TableTransformer(Ferc1AbstractTableTransformer
         }
 
         new_facts = pd.DataFrame(facts_to_add).convert_dtypes()
-        return pd.concat([tbl_meta, new_facts])
+        return pd.concat([tbl_meta, duplicated_facts, new_facts])
 
 
 class BalanceSheetAssetsFerc1TableTransformer(Ferc1AbstractTableTransformer):


### PR DESCRIPTION
This PR follows the same process as the balance sheet assets table for two troublesome components: 
`long_term_portion_of_derivative_instrument_liabilities`, and `long_term_portion_of_derivative_instrument_liabilities_hedges`.

These factoids show up in two calculations: `current_and_accrued_liabilities` and `other_noncurrent_liabilities`. They should be added in `other_noncurrent_liabilities` and subtracted in `current_and_accrued_liabilities` but are currently weighted positively in both. We fix the issues these components cause in the XBRL explosion tree construction and their incorrect calculations by creating new components with the prefix "less_" and replacing them with the original components in the `current_and_accrued_liabilities` calculations, weighted as negative.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
