### PR TITLE
Add EPA CEMS concurrency limit to `pudl_etl`

### DIFF
--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -89,21 +89,16 @@ default_resources = {
 }
 
 # By default, limit CEMS year processing concurrency to prevent memory overload.
-default_config = {
-    "execution": {
-        "config": {
-            "multiprocess": {
-                "tag_concurrency_limits": [
-                    {
-                        "key": "datasource",
-                        "value": "epacems",
-                        "limit": 2,
-                    }
-                ],
-            },
-        }
+default_tag_concurrency_limits = [
+    {
+        "key": "datasource",
+        "value": "epacems",
+        "limit": 2,
     }
-}
+]
+default_config = pudl.helpers.get_dagster_execution_config(
+    tag_concurrency_limits=default_tag_concurrency_limits
+)
 
 
 def create_non_cems_selection(all_assets: list[AssetsDefinition]) -> AssetSelection:

--- a/src/pudl/etl/cli.py
+++ b/src/pudl/etl/cli.py
@@ -145,7 +145,13 @@ def pudl_etl(
             },
         },
     }
-    run_config.update(get_dagster_execution_config(dagster_workers))
+
+    run_config.update(
+        get_dagster_execution_config(
+            num_workers=dagster_workers,
+            tag_concurrency_limits=pudl.etl.default_tag_concurrency_limits,
+        )
+    )
 
     result = execute_job(
         pudl_etl_reconstructable_job,

--- a/src/pudl/etl/cli.py
+++ b/src/pudl/etl/cli.py
@@ -77,6 +77,15 @@ def pudl_etl_job_factory(
     help="Max number of processes Dagster can launch. Defaults to the number of CPUs.",
 )
 @click.option(
+    "--epacems-workers",
+    default=2,
+    type=int,
+    help=(
+        "Max number of processes Dagster can launch for EPA CEMS assets. Defaults "
+        "to max number of processes our typical local machines can handle."
+    ),
+)
+@click.option(
     "--gcs-cache-path",
     type=str,
     help=(
@@ -107,6 +116,7 @@ def pudl_etl_job_factory(
 def pudl_etl(
     etl_settings_yml: pathlib.Path,
     dagster_workers: int,
+    epacems_workers: int,
     gcs_cache_path: str,
     logfile: pathlib.Path,
     loglevel: str,
@@ -146,10 +156,18 @@ def pudl_etl(
         },
     }
 
+    tag_concurrency_limits = [
+        {
+            "key": "datasource",
+            "value": "epacems",
+            "limit": epacems_workers,
+        }
+    ]
+
     run_config.update(
         get_dagster_execution_config(
             num_workers=dagster_workers,
-            tag_concurrency_limits=pudl.etl.default_tag_concurrency_limits,
+            tag_concurrency_limits=tag_concurrency_limits,
         )
     )
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

#3096 limited concurrency for the `hourly_emissions_epacems` asset for the jobs being loaded into the `dagster-webserver`. This PR applies the limit to the `pudl_etl` command. 

I ran into an OOM issue when running a full build on the `rename-core-asset` branch. We haven't run into this issue yet on a nightly `dev` build which is a little suspicious. Maybe we've just been getting lucky on `pudl-deployment-dev`? I diffed the tag and dev machines specs and they are working with the same amount of CPUs and memory. Either way, I think we should be able to limit CEMS concurrency for the `pudl_etl` command.
# Testing

I ran `pudl_etl` locally and made sure only two partitions were executed at once.

```[tasklist]
# To-do list
- [ ] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
