### PR TITLE
remove duplication of explosion input table names

### DIFF
--- a/src/pudl/output/ferc1.py
+++ b/src/pudl/output/ferc1.py
@@ -1036,6 +1036,7 @@ def create_exploded_table_assets() -> list[AssetsDefinition]:
             "table_names_to_explode": [
                 "income_statement_ferc1",
                 "depreciation_amortization_summary_ferc1",
+                "electric_operating_expenses_ferc1",
                 "electric_operating_revenues_ferc1",
             ],
             "calculation_tolerance": EXPLOSION_CALCULATION_TOLERANCES[

--- a/src/pudl/output/ferc1.py
+++ b/src/pudl/output/ferc1.py
@@ -1036,7 +1036,6 @@ def create_exploded_table_assets() -> list[AssetsDefinition]:
             "table_names_to_explode": [
                 "income_statement_ferc1",
                 "depreciation_amortization_summary_ferc1",
-                "electric_operating_expenses_ferc1",
                 "electric_operating_revenues_ferc1",
             ],
             "calculation_tolerance": EXPLOSION_CALCULATION_TOLERANCES[
@@ -1055,7 +1054,6 @@ def create_exploded_table_assets() -> list[AssetsDefinition]:
         {
             "root_table": "balance_sheet_assets_ferc1",
             "table_names_to_explode": [
-                "balance_sheet_assets_ferc1",
                 "balance_sheet_assets_ferc1",
                 "utility_plant_summary_ferc1",
                 "plant_in_service_ferc1",
@@ -1077,7 +1075,6 @@ def create_exploded_table_assets() -> list[AssetsDefinition]:
         {
             "root_table": "balance_sheet_liabilities_ferc1",
             "table_names_to_explode": [
-                "balance_sheet_liabilities_ferc1",
                 "balance_sheet_liabilities_ferc1",
                 "retained_earnings_ferc1",
             ],


### PR DESCRIPTION
# PR Overview
found duplicate tables names in the inputs for the explosions. this pr removes them!

### before
```
income_statement_ferc1: has 5061 (18.15%) records whose calculations don't match. Adding correction records to make calculations match reported values.
balance_sheet_liabilities_ferc1: has 226 (6.91%) records whose calculations don't match. Adding correction records to make calculations match reported values.
balance_sheet_assets_ferc1: has 12021 (59.93%) records whose calculations don't match. Adding correction records to make calculations match reported values.
```

### after 
```
income_statement_ferc1: has 5061 (18.15%) records whose calculations don't match. Adding correction records to make calculations match reported values.
balance_sheet_liabilities_ferc1: has 226 (6.91%) records whose calculations don't match. Adding correction records to make calculations match reported values.
balance_sheet_assets_ferc1: has 12021 (59.93%) records whose calculations don't match. Adding correction records to make calculations match reported values.
```

so literally nothing has changed!... bc this list of tables gets eaten by `tables_to_explode` which is a dictionary so the duplicate tables were just getting overwritten. so nothing really changes here but this is still better imo.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [x] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
