### PR TITLE
Restructure build-deploy action

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -25,22 +25,30 @@ jobs:
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule
         if: ${{ (github.event_name == 'schedule') }}
         run: |
-          echo "This action was triggered by a schedule." && echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV && echo "GITHUB_REF=dev" >> $GITHUB_ENV
+          echo "This action was triggered by a schedule."
+          echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV
+          echo "GITHUB_REF=dev" >> $GITHUB_ENV
 
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
           ref: ${{ env.GITHUB_REF }}
 
-      - name: Get HEAD of the branch (main or dev)
+      - name: Compute action vars
         run: |
           echo "ACTION_SHA=$(git rev-parse HEAD)" >> $GITHUB_ENV
           echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+          echo "BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
+          echo "COMMIT_TIME=$(git log -1 --format=%cd --date=format:%Y-%m-%d-%H%M)" >> $GITHUB_ENV
+          echo "RUN_TIMESTAMP=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
 
       - name: Print action vars
         run: |
-          echo "ACTION_SHA: $ACTION_SHA" && \
-          echo "GITHUB_REF: $GITHUB_REF" && \
+          echo "ACTION_SHA: $ACTION_SHA"
+          echo "GITHUB_REF: $GITHUB_REF"
+          echo "BRANCH: $BRANCH"
+          echo "COMMIT_TIME: $COMMIT_TIME"
+          echo "RUN_TIMESTAMP: $RUN_TIMESTAMP"
           echo "GCE_INSTANCE: $GCE_INSTANCE"
 
       - name: Docker Metadata
@@ -85,17 +93,11 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Determine commit information
-        run: |-
-          echo "COMMIT_BRANCH=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-          echo "COMMIT_TIME=$(git log -1 --format=%cd --date=format:%Y-%m-%d-%H%M)" >> $GITHUB_ENV
-          echo "RUN_TIMESTAMP=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
-
       # Deploy PUDL image to GCE
       - name: Deploy
         env:
           DAGSTER_PG_PASSWORD: ${{ secrets.DAGSTER_PG_PASSWORD }}
-          PUDL_OUTPUT_PATH: ${{ env.GCS_OUTPUT_BUCKET }}/${{ env.RUN_TIMESTAMP }}-${{ env.SHORT_SHA }}-${{ env.COMMIT_BRANCH }}
+          PUDL_OUTPUT_PATH: ${{ env.GCS_OUTPUT_BUCKET }}/${{ env.RUN_TIMESTAMP }}-${{ env.SHORT_SHA }}-${{ env.BRANCH }}
         run: |-
           gcloud compute instances add-metadata "$GCE_INSTANCE" \
             --zone "$GCE_INSTANCE_ZONE" \
@@ -140,7 +142,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.24.0
         with:
           channel-id: "C03FHB9N0PQ"
-          slack-message: "build-deploy-pudl status: ${{ job.status }}\n${{ env.GCS_OUTPUT_BUCKET }}/${{ env.RUN_TIMESTAMP}}-${{ env.SHORT_SHA }}-${{ env.COMMIT_BRANCH }}"
+          slack-message: "build-deploy-pudl status: ${{ job.status }}\n${{ env.GCS_OUTPUT_BUCKET }}/${{ env.RUN_TIMESTAMP}}-${{ env.SHORT_SHA }}-${{ env.BRANCH }}"
         env:
           channel-id: "C03FHB9N0PQ"
           SLACK_BOT_TOKEN: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}


### PR DESCRIPTION
Move computation of various env variables into single step, print them out and use slightly different logic for calculating branch name.