### PR TITLE
Reduce FERC1 match threshold in test to 85%

### DIFF
--- a/test/integration/record_linkage_test.py
+++ b/test/integration/record_linkage_test.py
@@ -236,5 +236,5 @@ def test_classify_plants_ferc1(mock_ferc1_plants_df):
         .sum()
     )
     ratio_correct = correctly_matched / len(mock_ferc1_plants_df)
-    logger.info(f"Percent correctly matched: {ratio_correct*100:.2f}%")
-    assert ratio_correct > 0.95, "Percent of correctly matched FERC records below 85%."
+    logger.info(f"Percent correctly matched: {ratio_correct:.2%}")
+    assert ratio_correct > 0.85, "Percent of correctly matched FERC records below 85%."


### PR DESCRIPTION
# Overview

- Reduce FERC1 match threshold in test to 85%

Closes #3196

# Testing

How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
