### PR TITLE
Fix XBRL extraction clobber

### DIFF
--- a/notebooks/work-in-progress/CEMS_by_utility.ipynb
+++ b/notebooks/work-in-progress/CEMS_by_utility.ipynb
@@ -47,7 +47,7 @@
     "from pudl.workspace.setup import PudlPaths\n",
     "\n",
     "\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db(\"ferc1\"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri(\"ferc1\"))\n",
     "\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db())\n",
     "#display(pudl_engine)\n",

--- a/notebooks/work-in-progress/better-heatrates.ipynb
+++ b/notebooks/work-in-progress/better-heatrates.ipynb
@@ -324,7 +324,7 @@
     "from pudl.workspace.setup import PudlPaths\n",
     "\n",
     "# TODO(janrous): provide property for accessing ferc db?\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db(\"ferc1\"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri(\"ferc1\"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
     "\n",
     "API_KEY_EIA = os.environ[\"API_KEY_EIA\"]\n",

--- a/notebooks/work-in-progress/ferc714-output.ipynb
+++ b/notebooks/work-in-progress/ferc714-output.ipynb
@@ -142,7 +142,7 @@
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
     "\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db(\"ferc1\"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri(\"ferc1\"))\n",
     "display(ferc1_engine)\n",
     "\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",

--- a/notebooks/work-in-progress/jupyterhub-test.ipynb
+++ b/notebooks/work-in-progress/jupyterhub-test.ipynb
@@ -51,7 +51,7 @@
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
     "\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db(\"ferc1\"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri(\"ferc1\"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
     "pudl_out = pudl.output.pudltabl.PudlTabl(pudl_engine=pudl_engine)"
    ]

--- a/notebooks/work-in-progress/state-demand.ipynb
+++ b/notebooks/work-in-progress/state-demand.ipynb
@@ -113,7 +113,7 @@
     "#HARVEST_ACCOUNT_ID = os.environ[\"HARVEST_ACCOUNT_ID\"]\n",
     "\n",
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db(\"ferc1\"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri(\"ferc1\"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
     "pudl_out = pudl.output.pudltabl.PudlTabl(pudl_engine=pudl_engine)"
    ]

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -2,7 +2,6 @@
 import io
 from datetime import date
 from pathlib import Path
-from urllib.parse import urlparse
 
 from dagster import Field, Noneable, op
 from ferc_xbrl_extractor.cli import run_main
@@ -86,9 +85,7 @@ def xbrl2sqlite(context) -> None:
             logger.info(f"Dataset ferc{form}_xbrl is disabled, skipping")
             continue
 
-        sql_path = Path(
-            urlparse(PudlPaths().sqlite_db(f"ferc{form.value}_xbrl")).path
-        ).resolve()
+        sql_path = PudlPaths().sqlite_db_path(f"ferc{form.value}_xbrl")
 
         if sql_path.exists():
             if clobber:

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -86,7 +86,9 @@ def xbrl2sqlite(context) -> None:
             logger.info(f"Dataset ferc{form}_xbrl is disabled, skipping")
             continue
 
-        sql_path = Path(urlparse(PudlPaths().sqlite_db(f"ferc{form.value}_xbrl")).path)
+        sql_path = Path(
+            urlparse(PudlPaths().sqlite_db(f"ferc{form.value}_xbrl")).path
+        ).resolve()
 
         if sql_path.exists():
             if clobber:

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -426,8 +426,9 @@ class PudlSQLiteIOManager(SQLiteIOManager):
 
         super().__init__(base_dir, db_name, md, timeout)
 
-        existing_schema_context = MigrationContext.configure(self.engine.connect())
-        metadata_diff = compare_metadata(existing_schema_context, self.md)
+        with self.engine.connect() as conn:
+            existing_schema_context = MigrationContext.configure(conn)
+            metadata_diff = compare_metadata(existing_schema_context, self.md)
         if metadata_diff:
             logger.info(f"Metadata diff:\n\n{metadata_diff}")
             raise RuntimeError(

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -426,9 +426,8 @@ class PudlSQLiteIOManager(SQLiteIOManager):
 
         super().__init__(base_dir, db_name, md, timeout)
 
-        with self.engine.connect() as conn:
-            existing_schema_context = MigrationContext.configure(conn)
-            metadata_diff = compare_metadata(existing_schema_context, self.md)
+        existing_schema_context = MigrationContext.configure(self.engine.connect())
+        metadata_diff = compare_metadata(existing_schema_context, self.md)
         if metadata_diff:
             logger.info(f"Metadata diff:\n\n{metadata_diff}")
             raise RuntimeError(

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -73,20 +73,23 @@ class PudlPaths(BaseSettings):
         return self.input_dir
 
     @property
-    def pudl_db(self) -> Path:
+    def pudl_db(self) -> str:
         """Returns url of locally stored pudl sqlite database."""
-        return self.sqlite_db("pudl")
+        return self.sqlite_db_uri("pudl")
 
-    def sqlite_db(self, name: str) -> str:
-        """Returns url of locally stored pudl slqlite database with given name.
+    def sqlite_db_uri(self, name: str) -> str:
+        """Returns url of locally stored pudl sqlite database with given name.
 
         The name is expected to be the name of the database without the .sqlite
         suffix. E.g. pudl, ferc1 and so on.
         """
-        db_path = self.output_dir / f"{name}.sqlite"
         # SQLite URI has 3 slashes - 2 to separate URI scheme, 1 to separate creds
         # sqlite://{credentials}/{db_path}
-        return f"sqlite:///{db_path}"
+        return f"sqlite:///{self.sqlite_db_path(name)}"
+
+    def sqlite_db_path(self, name: str) -> Path:
+        """Return path to locally stored SQLite DB file."""
+        return self.output_dir / f"{name}.sqlite"
 
     def output_file(self, filename: str) -> Path:
         """Path to file in PUDL output directory."""

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -84,7 +84,9 @@ class PudlPaths(BaseSettings):
         suffix. E.g. pudl, ferc1 and so on.
         """
         db_path = self.output_dir / f"{name}.sqlite"
-        return f"sqlite://{db_path}"
+        # SQLite URI has 3 slashes - 2 to separate URI scheme, 1 to separate creds
+        # sqlite://{credentials}/{db_path}
+        return f"sqlite:///{db_path}"
 
     def output_file(self, filename: str) -> Path:
         """Path to file in PUDL output directory."""

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -54,12 +54,12 @@ class PudlPaths(BaseSettings):
     @property
     def input_dir(self) -> Path:
         """Path to PUDL input directory."""
-        return Path(self.pudl_input)
+        return Path(self.pudl_input).absolute()
 
     @property
     def output_dir(self) -> Path:
         """Path to PUDL output directory."""
-        return Path(self.pudl_output)
+        return Path(self.pudl_output).absolute()
 
     @property
     def settings_dir(self) -> Path:
@@ -83,9 +83,8 @@ class PudlPaths(BaseSettings):
         The name is expected to be the name of the database without the .sqlite
         suffix. E.g. pudl, ferc1 and so on.
         """
-        db_path = PudlPaths().output_dir / f"{name}.sqlite"
-        return f"sqlite:///{db_path}"
-        return self.output_dir / f"{name}.sqlite"
+        db_path = self.output_dir / f"{name}.sqlite"
+        return f"sqlite://{db_path}"
 
     def output_file(self, filename: str) -> Path:
         """Path to file in PUDL output directory."""

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -122,9 +122,9 @@ def test_xbrl2sqlite(settings, forms, mocker):
             form,
             mock_datastore,
             output_path=PudlPaths().output_dir,
+            sql_path=PudlPaths().output_dir / f"ferc{form.value}_xbrl.sqlite",
             batch_size=20,
             workers=10,
-            clobber=True,
         )
 
 
@@ -158,7 +158,7 @@ def test_convert_form(mocker):
             form,
             FakeDatastore(),
             output_path=output_path,
-            clobber=True,
+            sql_path=output_path / f"ferc{form.value}_xbrl.sqlite",
             batch_size=10,
             workers=5,
         )
@@ -169,8 +169,8 @@ def test_convert_form(mocker):
             expected_calls.append(
                 mocker.call(
                     instance_path=f"filings_{year}_{form.value}",
-                    sql_path=str(output_path / f"ferc{form.value}_xbrl.sqlite"),
-                    clobber=True,
+                    sql_path=output_path / f"ferc{form.value}_xbrl.sqlite",
+                    clobber=False,
                     taxonomy=f"raw_archive_{year}_{form.value}",
                     entry_point=f"taxonomy_entry_point_{year}_{form.value}",
                     form_number=form.value,

--- a/test/validate/notebooks/validate_bf_eia923.ipynb
+++ b/test/validate/notebooks/validate_bf_eia923.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db(\"ferc1\"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri(\"ferc1\"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)"
    ]
   },

--- a/test/validate/notebooks/validate_fbp_ferc1.ipynb
+++ b/test/validate/notebooks/validate_fbp_ferc1.ipynb
@@ -81,7 +81,7 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db(\"ferc1\"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri(\"ferc1\"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)"
    ]
   },

--- a/test/validate/notebooks/validate_frc_eia923.ipynb
+++ b/test/validate/notebooks/validate_frc_eia923.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db(\"ferc1\"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri(\"ferc1\"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)"
    ]
   },

--- a/test/validate/notebooks/validate_fuel_ferc1.ipynb
+++ b/test/validate/notebooks/validate_fuel_ferc1.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db("ferc1"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
     "pudl_settings"
    ]

--- a/test/validate/notebooks/validate_gens_eia860.ipynb
+++ b/test/validate/notebooks/validate_gens_eia860.ipynb
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db("ferc1"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)"
    ]
   },

--- a/test/validate/notebooks/validate_gf_eia923.ipynb
+++ b/test/validate/notebooks/validate_gf_eia923.ipynb
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db("ferc1"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
     "pudl_settings"
    ]

--- a/test/validate/notebooks/validate_mcoe.ipynb
+++ b/test/validate/notebooks/validate_mcoe.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db("ferc1"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
     "pudl_settings"
    ]

--- a/test/validate/notebooks/validate_plants_steam_ferc1.ipynb
+++ b/test/validate/notebooks/validate_plants_steam_ferc1.ipynb
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db("ferc1"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
     "pudl_settings"
    ]


### PR DESCRIPTION
On dev, if you set `clobber: True` in the `ferc_to_sqlite` job config, it will clobber the existing database when extracting 2021 data, and then clobber it again when extracting 2022 data.

* clobbering happens on PUDL side now, instead of on ferc-xbrl-extractor side - so it gets called once per op instead of once per form
* you can still clobber when running ferc-xbrl-extractor on its own

This was *probably* the cause of the missing 2021 XBRL data that @cmgosnell ran into yesterday.