### PR TITLE
Tell setuptools_scm to ignore non-version tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,13 +152,13 @@ where = ["src"]
 [tool.setuptools_scm]
 tag_regex = "^v(?P<version>20\\d{2}\\.\\d{1,2}\\.\\d{1,2})$"
 git_describe_command = [
-    'git',
-    'describe',
-    '--dirty',
-    '--tags',
-    '--long',
-    '--match',
-    'v20*',
+    "git",
+    "describe",
+    "--dirty",
+    "--tags",
+    "--long",
+    "--match",
+    "v20*",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,16 @@ include-package-data = true
 where = ["src"]
 
 [tool.setuptools_scm]
+tag_regex = "^v(?P<version>20\\d{2}\\.\\d{1,2}\\.\\d{1,2})$"
+git_describe_command = [
+    'git',
+    'describe',
+    '--dirty',
+    '--tags',
+    '--long',
+    '--match',
+    'v20*',
+]
 
 [tool.ruff]
 select = [
@@ -263,9 +273,7 @@ filterwarnings = [
     "once:The behavior of DataFrame concatenation with empty or all-NA entries is deprecated.:FutureWarning",
 ]
 
-markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
-]
+markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 # Oddly, despite the use of --cov-config=pyproject.toml here, pytest does not seem to
 # pick up the source directories specified in the [tool.coverage.run] section below.
 # (though it *does* pick up the omit parameters!). This means we need to specify the


### PR DESCRIPTION
# Overview

Update configuration for `setuptools_scm` such that it only considers tags matching `v20*` when trying to determine the current version.

Related to #3140

# Testing

After altering `pyproject.toml` I attempted to install the PUDL package using `pip`

```[tasklist]
# To-do list
- [ ] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
