### PR TITLE
Simplify process of bootstrapping pudl-dev conda env.

### DIFF
--- a/.github/workflows/update-conda-lockfile.yml
+++ b/.github/workflows/update-conda-lockfile.yml
@@ -7,6 +7,7 @@ on:
     - cron: "0 9 * * 1-5" # Weekdays at 9AM UTC
   push:
     paths:
+      - "Makefile"
       - "pyproject.toml"
       - "environments/*"
       - ".github/workflows/update-conda-lockfile.yml"

--- a/Makefile
+++ b/Makefile
@@ -39,26 +39,31 @@ conda-clean:
 
 # Regenerate the conda lockfile and render platform specific conda environments.
 conda-lock.yml: pyproject.toml
-	conda-lock \
+	${mamba} run --name base ${mamba} install --yes conda-lock prettier
+	${mamba} run --name base conda-lock \
 		--${mamba} \
 		--file=pyproject.toml \
 		--lockfile=environments/conda-lock.yml
-	cd environments && conda-lock render \
+	cd environments && ${mamba} run --name base conda-lock render \
 		--kind env \
 		--dev-dependencies \
 		conda-lock.yml
-	prettier --write environments/*.yml
+	${mamba} run --name base prettier --write environments/*.yml
 
 # Create the pudl-dev conda environment based on the universal lockfile
 .PHONY: pudl-dev
-pudl-dev: conda-lock.yml
+pudl-dev:
 	${mamba} run --name base ${mamba} env remove --name pudl-dev
-	conda-lock install --name pudl-dev --${mamba} --dev environments/conda-lock.yml
+	${mamba} run --name base conda-lock install \
+		--name pudl-dev \
+		--${mamba} \
+		--dev environments/conda-lock.yml
 	echo "To activate the fresh environment run: mamba activate pudl-dev"
 
 .PHONY: install-pudl
 install-pudl: pudl-dev
 	${mamba} run --name pudl-dev pip install --no-cache-dir --no-deps --editable .
+	echo "To activate the fresh environment run: mamba activate pudl-dev"
 
 ########################################################################################
 # Build documentation for local use or testing

--- a/docs/dev/dev_setup.rst
+++ b/docs/dev/dev_setup.rst
@@ -44,14 +44,6 @@ with the following commands:
     $ mamba update mamba
     $ conda config --set channel_priority strict
 
-At this point you should have a ``base`` ``conda`` environment. You'll need to install
-``conda-lock`` to work with our environment lockfiles, discussed below:
-
-.. code-block:: console
-
-    $ mamba activate base
-    $ mamba install conda-lock
-
 ------------------------------------------------------------------------------
 Fork and Clone the PUDL Repository
 ------------------------------------------------------------------------------
@@ -128,6 +120,7 @@ and then create a fresh ``pudl-dev`` environment using the new lockfile, you can
 .. code-block:: console
 
     $ make conda-clean
+    $ make conda-lock.yml
     $ make install-pudl
 
 However, unless you are adding or removing dependencies from ``pyproject.toml`` it is

--- a/environments/conda-linux-64.lock.yml
+++ b/environments/conda-linux-64.lock.yml
@@ -98,7 +98,7 @@ dependencies:
   - libprotobuf=4.24.4=hf27288f_0
   - libre2-11=2023.06.02=h7a70373_0
   - librttopo=1.1.0=hb58d41b_14
-  - libsqlite=3.44.0=h2797004_0
+  - libsqlite=3.44.1=h2797004_0
   - libssh2=1.11.0=h0841786_0
   - libxcb=1.15=h0b41bf4_0
   - libxml2=2.11.6=h232c23b_0
@@ -131,7 +131,7 @@ dependencies:
   - pandoc=3.1.3=h32600fe_0
   - python=3.11.6=hab00c5b_0_cpython
   - re2=2023.06.02=h2873b5e_0
-  - sqlite=3.44.0=h2c6b66d_0
+  - sqlite=3.44.1=h2c6b66d_0
   - xorg-libx11=1.8.7=h8ee46fc_0
   - aiofiles=23.2.1=pyhd8ed1ab_0
   - alabaster=0.7.13=pyhd8ed1ab_0

--- a/environments/conda-lock.yml
+++ b/environments/conda-lock.yml
@@ -12713,16 +12713,16 @@ package:
     category: main
     optional: false
   - name: libsqlite
-    version: 3.44.0
+    version: 3.44.1
     manager: conda
     platform: linux-64
     dependencies:
       libgcc-ng: ">=12"
       libzlib: ">=1.2.13,<1.3.0a0"
-    url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.0-h2797004_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.44.1-h2797004_0.conda
     hash:
-      md5: b58e6816d137f3aabf77d341dd5d732b
-      sha256: 74ef5dcb900c38bec53140036e5e2a9cc7ffcd806da479ea2305f962a358a259
+      md5: b4ad86d2527b890e43ff2efc68b239f4
+      sha256: c37bb6ec8b09f690d84e8f14fabb75e00c221d11a256137d5b206e26f37e9483
     category: main
     optional: false
   - name: libsqlite
@@ -20937,19 +20937,19 @@ package:
     category: main
     optional: false
   - name: sqlite
-    version: 3.44.0
+    version: 3.44.1
     manager: conda
     platform: linux-64
     dependencies:
       libgcc-ng: ">=12"
-      libsqlite: 3.44.0
+      libsqlite: 3.44.1
       libzlib: ">=1.2.13,<1.3.0a0"
       ncurses: ">=6.4,<7.0a0"
       readline: ">=8.2,<9.0a0"
-    url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.44.0-h2c6b66d_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/sqlite-3.44.1-h2c6b66d_0.conda
     hash:
-      md5: df56c636df4a98990462d66ac7be2330
-      sha256: ae7031a471868c7057cc16eded7bb58fa3723d9c1650c9d3eb8de1ff65d89dbb
+      md5: cf535736bb0de7bf388dbfd2d6a50f53
+      sha256: a0a2fc6c9d7e170c5738ad134f8b71f51a1c982c4496c47f8caa73ef4e5b17c8
     category: main
     optional: false
   - name: sqlite


### PR DESCRIPTION
# PR Overview

Some small improvements to the ergonomics of setting up the `pudl-dev` conda environment, especially for the first time:
* Use `make` to install `conda-lock` and `prettier` in the user's base conda environment using `mamba run`, rather than requiring it to be done manually. This means the only setup requirements are `mamba` and `make`.
* Remove the make dependency that was causing many first-time environment installations to also rebuild the `conda-lock.yml` file -- that will get taken care of automatically in CI if need be (because `pyproject.toml` or other dependency files were changed).
* Update dev setup docs to reflect this simplification.
* Add `Makefile` to the list of paths that triggers a rebuild of the conda lockfile... since it affects the process.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
