### PR TITLE
Clean up nightly build/deploy w/o nightly branch update.

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -47,6 +47,7 @@ jobs:
           echo "BUILD_ID: $BUILD_ID"
 
       - name: Tag nightly build
+        # TESTING -- SHOULD ONLY RUN ON SCHEDULE
         if: ${{ (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch') }}
         run: |
           git config user.email "pudl@catalyst.coop"

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.BUILD_REF }}
+          fetch-depth: 0
 
       - name: Set action environment variables
         run: |

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -19,7 +19,7 @@ jobs:
     name: Build Docker image, push to Docker Hub and deploy to a GCE VM
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
     steps:
       - name: Use pudl-deployment-dev vm and dev branch if running on a schedule

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   GCP_BILLING_PROJECT: ${{ secrets.GCP_BILLING_PROJECT }}
-  GITHUB_REF: ${{ github.ref_name }} # This is changed to dev if running on a schedule
+  BUILD_REF: ${{ github.ref_name }} # This is changed to dev if running on a schedule
   GCE_INSTANCE: pudl-deployment-tag # This is changed to pudl-deployment-dev if running on a schedule
   GCE_INSTANCE_ZONE: ${{ secrets.GCE_INSTANCE_ZONE }}
   GCS_OUTPUT_BUCKET: gs://nightly-build-outputs.catalyst.coop
@@ -27,27 +27,23 @@ jobs:
         run: |
           echo "This action was triggered by a schedule."
           echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV
-          echo "GITHUB_REF=dev" >> $GITHUB_ENV
+          echo "BUILD_REF=dev" >> $GITHUB_ENV
 
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ env.GITHUB_REF }}
+          ref: ${{ env.BUILD_REF }}
 
       - name: Set action environment variables
         run: |
           echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
-          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "BUILD_TIMESTAMP=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
-          echo "BUILD_ID=${BUILD_TIMESTAMP}-${SHORT_SHA}-${GITHUB_REF}" >> $GITHUB_ENV
+          echo "BUILD_ID=$(date +%Y-%m-%d-%H%M)-$(git rev-parse --short HEAD)-${BUILD_REF}" >> $GITHUB_ENV
 
       - name: Show freshly set envvars
         run: |
           echo "GCE_INSTANCE: $GCE_INSTANCE"
-          echo "GITHUB_REF: $GITHUB_REF"
+          echo "BUILD_REF: $BUILD_REF"
           echo "NIGHTLY_TAG: $NIGHTLY_TAG"
-          echo "SHORT_SHA: $SHORT_SHA"
-          echo "BUILD_TIMESTAMP: $BUILD_TIMESTAMP"
           echo "BUILD_ID: $BUILD_ID"
 
       - name: Tag nightly build
@@ -55,7 +51,7 @@ jobs:
         run: |
           git config user.email "pudl@catalyst.coop"
           git config user.name "pudlbot"
-          git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG $GITHUB_REF
+          git tag -a -m "$NIGHTLY_TAG" $NIGHTLY_TAG $BUILD_REF
           git push origin $NIGHTLY_TAG
 
       - name: Docker Metadata
@@ -66,7 +62,7 @@ jobs:
           flavor: |
             latest=auto
           tags: |
-            type=raw,value=${{ env.GITHUB_REF }}
+            type=raw,value=${{ env.BUILD_REF}}
             type=ref,event=tag
 
       - name: Set up Docker Buildx
@@ -111,7 +107,7 @@ jobs:
             --metadata-from-file startup-script=./docker/vm_startup_script.sh
           gcloud compute instances update-container "$GCE_INSTANCE" \
             --zone "$GCE_INSTANCE_ZONE" \
-            --container-image "docker.io/catalystcoop/pudl-etl:${{ env.GITHUB_REF }}" \
+            --container-image "docker.io/catalystcoop/pudl-etl:${{ env.BUILD_REF}}" \
             --container-command "micromamba" \
             --container-arg="run" \
             --container-arg="--prefix" \
@@ -121,7 +117,7 @@ jobs:
             --container-arg="bash" \
             --container-arg="./docker/gcp_pudl_etl.sh" \
             --container-env-file="./docker/.env" \
-            --container-env GITHUB_REF=${{ env.GITHUB_REF }} \
+            --container-env BUILD_REF=${{ env.BUILD_REF}} \
             --container-env BUILD_ID=${{ env.BUILD_ID }} \
             --container-env NIGHTLY_TAG=${{ env.NIGHTLY_TAG }} \
             --container-env GITHUB_ACTION_TRIGGER=${{ github.event_name }} \

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -33,7 +33,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ env.BUILD_REF }}
-          fetch-depth: 0
 
       - name: Set action environment variables
         run: |

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -44,7 +44,7 @@ jobs:
           echo "SHORT_SHA: $SHORT_SHA"
           echo "BUILD_TIMESTAMP=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
           echo "BUILD_TIMESTAMP: $BUILD_TIMESTAMP"
-          echo "BUILD_ID=${BUILD_TIMESTAMP}-${SHORT_SHA}-${GITHUB_REF}
+          echo "BUILD_ID=${BUILD_TIMESTAMP}-${SHORT_SHA}-${GITHUB_REF}" >> $GITHUB_ENV
           echo "BUILD_ID: $BUILD_ID"
 
       - name: Tag nightly build

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -47,7 +47,7 @@ jobs:
           echo "BUILD_ID: $BUILD_ID"
 
       - name: Tag nightly build
-        if: ${{ (github.event_name == 'schedule') }}
+        if: ${{ (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch') }}
         run: |
           git config user.email "pudl@catalyst.coop"
           git config user.name "pudlbot"

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -141,9 +141,7 @@ jobs:
 
       # Start the VM
       - name: Start the deploy-pudl-vm
-        run: |
-          gcloud compute instances start "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE"
-          gcloud compute ssh "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE" -- "docker image ls catalyst-coop/pudl-etl --digests"
+        run: gcloud compute instances start "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE"
 
       - name: Post to a pudl-deployments channel
         id: slack

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -47,8 +47,7 @@ jobs:
           echo "BUILD_ID: $BUILD_ID"
 
       - name: Tag nightly build
-        # TESTING -- SHOULD ONLY RUN ON SCHEDULE
-        if: ${{ (github.event_name == 'schedule') || (github.event_name == 'workflow_dispatch') }}
+        if: ${{ (github.event_name == 'schedule') }}
         run: |
           git config user.email "pudl@catalyst.coop"
           git config user.name "pudlbot"

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -142,7 +142,9 @@ jobs:
 
       # Start the VM
       - name: Start the deploy-pudl-vm
-        run: gcloud compute instances start "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE"
+        run: |
+          gcloud compute instances start "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE"
+          gcloud compute ssh "$GCE_INSTANCE" --zone="$GCE_INSTANCE_ZONE" -- "docker image ls catalyst-coop/pudl-etl --digests"
 
       - name: Post to a pudl-deployments channel
         id: slack

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -27,9 +27,7 @@ jobs:
         run: |
           echo "This action was triggered by a schedule."
           echo "GCE_INSTANCE=pudl-deployment-dev" >> $GITHUB_ENV
-          echo "GCE_INSTANCE: $GCE_INSTANCE"
           echo "GITHUB_REF=dev" >> $GITHUB_ENV
-          echo "GITHUB_REF: $GITHUB_REF"
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -39,12 +37,17 @@ jobs:
       - name: Set action environment variables
         run: |
           echo "NIGHTLY_TAG=nightly-$(date +%Y-%m-%d)" >> $GITHUB_ENV
-          echo "NIGHTLY_TAG: $NIGHTLY_TAG"
           echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-          echo "SHORT_SHA: $SHORT_SHA"
           echo "BUILD_TIMESTAMP=$(date +%Y-%m-%d-%H%M)" >> $GITHUB_ENV
-          echo "BUILD_TIMESTAMP: $BUILD_TIMESTAMP"
           echo "BUILD_ID=${BUILD_TIMESTAMP}-${SHORT_SHA}-${GITHUB_REF}" >> $GITHUB_ENV
+
+      - name: Show freshly set envvars
+        run: |
+          echo "GCE_INSTANCE: $GCE_INSTANCE"
+          echo "GITHUB_REF: $GITHUB_REF"
+          echo "NIGHTLY_TAG: $NIGHTLY_TAG"
+          echo "SHORT_SHA: $SHORT_SHA"
+          echo "BUILD_TIMESTAMP: $BUILD_TIMESTAMP"
           echo "BUILD_ID: $BUILD_ID"
 
       - name: Tag nightly build

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -105,9 +105,8 @@ function update_nightly_branch() {
     git config user.name "pudlbot"
     git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
     echo "WTAF: Updating nightly branch to point at $NIGHTLY_TAG."
+    git fetch origin nightly:nightly
     git checkout nightly
-    git branch --set-upstream-to=origin/nightly
-    git pull
     git merge --ff-only "$NIGHTLY_TAG"
     ETL_SUCCESS=${PIPESTATUS[0]}
     git push

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -104,7 +104,7 @@ function update_nightly_branch() {
     git config user.email "pudl@catalyst.coop"
     git config user.name "pudlbot"
     git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
-    echo "Updating nightly branch to point at $NIGHTLY_TAG."
+    echo "OMFG: Updating nightly branch to point at $NIGHTLY_TAG."
     git checkout nightly
     git branch --set-upstream-to=origin/nightly
     git pull

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -116,6 +116,7 @@ if [[ $ETL_SUCCESS == 0 ]]; then
         git config user.name "pudlbot"
         git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
         # Update the nightly branch to point at newly successful nightly build tag
+        echo "Updating nightly branch to point at $NIGHTLY_TAG."
         git checkout nightly
         git merge --ff-only "$NIGHTLY_TAG"
         git push
@@ -147,7 +148,7 @@ if [[ $ETL_SUCCESS == 0 ]]; then
 fi
 
 # This way we also save the logs from latter steps in the script
-#sutil cp "$LOGFILE" "$PUDL_GCS_OUTPUT"
+#gsutil cp "$LOGFILE" "$PUDL_GCS_OUTPUT"
 
 # Notify slack about entire pipeline's success or failure;
 # PIPESTATUS[0] either refers to the failed ETL run or the last distribution

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -99,17 +99,40 @@ function notify_slack() {
     send_slack_msg "$message"
 }
 
+########################################################################################
+# Short circuit to test git operations:
+########################################################################################
+git config --unset http.https://github.com/.extraheader
+git config user.email "pudl@catalyst.coop"
+git config user.name "pudlbot"
+git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
+# Update the nightly branch to point at newly successful nightly build tag
+echo "Updating nightly branch to point at $NIGHTLY_TAG."
+git checkout origin/nightly
+git merge --ff-only "$NIGHTLY_TAG"
+ETL_SUCCESS=${PIPESTATUS[0]}
+git push
+if [[ $ETL_SUCCESS == 0 ]]; then
+    notify_slack "success"
+else
+    notify_slack "failure"
+fi
+shutdown_vm
+########################################################################################
+########################################################################################
+########################################################################################
+
 # # Run ETL. Copy outputs to GCS and shutdown VM if ETL succeeds or fails
 # 2>&1 redirects stderr to stdout.
-#run_pudl_etl 2>&1 | tee "$LOGFILE"
-#ETL_SUCCESS=${PIPESTATUS[0]}
-ETL_SUCCESS=0
+run_pudl_etl 2>&1 | tee "$LOGFILE"
+ETL_SUCCESS=${PIPESTATUS[0]}
 
-#copy_outputs_to_gcs
+
+copy_outputs_to_gcs
 
 # if pipeline is successful, distribute + publish datasette
 if [[ $ETL_SUCCESS == 0 ]]; then
-    # if [ "$GITHUB_ACTION_TRIGGER" = "workflow_dispatch" ]; then
+    if [ "$GITHUB_ACTION_TRIGGER" = "schedule" ]; then
         # Remove read-only authentication header added by git checkout
         git config --unset http.https://github.com/.extraheader
         git config user.email "pudl@catalyst.coop"
@@ -120,35 +143,35 @@ if [[ $ETL_SUCCESS == 0 ]]; then
         git checkout origin/nightly
         git merge --ff-only "$NIGHTLY_TAG"
         git push
-    # fi
+    fi
     # Deploy the updated data to datasette
-    # if [ "$BUILD_REF" = "dev" ] || [ "$GITHUB_ACTION_TRIGGER" = "workflow_dispatch" ]; then
-#       python ~/devtools/datasette/publish.py 2>&1 | tee -a "$LOGFILE"
-#       ETL_SUCCESS=${PIPESTATUS[0]}
-    # fi
+    if [ "$BUILD_REF" = "dev" ]; then
+        python ~/devtools/datasette/publish.py 2>&1 | tee -a "$LOGFILE"
+        ETL_SUCCESS=${PIPESTATUS[0]}
+    fi
 
     # Compress the SQLite DBs for easier distribution
     # Remove redundant multi-file EPA CEMS outputs prior to distribution
-#   gzip --verbose "$PUDL_OUTPUT"/*.sqlite && \
-#   rm -rf "$PUDL_OUTPUT/core_epacems__hourly_emissions/" && \
-#   rm -f "$PUDL_OUTPUT/metadata.yml"
-#   ETL_SUCCESS=${PIPESTATUS[0]}
+    gzip --verbose "$PUDL_OUTPUT"/*.sqlite && \
+    rm -rf "$PUDL_OUTPUT/core_epacems__hourly_emissions/" && \
+    rm -f "$PUDL_OUTPUT/metadata.yml"
+    ETL_SUCCESS=${PIPESTATUS[0]}
 
     # Dump outputs to s3 bucket if branch is dev or build was triggered by a tag
     # TODO: this behavior should be controlled by on/off switch here and this logic
     # should be moved to the triggering github action. Having it here feels
     # fragmented.
-#   if [ "$GITHUB_ACTION_TRIGGER" = "push" ] || [ "$BUILD_REF" = "dev" ] || [ "$GITHUB_ACTION_TRIGGER" = "workflow_dispatch" ]; then
-#       copy_outputs_to_distribution_bucket
-#       ETL_SUCCESS=${PIPESTATUS[0]}
-#       # TEMPORARY: this currently just makes a sandbox release, for testing:
-#       zenodo_data_release 2>&1 | tee -a "$LOGFILE"
-#       ETL_SUCCESS=${PIPESTATUS[0]}
-#   fi
+    if [ "$GITHUB_ACTION_TRIGGER" = "push" ] || [ "$BUILD_REF" = "dev" ]; then
+        copy_outputs_to_distribution_bucket
+        ETL_SUCCESS=${PIPESTATUS[0]}
+        # TEMPORARY: this currently just makes a sandbox release, for testing:
+        zenodo_data_release 2>&1 | tee -a "$LOGFILE"
+        ETL_SUCCESS=${PIPESTATUS[0]}
+    fi
 fi
 
 # This way we also save the logs from latter steps in the script
-#gsutil cp "$LOGFILE" "$PUDL_GCS_OUTPUT"
+gsutil cp "$LOGFILE" "$PUDL_GCS_OUTPUT"
 
 # Notify slack about entire pipeline's success or failure;
 # PIPESTATUS[0] either refers to the failed ETL run or the last distribution

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -109,7 +109,7 @@ function update_nightly_branch() {
     git checkout nightly
     git merge --ff-only "$NIGHTLY_TAG"
     ETL_SUCCESS=${PIPESTATUS[0]}
-    git push
+    git push -u origin
 }
 
 # Short circut the script to debug the nightly branch update

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -48,7 +48,7 @@ function run_pudl_etl() {
 }
 
 function shutdown_vm() {
-    upload_file_to_slack "$LOGFILE" "pudl_etl logs for $BUILD_ID:"
+    # upload_file_to_slack "$LOGFILE" "pudl_etl logs for $BUILD_ID:"
     # Shut down the vm instance when the etl is done.
     echo "Shutting down VM."
     ACCESS_TOKEN=$(curl \

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -104,7 +104,7 @@ function update_nightly_branch() {
     git config user.email "pudl@catalyst.coop"
     git config user.name "pudlbot"
     git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
-    echo "OMFG: Updating nightly branch to point at $NIGHTLY_TAG."
+    echo "WTAF: Updating nightly branch to point at $NIGHTLY_TAG."
     git checkout nightly
     git branch --set-upstream-to=origin/nightly
     git pull

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -117,7 +117,7 @@ if [[ $ETL_SUCCESS == 0 ]]; then
         git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
         # Update the nightly branch to point at newly successful nightly build tag
         echo "Updating nightly branch to point at $NIGHTLY_TAG."
-        git checkout nightly
+        git checkout origin/nightly
         git merge --ff-only "$NIGHTLY_TAG"
         git push
     # fi

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -104,7 +104,7 @@ function update_nightly_branch() {
     git config user.email "pudl@catalyst.coop"
     git config user.name "pudlbot"
     git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
-    echo "WTAF: Updating nightly branch to point at $NIGHTLY_TAG."
+    echo "BOGUS: Updating nightly branch to point at $NIGHTLY_TAG."
     git fetch origin nightly:nightly
     git checkout nightly
     git merge --ff-only "$NIGHTLY_TAG"

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -108,7 +108,7 @@ git config user.name "pudlbot"
 git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
 # Update the nightly branch to point at newly successful nightly build tag
 echo "Updating nightly branch to point at $NIGHTLY_TAG."
-git checkout origin/nightly
+git checkout nightly
 git merge --ff-only "$NIGHTLY_TAG"
 ETL_SUCCESS=${PIPESTATUS[0]}
 git push

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -117,68 +117,69 @@ if [[ $ETL_SUCCESS == 0 ]]; then
 else
     notify_slack "failure"
 fi
-#shutdown_vm
+shutdown_vm
+
 ########################################################################################
 ########################################################################################
 ########################################################################################
 
-# # # Run ETL. Copy outputs to GCS and shutdown VM if ETL succeeds or fails
-# # 2>&1 redirects stderr to stdout.
-# run_pudl_etl 2>&1 | tee "$LOGFILE"
-# ETL_SUCCESS=${PIPESTATUS[0]}
+# # Run ETL. Copy outputs to GCS and shutdown VM if ETL succeeds or fails
+# 2>&1 redirects stderr to stdout.
+run_pudl_etl 2>&1 | tee "$LOGFILE"
+ETL_SUCCESS=${PIPESTATUS[0]}
 
-# copy_outputs_to_gcs
+copy_outputs_to_gcs
 
-# # if pipeline is successful, distribute + publish datasette
-# if [[ $ETL_SUCCESS == 0 ]]; then
-#     if [ "$GITHUB_ACTION_TRIGGER" = "schedule" ]; then
-#         # Remove read-only authentication header added by git checkout
-#         git config --unset http.https://github.com/.extraheader
-#         git config user.email "pudl@catalyst.coop"
-#         git config user.name "pudlbot"
-#         git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
-#         # Update the nightly branch to point at newly successful nightly build tag
-#         echo "Updating nightly branch to point at $NIGHTLY_TAG."
-#         git checkout origin/nightly
-#         git merge --ff-only "$NIGHTLY_TAG"
-#         git push
-#     fi
-#     # Deploy the updated data to datasette
-#     if [ "$BUILD_REF" = "dev" ]; then
-#         python ~/devtools/datasette/publish.py 2>&1 | tee -a "$LOGFILE"
-#         ETL_SUCCESS=${PIPESTATUS[0]}
-#     fi
+# if pipeline is successful, distribute + publish datasette
+if [[ $ETL_SUCCESS == 0 ]]; then
+    if [ "$GITHUB_ACTION_TRIGGER" = "schedule" ]; then
+        # Remove read-only authentication header added by git checkout
+        git config --unset http.https://github.com/.extraheader
+        git config user.email "pudl@catalyst.coop"
+        git config user.name "pudlbot"
+        git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git"
+        # Update the nightly branch to point at newly successful nightly build tag
+        echo "Updating nightly branch to point at $NIGHTLY_TAG."
+        git checkout nightly
+        git merge --ff-only "$NIGHTLY_TAG"
+        git push
+    fi
+    # Deploy the updated data to datasette
+    if [ "$BUILD_REF" = "dev" ]; then
+        python ~/devtools/datasette/publish.py 2>&1 | tee -a "$LOGFILE"
+        ETL_SUCCESS=${PIPESTATUS[0]}
+    fi
 
-#     # Compress the SQLite DBs for easier distribution
-#     # Remove redundant multi-file EPA CEMS outputs prior to distribution
-#     gzip --verbose "$PUDL_OUTPUT"/*.sqlite && \
-#     rm -rf "$PUDL_OUTPUT/core_epacems__hourly_emissions/" && \
-#     rm -f "$PUDL_OUTPUT/metadata.yml"
-#     ETL_SUCCESS=${PIPESTATUS[0]}
+    # Compress the SQLite DBs for easier distribution
+    # Remove redundant multi-file EPA CEMS outputs prior to distribution
+    gzip --verbose "$PUDL_OUTPUT"/*.sqlite && \
+    rm -rf "$PUDL_OUTPUT/core_epacems__hourly_emissions/" && \
+    rm -f "$PUDL_OUTPUT/metadata.yml"
+    ETL_SUCCESS=${PIPESTATUS[0]}
 
-#     # Dump outputs to s3 bucket if branch is dev or build was triggered by a tag
-#     # TODO: this behavior should be controlled by on/off switch here and this logic
-#     # should be moved to the triggering github action. Having it here feels
-#     # fragmented.
-#     if [ "$GITHUB_ACTION_TRIGGER" = "push" ] || [ "$BUILD_REF" = "dev" ]; then
-#         copy_outputs_to_distribution_bucket
-#         ETL_SUCCESS=${PIPESTATUS[0]}
-#         # TEMPORARY: this currently just makes a sandbox release, for testing:
-#         zenodo_data_release 2>&1 | tee -a "$LOGFILE"
-#         ETL_SUCCESS=${PIPESTATUS[0]}
-#     fi
-# fi
+    # Dump outputs to s3 bucket if branch is dev or build was triggered by a tag
+    # TODO: this behavior should be controlled by on/off switch here and this logic
+    # should be moved to the triggering github action. Having it here feels
+    # fragmented.
+    if [ "$GITHUB_ACTION_TRIGGER" = "push" ] || [ "$BUILD_REF" = "dev" ]; then
+        copy_outputs_to_distribution_bucket
+        ETL_SUCCESS=${PIPESTATUS[0]}
+        # TEMPORARY: this currently just makes a sandbox release, for testing:
+        zenodo_data_release 2>&1 | tee -a "$LOGFILE"
+        ETL_SUCCESS=${PIPESTATUS[0]}
+    fi
+fi
 
-# # This way we also save the logs from latter steps in the script
-# gsutil cp "$LOGFILE" "$PUDL_GCS_OUTPUT"
+# This way we also save the logs from latter steps in the script
+gsutil cp "$LOGFILE" "$PUDL_GCS_OUTPUT"
 
-# # Notify slack about entire pipeline's success or failure;
-# # PIPESTATUS[0] either refers to the failed ETL run or the last distribution
-# # task that was run above
-# if [[ $ETL_SUCCESS == 0 ]]; then
-#     notify_slack "success"
-# else
-#     notify_slack "failure"
-# fi
+# Notify slack about entire pipeline's success or failure;
+# PIPESTATUS[0] either refers to the failed ETL run or the last distribution
+# task that was run above
+if [[ $ETL_SUCCESS == 0 ]]; then
+    notify_slack "success"
+else
+    notify_slack "failure"
+fi
 
-# shutdown_vm
+shutdown_vm


### PR DESCRIPTION
Takes the working elements of #3183 and gets them merged into `main` so the builds are working again.

- Fix syntax error in build-deploy-pudl workflow.
- Move envvar printing into separate step
- Rename GITHUB_REF to BUILD_REF
- set the nightly tag, so we have something to merge
- Allow write permissions for git tagging in nightly builds workflow
- Functionalize udpate_nightly_branch()
- Set origin for nightly when pushing.
- Temporarily disable nightly branch updates to fix nightly builds.
