### PR TITLE
Add assertions and workflow updates to debug ogr2ogr failure.

### DIFF
--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -28,17 +28,20 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: Install Conda environment using mamba
-        uses: mamba-org/provision-with-micromamba@v16
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: test/test-environment.yml
-          cache-env: true
-          channels: conda-forge,defaults
-          channel-priority: strict
+          cache-environment: true
+          condarc: |
+            channels:
+            - conda-forge
+            - defaults
+            channel_priority: strict
 
       - name: Log environment details
         run: |
@@ -68,17 +71,20 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: Install Conda environment using mamba
-        uses: mamba-org/provision-with-micromamba@v16
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: test/test-environment.yml
-          cache-env: true
-          channels: conda-forge,defaults
-          channel-priority: strict
+          cache-environment: true
+          condarc: |
+            channels:
+            - conda-forge
+            - defaults
+            channel_priority: strict
 
       - name: Log environment details
         run: |
@@ -118,17 +124,20 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
 
       - name: Install Conda environment using mamba
-        uses: mamba-org/provision-with-micromamba@v16
+        uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: test/test-environment.yml
-          cache-env: true
-          channels: conda-forge,defaults
-          channel-priority: strict
+          cache-environment: true
+          condarc: |
+            channels:
+            - conda-forge
+            - defaults
+            channel_priority: strict
 
       - name: Log environment details
         run: |
@@ -189,7 +198,7 @@ jobs:
       - ci-integration
       - ci-static
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Download coverage
         id: download-unit
         uses: actions/download-artifact@v3

--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -17,6 +17,10 @@ dependencies:
   - python-snappy>=0.6,<1
   - sqlite>=3.36,<4
 
+  # libabseil 20230802 isn't linked by libgdal-3.7.1, which is dependency of
+  # fiona==1.9.4, dependency of geopandas 0.13.2
+  - libabseil==20230125.3
+
   # These are not normal Python packages available on PyPI
   - nodejs # Useful for Jupyter
   - pandoc # Useful for rendering RST files in Atom

--- a/src/pudl/convert/censusdp1tract_to_sqlite.py
+++ b/src/pudl/convert/censusdp1tract_to_sqlite.py
@@ -62,7 +62,8 @@ def censusdp1tract_to_sqlite(context):
     # program happens to be in the user's path and named ogr2ogr. This is a
     # fragile solution that will not work on all platforms, but should cover
     # conda environments, Docker, and continuous integration on GitHub.
-    ogr2ogr = os.environ.get("CONDA_PREFIX", "/usr") + "/bin/ogr2ogr"
+    ogr2ogr = Path(os.environ.get("CONDA_PREFIX", "/usr")) / "bin/ogr2ogr"
+    assert ogr2ogr.exists()
     # Extract the sippzed GeoDB archive from the Datastore into a temporary
     # directory so that ogr2ogr can operate on it. Output the resulting SQLite
     # database into the user's PUDL workspace. We do not need to keep the
@@ -71,10 +72,13 @@ def censusdp1tract_to_sqlite(context):
     with TemporaryDirectory() as tmpdir:
         # Use datastore to grab the Census DP1 zipfile
         tmpdir_path = Path(tmpdir)
+        assert tmpdir_path.is_dir()
         zip_ref = ds.get_zipfile_resource(
             "censusdp1tract", year=context.op_config["year"]
         )
         extract_root = tmpdir_path / Path(zip_ref.filelist[0].filename)
+        out_dir = PudlPaths().output_dir
+        assert out_dir.is_dir()
         out_path = PudlPaths().output_dir / "censusdp1tract.sqlite"
 
         if out_path.exists():
@@ -86,10 +90,11 @@ def censusdp1tract_to_sqlite(context):
                     f"Move {out_path} aside or set clobber=True and try again."
                 )
 
-        logger.info("Extracting the Census DP1 GeoDB to %s", out_path)
+        logger.info(f"Extracting the Census DP1 GeoDB to {out_path}")
         zip_ref.extractall(tmpdir_path)
-        logger.info("extract_root = %s", extract_root)
-        logger.info("out_path = %s", out_path)
+        logger.info(f"extract_root = {extract_root}")
+        assert extract_root.is_dir()
+        logger.info(f"out_path = {out_path}")
         subprocess.run(
             [ogr2ogr, str(out_path), str(extract_root)], check=True  # noqa: S603
         )

--- a/src/pudl/convert/censusdp1tract_to_sqlite.py
+++ b/src/pudl/convert/censusdp1tract_to_sqlite.py
@@ -96,6 +96,8 @@ def censusdp1tract_to_sqlite(context):
         assert extract_root.is_dir()
         logger.info(f"out_path = {out_path}")
         subprocess.run(
-            [ogr2ogr, str(out_path), str(extract_root)], check=True  # noqa: S603
+            [ogr2ogr, str(out_path), str(extract_root)],  # noqa: S603
+            check=True,
+            capture_output=True,
         )
     return out_path

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -14,3 +14,7 @@ dependencies:
   - tox>=4,<5
   - google-cloud-sdk>=386,<446
   - sqlite-utils~=3.29
+
+  # libabseil 20230802 isn't linked by libgdal-3.7.1, which is dependency of
+  # fiona==1.9.4, dependency of geopandas 0.13.2
+  - libabseil==20230125.3


### PR DESCRIPTION
# PR Overview

Something is suddenly breaking our use of `ogr2ogr` in a subprocess to extract the Census DP1 GeoDataBase, but only in CI not locally. This PR is an attempt to debug why.

* Update `tox-pytest` workflow to use `setup-micromamba` and `checkout@v4`
* Add some assertions about the inputs & output paths involved in running `ogr2ogr`

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
