### PR TITLE
Fix validation `test_fbp_ferc1_mismatched_fuels` error

### DIFF
--- a/src/pudl/analysis/classify_plants_ferc1.py
+++ b/src/pudl/analysis/classify_plants_ferc1.py
@@ -546,7 +546,7 @@ def revert_filled_in_string_nulls(df: pd.DataFrame) -> pd.DataFrame:
         if col in df.columns:
             # the replace to_replace={column_name: {"", pd.NA}} mysteriously doesn't work.
             df[col] = df[col].replace(
-                to_replace=[""],
+                to_replace=["", "nan"],
                 value=pd.NA,
             )
     return df

--- a/src/pudl/analysis/classify_plants_ferc1.py
+++ b/src/pudl/analysis/classify_plants_ferc1.py
@@ -736,6 +736,12 @@ def fuel_by_plant_ferc1(
 
     # Label each plant-year record by primary fuel:
     df.loc[:, ["primary_fuel_by_cost", "primary_fuel_by_mmbtu"]] = pd.NA
+    df = df.astype(
+        {
+            "primary_fuel_by_cost": pd.StringDtype(),
+            "primary_fuel_by_mmbtu": pd.StringDtype(),
+        }
+    )
     for fuel_str in fuel_categories:
         try:
             mmbtu_mask = df[f"{fuel_str}_fraction_mmbtu"] > thresh

--- a/src/pudl/output/ferc1.py
+++ b/src/pudl/output/ferc1.py
@@ -810,10 +810,6 @@ def denorm_fuel_by_plant_ferc1(
         return df[df.fuel_type_code_pudl != "other"].copy()
 
     thresh = context.op_config["thresh"]
-    # The existing function expects `fuel_type_code_pudl` to be an object, rather than
-    # a category. This is a legacy of pre-dagster code, and we convert here to prevent
-    # further retooling in the code-base.
-    fuel_ferc1["fuel_type_code_pudl"] = fuel_ferc1["fuel_type_code_pudl"].astype(str)
 
     fuel_categories = list(
         pudl.transform.ferc1.FuelFerc1TableTransformer()


### PR DESCRIPTION
# PR Overview
We were getting the following error:

```python
FAILED test/validate/fbp_ferc1_test.py::test_fbp_ferc1_mismatched_fuels[ferc1_annual] - AssertionError: Too many records (9.69%) have mismatched primary fuel types.
```

I determined that this was happening bc the nulls in the fuel table were somehow getting converted to `"nan"`:

![image](https://github.com/catalyst-cooperative/pudl/assets/25487998/af1a56fb-d67e-4ad9-93db-abb56be6ebf1)

### first solution:
A part of the `pudl.analysis.classify_plants_ferc1.fuel_by_plant_ferc1` step does convert nulls to `""` and there is a post-processing step that we were already applying (`pudl.analysis.classify_plants_ferc1.revert_filled_in_string_nulls`). I simply added `"nan"` in here.

Still tbh do no know why these `"nan"`s were all of a sudden appearing but hey.. they are gone now 👀 

### current solution:
it looooks as if the "nan" is added in right here...
```python
for fuel_str in fuel_categories:
    try:
        mmbtu_mask = df[f"{fuel_str}_fraction_mmbtu"] > thresh
        df.loc[mmbtu_mask, "primary_fuel_by_mmbtu"] = fuel_str
    except KeyError:
        pass

    try:
        cost_mask = df[f"{fuel_str}_fraction_cost"] > thresh
        df.loc[cost_mask, "primary_fuel_by_cost"] = fuel_str
    except KeyError:
        pass
```
So I stopped em in their tracks 🚥 . these columns don't exist before this loop and not all of the records get labeled with a `fuel_str` bc not all of the records meet the `thresh` so I added the whole column before the loop w/ values of `pd.NA` 

# PR Checklist

- [x] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
