### PR TITLE
TESTONLY Import faster xbrl

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "bottleneck>=1.3.4", # pandas[performance]
     "build>=1.0",
     "catalystcoop.dbfread>=3.0,<3.1",
-    "catalystcoop.ferc-xbrl-extractor>=1.2.0,<2",
+    "catalystcoop.ferc-xbrl-extractor@cache-snakecase",  # import fixed version of extractor
     "click>=8",
     "coloredlogs>=14.0", # Dagster requires 14.0
     "conda-lock>=2.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "bottleneck>=1.3.4", # pandas[performance]
     "build>=1.0",
     "catalystcoop.dbfread>=3.0,<3.1",
-    "catalystcoop.ferc-xbrl-extractor@cache-snakecase",  # import fixed version of extractor
+    "catalystcoop.ferc-xbrl-extractor@git+https://github.com/catalyst-cooperative/ferc-xbrl-extractor#egg=cache-snakecase",  # import fixed version of extractor
     "click>=8",
     "coloredlogs>=14.0", # Dagster requires 14.0
     "conda-lock>=2.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "bottleneck>=1.3.4", # pandas[performance]
     "build>=1.0",
     "catalystcoop.dbfread>=3.0,<3.1",
-    "catalystcoop.ferc-xbrl-extractor@git+https://github.com/catalyst-cooperative/ferc-xbrl-extractor#egg=cache-snakecase",  # import fixed version of extractor
+    "catalystcoop.ferc-xbrl-extractor@git+https://github.com/catalyst-cooperative/ferc-xbrl-extractor@cache-snakecase",  # import fixed version of extractor
     "click>=8",
     "coloredlogs>=14.0", # Dagster requires 14.0
     "conda-lock>=2.5.1",


### PR DESCRIPTION
This attempts to import `ferc-xbrl-extractor` directly from github and from specific branch to test the changes. Once `ci-integration` is run, we could assess the speed up of this.