### PR TITLE
Fixing 2022 FERC ETL integration errors

### DIFF
--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -365,7 +365,7 @@ SOURCES: dict[str, Any] = {
         },
         "field_namespace": "ferc1",
         "working_partitions": {
-            "years": sorted(set(range(1994, 2022))),
+            "years": sorted(set(range(1994, 2023))),
         },
         "contributors": [
             CONTRIBUTORS["catalyst-cooperative"],

--- a/src/pudl/transform/params/ferc1.py
+++ b/src/pudl/transform/params/ferc1.py
@@ -328,6 +328,7 @@ FUEL_CATEGORIES: dict[str, set[str]] = {
     "categories": {
         "coal": {
             "bit coal",
+            "bit-coal",
             "ciak",
             "coa",
             "coal",


### PR DESCRIPTION
Subset of issues in #2813, fixing errors introduced in the 2022 runthrough of FERC1 data through the new XBRL extractor.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
