### PR TITLE
Add GHA workflow for release-on-tag

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     tags:
-      - "v**"
+      - "v20*"
   schedule:
     - cron: "0 6 * * 1-5" # Weekdays at midnight on MST
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,121 @@
+---
+name: release
+
+on: push
+
+jobs:
+  build-distribution:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - name: Build source and wheel distributions
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          twine check --strict dist/*
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+
+  publish-test-pypi:
+    name: Upload release to PyPI Test Server
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')
+    needs:
+      - build-distribution
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://test.pypi.org/p/catalystcoop.pudl
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI Test Server
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+
+  publish-pypi:
+    name: Upload release to PyPI
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')
+    needs:
+      - build-distribution
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/catalystcoop.pudl
+    permissions:
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  publish-github:
+    name: Release package on GitHub
+    needs:
+      - publish-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v3
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: Sign dist with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v2.1.0
+        with:
+          inputs: ./dist/*.tar.gz ./dist/*.whl
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create '${{ github.ref_name }}' ./dist/*.tar.gz ./dist/*.whl
+          --generate-notes
+          --repo '${{ github.repository }}'
+
+  notify-slack:
+    runs-on: ubuntu-latest
+    needs:
+      - publish-github
+    if: ${{ always() }}
+    steps:
+      - name: Inform the Codemonkeys
+        uses: 8398a7/action-slack@v3
+        continue-on-error: true
+        with:
+          status: custom
+          fields: workflow,job,commit,repo,ref,author,took
+          custom_payload: |
+            {
+              username: 'action-slack',
+              icon_emoji: ':octocat:',
+              attachments: [{
+                color: '${{ needs.publish-github.result }}' === 'success' ? 'good' : '${{ needs.publish-github.result }}' === 'failure' ? 'danger' : 'warning',
+                text: `${process.env.AS_REPO}@${process.env.AS_REF}\n ${process.env.AS_WORKFLOW} (${process.env.AS_COMMIT})\n by ${process.env.AS_AUTHOR}\n Status: ${{ needs.publish-github.result }}`,
+              }]
+            }
+        env:
+          GITHUB_TOKEN: ${{ github.token }} # required
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
+          MATRIX_CONTEXT: ${{ toJson(matrix) }} # required

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,30 +48,30 @@ jobs:
         with:
           repository-url: https://test.pypi.org/legacy/
 
-  publish-pypi:
-    name: Upload release to PyPI
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')
-    needs:
-      - build-distribution
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/catalystcoop.pudl
-    permissions:
-      id-token: write
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v3
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+  #publish-pypi:
+  #  name: Upload release to PyPI
+  #  if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')
+  #  needs:
+  #    - build-distribution
+  #  runs-on: ubuntu-latest
+  #  environment:
+  #    name: pypi
+  #    url: https://pypi.org/p/catalystcoop.pudl
+  #  permissions:
+  #    id-token: write
+  #  steps:
+  #    - name: Download all the dists
+  #      uses: actions/download-artifact@v3
+  #      with:
+  #        name: python-package-distributions
+  #        path: dist/
+  #    - name: Publish distribution to PyPI
+  #      uses: pypa/gh-action-pypi-publish@release/v1
 
   publish-github:
     name: Release package on GitHub
     needs:
-      - publish-pypi
+      - publish-test-pypi
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
# PR Overview

- Sets up a workflow to do GitHub (and possibly PyPI) releases automatically any time a tag is pushed starting with `v20` (matching calendar versions like `v2023.12.05` for the next 77 years).
- This includes a new job that attempts to build valid source & binary (wheel) distribution of the repo on every push, creating the files which would then be distributed if the right tag is pushed to `main`
- The publication of a GitHub release triggers the archiving of the PUD **repository** on Zenodo (through the GitHub-Zenodo integration app we have set up already), which is one of the goals of the automated releases. See #2756 
- We already have a build-on-tag action set up. The data release work (creating a new **data** archive on Zenodo, pushing to persistent locations on GCP/S3) will be done in the nightly build system.

# Questions / Issues
- In an ideal world it seems like none of the distribution would happen until after the build initiated by the tag had completed successfully. What kinds of issues/changes can creep into the system between getting a good nightly build, and tagging the associated commit for release?

# PR Checklist

- [ ] Merge the most recent version of the branch you are merging into (probably `dev`).
- [ ] All CI checks are passing. [Run tests locally to debug failures](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#running-tests-with-tox)
- [ ] Make sure you've included good docstrings.
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] Include unit tests for new functions and classes.
- [ ] Defensive data quality/sanity checks in analyses & data processing functions.
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) and reference reference the PR and related issues.
- [ ] Do your own explanatory review of the PR to help the reviewer understand what's going on and identify issues preemptively.
