### PR TITLE
dotenv compatibility

### DIFF
--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -24,7 +24,7 @@ class PudlPaths(BaseSettings):
 
     pudl_input: PotentialDirectoryPath
     pudl_output: PotentialDirectoryPath
-    model_config = SettingsConfigDict(env_file=".env")
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
 
     @property
     def input_dir(self) -> Path:


### PR DESCRIPTION
When I tried to run `make docs-build`, I would get a validation error from `PudlPaths()`:

```
exception: 1 validation error for PudlPaths                                                                                                       
dagster_home                                                                                                                    
  Extra inputs are not permitted [type=extra_forbidden, input_value='/Users/dazhong-catalyst/work/dagster_home', input_type=str]
    For further information visit https://errors.pydantic.dev/2.5/v/extra_forbidden
```

This happened because my `pudl/.env` file contains:

```
PUDL_OUTPUT=/Users/dazhong-catalyst/pudl_workspace/output
PUDL_INPUT=/Users/dazhong-catalyst/pudl_workspace/data
DAGSTER_HOME=/Users/dazhong-catalyst/work/dagster_home
```

At the bottom of the [dotenv section](https://docs.pydantic.dev/latest/concepts/pydantic_settings/#dotenv-env-support) of the Pydantic docs, they suggest

> For compatibility with pydantic 1.x BaseSettings you should use extra=ignore:

So I did that.

Then I tried running `make docs-build` and it didn't throw that error anymore. Huzzah.