### PR TITLE
Switch regex strategy to sampling strategy to improve performance

### DIFF
--- a/test/unit/io_managers_test.py
+++ b/test/unit/io_managers_test.py
@@ -354,7 +354,7 @@ def test_ferc_xbrl_sqlite_io_manager_dedupes(mocker, tmp_path):
 example_schema = pandera.DataFrameSchema(
     {
         "entity_id": pandera.Column(
-            str, pandera.Check.isin(r"C0123456789"), nullable=False
+            str, pandera.Check.isin("C0123456789"), nullable=False
         ),
         "date": pandera.Column("datetime64[ns]", nullable=False),
         "utility_type": pandera.Column(
@@ -370,6 +370,7 @@ example_schema = pandera.DataFrameSchema(
 )
 
 
+@hypothesis.settings(print_blob=True, deadline=400)
 @hypothesis.given(example_schema.strategy(size=3))
 def test_filter_for_freshest_data(df):
     # XBRL context is the identifying metadata for reported values

--- a/test/unit/io_managers_test.py
+++ b/test/unit/io_managers_test.py
@@ -354,7 +354,7 @@ def test_ferc_xbrl_sqlite_io_manager_dedupes(mocker, tmp_path):
 example_schema = pandera.DataFrameSchema(
     {
         "entity_id": pandera.Column(
-            str, pandera.Check.str_matches(r"[0-9a-zA-Z]+"), nullable=False
+            str, pandera.Check.isin(r"C0123456789"), nullable=False
         ),
         "date": pandera.Column("datetime64[ns]", nullable=False),
         "utility_type": pandera.Column(
@@ -365,7 +365,7 @@ example_schema = pandera.DataFrameSchema(
         "publication_time": pandera.Column("datetime64[ns]", nullable=False),
         "int_factoid": pandera.Column(int),
         "float_factoid": pandera.Column(float),
-        "str_factoid": pandera.Column("str"),
+        "str_factoid": pandera.Column(str),
     }
 )
 


### PR DESCRIPTION
See this failure, which is due to slow strategies: https://github.com/catalyst-cooperative/pudl/pull/2968#issuecomment-1788120124

We already know that pandera strategy generation is slow - combining that with the slowness of generating strings based on regex was too much I think.