### PR TITLE
Fix missing keywords in archived datasources

### DIFF
--- a/src/pudl/metadata/constants.py
+++ b/src/pudl/metadata/constants.py
@@ -259,6 +259,34 @@ KEYWORDS: dict[str, list[str]] = {
         "government",
         "federal",
     ],
+    "msha": [
+        "msha",
+        "mshamines",
+        "mine safety and health administration",
+        "mines",
+        "mining",
+        "coal",
+        "metal",
+    ],
+    "phmsa": [
+        "phmsa",
+        "phmsagas",
+        "pipelines and hazardous materials safety administration",
+        "pipelines",
+        "natural gas",
+        "transmission",
+        "distribution",
+        "gathering",
+        "liquified natural gas",
+        "lng",
+        "underground natural gas storage",
+    ],
+    "eia_water": [
+        "eia thermoelectric cooling water",
+        "eia waterthermoelectric",
+        "cooling water",
+        "water usage",
+    ],
 }
 
 XBRL_TABLES = [

--- a/src/pudl/metadata/constants.py
+++ b/src/pudl/metadata/constants.py
@@ -267,6 +267,7 @@ KEYWORDS: dict[str, list[str]] = {
         "mining",
         "coal",
         "metal",
+        "department of labor",
     ],
     "phmsa": [
         "phmsa",
@@ -280,12 +281,16 @@ KEYWORDS: dict[str, list[str]] = {
         "liquified natural gas",
         "lng",
         "underground natural gas storage",
+        "department of transportation",
+        "us dot",
     ],
     "eia_water": [
         "eia thermoelectric cooling water",
         "eia waterthermoelectric",
         "cooling water",
         "water usage",
+        "water energy nexus",
+        "energy water nexus",
     ],
 }
 

--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -50,11 +50,10 @@ SOURCES: dict[str, Any] = {
                 [
                     "eia176",
                     "form 176",
+                    "natural gas",
                 ]
                 + KEYWORDS["eia"]
                 + KEYWORDS["us_govt"]
-                + KEYWORDS["fuels"]
-                + KEYWORDS["environment"]
             )
         ),
         "license_raw": LICENSES["us-govt"],
@@ -261,6 +260,9 @@ SOURCES: dict[str, Any] = {
         "description": (
             "Monthly cooling water usage by generator and boiler. Data "
             "collected in conjunction with the EIA-860 and EIA-923."
+        ),
+        "keywords": sorted(
+            set(KEYWORDS["eia"] + KEYWORDS["us_govt"] + KEYWORDS["eia_water"])
         ),
         "license_raw": LICENSES["us-govt"],
         "license_pudl": LICENSES["cc-by-4.0"],
@@ -523,6 +525,17 @@ SOURCES: dict[str, Any] = {
             "as well as transaction information for short-term and long-term "
             "market-based power sales and cost-based power sales."
         ),
+        "keywords": sorted(
+            set(
+                [
+                    "ferceqr",
+                    "electric quarterly report",
+                ]
+                + KEYWORDS["ferc"]
+                + KEYWORDS["us_govt"]
+                + KEYWORDS["electricity"]
+            )
+        ),
         "license_raw": LICENSES["us-govt"],
         "license_pudl": LICENSES["cc-by-4.0"],
     },
@@ -535,6 +548,7 @@ SOURCES: dict[str, Any] = {
             "mine (Active, Abandoned, NonProducing, etc.), the current owner and "
             "operating company, commodity codes and physical attributes of the mine."
         ),
+        "keywords": sorted(set(KEYWORDS["msha"] + KEYWORDS["us_govt"])),
         "license_raw": LICENSES["us-govt"],
         "license_pudl": LICENSES["cc-by-4.0"],
     },
@@ -548,6 +562,7 @@ SOURCES: dict[str, Any] = {
             "pipeline mileage, facilities, commodities transported, miles by material, "
             "and installation dates."
         ),
+        "keywords": sorted(set(KEYWORDS["phmsa"] + KEYWORDS["us_govt"])),
         "license_raw": LICENSES["us-govt"],
         "license_pudl": LICENSES["cc-by-4.0"],
     },


### PR DESCRIPTION
Addresses #2850 and [issue #80 in the pudl-archiver repo](https://github.com/catalyst-cooperative/pudl-archiver/issues/80). The lack of keywords is a blocking issue for PHMSA data extraction using the pudl Datastore, so this iceboxed issue is now a priority again. While I'm at it, I may as well fix all the other datasets that are missing keywords / have inadequate ones.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [x] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
