### PR TITLE
Fix docker builds

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -1,0 +1,36 @@
+---
+name: docker-build-test
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  pudl_docker_build:
+    name: Test building the PUDL ETL Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Docker Metadata
+        id: docker_metadata
+        uses: docker/metadata-action@v4.4.0
+        with:
+          images: catalystcoop/pudl-etl
+          flavor: |
+            latest=auto
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+
+      - name: Build image but do not push to Docker Hub
+        uses: docker/build-push-action@v4.0.0
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM condaforge/mambaforge:4.12.0-0
+FROM condaforge/mambaforge:23.3.1-1
 
 # Install curl and js
 # awscli requires unzip, less, groff and mandoc
@@ -27,7 +27,7 @@ WORKDIR ${CONTAINER_HOME}
 ENV CONDA_PREFIX=${CONTAINER_HOME}/env
 ENV PUDL_REPO=${CONTAINER_HOME}/pudl
 ENV CONDA_RUN="conda run --no-capture-output --prefix ${CONDA_PREFIX}"
-ENV PYTHON_VERSION="3.10"
+ENV PYTHON_VERSION="3.11"
 
 ENV CONTAINER_PUDL_WORKSPACE=${CONTAINER_HOME}/pudl_work
 ENV PUDL_INPUT=${CONTAINER_PUDL_WORKSPACE}/data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "networkx>=2.2,<3.2",
     "numpy>=1.18.5,!=1.23.0,<1.26",
     "pandas[parquet,excel,fss,gcp,compression]>=2.0,<2.1",
-    "pyarrow>=5,<13.1",
+    "pyarrow>=7,<13",
     "pydantic[email]>=1.7,<2",
     "python-dotenv>=0.21,<1.1",
     "pyyaml>=5,<6.1",

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -8,9 +8,6 @@ dependencies:
   - geopandas>=0.13,<0.14
   - pip>=22,<24
   - shapely>=2,<3
-  - pandas>=2,<2.1
-  - urllib3<2
-  - numpy<1.25
   - python-snappy>=0.6,<1
   - setuptools<69
   - sqlite>=3.36,<4

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -8,6 +8,9 @@ dependencies:
   - geopandas>=0.13,<0.14
   - pip>=22,<24
   - shapely>=2,<3
+  - pandas>=2,<2.1
+  - urllib3<2
+  - numpy<1.25
   - python-snappy>=0.6,<1
   - setuptools<69
   - sqlite>=3.36,<4

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -12,5 +12,5 @@ dependencies:
   - setuptools<69
   - sqlite>=3.36,<4
   - tox>=4,<5
-  - google-cloud-sdk>=386.0.0,<413.0.0
+  - google-cloud-sdk>=386,<446
   - sqlite-utils~=3.29


### PR DESCRIPTION
# PR Overview

* Debug docker build failures that started August 29th see #2836 
* Update `mambaforge` Docker image to a recent version -- we were a year out of date.
* Use Python 3.11 in the base environment in the Docker container.
* Pin `pyarrow<13` for the time being as that introduced the `GLIBCXX` issue.
* Allow a much more recent version of the `google-cloud-sdk` in our test environment.
* Create a `docker-build-test` workflow that runs on `pull_request` to avoid this kind of issue in the future.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [x] Make sure you've included good docstrings.
- [x] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [x] Include unit tests for new functions and classes.
- [x] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
