### PR TITLE
Attempt to create sandbox data release in nightly builds.

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -125,6 +125,7 @@ jobs:
             --container-env DAGSTER_PG_HOST="104.154.182.24" \
             --container-env DAGSTER_PG_DB="dagster-storage" \
             --container-env FLY_ACCESS_TOKEN=${{ secrets.FLY_ACCESS_TOKEN }} \
+            --container-env ZENODO_SANDBOX_TOKEN_PUBLISH=${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }} \
             --container-env PUDL_SETTINGS_YML="/home/mambauser/src/pudl/package_data/settings/etl_full.yml" \
             --container-env PUDL_GCS_OUTPUT=${{ env.GCS_OUTPUT_BUCKET }}/${{ env.COMMIT_TIME }}-${{ env.SHORT_SHA }}-${{ env.COMMIT_BRANCH }}
 

--- a/environments/conda-linux-64.lock.yml
+++ b/environments/conda-linux-64.lock.yml
@@ -262,7 +262,7 @@ dependencies:
   - rpds-py=0.13.2=py311h46250e7_0
   - rtree=1.1.0=py311h3bb2b0f_0
   - ruamel.yaml.clib=0.2.7=py311h459d7ec_2
-  - ruff=0.1.7=py311h7145743_0
+  - ruff=0.1.8=py311h7145743_0
   - send2trash=1.8.2=pyh41d4057_0
   - setuptools=68.2.2=pyhd8ed1ab_0
   - shellingham=1.5.4=pyhd8ed1ab_0
@@ -329,7 +329,7 @@ dependencies:
   - clikit=0.6.2=pyhd8ed1ab_2
   - coloredlogs=14.0=pyhd8ed1ab_3
   - comm=0.1.4=pyhd8ed1ab_0
-  - coverage=7.3.2=py311h459d7ec_0
+  - coverage=7.3.3=py311h459d7ec_0
   - curl=8.5.0=hca28451_0
   - fonttools=4.46.0=py311h459d7ec_0
   - gitdb=4.0.11=pyhd8ed1ab_0
@@ -402,7 +402,7 @@ dependencies:
   - arrow=1.3.0=pyhd8ed1ab_0
   - async-timeout=4.0.3=pyhd8ed1ab_0
   - aws-c-s3=0.4.1=hfadff92_0
-  - botocore=1.33.13=pyhd8ed1ab_0
+  - botocore=1.34.0=pyhd8ed1ab_0
   - branca=0.7.0=pyhd8ed1ab_1
   - croniter=2.0.1=pyhd8ed1ab_0
   - cryptography=41.0.7=py311hcb13ee4_1
@@ -477,10 +477,10 @@ dependencies:
   - pybtex-docutils=1.0.3=py311h38be061_1
   - pydantic=2.5.2=pyhd8ed1ab_0
   - pyopenssl=23.3.0=pyhd8ed1ab_0
-  - readthedocs-sphinx-ext=2.2.3=pyhd8ed1ab_0
+  - readthedocs-sphinx-ext=2.2.4=pyhd8ed1ab_0
   - requests-toolbelt=0.10.1=pyhd8ed1ab_0
   - responses=0.24.1=pyhd8ed1ab_0
-  - s3transfer=0.8.2=pyhd8ed1ab_0
+  - s3transfer=0.9.0=pyhd8ed1ab_0
   - scipy=1.11.4=py311h64a7726_0
   - secretstorage=3.3.3=py311h38be061_2
   - shapely=2.0.2=py311h2032efe_1
@@ -489,7 +489,7 @@ dependencies:
   - typer=0.9.0=pyhd8ed1ab_0
   - uvicorn-standard=0.24.0.post1=h38be061_0
   - aws-sdk-cpp=1.11.182=h8beafcf_7
-  - boto3=1.33.13=pyhd8ed1ab_0
+  - boto3=1.34.0=pyhd8ed1ab_0
   - cachecontrol-with-filecache=0.13.1=pyhd8ed1ab_0
   - dagster=1.5.12=pyhd8ed1ab_0
   - datasette=0.64.4=pyhd8ed1ab_1

--- a/environments/conda-lock.yml
+++ b/environments/conda-lock.yml
@@ -1914,93 +1914,93 @@ package:
     category: main
     optional: false
   - name: boto3
-    version: 1.33.13
+    version: 1.34.0
     manager: conda
     platform: linux-64
     dependencies:
-      botocore: ">=1.33.13,<1.34.0"
+      botocore: ">=1.34.0,<1.35.0"
       jmespath: ">=0.7.1,<2.0.0"
-      python: ">=3.7"
-      s3transfer: ">=0.8.2,<0.9.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.33.13-pyhd8ed1ab_0.conda
+      python: ">=3.8"
+      s3transfer: ">=0.9.0,<0.10.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.0-pyhd8ed1ab_0.conda
     hash:
-      md5: 4a1b38a0938b9fc23fb4fc202d832097
-      sha256: 01f797f967ac92346a5bffdae165c5d4bacda8405b828fcd58534a0f82287f76
+      md5: 82cc20a8fee273e54cecf129a30745df
+      sha256: 1da6d4c5dcef598e75b44d54184c9b0495ee3adf8ed9c42ea14a867fd8aad60c
     category: main
     optional: false
   - name: boto3
-    version: 1.33.13
+    version: 1.34.0
     manager: conda
     platform: osx-64
     dependencies:
-      python: ">=3.7"
+      python: ">=3.8"
       jmespath: ">=0.7.1,<2.0.0"
-      s3transfer: ">=0.8.2,<0.9.0"
-      botocore: ">=1.33.13,<1.34.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.33.13-pyhd8ed1ab_0.conda
+      s3transfer: ">=0.9.0,<0.10.0"
+      botocore: ">=1.34.0,<1.35.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.0-pyhd8ed1ab_0.conda
     hash:
-      md5: 4a1b38a0938b9fc23fb4fc202d832097
-      sha256: 01f797f967ac92346a5bffdae165c5d4bacda8405b828fcd58534a0f82287f76
+      md5: 82cc20a8fee273e54cecf129a30745df
+      sha256: 1da6d4c5dcef598e75b44d54184c9b0495ee3adf8ed9c42ea14a867fd8aad60c
     category: main
     optional: false
   - name: boto3
-    version: 1.33.13
+    version: 1.34.0
     manager: conda
     platform: osx-arm64
     dependencies:
-      python: ">=3.7"
+      python: ">=3.8"
       jmespath: ">=0.7.1,<2.0.0"
-      s3transfer: ">=0.8.2,<0.9.0"
-      botocore: ">=1.33.13,<1.34.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.33.13-pyhd8ed1ab_0.conda
+      s3transfer: ">=0.9.0,<0.10.0"
+      botocore: ">=1.34.0,<1.35.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.34.0-pyhd8ed1ab_0.conda
     hash:
-      md5: 4a1b38a0938b9fc23fb4fc202d832097
-      sha256: 01f797f967ac92346a5bffdae165c5d4bacda8405b828fcd58534a0f82287f76
+      md5: 82cc20a8fee273e54cecf129a30745df
+      sha256: 1da6d4c5dcef598e75b44d54184c9b0495ee3adf8ed9c42ea14a867fd8aad60c
     category: main
     optional: false
   - name: botocore
-    version: 1.33.13
+    version: 1.34.0
     manager: conda
     platform: linux-64
     dependencies:
       jmespath: ">=0.7.1,<2.0.0"
-      python: ">=3.7"
+      python: ">=3.8"
       python-dateutil: ">=2.1,<3.0.0"
       urllib3: ">=1.25.4,<1.27"
-    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.33.13-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.0-pyhd8ed1ab_0.conda
     hash:
-      md5: d2566fd9134b6f8b8e69a07e9a1fa17e
-      sha256: 498d08274880ef279e9a6dd68f66b384d71321d92301fa60330712f9edceab0c
+      md5: 61c8f5df4abbfa8ab19b1b307913723c
+      sha256: 2d72f7a2703c1044a6532b353b6a7e553e587a4a5fae78745e35b55b5b3a7ad4
     category: main
     optional: false
   - name: botocore
-    version: 1.33.13
+    version: 1.34.0
     manager: conda
     platform: osx-64
     dependencies:
-      python: ">=3.7"
+      python: ">=3.8"
       python-dateutil: ">=2.1,<3.0.0"
       jmespath: ">=0.7.1,<2.0.0"
       urllib3: ">=1.25.4,<1.27"
-    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.33.13-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.0-pyhd8ed1ab_0.conda
     hash:
-      md5: d2566fd9134b6f8b8e69a07e9a1fa17e
-      sha256: 498d08274880ef279e9a6dd68f66b384d71321d92301fa60330712f9edceab0c
+      md5: 61c8f5df4abbfa8ab19b1b307913723c
+      sha256: 2d72f7a2703c1044a6532b353b6a7e553e587a4a5fae78745e35b55b5b3a7ad4
     category: main
     optional: false
   - name: botocore
-    version: 1.33.13
+    version: 1.34.0
     manager: conda
     platform: osx-arm64
     dependencies:
-      python: ">=3.7"
+      python: ">=3.8"
       python-dateutil: ">=2.1,<3.0.0"
       jmespath: ">=0.7.1,<2.0.0"
       urllib3: ">=1.25.4,<1.27"
-    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.33.13-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.34.0-pyhd8ed1ab_0.conda
     hash:
-      md5: d2566fd9134b6f8b8e69a07e9a1fa17e
-      sha256: 498d08274880ef279e9a6dd68f66b384d71321d92301fa60330712f9edceab0c
+      md5: 61c8f5df4abbfa8ab19b1b307913723c
+      sha256: 2d72f7a2703c1044a6532b353b6a7e553e587a4a5fae78745e35b55b5b3a7ad4
     category: main
     optional: false
   - name: bottleneck
@@ -3537,7 +3537,7 @@ package:
     category: main
     optional: false
   - name: coverage
-    version: 7.3.2
+    version: 7.3.3
     manager: conda
     platform: linux-64
     dependencies:
@@ -3545,38 +3545,38 @@ package:
       python: ">=3.11,<3.12.0a0"
       python_abi: 3.11.*
       tomli: ""
-    url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.3.2-py311h459d7ec_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.3.3-py311h459d7ec_0.conda
     hash:
-      md5: 7b3145fed7adc7c63a0e08f6f29f5480
-      sha256: 8b56edd4336e7fc6ff9b73436a3a270cf835f57cf4d0565c6e240c40f1981085
+      md5: 9db2c1316e96068c0189beaeb716f3fe
+      sha256: 9a0236150852e33c52d91d5503975b8e559e533ac8f85e95224ce2b17faef9c1
     category: main
     optional: false
   - name: coverage
-    version: 7.3.2
+    version: 7.3.3
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.11,<3.12.0a0"
       python_abi: 3.11.*
       tomli: ""
-    url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.3.2-py311h2725bcf_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.3.3-py311he705e18_0.conda
     hash:
-      md5: 0ce651c68a0322a6eacef726025b938a
-      sha256: ada34f95907fe0cd98d4d12e439bd1508363738f8b0fbe88d14cb398f4235af6
+      md5: 80615a35595d46e9786d28ec61ceec9a
+      sha256: baf2c9e923646abf228cc3655d9080f7e2ade0f70472974a37a4fa4b3ae4410b
     category: main
     optional: false
   - name: coverage
-    version: 7.3.2
+    version: 7.3.3
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.11,<3.12.0a0"
       python_abi: 3.11.*
       tomli: ""
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.3.2-py311heffc1b2_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.3.3-py311h05b510d_0.conda
     hash:
-      md5: 75928ad6625a73ff93f08be98014248c
-      sha256: 88d116c4c51a106c43937b950d3fd14007800fb7b3945573a5a117533c450e6b
+      md5: 15f7a4fdf06d5d1383dc0b2257279cfa
+      sha256: 38ad704411b491eaaf5db61aca8b05e33d2d827eaf54580203b2d5e1cbc411af
     category: main
     optional: false
   - name: crashtest
@@ -18998,7 +18998,7 @@ package:
     category: main
     optional: false
   - name: readthedocs-sphinx-ext
-    version: 2.2.3
+    version: 2.2.4
     manager: conda
     platform: linux-64
     dependencies:
@@ -19006,14 +19006,14 @@ package:
       packaging: ""
       python: ">=3.6"
       requests: ""
-    url: https://conda.anaconda.org/conda-forge/noarch/readthedocs-sphinx-ext-2.2.3-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/readthedocs-sphinx-ext-2.2.4-pyhd8ed1ab_0.conda
     hash:
-      md5: 6bc1a00f5502f9ed13526e4c6bea6900
-      sha256: 464cfb706266a2dfbee7d0226c83114c9868a65f9fc7e05b223faac8bd2b3f8e
+      md5: 86dd35106fb71b2e2060b557e3bdd49a
+      sha256: 9c0568d4df3b34a54e4c0a3c9780bf947797e4d453ad6c1511467eae188f8232
     category: main
     optional: false
   - name: readthedocs-sphinx-ext
-    version: 2.2.3
+    version: 2.2.4
     manager: conda
     platform: osx-64
     dependencies:
@@ -19021,14 +19021,14 @@ package:
       packaging: ""
       python: ">=3.6"
       jinja2: ">=2.9"
-    url: https://conda.anaconda.org/conda-forge/noarch/readthedocs-sphinx-ext-2.2.3-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/readthedocs-sphinx-ext-2.2.4-pyhd8ed1ab_0.conda
     hash:
-      md5: 6bc1a00f5502f9ed13526e4c6bea6900
-      sha256: 464cfb706266a2dfbee7d0226c83114c9868a65f9fc7e05b223faac8bd2b3f8e
+      md5: 86dd35106fb71b2e2060b557e3bdd49a
+      sha256: 9c0568d4df3b34a54e4c0a3c9780bf947797e4d453ad6c1511467eae188f8232
     category: main
     optional: false
   - name: readthedocs-sphinx-ext
-    version: 2.2.3
+    version: 2.2.4
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -19036,10 +19036,10 @@ package:
       packaging: ""
       python: ">=3.6"
       jinja2: ">=2.9"
-    url: https://conda.anaconda.org/conda-forge/noarch/readthedocs-sphinx-ext-2.2.3-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/readthedocs-sphinx-ext-2.2.4-pyhd8ed1ab_0.conda
     hash:
-      md5: 6bc1a00f5502f9ed13526e4c6bea6900
-      sha256: 464cfb706266a2dfbee7d0226c83114c9868a65f9fc7e05b223faac8bd2b3f8e
+      md5: 86dd35106fb71b2e2060b557e3bdd49a
+      sha256: 9c0568d4df3b34a54e4c0a3c9780bf947797e4d453ad6c1511467eae188f8232
     category: main
     optional: false
   - name: recordlinkage
@@ -19764,7 +19764,7 @@ package:
     category: main
     optional: false
   - name: ruff
-    version: 0.1.7
+    version: 0.1.8
     manager: conda
     platform: linux-64
     dependencies:
@@ -19772,40 +19772,38 @@ package:
       libstdcxx-ng: ">=12"
       python: ">=3.11,<3.12.0a0"
       python_abi: 3.11.*
-    url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.7-py311h7145743_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.1.8-py311h7145743_0.conda
     hash:
-      md5: 7e4329efd6a902a64470bfbe21a83e21
-      sha256: c82eb1b904671ab0eb3212f18aa7af14e51b66a8e893d18a3089d29a334e1e0d
+      md5: ed03c6cf88c287ce426c4d93013fbcbe
+      sha256: 4424017fbda80241dcd2b1b524605db1100c9e3061bbcb3a7d64e624acdae3dc
     category: main
     optional: false
   - name: ruff
-    version: 0.1.7
+    version: 0.1.8
     manager: conda
     platform: osx-64
     dependencies:
-      __osx: ">=10.9"
-      libcxx: ">=16.0.6"
+      libcxx: ">=15"
       python: ">=3.11,<3.12.0a0"
       python_abi: 3.11.*
-    url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.7-py311hec6fdf1_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.1.8-py311ha071555_0.conda
     hash:
-      md5: d21a7d577aa62ce3a2b1eb124da50446
-      sha256: 8aac6c5324504cd6b453be725b0ba8cca478468fb5c328cec79301b552477dc7
+      md5: 04b9bfe5f5d9703ceb20dc6fe2f39b04
+      sha256: b60d25d4ebd0fd3f3a99c7cd5f70bdb4d20bd7f8ecebe038d62d459bf1212069
     category: main
     optional: false
   - name: ruff
-    version: 0.1.7
+    version: 0.1.8
     manager: conda
     platform: osx-arm64
     dependencies:
-      __osx: ">=10.9"
-      libcxx: ">=16.0.6"
+      libcxx: ">=15"
       python: ">=3.11,<3.12.0a0"
       python_abi: 3.11.*
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.7-py311h6fc163c_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.1.8-py311h8c97afb_0.conda
     hash:
-      md5: 86298e47df0a6b448df8632df3d1f4a9
-      sha256: 37d5b2a72c3a5114d43d49a250dffd81d1b064d673e5faf3932c6bf56f2e7c76
+      md5: 4a7cd1ed55f1c2b280682e5fc919d8b9
+      sha256: 57b99e0af55d4a8188e5ec6e25c1da9a6b3e55a9ab7c87848aad12a158fddf76
     category: main
     optional: false
   - name: s2n
@@ -19822,42 +19820,42 @@ package:
     category: main
     optional: false
   - name: s3transfer
-    version: 0.8.2
+    version: 0.9.0
     manager: conda
     platform: linux-64
     dependencies:
       botocore: ">=1.33.2,<2.0a.0"
-      python: ">=3.7"
-    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.8.2-pyhd8ed1ab_0.conda
+      python: ">=3.8"
+    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.9.0-pyhd8ed1ab_0.conda
     hash:
-      md5: 75e12933f4bf755c9cdd37072bcb6203
-      sha256: 2e5679abcec8eb646df37518ecdbdaa224d7ff5295a1e56707317d52b47d9c79
+      md5: 27ad14e5fc6a13f05b90140debc72cd2
+      sha256: c9fc315d830238113160471467259740593966bcf59f17287a0baeaf1f6a76d8
     category: main
     optional: false
   - name: s3transfer
-    version: 0.8.2
+    version: 0.9.0
     manager: conda
     platform: osx-64
     dependencies:
-      python: ">=3.7"
+      python: ">=3.8"
       botocore: ">=1.33.2,<2.0a.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.8.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.9.0-pyhd8ed1ab_0.conda
     hash:
-      md5: 75e12933f4bf755c9cdd37072bcb6203
-      sha256: 2e5679abcec8eb646df37518ecdbdaa224d7ff5295a1e56707317d52b47d9c79
+      md5: 27ad14e5fc6a13f05b90140debc72cd2
+      sha256: c9fc315d830238113160471467259740593966bcf59f17287a0baeaf1f6a76d8
     category: main
     optional: false
   - name: s3transfer
-    version: 0.8.2
+    version: 0.9.0
     manager: conda
     platform: osx-arm64
     dependencies:
-      python: ">=3.7"
+      python: ">=3.8"
       botocore: ">=1.33.2,<2.0a.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.8.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.9.0-pyhd8ed1ab_0.conda
     hash:
-      md5: 75e12933f4bf755c9cdd37072bcb6203
-      sha256: 2e5679abcec8eb646df37518ecdbdaa224d7ff5295a1e56707317d52b47d9c79
+      md5: 27ad14e5fc6a13f05b90140debc72cd2
+      sha256: c9fc315d830238113160471467259740593966bcf59f17287a0baeaf1f6a76d8
     category: main
     optional: false
   - name: scikit-learn

--- a/environments/conda-osx-64.lock.yml
+++ b/environments/conda-osx-64.lock.yml
@@ -246,7 +246,7 @@ dependencies:
   - rpds-py=0.13.2=py311h5e0f0e4_0
   - rtree=1.1.0=py311hbc1f44b_0
   - ruamel.yaml.clib=0.2.7=py311h2725bcf_2
-  - ruff=0.1.7=py311hec6fdf1_0
+  - ruff=0.1.8=py311ha071555_0
   - setuptools=68.2.2=pyhd8ed1ab_0
   - shellingham=1.5.4=pyhd8ed1ab_0
   - simpleeval=0.9.13=pyhd8ed1ab_1
@@ -308,7 +308,7 @@ dependencies:
   - clikit=0.6.2=pyhd8ed1ab_2
   - coloredlogs=14.0=pyhd8ed1ab_3
   - comm=0.1.4=pyhd8ed1ab_0
-  - coverage=7.3.2=py311h2725bcf_0
+  - coverage=7.3.3=py311he705e18_0
   - curl=8.5.0=h726d00d_0
   - fonttools=4.46.0=py311he705e18_0
   - gitdb=4.0.11=pyhd8ed1ab_0
@@ -382,7 +382,7 @@ dependencies:
   - arrow=1.3.0=pyhd8ed1ab_0
   - async-timeout=4.0.3=pyhd8ed1ab_0
   - aws-crt-cpp=0.24.7=hf3941dc_6
-  - botocore=1.33.13=pyhd8ed1ab_0
+  - botocore=1.34.0=pyhd8ed1ab_0
   - branca=0.7.0=pyhd8ed1ab_1
   - croniter=2.0.1=pyhd8ed1ab_0
   - cryptography=41.0.7=py311h48c7838_1
@@ -459,10 +459,10 @@ dependencies:
   - pybtex-docutils=1.0.3=py311h6eed73b_1
   - pydantic=2.5.2=pyhd8ed1ab_0
   - pyopenssl=23.3.0=pyhd8ed1ab_0
-  - readthedocs-sphinx-ext=2.2.3=pyhd8ed1ab_0
+  - readthedocs-sphinx-ext=2.2.4=pyhd8ed1ab_0
   - requests-toolbelt=0.10.1=pyhd8ed1ab_0
   - responses=0.24.1=pyhd8ed1ab_0
-  - s3transfer=0.8.2=pyhd8ed1ab_0
+  - s3transfer=0.9.0=pyhd8ed1ab_0
   - scipy=1.11.4=py311he0bea55_0
   - send2trash=1.8.2=pyhd1c38e8_0
   - shapely=2.0.2=py311h4c12f3d_1
@@ -470,7 +470,7 @@ dependencies:
   - typeguard=4.1.5=pyhd8ed1ab_1
   - typer=0.9.0=pyhd8ed1ab_0
   - uvicorn-standard=0.24.0.post1=h6eed73b_0
-  - boto3=1.33.13=pyhd8ed1ab_0
+  - boto3=1.34.0=pyhd8ed1ab_0
   - cachecontrol-with-filecache=0.13.1=pyhd8ed1ab_0
   - dagster=1.5.12=pyhd8ed1ab_0
   - datasette=0.64.4=pyhd8ed1ab_1

--- a/environments/conda-osx-arm64.lock.yml
+++ b/environments/conda-osx-arm64.lock.yml
@@ -246,7 +246,7 @@ dependencies:
   - rpds-py=0.13.2=py311h94f323b_0
   - rtree=1.1.0=py311hd698ff7_0
   - ruamel.yaml.clib=0.2.7=py311heffc1b2_2
-  - ruff=0.1.7=py311h6fc163c_0
+  - ruff=0.1.8=py311h8c97afb_0
   - setuptools=68.2.2=pyhd8ed1ab_0
   - shellingham=1.5.4=pyhd8ed1ab_0
   - simpleeval=0.9.13=pyhd8ed1ab_1
@@ -308,7 +308,7 @@ dependencies:
   - clikit=0.6.2=pyhd8ed1ab_2
   - coloredlogs=14.0=pyhd8ed1ab_3
   - comm=0.1.4=pyhd8ed1ab_0
-  - coverage=7.3.2=py311heffc1b2_0
+  - coverage=7.3.3=py311h05b510d_0
   - curl=8.5.0=h2d989ff_0
   - fonttools=4.46.0=py311h05b510d_0
   - gitdb=4.0.11=pyhd8ed1ab_0
@@ -382,7 +382,7 @@ dependencies:
   - arrow=1.3.0=pyhd8ed1ab_0
   - async-timeout=4.0.3=pyhd8ed1ab_0
   - aws-crt-cpp=0.24.7=hba4ac3b_6
-  - botocore=1.33.13=pyhd8ed1ab_0
+  - botocore=1.34.0=pyhd8ed1ab_0
   - branca=0.7.0=pyhd8ed1ab_1
   - croniter=2.0.1=pyhd8ed1ab_0
   - cryptography=41.0.7=py311h08c85a6_1
@@ -459,10 +459,10 @@ dependencies:
   - pybtex-docutils=1.0.3=py311h267d04e_1
   - pydantic=2.5.2=pyhd8ed1ab_0
   - pyopenssl=23.3.0=pyhd8ed1ab_0
-  - readthedocs-sphinx-ext=2.2.3=pyhd8ed1ab_0
+  - readthedocs-sphinx-ext=2.2.4=pyhd8ed1ab_0
   - requests-toolbelt=0.10.1=pyhd8ed1ab_0
   - responses=0.24.1=pyhd8ed1ab_0
-  - s3transfer=0.8.2=pyhd8ed1ab_0
+  - s3transfer=0.9.0=pyhd8ed1ab_0
   - scipy=1.11.4=py311h2b215a9_0
   - send2trash=1.8.2=pyhd1c38e8_0
   - shapely=2.0.2=py311h0815064_1
@@ -470,7 +470,7 @@ dependencies:
   - typeguard=4.1.5=pyhd8ed1ab_1
   - typer=0.9.0=pyhd8ed1ab_0
   - uvicorn-standard=0.24.0.post1=ha1ab1f8_0
-  - boto3=1.33.13=pyhd8ed1ab_0
+  - boto3=1.34.0=pyhd8ed1ab_0
   - cachecontrol-with-filecache=0.13.1=pyhd8ed1ab_0
   - dagster=1.5.12=pyhd8ed1ab_0
   - datasette=0.64.4=pyhd8ed1ab_1


### PR DESCRIPTION
# Overview

Attempt to create a sandbox data release after the nightly builds succeed.  This is just meant to test the data release publication process until we switch over to creating real releases from tagged builds.

I think the workflow needs to be added to `main` before it'll work in the scheduled builds though.

I added the `ZENODO_SANDBOX_TOKEN_PUBLISH` to the organization secrets.