### PR TITLE
Skip integraton tests on draft PRs

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -1,7 +1,13 @@
 ---
 name: tox-pytest
 
-on: [pull_request]
+on:
+  pull_request:
+    types:
+      - created
+      - opened
+      - synchronize
+      - ready_for_review
 
 env:
   PUDL_OUTPUT: /home/runner/pudl-work/output
@@ -101,6 +107,7 @@ jobs:
     runs-on:
       group: large-runner-group
       labels: ubuntu-22.04-4core
+    if: github.event.pull_request.draft == false
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
To save time/energy/$, we can only run the long CI jobs on PRs that are nominally ready for review.


Testing plan:
* [x] make this a draft PR, and see if ci-integration runs
* [x] turn this into a non-draft PR, and see if ci-integration runs