### PR TITLE
Update lockfiles on pre-commit

### DIFF
--- a/.github/workflows/update-conda-lockfile.yml
+++ b/.github/workflows/update-conda-lockfile.yml
@@ -5,12 +5,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 9 * * 1" # Mondays at 9AM UTC
-  push:
-    paths:
-      - "Makefile"
-      - "pyproject.toml"
-      - "environments/*"
-      - ".github/workflows/update-conda-lockfile.yml"
 
 # What branch does this action run on?
 # - workflow_dispatch: Whatever branch it was run against.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -101,5 +101,5 @@ ci:
   autoupdate_branch: dev
   autoupdate_commit_msg: "[pre-commit.ci] pre-commit autoupdate"
   autoupdate_schedule: weekly
-  skip: [unit-tests, nb-output-clear]
+  skip: [unit-tests, nb-output-clear, conda-lock]
   submodules: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,15 @@ repos:
         always_run: true
         entry: pytest --doctest-modules src/pudl test/unit -m "not slow"
 
+      - id: conda-lock
+        name: conda-lock
+        stages: [commit]
+        language: system
+        verbose: false
+        files: "pyproject.toml"
+        always_run: false
+        entry: make conda-clean conda-lock.yml
+
 # Configuration for pre-commit.ci
 ci:
   autofix_commit_msg: |


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #3133.

We introduced `conda-lock` and lockfiles in an attempt to avoid instability caused by frequent dependency version changes. 

However, we have been re-locking very eagerly, which means that we are actually still very susceptible to dependency version changes that break our ETL. It also chews through our CI budget.

At least it's very easy to see what changed in the environment between runs!

So we decided to only re-lock:
* before committing a change to `pyproject.toml`
* once a week

This adds a simple hook to `.pre-commit-config.yaml` which runs our re-locking `make` command when `pyproject.toml` changes.

If `pyproject.toml` doesn't change, the hook is skipped; if `pyproject.toml` changes, it runs `make conda-clean conda-lock.yml`.

If `make` doesn't actually change any of the `environment/*` files, pre-commit will pass; otherwise the check will fail and you'll have to re-add & re-commit, much like any other pre-commit check we run.

Sometimes the lock will have updated between the first time you ran the hook and the second time, because some package update happened - in that case you'll have to re-add & re-commit a third time.


# Testing

To make sure this worked, I added some comments to `pyproject.toml` and attempted to commit - that triggered a re-lock. Then I added the lockfile changes and re-committed - this time it still re-locked (because `pyproject.toml` diffs were still in the commit) but because the lockfiles didn't change, the pre-commit check passed. 

```[tasklist]
# To-do list
- [x] Review the PR yourself and call out any questions or issues you have
```
