### PR TITLE
Fix calculating the report_date in demand_hourly_pa_ferc714

### DIFF
--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -3005,7 +3005,12 @@ FIELD_METADATA_BY_RESOURCE: dict[str, dict[str, Any]] = {
                     "Pacific/Honolulu",
                 ]
             }
-        }
+        },
+        "report_date": {
+            "constraints": {
+                "required": True,
+            }
+        },
     },
 }
 

--- a/src/pudl/transform/ferc714.py
+++ b/src/pudl/transform/ferc714.py
@@ -505,9 +505,7 @@ def demand_hourly_pa_ferc714(
     df.loc[mask, "demand_mwh"] *= -1
 
     # Convert report_date to first day of year
-    df["report_date"] = pd.Series(
-        df.loc[:, "report_date"].to_numpy().astype("datetime64[Y]")
-    )
+    df["report_date"] = df.report_date.dt.to_period("Y").dt.to_timestamp()
 
     # Format result
     columns = [


### PR DESCRIPTION
For some reason `report_date` could be missing for some number of records (0.7%). This addresses that problem by changing the way we align the reports to year boundaries.