### PR TITLE
cleanup the excel extractor to no longer look for a single file

### DIFF
--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -407,6 +407,7 @@ class Datastore:
 
     def get_zipfile_resource(self, dataset: str, **filters: Any) -> zipfile.ZipFile:
         """Retrieves unique resource and opens it as a ZipFile."""
+        # TODO: add some check if the result of get_unique_resource isn't a zip file.
         return zipfile.ZipFile(io.BytesIO(self.get_unique_resource(dataset, **filters)))
 
     def get_zipfile_resources(


### PR DESCRIPTION
# Overview
What problem does this address?
In #3189 we started to use a eia860m archive with zipped files instead of stand xlsx files. which means that we can remove some cruft that handled this in the excel extractor.

What did you change?
I mostly just removed the option for an archive to go grab an individual file. now it always looks for a zipped resource

# Testing

How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [x] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
