### PR TITLE
Remove libabseil version pins since gdal & geopandas have new versions.

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -17,10 +17,6 @@ dependencies:
   - python-snappy>=0.6,<1
   - sqlite>=3.36,<4
 
-  # libabseil 20230802 isn't linked by libgdal-3.7.1, which is dependency of
-  # fiona==1.9.4, dependency of geopandas 0.13.2
-  - libabseil==20230125.3
-
   # These are not normal Python packages available on PyPI
   - nodejs # Useful for Jupyter
   - pandoc # Useful for rendering RST files in Atom

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -14,7 +14,3 @@ dependencies:
   - tox>=4,<5
   - google-cloud-sdk>=386,<446
   - sqlite-utils~=3.29
-
-  # libabseil 20230802 isn't linked by libgdal-3.7.1, which is dependency of
-  # fiona==1.9.4, dependency of geopandas 0.13.2
-  - libabseil==20230125.3


### PR DESCRIPTION
# PR Overview

A new patch version `gdal==3.7.2` and a new minor version `geopandas==0.14.0` have been released, potentially fixing this linking error? Let's find out.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
