### PR TITLE
Sort DBs Fly Datasette; don't distribute Datasette's metadata.yml

### DIFF
--- a/devtools/datasette/fly/run.sh
+++ b/devtools/datasette/fly/run.sh
@@ -7,4 +7,4 @@ find /data/ -name '*.sqlite' -delete
 mv all_dbs.tar.zst /data
 zstd -f -d /data/all_dbs.tar.zst -o /data/all_dbs.tar
 tar -xf /data/all_dbs.tar --directory /data
-datasette serve --host 0.0.0.0 /data/*.sqlite --cors --inspect-file inspect-data.json --metadata metadata.yml --setting sql_time_limit_ms 5000 --port $PORT
+datasette serve --host 0.0.0.0 /data/pudl.sqlite /data/ferc*.sqlite /data/censusdp1tract.sqlite --cors --inspect-file inspect-data.json --metadata metadata.yml --setting sql_time_limit_ms 5000 --port $PORT

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -104,7 +104,8 @@ if [[ $ETL_SUCCESS == 0 ]]; then
     # Compress the SQLite DBs for easier distribution
     # Remove redundant multi-file EPA CEMS outputs prior to distribution
     gzip --verbose $PUDL_OUTPUT/*.sqlite && \
-    rm -rf $PUDL_OUTPUT/hourly_emissions_epacems/
+    rm -rf $PUDL_OUTPUT/hourly_emissions_epacems/ && \
+    rm -f $PUDL_OUTPUT/metadata.yml
     ETL_SUCCESS=${PIPESTATUS[0]}
 
     # Dump outputs to s3 bucket if branch is dev or build was triggered by a tag


### PR DESCRIPTION
# PR Overview

* Remove the Datasette-specific `metadata.yml` from the outputs folder before uploading to GCS/S3 for distribution.
* Manually sort SQLite DBs in Fly.io datasette script so that PUDL comes first.

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
