### PR TITLE
update the 860m doi

### DIFF
--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -141,7 +141,10 @@ class DatapackageDescriptor:
             if name and res["name"] != name:
                 continue
             for k, v in res.get("parts", {}).items():
-                partitions[k].add(v)
+                if isinstance(v, list):
+                    partitions[k] |= set(v)  # Add all items from list
+                else:
+                    partitions[k].add(v)
         return partitions
 
     def get_partition_filters(self, **filters: Any) -> Iterator[dict[str, str]]:

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -104,7 +104,6 @@ class DatapackageDescriptor:
                     f"Resource filter values should be all lowercase: {k}={v}"
                 )
         parts = res.get("parts", {})
-
         # If partitions are list, match whole list if it contains desired element
         if set(map(type, parts.values())) == {list}:
             return all(
@@ -180,7 +179,7 @@ class ZenodoDoiSettings(BaseSettings):
 
     censusdp1tract: ZenodoDoi = "10.5281/zenodo.4127049"
     eia860: ZenodoDoi = "10.5281/zenodo.10067566"
-    eia860m: ZenodoDoi = "10.5281/zenodo.10204686"
+    eia860m: ZenodoDoi = "10.5281/zenodo.10423813"
     eia861: ZenodoDoi = "10.5281/zenodo.10204708"
     eia923: ZenodoDoi = "10.5281/zenodo.10067550"
     eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.7067367"


### PR DESCRIPTION
# Overview

Closes #3186.

What problem does this address?
We had to make a new zenodo archive with eia860m a years worth of monthly files zipped together into one resource because *file upload limits*. So this pr 

What did you change?
basically nothing except the DOI. bc @e-belfer added a little logic into the datastore to work with partitions that are lists of partitions. And the excel extractor/the datastore combined  already knows how to grab a file out of a zipped file bc of course it does bc so many of our one partition resources have many files. The main place where this is happening is `load_excel_file`.

We could remove the first `try` in `load_excel_file` because the old eia860m archive being individual files was actually the edge case.

# Testing

How did you make sure this worked? How can a reviewer verify this?
I ran the fast etl locally. But first I thought I was going to have to muck with the excel extractor so I setup a little notebook testing situation and the simplest setup gave me the eia860m outputs:

```python
from pudl.extract.eia860m import Extractor
from pudl.workspace.datastore import Datastore

ds = Datastore(local_cache_path=pudl.workspace.setup.PudlPaths().pudl_input)
self = Extractor(ds=ds)
raw_eia860m_dfs = self.extract(year_month=pudl.metadata.sources.SOURCES["eia860m"]["working_partitions"]["year_month"])
```


```[tasklist]
# To-do list
- [ ] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
