### PR TITLE
Hotfix docker build by setting LD_LIBRARY_PATH

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,6 +48,9 @@ RUN mamba create --copy --prefix ${CONDA_PREFIX} --yes python=${PYTHON_VERSION} 
 # Copy the cloned pudl repository into the user's home directory
 COPY --chown=catalyst:catalyst . ${CONTAINER_HOME}
 
+# TODO(rousik): The following is a workaround for sudden breakage where conda
+# can't find libraries contained within the environment. It's unclear why!
+ENV LD_LIBRARY_PATH=${CONDA_PREFIX}/lib
 # We need information from .git to get version with setuptools_scm so we mount that
 # directory without copying it into the image.
 RUN --mount=type=bind,source=.git,target=${PUDL_REPO}/.git \


### PR DESCRIPTION
For some reason, `pudl_setup` and other tools would not properly link with libraries provided by conda and living in `/home/catalyst/env/lib`. This sets the path so that linker correctly finds those things as per:

https://stackoverflow.com/questions/13428910/how-to-set-the-environment-variable-ld-library-path-in-linux