### PR TITLE
Test if Google cloud CLI in conda env is what breaks pyarrow 13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ FROM condaforge/mambaforge:23.3.1-1
 # awscli requires unzip, less, groff and mandoc
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y curl jq unzip less groff mandoc && \
+    apt-get install --no-install-recommends -y curl jq unzip less groff mandoc tar && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -18,8 +18,9 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
     ./aws/install
 # Install google cloud cli:
 RUN curl -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-445.0.0-linux-x86_64.tar.gz" && \
-    tar -xf google-cloud-cli-445.0.0-linux-x86.tar.gz && \
-    ./google-cloud-sdk/install.sh --quiet
+    tar -xf google-cloud-cli-445.0.0-linux-x86_64.tar.gz && \
+    ./google-cloud-sdk/install.sh --quiet && \
+    rm -f ./google-cloud-cli-445.0.0-linux-x86_64.tar.gz
 
 # Create a non-root user inside the container
 # hadolint ignore=DL3059

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,16 +3,23 @@ FROM condaforge/mambaforge:23.3.1-1
 # Install curl and js
 # awscli requires unzip, less, groff and mandoc
 # hadolint ignore=DL3008
-RUN apt-get update && apt-get install --no-install-recommends -y curl jq unzip less groff mandoc \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y curl jq unzip less groff mandoc && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Configure gsutil authentication
 # hadolint ignore=DL3059
 RUN printf '[GoogleCompute]\nservice_account = default' > /etc/boto.cfg
 
 # Install awscli2
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install
+# Install google cloud cli:
+RUN curl -O "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-445.0.0-linux-x86_64.tar.gz" && \
+    tar -xf google-cloud-cli-445.0.0-linux-x86.tar.gz && \
+    ./google-cloud-sdk/install.sh --quiet
 
 # Create a non-root user inside the container
 # hadolint ignore=DL3059
@@ -30,7 +37,7 @@ ENV CONDA_RUN="conda run --no-capture-output --prefix ${CONDA_PREFIX}"
 ENV PYTHON_VERSION="3.11"
 
 ENV CONTAINER_PUDL_WORKSPACE=${CONTAINER_HOME}/pudl_work
-ENV PUDL_INPUT=${CONTAINER_PUDL_WORKSPACE}/data
+ENV PUDL_INPUT=${CONTAINER_PUDL_WORKSPACE}/input
 ENV PUDL_OUTPUT=${CONTAINER_PUDL_WORKSPACE}/output
 ENV DAGSTER_HOME=${CONTAINER_PUDL_WORKSPACE}/dagster_home
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "networkx>=2.2,<3.2",
     "numpy>=1.18.5,!=1.23.0,<1.26",
     "pandas[parquet,excel,fss,gcp,compression]>=2.0,<2.1",
-    "pyarrow>=7,<13",
+    "pyarrow>=7,<13.1",
     "pydantic[email]>=1.7,<2",
     "python-dotenv>=0.21,<1.1",
     "pyyaml>=5,<6.1",

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -12,5 +12,4 @@ dependencies:
   - setuptools<69
   - sqlite>=3.36,<4
   - tox>=4,<5
-  - google-cloud-sdk>=386,<446
   - sqlite-utils~=3.29


### PR DESCRIPTION
# PR Overview

I came across a reference to conflicts between glibc from google cloud and other packages and wondered if that might be the problem with pyarrow 13 and wanted to test it out...

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
