### PR TITLE
Unpin croniter as package metadata has been fixed.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "catalystcoop.dbfread>=3.0,<3.1",
     "catalystcoop.ferc-xbrl-extractor>=1.1.1,<1.2",
     "coloredlogs>=14.0,<15.1",  # Dagster requires 14.0
-    "croniter<2",  # 2.0.0 seems to break mamba
     "dagster-webserver>=1.4,<1.6",
     "dagster>=1.4,<1.6",
     "dask>=2022.5,<2023.9.4",


### PR DESCRIPTION
# PR Overview

Unpin `croniter` as the package metadata bug has been fixed in version 2.0.1.

See https://github.com/kiorky/croniter/issues/54

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
