### PR TITLE
update excepted rows for no-fips id-ed respondents but keep annualize…

### DIFF
--- a/src/pudl/output/ferc714.py
+++ b/src/pudl/output/ferc714.py
@@ -652,18 +652,20 @@ def summarized_demand_ferc714(
             demand_hourly_pa_ferc714.loc[
                 :, ["report_date", "respondent_id_ferc714", "demand_mwh"]
             ],
+            on=["report_date", "respondent_id_ferc714"],
             how="left",
         )
-        .groupby(["report_date", "respondent_id_ferc714"])
-        .agg({"demand_mwh": sum})
+        .groupby(["report_date", "respondent_id_ferc714"], as_index=False)[
+            ["demand_mwh"]
+        ]
+        .sum(min_count=1)
         .rename(columns={"demand_mwh": "demand_annual_mwh"})
-        .reset_index()
         .merge(
             georeferenced_counties_ferc714.groupby(
-                ["report_date", "respondent_id_ferc714"]
-            )
-            .agg({"population": sum, "area_km2": sum})
-            .reset_index()
+                ["report_date", "respondent_id_ferc714"], as_index=False
+            )[["population", "area_km2"]].sum(min_count=1),
+            on=["report_date", "respondent_id_ferc714"],
+            how="left",
         )
         .assign(
             population_density_km2=lambda x: x.population / x.area_km2,

--- a/test/validate/service_territory_test.py
+++ b/test/validate/service_territory_test.py
@@ -46,3 +46,22 @@ def test_minmax_rows(
             pv.check_max_rows, expected_rows=expected_rows, margin=0.0, df_name=df_name
         )
     )
+
+
+def test_report_year_discrepency_in_demand_hourly_pa_ferc714(pudl_out_orig):
+    """Test if the vast majority of the years in the two date columns line up."""
+    demand_hourly_pa_ferc714 = pudl_out_orig.demand_hourly_pa_ferc714()
+    mismatched_report_years = demand_hourly_pa_ferc714[
+        (
+            demand_hourly_pa_ferc714.utc_datetime.dt.year
+            != demand_hourly_pa_ferc714.report_date.dt.year
+        )
+    ]
+    if (
+        off_ratio := len(mismatched_report_years) / len(demand_hourly_pa_ferc714)
+    ) > 0.001:
+        raise AssertionError(
+            f"Found more ({off_ratio:.2%}) than expected (>.1%) FERC714 records"
+            " where the report year from the utc_datetime differs from the "
+            "report_date column."
+        )

--- a/test/validate/service_territory_test.py
+++ b/test/validate/service_territory_test.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
     "df_name,expected_rows",
     [
         ("summarized_demand_ferc714", 3_195),
-        ("fipsified_respondents_ferc714", 135_627),
+        ("fipsified_respondents_ferc714", 135_537),
         ("compiled_geometry_balancing_authority_eia861", 112_507),
         ("compiled_geometry_utility_eia861", 247_705),
     ],


### PR DESCRIPTION
# PR Overview

#3021

still don't know whyyyy the records from `fipsified_respondents_ferc714` are now dropped, but those none of those records had any FIPS codes previously so I think it is okay to drop them.

in the `summarized_demand_ferc714` case, the annualized records were being dropped because of a merge with the `fipsified_respondents_ferc714`. I made this merge a left merge so those records are now preserved. I also did a little merge/groupby cleanup for speed - shaved 15 seconds wahoo lol.

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [x] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [x] Make sure you've included good docstrings.
- [x] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [x] Include unit tests for new functions and classes.
- [x] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
