### PR TITLE
Remove libsnappy binary dependency

### DIFF
--- a/devtools/environment.yml
+++ b/devtools/environment.yml
@@ -14,7 +14,6 @@ dependencies:
   # benefit from binary libraries which conda can install.
   - geopandas>=0.13,<0.15
   - shapely>=2,<3
-  - python-snappy>=0.6,<1
   - sqlite>=3.36,<4
 
   # These are not normal Python packages available on PyPI

--- a/docs/docs-environment.yml
+++ b/docs/docs-environment.yml
@@ -6,7 +6,6 @@ dependencies:
   - geopandas>=0.13,<0.15
   - pip>=22,<24
   - python>=3.11,<3.12
-  - python-snappy>=0.6,<1
   - setuptools<69
   - shapely>=2,<3
   - sqlite>=3.36,<4

--- a/test/test-environment.yml
+++ b/test/test-environment.yml
@@ -8,7 +8,6 @@ dependencies:
   - geopandas>=0.13,<0.15
   - pip>=22,<24
   - shapely>=2,<3
-  - python-snappy>=0.6,<1
   - setuptools<69
   - sqlite>=3.36,<4
   - tox>=4,<5


### PR DESCRIPTION
# PR Overview

Remove the `python-snappy` dependency from our conda environments, since it no longer seems to be a requirement for working with snappy compression in Apache Parquet files. PyArrow/Parquet now uses snappy compression by default and it seems like they're statically linking or re-implementing libsnappy rather than requiring it to be installed on the user's system (which seems great).

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
