### PR TITLE
New zenodo api bandaid

### DIFF
--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -61,7 +61,7 @@ class DatapackageDescriptor:
         parsed_path = urlparse(resource_path)
         if parsed_path.path.startswith("/api/files"):
             record_number = self.doi.lower().rsplit("zenodo.", 1)[-1]
-            new_path = f"/api/records/{record_number}/files/{name}/content"
+            new_path = f"/records/{record_number}/files/{name}"
             new_url = ParseResult(**(parsed_path._asdict() | {"path": new_path}))
 
             return new_url.geturl()

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -239,18 +239,6 @@ class ZenodoFetcher:
         """Returns list of supported datasets."""
         return [name for name, doi in sorted(self.zenodo_dois)]
 
-    def _get_token(self: Self, url: HttpUrl) -> str:
-        """Return the appropriate read-only Zenodo personal access token.
-
-        These tokens are associated with the pudl@catalyst.coop Zenodo account, which
-        owns all of the Catalyst raw data archives.
-        """
-        if "sandbox" in url:
-            token = "qyPC29wGPaflUUVAv1oGw99ytwBqwEEdwi4NuUrpwc3xUcEwbmuB4emwysco"  # noqa: S105
-        else:
-            token = "KXcG5s9TqeuPh1Ukt5QYbzhCElp9LxuqAuiwdqHP0WS4qGIQiydHn6FBtdJ5"  # noqa: S105
-        return token
-
     def _get_url(self: Self, doi: ZenodoDoi) -> HttpUrl:
         """Construct a Zenodo depsition URL based on its Zenodo DOI."""
         match = re.search(r"(10\.5072|10\.5281)/zenodo.([\d]+)", doi)
@@ -270,9 +258,7 @@ class ZenodoFetcher:
 
     def _fetch_from_url(self: Self, url: HttpUrl) -> requests.Response:
         logger.info(f"Retrieving {url} from zenodo")
-        response = self.http.get(
-            url, params={"access_token": self._get_token(url)}, timeout=self.timeout
-        )
+        response = self.http.get(url, timeout=self.timeout)
         if response.status_code == requests.codes.ok:
             logger.debug(f"Successfully downloaded {url}")
             return response

--- a/test/unit/settings_test.py
+++ b/test/unit/settings_test.py
@@ -19,7 +19,6 @@ from pudl.settings import (
     _convert_settings_to_dagster_config,
 )
 from pudl.workspace.datastore import Datastore
-from pudl.workspace.setup import PudlPaths
 
 
 class TestGenericDatasetSettings:
@@ -263,7 +262,7 @@ def test_partitions_with_json_normalize(pudl_etl_settings):
 
 def test_partitions_for_datasource_table(pudl_etl_settings):
     """Test whether or not we can make the datasource table."""
-    ds = Datastore(local_cache_path=PudlPaths().data_dir)
+    ds = Datastore(local_cache_path=None)
     datasource = pudl_etl_settings.make_datasources_table(ds)
     datasets = pudl_etl_settings.get_datasets().keys()
     if datasource.empty and datasets != 0:

--- a/test/unit/settings_test.py
+++ b/test/unit/settings_test.py
@@ -19,6 +19,7 @@ from pudl.settings import (
     _convert_settings_to_dagster_config,
 )
 from pudl.workspace.datastore import Datastore
+from pudl.workspace.setup import PudlPaths
 
 
 class TestGenericDatasetSettings:
@@ -262,7 +263,7 @@ def test_partitions_with_json_normalize(pudl_etl_settings):
 
 def test_partitions_for_datasource_table(pudl_etl_settings):
     """Test whether or not we can make the datasource table."""
-    ds = Datastore(local_cache_path=None)
+    ds = Datastore(local_cache_path=PudlPaths().data_dir)
     datasource = pudl_etl_settings.make_datasources_table(ds)
     datasets = pudl_etl_settings.get_datasets().keys()
     if datasource.empty and datasets != 0:

--- a/test/unit/workspace/datastore_test.py
+++ b/test/unit/workspace/datastore_test.py
@@ -103,7 +103,7 @@ class TestDatapackageDescriptor(unittest.TestCase):
 
         assert (
             descriptor.get_resource_path("datapackage.json")
-            == "https://zenodo.org/api/records/123123/files/datapackage.json/content"
+            == "https://zenodo.org/records/123123/files/datapackage.json"
         )
 
     def test_get_resources_filtering(self):

--- a/test/unit/workspace/datastore_test.py
+++ b/test/unit/workspace/datastore_test.py
@@ -92,6 +92,20 @@ class TestDatapackageDescriptor(unittest.TestCase):
         # The following resource does not exist and should throw KeyError
         self.assertRaises(KeyError, desc.get_resource_path, "other")
 
+    def test_modernize_zenodo_legacy_api_url(self):
+        legacy_url = "https://zenodo.org/api/files/082e4932-c772-4e9c-a670-376a1acc3748/datapackage.json"
+
+        descriptor = datastore.DatapackageDescriptor(
+            {"resources": [{"name": "datapackage.json", "path": legacy_url}]},
+            dataset="test",
+            doi="10.5281/zenodo.123123",
+        )
+
+        assert (
+            descriptor.get_resource_path("datapackage.json")
+            == "https://zenodo.org/api/records/123123/files/datapackage.json/content"
+        )
+
     def test_get_resources_filtering(self):
         """Verifies correct operation of get_resources()."""
         desc = _make_descriptor(
@@ -197,11 +211,11 @@ class TestZenodoFetcher(unittest.TestCase):
     """Unit tests for ZenodoFetcher class."""
 
     MOCK_EPACEMS_DEPOSITION = {
-        "files": [
-            {"filename": "random.zip"},
+        "entries": [
+            {"key": "random.zip"},
             {
-                "filename": "datapackage.json",
-                "links": {"download": "http://localhost/my/datapackage.json"},
+                "key": "datapackage.json",
+                "links": {"content": "http://localhost/my/datapackage.json"},
             },
         ]
     }
@@ -282,7 +296,7 @@ class TestZenodoFetcher(unittest.TestCase):
         fetcher = datastore.ZenodoFetcher()
         responses.add(
             responses.GET,
-            f"https://zenodo.org/api/deposit/depositions/{self.PROD_EPACEMS_ZEN_ID}",
+            f"https://zenodo.org/api/records/{self.PROD_EPACEMS_ZEN_ID}/files",
             json=self.MOCK_EPACEMS_DEPOSITION,
         )
         responses.add(


### PR DESCRIPTION
Closes #2939 .

* Use new record files API endpoint to get datapackage.json
* Add shim to re-construct legacy URLs that are in `datapackage.json` / pretend that we were using the "best, most stable URLs" the whole time
* remove access keys, yay