### PR TITLE
Fix validation errors for 2022 EIA data

### DIFF
--- a/src/pudl/analysis/mcoe.py
+++ b/src/pudl/analysis/mcoe.py
@@ -4,6 +4,7 @@ from typing import Any
 import pandas as pd
 
 import pudl
+from pudl.helpers import oob_to_nan
 from pudl.metadata.fields import apply_pudl_dtypes
 
 DEFAULT_GENS_COLS = [
@@ -525,9 +526,10 @@ def mcoe(
             how="left" if all_gens else "right",
         ).pipe(pudl.validate.no_null_rows, df_name="mcoe_all_gens", thresh=0.9)
 
-    # Organize the dataframe for easier legibility
+    # Remove inf values from fuel cost and organize the dataframe for easier legibility
     mcoe_out = (
-        mcoe_out.pipe(
+        mcoe_out.pipe(oob_to_nan, ["fuel_cost_per_mwh"], ub=1e10)
+        .pipe(
             pudl.helpers.organize_cols,
             DEFAULT_GENS_COLS,
         )

--- a/src/pudl/validate.py
+++ b/src/pudl/validate.py
@@ -351,7 +351,7 @@ def vs_bounds(
     if hi_q <= 1 and hi_bool:
         hi_test = weighted_quantile(df[data_col], df[weight_col], hi_q)
         logger.info(f"{data_col} ({hi_q:.0%}): {hi_test:.6} <= {hi_bound:.6}")
-        if weighted_quantile(df[data_col], df[weight_col], hi_q) > hi_bound:
+        if hi_test > hi_bound:
             raise ValueError(
                 f"{hi_q:.0%} quantile ({hi_test}) "
                 f"is above upper bound ({hi_bound}) "
@@ -2729,12 +2729,13 @@ mcoe_fuel_cost_per_mwh = [
         "weight_col": "net_generation_mwh",
     },
     {  # EIA natural gas reporting really only becomes usable in 2015.
+        # Adjusted hi_bound for extra high gas prices in 2022.
         "title": "Natural Gas Fuel Costs (tails, 2015+)",
         "query": "fuel_type_code_pudl=='gas' and report_date>='2015-01-01'",
         "low_q": 0.05,
         "low_bound": 10.0,
         "hi_q": 0.95,
-        "hi_bound": 55.0,
+        "hi_bound": 61.4,
         "data_col": "fuel_cost_per_mwh",
         "weight_col": "net_generation_mwh",
     },
@@ -2773,12 +2774,13 @@ mcoe_fuel_cost_per_mmbtu = [
         "weight_col": "total_mmbtu",
     },
     {  # EIA natural gas reporting really only becomes usable in 2015.
+        # Adjusted the hi_bound for extra high gas prices in 2022.
         "title": "Natural Gas Fuel Costs (tails, 2015+)",
         "query": "fuel_type_code_pudl=='gas' and report_date>='2015-01-01'",
         "low_q": 0.05,
         "low_bound": 1.65,
         "hi_q": 0.95,
-        "hi_bound": 6.7,
+        "hi_bound": 7.8,
         "data_col": "fuel_cost_per_mmbtu",
         "weight_col": "total_mmbtu",
     },

--- a/test/validate/mcoe_test.py
+++ b/test/validate/mcoe_test.py
@@ -117,7 +117,7 @@ def test_no_null_rows_mcoe(pudl_out_mcoe, live_dbs, df_name, thresh):
         ("hr_by_gen", 593_988, 49_649),
         ("fuel_cost", 593_988, 49_649),
         ("capacity_factor", 5_178_892, 433_286),
-        ("mcoe", 4_872_841, 433_318),
+        ("mcoe", 5_179_276, 433_318),
     ],
 )
 def test_minmax_rows_mcoe(pudl_out_mcoe, live_dbs, monthly_rows, annual_rows, df_name):

--- a/test/validate/mcoe_test.py
+++ b/test/validate/mcoe_test.py
@@ -113,11 +113,11 @@ def test_no_null_rows_mcoe(pudl_out_mcoe, live_dbs, df_name, thresh):
 @pytest.mark.parametrize(
     "df_name,monthly_rows,annual_rows",
     [
-        ("hr_by_unit", 362_381, 30_340),
-        ("hr_by_gen", 555_119, 46_408),
-        ("fuel_cost", 555_119, 46_408),
-        ("capacity_factor", 4_872_457, 407_656),
-        ("mcoe", 4_872_841, 407_688),
+        ("hr_by_unit", 382_772, 32_042),
+        ("hr_by_gen", 593_988, 49_649),
+        ("fuel_cost", 593_988, 49_649),
+        ("capacity_factor", 5_178_892, 433_286),
+        ("mcoe", 4_872_841, 433_318),
     ],
 )
 def test_minmax_rows_mcoe(pudl_out_mcoe, live_dbs, monthly_rows, annual_rows, df_name):


### PR DESCRIPTION
# This PR: 
- Updates the minmax rows for the mcoe table.
- Extends the upper bounds of acceptable values for gas prices (due to crazy spikes in 2022).
- Removes `inf` values from the fuel cost columns.

We ran some testing on the later to make sure it was a reasonable assumption. Looking at the mcoe table, we tested the fuel cost per mmbtu and mwh (weighted against fuel consumed and net gen, respectively). It shows a definitive bump in 2022:

For mwh:
![Screen Shot 2023-08-09 at 7 37 38 PM](https://github.com/catalyst-cooperative/pudl/assets/49878195/b0e31027-5f6a-4ac8-9e99-bb7d7fbcc75e)

And for mmbtu:
<img width="1040" alt="Screen Shot 2023-08-09 at 7 45 39 PM" src="https://github.com/catalyst-cooperative/pudl/assets/49878195/d5af6dd8-93fd-4540-9f5a-c774269bbb36">

This is consistent with price hikes in 2022 (largely due to the situation in Ukraine). Shown in mmtbu below:
<img width="302" alt="Screen Shot 2023-08-09 at 7 46 47 PM" src="https://github.com/catalyst-cooperative/pudl/assets/49878195/23ddf470-1ff4-4aa1-9660-656d40c20444">

When looking at the `fuel_recipts_costs` table, you can see that in 2022 the spot market prices were higher than the contracts which is also consistent with expectations.

<img width="1043" alt="Screen Shot 2023-08-09 at 8 13 36 PM" src="https://github.com/catalyst-cooperative/pudl/assets/49878195/c08b510f-df9e-4a21-a8f2-791b30aec313">



