### PR TITLE
Improve nightly build and deployment logic

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+---
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci
+      - pudlbot
+    labels:
+      - conda-lock
+      - dependencies
+  categories:
+    - title: New Data
+      labels:
+        - new-data
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           git config user.email "pudl@catalyst.coop"
           git config user.name "PudlBot"
-          git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG
+          git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG $GITHUB_REF
           git push origin $NIGHTLY_TAG
 
       - name: Get HEAD of the branch (main or dev)

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -137,6 +137,7 @@ jobs:
             --container-env DAGSTER_PG_HOST="104.154.182.24" \
             --container-env DAGSTER_PG_DB="dagster-storage" \
             --container-env FLY_ACCESS_TOKEN=${{ secrets.FLY_ACCESS_TOKEN }} \
+            --container-env PUDL_BOT_PAT=${{ secrets.PUDL_BOT_PAT }} \
             --container-env ZENODO_SANDBOX_TOKEN_PUBLISH=${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }} \
             --container-env PUDL_SETTINGS_YML="/home/mambauser/src/pudl/package_data/settings/etl_full.yml" \
             --container-env PUDL_GCS_OUTPUT=${{ env.PUDL_OUTPUT_PATH }}

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -140,7 +140,7 @@ jobs:
             --container-env FLY_ACCESS_TOKEN=${{ secrets.FLY_ACCESS_TOKEN }} \
             --container-env PUDL_BOT_PAT=${{ secrets.PUDL_BOT_PAT }} \
             --container-env ZENODO_SANDBOX_TOKEN_PUBLISH=${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }} \
-            --container-env PUDL_SETTINGS_YML="/home/mambauser/src/pudl/package_data/settings/etl_full.yml" \
+            --container-env PUDL_SETTINGS_YML="/home/mambauser/pudl/src/pudl/package_data/settings/etl_full.yml" \
             --container-env PUDL_GCS_OUTPUT=${{ env.PUDL_OUTPUT_PATH }}
 
       # Start the VM

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -26,6 +26,14 @@ jobs:
         if: ${{ (github.event_name == 'schedule') }}
         run: |
           echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "GITHUB_REF=dev" >> $GITHUB_ENV
+          echo "RUN_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+
+      - name: Tag nightly build
+        if: ${{ (github.event_name == 'schedule') }}
+        uses: EndBug/latest-tag@1
+        with:
+          ref: nightly-${{ env.RUN_DATE }}
+          description: "Nightly build for ${{ env.RUN_DATE }}"
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -45,7 +53,7 @@ jobs:
 
       - name: Docker Metadata
         id: docker_metadata
-        uses: docker/metadata-action@v5.3.0
+        uses: docker/metadata-action@v5
         with:
           images: catalystcoop/pudl-etl
           flavor: |
@@ -55,17 +63,17 @@ jobs:
             type=ref,event=tag
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build image and push to Docker Hub
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile
@@ -137,7 +145,7 @@ jobs:
 
       - name: Post to a pudl-deployments channel
         id: slack
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v1
         with:
           channel-id: "C03FHB9N0PQ"
           slack-message: "build-deploy-pudl status: ${{ job.status }}\n${{ env.GCS_OUTPUT_BUCKET }}/${{ env.RUN_TIMESTAMP}}-${{ env.SHORT_SHA }}-${{ env.COMMIT_BRANCH }}"

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -124,6 +124,7 @@ jobs:
             --container-env-file="./docker/.env" \
             --container-env ACTION_SHA=$ACTION_SHA \
             --container-env GITHUB_REF=${{ env.GITHUB_REF }} \
+            --container-env NIGHTLY_TAG=${{ env.NIGHTLY_TAG }} \
             --container-env GITHUB_ACTION_TRIGGER=${{ github.event_name }} \
             --container-env SLACK_TOKEN=${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }} \
             --container-env GCE_INSTANCE=${{ env.GCE_INSTANCE }} \

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -26,19 +26,21 @@ jobs:
         if: ${{ (github.event_name == 'schedule') }}
         run: |
           echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "GITHUB_REF=dev" >> $GITHUB_ENV
-          echo "RUN_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
-
-      - name: Tag nightly build
-        if: ${{ (github.event_name == 'schedule') }}
-        uses: EndBug/latest-tag@1
-        with:
-          ref: nightly-${{ env.RUN_DATE }}
-          description: "Nightly build for ${{ env.RUN_DATE }}"
+          echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
+          echo "NIGHTLY_TAG: $NIGHTLY_TAG"
 
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           ref: ${{ env.GITHUB_REF }}
+
+      - name: Tag nightly build
+        if: ${{ (github.event_name == 'schedule') }}
+        run: |
+          git config user.email "pudl@catalyst.coop"
+          git config user.name "PudlBot"
+          git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG
+          git push origin $NIGHTLY_TAG
 
       - name: Get HEAD of the branch (main or dev)
         run: |

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -25,33 +25,35 @@ jobs:
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule
         if: ${{ (github.event_name == 'schedule') }}
         run: |
-          echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "GITHUB_REF=dev" >> $GITHUB_ENV
-          echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
-          echo "NIGHTLY_TAG: $NIGHTLY_TAG"
+          echo "This action was triggered by a schedule."
+          echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV
+          echo "GCE_INSTANCE: $GCE_INSTANCE"
+          echo "GITHUB_REF=dev" >> $GITHUB_ENV
+          echo "GITHUB_REF: $GITHUB_REF"
 
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           ref: ${{ env.GITHUB_REF }}
 
+      - name: Set action environment variables
+        run: |
+          echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
+          echo "NIGHTLY_TAG: $NIGHTLY_TAG"
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "SHORT_SHA: $SHORT_SHA"
+          echo "BUILD_TIMESTAMP=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
+          echo "BUILD_TIMESTAMP: $BUILD_TIMESTAMP"
+          echo "BUILD_ID=${BUILD_TIMESTAMP}-${SHORT_SHA}-${GITHUB_REF}
+          echo "BUILD_ID: $BUILD_ID"
+
       - name: Tag nightly build
         if: ${{ (github.event_name == 'schedule') }}
         run: |
           git config user.email "pudl@catalyst.coop"
-          git config user.name "PudlBot"
+          git config user.name "pudlbot"
           git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG $GITHUB_REF
           git push origin $NIGHTLY_TAG
-
-      - name: Get HEAD of the branch (main or dev)
-        run: |
-          echo "ACTION_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-
-      - name: Print action vars
-        run: |
-          echo "ACTION_SHA: $ACTION_SHA" && \
-          echo "GITHUB_REF: $GITHUB_REF" && \
-          echo "GCE_INSTANCE: $GCE_INSTANCE"
 
       - name: Docker Metadata
         id: docker_metadata
@@ -95,17 +97,11 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Determine commit information
-        run: |-
-          echo "COMMIT_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-          echo "COMMIT_TIME=$(git log -1 --format=%cd --date=format:%Y-%m-%d-%H%M)" >> $GITHUB_ENV
-          echo "RUN_TIMESTAMP=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
-
       # Deploy PUDL image to GCE
       - name: Deploy
         env:
           DAGSTER_PG_PASSWORD: ${{ secrets.DAGSTER_PG_PASSWORD }}
-          PUDL_OUTPUT_PATH: ${{ env.GCS_OUTPUT_BUCKET }}/${{ env.RUN_TIMESTAMP }}-${{ env.SHORT_SHA }}-${{ env.COMMIT_BRANCH }}
+          PUDL_OUTPUT_PATH: ${{ env.GCS_OUTPUT_BUCKET }}/${{ env.BUILD_ID }}
         run: |-
           gcloud compute instances add-metadata "$GCE_INSTANCE" \
             --zone "$GCE_INSTANCE_ZONE" \
@@ -152,7 +148,7 @@ jobs:
         uses: slackapi/slack-github-action@v1
         with:
           channel-id: "C03FHB9N0PQ"
-          slack-message: "build-deploy-pudl status: ${{ job.status }}\n${{ env.GCS_OUTPUT_BUCKET }}/${{ env.RUN_TIMESTAMP}}-${{ env.SHORT_SHA }}-${{ env.COMMIT_BRANCH }}"
+          slack-message: "build-deploy-pudl status: ${{ job.status }}\n${{ env.GCS_OUTPUT_BUCKET }}/${{ env.BUILD_ID }}"
         env:
           channel-id: "C03FHB9N0PQ"
           SLACK_BOT_TOKEN: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -118,8 +118,8 @@ jobs:
             --container-arg="bash" \
             --container-arg="./docker/gcp_pudl_etl.sh" \
             --container-env-file="./docker/.env" \
-            --container-env ACTION_SHA=$ACTION_SHA \
             --container-env GITHUB_REF=${{ env.GITHUB_REF }} \
+            --container-env BUILD_ID=${{ env.BUILD_ID }} \
             --container-env NIGHTLY_TAG=${{ env.NIGHTLY_TAG }} \
             --container-env GITHUB_ACTION_TRIGGER=${{ github.event_name }} \
             --container-env SLACK_TOKEN=${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }} \

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -17,20 +17,22 @@ jobs:
 
       - name: Docker Metadata
         id: docker_metadata
-        uses: docker/metadata-action@v5.3.0
+        uses: docker/metadata-action@v5
         with:
           images: catalystcoop/pudl-etl
           flavor: |
             latest=auto
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3.0.0
+        uses: docker/setup-buildx-action@v3
 
       - name: Build image but do not push to Docker Hub
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v5
         with:
           context: .
           file: docker/Dockerfile
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          secrets: |
+            "GITHUB_REF=${{ github.ref_name }}"

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -34,5 +34,3 @@ jobs:
           push: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          secrets: |
-            "GITHUB_REF=${{ github.ref_name }}"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -107,6 +107,8 @@ jobs:
       - name: Test pushing a tag
         run: |
           echo "RUN_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+          git config user.email "pudl@catalyst.coop"
+          git config user.name "PudlBot"
           git tag -a -m "Testy McTesterTag" test-${{ env.RUN_DATE }}
           git push origin test-${{ env.RUN_DATE }}
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -93,20 +93,6 @@ jobs:
           which sqlite3
           sqlite3 --version
 
-      - name: Set the nightly tag
-        run: |
-          echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
-
-      - name: Test pushing a tag
-        run: |
-          echo "1 NIGHTLY_TAG: $NIGHTLY_TAG"
-          echo "2 NIGHTLY_TAG: ${{ env.NIGHTLY_TAG}}"
-          echo "3 NIGHTLY_TAG: " ${{ env.NIGHTLY_TAG}}
-          git config user.email "pudl@catalyst.coop"
-          git config user.name "PudlBot"
-          git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG
-          git push origin $NIGHTLY_TAG
-
       - name: Run PUDL unit tests and collect test coverage
         run: |
           pip install --no-deps --editable .

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -93,6 +93,14 @@ jobs:
           which sqlite3
           sqlite3 --version
 
+      - name: Test pushing a tag
+        run: |
+          echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
+          git config user.email "pudl@catalyst.coop"
+          git config user.name "PudlBot"
+          git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG
+          git push origin $NIGHTLY_TAG
+
       - name: Run PUDL unit tests and collect test coverage
         run: |
           pip install --no-deps --editable .
@@ -103,14 +111,6 @@ jobs:
         with:
           name: coverage-unit
           path: coverage.xml
-
-      - name: Test pushing a tag
-        run: |
-          echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
-          git config user.email "pudl@catalyst.coop"
-          git config user.name "PudlBot"
-          git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG
-          git push origin $NIGHTLY_TAG
 
   ci-integration:
     runs-on:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -98,6 +98,7 @@ jobs:
           echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
           git config user.email "pudl@catalyst.coop"
           git config user.name "PudlBot"
+          echo "nightly tag is: $NIGHTLY_TAG"
           git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG
           git push origin $NIGHTLY_TAG
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -106,11 +106,11 @@ jobs:
 
       - name: Test pushing a tag
         run: |
-          echo "RUN_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+          echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
           git config user.email "pudl@catalyst.coop"
           git config user.name "PudlBot"
-          git tag -a -m "Testy McTesterTag" test-${{ env.RUN_DATE }}
-          git push origin test-${{ env.RUN_DATE }}
+          git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG
+          git push origin $NIGHTLY_TAG
 
   ci-integration:
     runs-on:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -93,12 +93,17 @@ jobs:
           which sqlite3
           sqlite3 --version
 
-      - name: Test pushing a tag
+      - name: Set the nightly tag
         run: |
           echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
+
+      - name: Test pushing a tag
+        run: |
+          echo "1 NIGHTLY_TAG: $NIGHTLY_TAG"
+          echo "2 NIGHTLY_TAG: ${{ env.NIGHTLY_TAG}}"
+          echo "3 NIGHTLY_TAG: " ${{ env.NIGHTLY_TAG}}
           git config user.email "pudl@catalyst.coop"
           git config user.name "PudlBot"
-          echo "nightly tag is: $NIGHTLY_TAG"
           git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG
           git push origin $NIGHTLY_TAG
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -104,6 +104,12 @@ jobs:
           name: coverage-unit
           path: coverage.xml
 
+      - name: Test pushing a tag
+        run: |
+          echo "RUN_DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+          git tag -a -m "Testy McTesterTag" test-${{ env.RUN_DATE }}
+          git push origin test-${{ env.RUN_DATE }}
+
   ci-integration:
     runs-on:
       group: large-runner-group

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
           name: python-package-distributions
           path: dist/
       - name: Sign dist with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.0
+        uses: sigstore/gh-action-sigstore-python@v2
         with:
           inputs: ./dist/*.tar.gz ./dist/*.whl
       - name: Upload artifact signatures to GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,9 +98,10 @@ jobs:
       - name: Tag the current stable commit
         run: |
           git config user.email "pudl@catalyst.coop"
-          git config user.name "PudlBot"
-          git tag -a -m "stable" stable
-          git push origin stable
+          git config user.name "pudlbot"
+          git checkout stable
+          git merge --ff-only ${{ github.ref_name }}
+          git push
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,11 +95,12 @@ jobs:
           --discussion-category Announcements
           --generate-notes
           --repo '${{ github.repository }}'
-      - name: Tag stable release
-        uses: EndBug/latest-tag@1
-        with:
-          ref: stable
-          description: "The current stable release of catalystcoop.pudl"
+      - name: Tag the current stable commit
+        run: |
+          git config user.email "pudl@catalyst.coop"
+          git config user.name "PudlBot"
+          git tag -a -m "stable" stable
+          git push origin stable
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,11 @@ jobs:
           --discussion-category Announcements
           --generate-notes
           --repo '${{ github.repository }}'
+      - name: Tag stable release
+        uses: EndBug/latest-tag@1
+        with:
+          ref: stable
+          description: "The current stable release of catalystcoop.pudl"
 
   notify-slack:
     runs-on: ubuntu-latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,8 @@ RUN mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME} ${PUDL_REPO}
 # Copy dagster configuration file
 COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 
-# Copy the cloned pudl repository into the user's home directory
+# Copy the cloned pudl repository into the container
+# This includes the .git directory, so it is a whole repo
 COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${PUDL_REPO}
 
 # Create a conda environment based on the specification in the repo
@@ -60,6 +61,5 @@ RUN ${CONDA_RUN} bash -c 'curl -L https://fly.io/install.sh | sh'
 ENV PATH="${CONTAINER_HOME}/.fly/bin:$PATH"
 
 WORKDIR ${PUDL_REPO}
-RUN git config -l
 # Run the unit tests:
 CMD ["micromamba", "run", "--prefix", "${CONDA_PREFIX}", "--attach", "''", "pytest", "test/unit"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 
 # Copy the cloned pudl repository into the user's home directory
 # COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
-RUN "git clone --depth 2 --single-branch ${GITHUB_REF} https://github.com/catalyst-cooperative/pudl.git"
+RUN git clone --depth 2 --single-branch "$GITHUB_REF" https://github.com/catalyst-cooperative/pudl.git
 WORKDIR ${PUDL_REPO}
 # Create a conda environment based on the specification in the repo
 RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file environments/conda-lock.yml && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ ENV PUDL_INPUT=${CONTAINER_PUDL_WORKSPACE}/input
 ENV PUDL_OUTPUT=${CONTAINER_PUDL_WORKSPACE}/output
 ENV DAGSTER_HOME=${CONTAINER_PUDL_WORKSPACE}/dagster_home
 
-RUN mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME}
+RUN mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME} ${PUDL_REPO}
 
 # Copy dagster configuration file
 COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
@@ -39,8 +39,7 @@ COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${PUDL_REPO}
 
 # Create a conda environment based on the specification in the repo
-RUN ls -a pudl pudl_work && \
-    micromamba create --prefix ${CONDA_PREFIX} --yes --file ${PUDL_REPO}/environments/conda-lock.yml && \
+RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file ${PUDL_REPO}/environments/conda-lock.yml && \
     micromamba clean -afy
 
 # TODO(rousik): The following is a workaround for sudden breakage where conda
@@ -50,15 +49,14 @@ RUN ${CONDA_RUN} pip install --no-cache-dir --no-deps --editable ${PUDL_REPO}
 
 # Install awscli2
 # Change back to root because the install script needs access to /usr/local/aws-cli
+# curl commands run within conda environment because curl is installed by conda.
 USER root
-RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
-    unzip awscliv2.zip && \
-    ./aws/install
+RUN ${CONDA_RUN} bash -c 'curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install'
 USER $MAMBA_USER
 
 # Install flyctl
 # hadolint ignore=DL3059
-RUN curl -L https://fly.io/install.sh | sh
+RUN ${CONDA_RUN} bash -c 'curl -L https://fly.io/install.sh | sh'
 ENV PATH="${CONTAINER_HOME}/.fly/bin:$PATH"
 
 WORKDIR ${PUDL_REPO}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${PUDL_REPO}
 
 # Create a conda environment based on the specification in the repo
-RUN ls -a && \
+RUN ls -a pudl pudl_work && \
     micromamba create --prefix ${CONDA_PREFIX} --yes --file ${PUDL_REPO}/environments/conda-lock.yml && \
     micromamba clean -afy
 
@@ -51,14 +51,17 @@ RUN ${CONDA_RUN} pip install --no-cache-dir --no-deps --editable ${PUDL_REPO}
 # Install awscli2
 # Change back to root because the install script needs access to /usr/local/aws-cli
 USER root
-RUN ${CONDA_RUN} bash -c 'curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install'
+RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+    unzip awscliv2.zip && \
+    ./aws/install
 USER $MAMBA_USER
 
 # Install flyctl
 # hadolint ignore=DL3059
-RUN ${CONDA_RUN} bash -c 'curl -L https://fly.io/install.sh | sh'
+RUN curl -L https://fly.io/install.sh | sh
 ENV PATH="${CONTAINER_HOME}/.fly/bin:$PATH"
 
 WORKDIR ${PUDL_REPO}
+RUN git config -l
 # Run the unit tests:
 CMD ["micromamba", "run", "--prefix", "${CONDA_PREFIX}", "--attach", "''", "pytest", "test/unit"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,19 +36,17 @@ RUN mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME}
 COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 
 # Copy the cloned pudl repository into the user's home directory
-COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
+COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${PUDL_REPO}
 
 # Create a conda environment based on the specification in the repo
-RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file environments/conda-lock.yml && \
+RUN ls -a && \
+    micromamba create --prefix ${CONDA_PREFIX} --yes --file ${PUDL_REPO}/environments/conda-lock.yml && \
     micromamba clean -afy
 
 # TODO(rousik): The following is a workaround for sudden breakage where conda
 # can't find libraries contained within the environment. It's unclear why!
 ENV LD_LIBRARY_PATH=${CONDA_PREFIX}/lib
-# We need information from .git to get version with setuptools_scm so we mount that
-# directory without copying it into the image.
-#RUN --mount=type=bind,source=.git,target=${PUDL_REPO}/.git \
-RUN ${CONDA_RUN} pip install --no-cache-dir --no-deps --editable .
+RUN ${CONDA_RUN} pip install --no-cache-dir --no-deps --editable ${PUDL_REPO}
 
 # Install awscli2
 # Change back to root because the install script needs access to /usr/local/aws-cli
@@ -61,5 +59,6 @@ USER $MAMBA_USER
 RUN ${CONDA_RUN} bash -c 'curl -L https://fly.io/install.sh | sh'
 ENV PATH="${CONTAINER_HOME}/.fly/bin:$PATH"
 
+WORKDIR ${PUDL_REPO}
 # Run the unit tests:
 CMD ["micromamba", "run", "--prefix", "${CONDA_PREFIX}", "--attach", "''", "pytest", "test/unit"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,8 @@ COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 
 # Copy the cloned pudl repository into the user's home directory
 # COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
-RUN git clone --depth 2 --single-branch "$GITHUB_REF" https://github.com/catalyst-cooperative/pudl.git
+RUN git clone --depth 2 https://github.com/catalyst-cooperative/pudl.git && \
+    git checkout "$GITHUB_REF"
 WORKDIR ${PUDL_REPO}
 # Create a conda environment based on the specification in the repo
 RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file environments/conda-lock.yml && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,9 @@ RUN mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME}
 COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 
 # Copy the cloned pudl repository into the user's home directory
-COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
+# COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
+RUN "git clone --depth 2 --single-branch ${GITHUB_REF} https://github.com/catalyst-cooperative/pudl.git"
+WORKDIR ${PUDL_REPO}
 # Create a conda environment based on the specification in the repo
 RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file environments/conda-lock.yml && \
     micromamba clean -afy
@@ -46,11 +48,12 @@ RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file environments/conda-l
 ENV LD_LIBRARY_PATH=${CONDA_PREFIX}/lib
 # We need information from .git to get version with setuptools_scm so we mount that
 # directory without copying it into the image.
-RUN --mount=type=bind,source=.git,target=${PUDL_REPO}/.git \
-    ${CONDA_RUN} pip install --no-cache-dir --no-deps --editable .
+#RUN --mount=type=bind,source=.git,target=${PUDL_REPO}/.git \
+RUN ${CONDA_RUN} pip install --no-cache-dir --no-deps --editable .
 
 # Install awscli2
 # Change back to root because the install script needs access to /usr/local/aws-cli
+WORKDIR ${CONTAINER_HOME}
 USER root
 RUN ${CONDA_RUN} bash -c 'curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install'
 USER $MAMBA_USER
@@ -60,6 +63,6 @@ USER $MAMBA_USER
 RUN ${CONDA_RUN} bash -c 'curl -L https://fly.io/install.sh | sh'
 ENV PATH="${CONTAINER_HOME}/.fly/bin:$PATH"
 
-
+WORKDIR ${PUDL_REPO}
 # Run the unit tests:
 CMD ["micromamba", "run", "--prefix", "${CONDA_PREFIX}", "--attach", "''", "pytest", "test/unit"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,7 +37,7 @@ COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 
 # Copy the cloned pudl repository into the user's home directory
 # COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
-RUN git clone --depth 2 https://github.com/catalyst-cooperative/pudl.git && \
+RUN git clone --depth 2 https://github.com/catalyst-cooperative/pudl.git
 WORKDIR ${PUDL_REPO}
 RUN git checkout "$GITHUB_REF"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,8 +38,9 @@ COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 # Copy the cloned pudl repository into the user's home directory
 # COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
 RUN git clone --depth 2 https://github.com/catalyst-cooperative/pudl.git && \
-    git checkout "$GITHUB_REF"
 WORKDIR ${PUDL_REPO}
+RUN git checkout "$GITHUB_REF"
+
 # Create a conda environment based on the specification in the repo
 RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file environments/conda-lock.yml && \
     micromamba clean -afy

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:1.5.3
+FROM mambaorg/micromamba:1.5.5
 
 USER root
 
@@ -36,12 +36,7 @@ RUN mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME}
 COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 
 # Copy the cloned pudl repository into the user's home directory
-# COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
-RUN git clone --depth 2 https://github.com/catalyst-cooperative/pudl.git
-WORKDIR ${PUDL_REPO}
-RUN env
-ENV GITHUB_REF=${GITHUB_REF}
-RUN git checkout "$GITHUB_REF"
+COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
 
 # Create a conda environment based on the specification in the repo
 RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file environments/conda-lock.yml && \
@@ -57,7 +52,6 @@ RUN ${CONDA_RUN} pip install --no-cache-dir --no-deps --editable .
 
 # Install awscli2
 # Change back to root because the install script needs access to /usr/local/aws-cli
-WORKDIR ${CONTAINER_HOME}
 USER root
 RUN ${CONDA_RUN} bash -c 'curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && unzip awscliv2.zip && ./aws/install'
 USER $MAMBA_USER
@@ -67,6 +61,5 @@ USER $MAMBA_USER
 RUN ${CONDA_RUN} bash -c 'curl -L https://fly.io/install.sh | sh'
 ENV PATH="${CONTAINER_HOME}/.fly/bin:$PATH"
 
-WORKDIR ${PUDL_REPO}
 # Run the unit tests:
 CMD ["micromamba", "run", "--prefix", "${CONDA_PREFIX}", "--attach", "''", "pytest", "test/unit"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,13 +35,16 @@ RUN mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME} ${PUDL_REPO}
 # Copy dagster configuration file
 COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 
-# Copy the cloned pudl repository into the container
-# This includes the .git directory, so it is a whole repo
-COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${PUDL_REPO}
-
+# Copy conda-lock.yml in so we can build the conda environment and cache that layer in
+# the Docker image before installing PUDL.
+COPY environments/conda-lock.yml ${PUDL_REPO}/environments/conda-lock.yml
 # Create a conda environment based on the specification in the repo
 RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file ${PUDL_REPO}/environments/conda-lock.yml && \
     micromamba clean -afy
+
+# Copy the rest of the cloned PUDL repo into the image.
+# This includes the .git directory, so it is a whole repo
+COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${PUDL_REPO}
 
 # TODO(rousik): The following is a workaround for sudden breakage where conda
 # can't find libraries contained within the environment. It's unclear why!

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,8 @@ COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 # COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
 RUN git clone --depth 2 https://github.com/catalyst-cooperative/pudl.git
 WORKDIR ${PUDL_REPO}
+RUN env
+ENV GITHUB_REF=${GITHUB_REF}
 RUN git checkout "$GITHUB_REF"
 
 # Create a conda environment based on the specification in the repo

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,12 +35,11 @@ RUN mkdir -p ${PUDL_INPUT} ${PUDL_OUTPUT} ${DAGSTER_HOME}
 # Copy dagster configuration file
 COPY docker/dagster.yaml ${DAGSTER_HOME}/dagster.yaml
 
-# Create a conda environment based on the specification in the repo
-COPY environments/conda-lock.yml environments/conda-lock.yml
-RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file environments/conda-lock.yml && \
-    micromamba clean -afy
 # Copy the cloned pudl repository into the user's home directory
 COPY --chown=${MAMBA_USER}:${MAMBA_USER} . ${CONTAINER_HOME}
+# Create a conda environment based on the specification in the repo
+RUN micromamba create --prefix ${CONDA_PREFIX} --yes --file environments/conda-lock.yml && \
+    micromamba clean -afy
 
 # TODO(rousik): The following is a workaround for sudden breakage where conda
 # can't find libraries contained within the environment. It's unclear why!

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -101,6 +101,8 @@ function notify_slack() {
 
 if [ "$GITHUB_ACTION_TRIGGER" = "workflow_dispatch" ]; then
     echo "Deployed via workflow_dispatch, testing git authentication!"
+    # Remove the read-only authentication header
+    git config --unset http.https://github.com/.extraheader
     git config user.email "pudl@catalyst.coop"
     git config user.name "pudlbot"
     git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -3,7 +3,7 @@
 # This script won't work locally because it needs adequate GCP permissions.
 
 # Set PUDL_GCS_OUTPUT *only* if it is currently unset
-: "${PUDL_GCS_OUTPUT:=gs://nightly-build-outputs.catalyst.coop/$ACTION_SHA-$GITHUB_REF}"
+: "${PUDL_GCS_OUTPUT:=gs://nightly-build-outputs.catalyst.coop/$BUILD_ID}"
 
 set -x
 
@@ -12,64 +12,64 @@ function send_slack_msg() {
 }
 
 function upload_file_to_slack() {
-    curl -F file=@$1 -F "initial_comment=$2" -F channels=C03FHB9N0PQ -H "Authorization: Bearer ${SLACK_TOKEN}" https://slack.com/api/files.upload
+    curl -F "file=@$1" -F "initial_comment=$2" -F channels=C03FHB9N0PQ -H "Authorization: Bearer ${SLACK_TOKEN}" https://slack.com/api/files.upload
 }
 
 function authenticate_gcp() {
     # Set the default gcloud project id so the zenodo-cache bucket
     # knows what project to bill for egress
-    gcloud config set project $GCP_BILLING_PROJECT
+    gcloud config set project "$GCP_BILLING_PROJECT"
 }
 
 function run_pudl_etl() {
-    send_slack_msg ":large_yellow_circle: Deployment started for $ACTION_SHA-$GITHUB_REF :floppy_disk:"
+    send_slack_msg ":large_yellow_circle: Deployment started for $BUILD_ID :floppy_disk:"
     authenticate_gcp && \
     alembic upgrade head && \
     ferc_to_sqlite \
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         --workers 8 \
-        $PUDL_SETTINGS_YML \
+        "$PUDL_SETTINGS_YML" \
     && pudl_etl \
         --loglevel DEBUG \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
-        $PUDL_SETTINGS_YML \
+        "$PUDL_SETTINGS_YML" \
     && pytest \
         -n auto \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
-        --etl-settings $PUDL_SETTINGS_YML \
+        --etl-settings "$PUDL_SETTINGS_YML" \
         --live-dbs test/integration test/unit \
     && pytest \
         -n auto \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
-        --etl-settings $PUDL_SETTINGS_YML \
+        --etl-settings "$PUDL_SETTINGS_YML" \
         --live-dbs test/validate \
-    && touch ${PUDL_OUTPUT}/success
+    && touch "$PUDL_OUTPUT/success"
 }
 
 function shutdown_vm() {
-    upload_file_to_slack $LOGFILE "pudl_etl logs for $ACTION_SHA-$GITHUB_REF:"
+    upload_file_to_slack "$LOGFILE" "pudl_etl logs for $BUILD_ID:"
     # Shut down the vm instance when the etl is done.
     echo "Shutting down VM."
     ACCESS_TOKEN=$(curl \
         "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token" \
         -H "Metadata-Flavor: Google" | jq -r '.access_token')
-    curl -X POST -H "Content-Length: 0" -H "Authorization: Bearer ${ACCESS_TOKEN}" https://compute.googleapis.com/compute/v1/projects/catalyst-cooperative-pudl/zones/$GCE_INSTANCE_ZONE/instances/$GCE_INSTANCE/stop
+    curl -X POST -H "Content-Length: 0" -H "Authorization: Bearer ${ACCESS_TOKEN}" "https://compute.googleapis.com/compute/v1/projects/catalyst-cooperative-pudl/zones/$GCE_INSTANCE_ZONE/instances/$GCE_INSTANCE/stop"
 }
 
 function copy_outputs_to_gcs() {
     echo "Copying outputs to GCP bucket $PUDL_GCS_OUTPUT"
-    gsutil -m cp -r $PUDL_OUTPUT ${PUDL_GCS_OUTPUT}
-    rm ${PUDL_OUTPUT}/success
+    gsutil -m cp -r "$PUDL_OUTPUT" "$PUDL_GCS_OUTPUT"
+    rm "$PUDL_OUTPUT/success"
 }
 
 function copy_outputs_to_distribution_bucket() {
     # Only attempt to update outputs if we have a real value of GITHUB_REF
     if [ -n "$GITHUB_REF" ]; then
         echo "Removing old $GITHUB_REF outputs from GCP distributon bucket."
-        gsutil -m -u $GCP_BILLING_PROJECT rm -r "gs://pudl.catalyst.coop/$GITHUB_REF"
+        gsutil -m -u "$GCP_BILLING_PROJECT" rm -r "gs://pudl.catalyst.coop/$GITHUB_REF"
         echo "Copying outputs to GCP distribution bucket"
-        gsutil -m -u $GCP_BILLING_PROJECT cp -r "$PUDL_OUTPUT/*" "gs://pudl.catalyst.coop/$GITHUB_REF"
+        gsutil -m -u "$GCP_BILLING_PROJECT" cp -r "$PUDL_OUTPUT/*" "gs://pudl.catalyst.coop/$GITHUB_REF"
 
         echo "Removing old $GITHUB_REF outputs from AWS distributon bucket."
         aws s3 rm "s3://pudl.catalyst.coop/$GITHUB_REF" --recursive
@@ -80,41 +80,28 @@ function copy_outputs_to_distribution_bucket() {
 
 function zenodo_data_release() {
     echo "Creating a new PUDL data release on Zenodo."
-    ~/devtools/zenodo/zenodo_data_release.py --publish --env sandbox --source-dir $PUDL_OUTPUT
+    ~/devtools/zenodo/zenodo_data_release.py --publish --env sandbox --source-dir "$PUDL_OUTPUT"
 }
 
 function notify_slack() {
     # Notify pudl-builds slack channel of deployment status
-    if [ $1 = "success" ]; then
+    if [ "$1" = "success" ]; then
         message=":large_green_circle: :sunglasses: :unicorn_face: :rainbow: The deployment succeeded!! :partygritty: :database_parrot: :blob-dance: :large_green_circle:\n\n "
         message+="<https://github.com/catalyst-cooperative/pudl/compare/main...${GITHUB_REF}|Make a PR for \`${GITHUB_REF}\` into \`main\`!>\n\n"
-    elif [ $1 = "failure" ]; then
+    elif [ "$1" = "failure" ]; then
         message=":large_red_square: Oh bummer the deployment failed ::fiiiiine: :sob: :cry_spin:\n\n "
     else
         echo "Invalid deployment status"
         exit 1
     fi
-    message+="See https://console.cloud.google.com/storage/browser/nightly-build-outputs.catalyst.coop/$ACTION_SHA-$GITHUB_REF for logs and outputs."
+    message+="See https://console.cloud.google.com/storage/browser/nightly-build-outputs.catalyst.coop/$BUILD_ID for logs and outputs."
 
     send_slack_msg "$message"
 }
 
-if [ "$GITHUB_ACTION_TRIGGER" = "workflow_dispatch" ]; then
-    echo "Deployed via workflow_dispatch, testing git authentication!"
-    # Remove the read-only authentication header
-    git config --unset http.https://github.com/.extraheader
-    git config user.email "pudl@catalyst.coop"
-    git config user.name "pudlbot"
-    git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
-    git config -l
-    git tag -a -m "Nightly test tag" nightly-tag-test
-    git push origin nightly-tag-test
-    shutdown_vm
-fi
-
 # # Run ETL. Copy outputs to GCS and shutdown VM if ETL succeeds or fails
 # 2>&1 redirects stderr to stdout.
-run_pudl_etl 2>&1 | tee $LOGFILE
+run_pudl_etl 2>&1 | tee "$LOGFILE"
 
 ETL_SUCCESS=${PIPESTATUS[0]}
 
@@ -122,42 +109,44 @@ copy_outputs_to_gcs
 
 # if pipeline is successful, distribute + publish datasette
 if [[ $ETL_SUCCESS == 0 ]]; then
-    if [ $GITHUB_ACTION_TRIGGER = "schedule" ]; then
-        # Update the nightly branch to point at newly successful nightly build tag
+    if [ "$GITHUB_ACTION_TRIGGER" = "schedule" ]; then
+        # Remove read-only authentication header added by git checkout
+        git config --unset http.https://github.com/.extraheader
         git config user.email "pudl@catalyst.coop"
         git config user.name "pudlbot"
-        git remote set-url origin https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git
+        git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
+        # Update the nightly branch to point at newly successful nightly build tag
         git checkout nightly
-        git merge --ff-only $NIGHTLY_TAG
+        git merge --ff-only "$NIGHTLY_TAG"
         git push
     fi
     # Deploy the updated data to datasette
-    if [ $GITHUB_REF = "dev" ]; then
-        python ~/devtools/datasette/publish.py 2>&1 | tee -a $LOGFILE
+    if [ "$GITHUB_REF" = "dev" ]; then
+        python ~/devtools/datasette/publish.py 2>&1 | tee -a "$LOGFILE"
         ETL_SUCCESS=${PIPESTATUS[0]}
     fi
 
     # Compress the SQLite DBs for easier distribution
     # Remove redundant multi-file EPA CEMS outputs prior to distribution
-    gzip --verbose $PUDL_OUTPUT/*.sqlite && \
-    rm -rf $PUDL_OUTPUT/hourly_emissions_epacems/ && \
-    rm -f $PUDL_OUTPUT/metadata.yml
+    gzip --verbose "$PUDL_OUTPUT"/*.sqlite && \
+    rm -rf "$PUDL_OUTPUT/core_epacems__hourly_emissions/" && \
+    rm -f "$PUDL_OUTPUT/metadata.yml"
     ETL_SUCCESS=${PIPESTATUS[0]}
 
     # Dump outputs to s3 bucket if branch is dev or build was triggered by a tag
     # TODO: this behavior should be controlled by on/off switch here and this logic
     # should be moved to the triggering github action. Having it here feels
     # fragmented.
-    if [ $GITHUB_ACTION_TRIGGER = "push" ] || [ $GITHUB_REF = "dev" ]; then
+    if [ "$GITHUB_ACTION_TRIGGER" = "push" ] || [ "$GITHUB_REF" = "dev" ]; then
         copy_outputs_to_distribution_bucket
         ETL_SUCCESS=${PIPESTATUS[0]}
-        zenodo_data_release 2>&1 | tee -a $LOGFILE
+        zenodo_data_release 2>&1 | tee -a "$LOGFILE"
         ETL_SUCCESS=${PIPESTATUS[0]}
     fi
 fi
 
 # This way we also save the logs from latter steps in the script
-gsutil cp $LOGFILE ${PUDL_GCS_OUTPUT}
+gsutil cp "$LOGFILE" "$PUDL_GCS_OUTPUT"
 
 # Notify slack about entire pipeline's success or failure;
 # PIPESTATUS[0] either refers to the failed ETL run or the last distribution

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -111,6 +111,12 @@ copy_outputs_to_gcs
 
 # if pipeline is successful, distribute + publish datasette
 if [[ $ETL_SUCCESS == 0 ]]; then
+    if [ $GITHUB_ACTION_TRIGGER = "schedule" ]; then
+        # Tag the nightly build
+        git config user.email "pudl@catalyst.coop"
+        git config user.name "PudlBot"
+        git tag -a -m "The most recent successful nightly build." nightly $GITHUB_REF
+        git push origin nightly
     # Deploy the updated data to datasette
     if [ $GITHUB_REF = "dev" ]; then
         python ~/devtools/datasette/publish.py 2>&1 | tee -a $LOGFILE

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -68,9 +68,13 @@ function copy_outputs_to_gcs() {
 }
 
 function copy_outputs_to_distribution_bucket() {
+    echo "Removing old outputs from GCP distributon bucket."
+    gsutil -m -u $GCP_BILLING_PROJECT rm -r "gs://pudl.catalyst.coop/$GITHUB_REF"
     echo "Copying outputs to GCP distribution bucket"
     gsutil -m -u $GCP_BILLING_PROJECT cp -r "$PUDL_OUTPUT/*" "gs://pudl.catalyst.coop/$GITHUB_REF"
 
+    echo "Removing old outputs from AWS distributon bucket."
+    aws s3 rm "s3://pudl.catalyst.coop/$GITHUB_REF" --recursive
     echo "Copying outputs to AWS distribution bucket"
     aws s3 cp "$PUDL_OUTPUT/" "s3://pudl.catalyst.coop/$GITHUB_REF" --recursive
 }


### PR DESCRIPTION
# Overview

- Remove minor versions from the GHA we depend on to minimize dependabot churn.
- Remove the logic that was updating conda lockfiles on push.
- Purge old files from distribution paths before uploading new outputs. This prevents stale files from hanging around after we change the name of a file.
- Tag commits that are used for nightly builds.
- Update `stable` branch to point at newly tagged release
- Update `nightly` branch to point at newly successful nightly build tag.
- Simplify Dockerfile / make it more internally consistent

## Issues / Questions:
- The nightly build jank continues. We need to dedicate some resources to consolidating it!

Part of #3140 