### PR TITLE
Pin transitive dependency croniter<2; bump pyarrow to v13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "catalystcoop.dbfread>=3.0,<3.1",
     "catalystcoop.ferc-xbrl-extractor>=1.1.1,<1.2",
     "coloredlogs>=14.0,<15.1",  # Dagster requires 14.0
+    "croniter<2",  # 2.0.0 seems to break mamba
     "dagster-webserver>=1.4,<1.6",
     "dagster>=1.4,<1.6",
     "dask>=2022.5,<2023.9.4",
@@ -39,7 +40,7 @@ dependencies = [
     "numpy>=1.24,<2.0a0",
     "openpyxl>=3.0.10",  # pandas[excel]
     "pandas[parquet,excel,fss,gcp,compression]>=2,<2.2",
-    "pyarrow>=12,<13",  # pandas[parquet]
+    "pyarrow>=13,<14",  # pandas[parquet]
     "pydantic>=1.7,<2",
     "python-dotenv>=1,<1.1",
     "pyxlsb>=1.0.9",  # pandas[excel]


### PR DESCRIPTION
# PR Overview

Apparently an issue in the packaging of `croniter==2.0.0` is causing `mamba` to crash with an `AssertionError` after the package is installed in a conda environment with `pip` so we need to pin to `croniter<2` See https://github.com/kiorky/croniter/issues/54

Also it seems that the dynamic library linking problem that we were having with `pyarrow==13.0.0` has been resolved so removing that pin.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
