### PR TITLE
Use digest instead of tag so VM uses right image.

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -92,6 +92,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build image and push to Docker Hub
+        id: docker-build
         if: ${{ env.SKIP_BUILD != 'true' }}
         uses: docker/build-push-action@v5
         with:
@@ -127,7 +128,7 @@ jobs:
             --metadata-from-file startup-script=./docker/vm_startup_script.sh
           gcloud compute instances update-container "$GCE_INSTANCE" \
             --zone "$GCE_INSTANCE_ZONE" \
-            --container-image "docker.io/catalystcoop/pudl-etl:${{ env.BUILD_REF }}" \
+            --container-image "docker.io/catalystcoop/pudl-etl@${{ steps.docker-build.outputs.digest }}" \
             --container-command "micromamba" \
             --container-arg="run" \
             --container-arg="--prefix" \


### PR DESCRIPTION
# Overview

Follow-up to #3195 ; Related to #3140 .

We were getting inconsistent behavior pulling the latest image for a certain tag off of Dockerhub - often we would get an out-of-date image running on the VM.

While investigating Google Batch, I found that this was due to Dockerhub not updating its tag references quickly enough. However, we can just refer to the actual image digest we just built, which is unambiguously the correct image.

Given how small this change is, I decided to pull this logic over to the non-Batch world as well, so we don't have to wait for me to get all the Batch stuff working.

# Testing
I short-circuited `gcp_pudl_etl.sh` and had it echo a short message to the logs.

Then:
1. change the line
2. push
3. run `build-deploy-pudl.yml`
4. observe that the output includes the changed line!

Then, I went back to how it works on `main`/`dev` now - using the branch name as the image tag, instead of the image digest. Repeating the flow above updated the changed line on the first iteration, but subsequent changes were not picked up.

So I'm convinced that this should alleviate our "VM doesn't pick up the latest image version" woes.

```[tasklist]
# To-do list
- [x] Manual testing detailed above
- [x] Review the PR yourself and call out any questions or issues you have
```
