### PR TITLE
Fix for harvesting owner utilities

### DIFF
--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -318,6 +318,12 @@ def _compile_all_entity_records(
             logger.debug(f"        {table_name}...")
             # create a copy of the df to muck with
             df = transformed_df.copy()
+            # TODO: take care of this elewhere, make less janky
+            # don't harvest owner utilities for plant and generator annual operator utility
+            if ((entity == EiaEntity.PLANTS) or (entity == EiaEntity.GENERATORS)) and (
+                table_name == "_core_eia860__ownership"
+            ):
+                continue
             # we know these columns must be in the dfs
             cols = []
             # check whether the columns are in the specific table


### PR DESCRIPTION
<!--

Making a PUDL Pull Request

Before making a PR you may want to check out our:

* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
* development process: https://catalystcoop-pudl.readthedocs.io/en/latest/dev/index.html

## PR Process Overview

* PRs have to get an approving review before merging into their development branch.
* Most PRs should be made against the `dev` branch, unless they are part of some larger ongoing refactoring, in which case there will be a persistent development branch for that work.
* It is much easier to do timely code reviews on smaller chunks of code. We try to keep PRs under 500 lines of code.
* Draft PRs are a good way to get early feedback on designs or several incremental commits that will add up to larger changes. If you want a review of a draft PR, make sure you contact the reviewer directly or mention their username in the PR comment, so they get a notification.
* How quickly we can review a PR will depend on how large and complex it is, and how busy we are, but ideally we strive to get an initial review done within a week. If there are going to be delays, we should at least comment on the PR to let you know the situation.
* If you believe you've addressed a reviewer's comments, respond with a brief note and mark the comment resolved. If further discussion is requried respond and do not resolve the comment.
* Before a PR is merged all reviewer comments should be resolved. If a reviewer doesn't feel that their comment has been sufficiently addressed, they may unresolve a comment.
* Be careful not to accidentally "start a review" when responding to comments! If this does happen, don't forget to submit the review you've started so the other PR participatns can see your comments (they are invisible to others if marked "Pending").
* In the period after an initial review when there is significant back-and-forth with the reviewer deciding what changes should actually be made, there should probably be daily interaction. If significant changes are required, it's usually best to request another review after those changes have been made.

Feel free to delete the commented-out parts of the template before submitting the PR.

-->

# PR Overview

<!--

Include a short narrative summary of what's going on in the PR. This can be a bulleted list. You might want to include:

* What are you changing and why?
* Are there any known unsolved problems remaining in the PR?
* Is there anything that you want a reivewer to pay particular attention to?
* What kind of feedback are you looking for on the PR?

-->

After I added harvesting of owner utilities a bug arose from harvesting owner utilities as "operator utilities" for the plant and generator entities and annual tables. 

Previously `_core_eia860__ownership` had `utility_id_eia` referring to operator utility. This utility ID would get harvested for generators and plants.

Now `_core_eia860__ownership` has `utility_id_eia` referring to owner utility and `operator_utility_id_eia` referring to the operator utility. The issue was that the owner utilities shouldn't be added to the generator and plant tables, where `utility_id_eia` refers to the operator.

The least quickest, least janky fix I could come up with for this is to skip the harvesting of the ownership table altogether. Ideally, we'd use `map_cols_dict` (I added this in the PPE PR) to grab operator utilities from the ownership table to add to the generator and plant tables, but this required dropping the owner utility columns from the ownership table. Ultimately, this seemed less foolproof and more janky in the short term than just skipping the ownership table.

Ultimately, I think we might want to rethink this harvesting process a little. It's already sort of weird that we have to harvest plants before utilities, so that we can subsequently drop some columns from the plants tables and harvest the utility columns that share names with the dropped plants columns. I'll highlight where this happens in the harvesting process. I'd actually like to do this for the current situation, but in reverse, where we harvest utilities first, drop owner columns, then harvest plants. But both can't happen in the current setup.

I still need change the validation row counts back.
 

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
