### PR TITLE
Use sphinx-autoapi 3.0 to work with astroid 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ license = { file = "LICENSE.txt" }
 dependencies = [
     "addfips>=0.4,<0.5",
     "alembic>=1.10.3,<1.13",
-    "astroid>=2,<3",
     "catalystcoop.dbfread>=3.0,<3.1",
     "catalystcoop.ferc-xbrl-extractor==0.8.3",
     "coloredlogs>=14.0,<15.1",  # Dagster requires 14.0
@@ -119,7 +118,7 @@ dev = [
 doc = [
     "doc8>=1.1,<1.2",
     "furo>=2022.4.7",
-    "sphinx-autoapi>=1.8,<2.2",
+    "sphinx-autoapi>=3,<4",
     "sphinx-issues>=1.2,<3.1",
     "sphinx-reredirects",
     "sphinx>=4,!=5.1.0,<7.3",


### PR DESCRIPTION
# PR Overview

Bump the version of `sphinx-autoapi` and remove astroid pin that is hopefully no longer available.

Also test our environment solving in CI... to see if the problems I'm having locally are platform dependent.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
