### PR TITLE
Only run release workflow on v20xx tags.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,10 @@
 ---
 name: release
 
-on: push
+on:
+  push:
+    tags:
+      - "v20*"
 
 jobs:
   build-distribution:
@@ -28,7 +31,6 @@ jobs:
 
   publish-test-pypi:
     name: Upload release to PyPI Test Server
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')
     needs:
       - build-distribution
     runs-on: ubuntu-latest
@@ -50,7 +52,6 @@ jobs:
 
   publish-pypi:
     name: Upload release to PyPI
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')
     needs:
       - build-distribution
     runs-on: ubuntu-latest
@@ -107,7 +108,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - publish-github
-    if: ${{ always() }}
     steps:
       - name: Inform the Codemonkeys
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
While playing with actions, I noticed that we're running the release workflow on *every* push which seems excessive... any reason to not filter at the trigger level?