### PR TITLE
Tweak metadata and pyarrow schema methods to work for all tables

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,10 +104,10 @@ jobs:
           git push
 
   notify-slack:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')
     runs-on: ubuntu-latest
     needs:
       - publish-github
-    if: ${{ always() }}
     steps:
       - name: Inform the Codemonkeys
         uses: 8398a7/action-slack@v3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -137,7 +137,7 @@ def data_dictionary_metadata_to_rst(app):
     """Export data dictionary metadata to RST for inclusion in the documentation."""
     # Create an RST Data Dictionary for the PUDL DB:
     print("Exporting PUDL DB data dictionary metadata to RST.")
-    skip_names = ["datasets", "accumulated_depreciation_ferc1", "entity_types_eia"]
+    skip_names = ["datasets", "accumulated_depreciation_ferc1"]
     names = [name for name in RESOURCE_METADATA if name not in skip_names]
     package = Package.from_resource_ids(resource_ids=tuple(sorted(names)))
     # Sort fields within each resource by name:

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -624,7 +624,9 @@ class Field(PudlMeta):
             name=self.name,
             type=self.to_pyarrow_dtype(),
             nullable=(not self.constraints.required),
-            metadata={"description": self.description},
+            metadata={
+                "description": self.description if self.description is not None else ""
+            },
         )
 
     def to_sql(  # noqa: C901
@@ -1318,9 +1320,10 @@ class Resource(PudlMeta):
         """Construct a PyArrow schema for the resource."""
         fields = [field.to_pyarrow() for field in self.schema.fields]
         metadata = {
-            "description": self.description,
-            "primary_key": ",".join(self.schema.primary_key),
+            "description": self.description if self.description is not None else ""
         }
+        if self.schema.primary_key is not None:
+            metadata |= {"primary_key": ",".join(self.schema.primary_key)}
         return pa.schema(fields=fields, metadata=metadata)
 
     def to_pandas_dtypes(self, **kwargs: Any) -> dict[str, str | pd.CategoricalDtype]:

--- a/src/pudl/metadata/codes.py
+++ b/src/pudl/metadata/codes.py
@@ -795,101 +795,6 @@ CODE_METADATA: dict[str, dict[str, Any]] = {
         "code_fixes": {"5": "F"},
         "ignored_codes": [],
     },
-    "entity_types_eia": {
-        "df": pd.DataFrame(
-            columns=[
-                "code",
-                "label",
-                "description",
-            ],
-            data=[
-                (
-                    "A",
-                    "municipal_marketing_authority",
-                    "Municipal Marketing Authority. Voted into existence by the residents of a municipality and given authority for creation by the state government. They are nonprofit organizations",
-                ),
-                (
-                    "B",
-                    "behind_the_meter",
-                    "Behind the Meter. Entities that install, own, and/or operate a system (usually photovoltaic), and sell, under a long term power purchase agreement (PPA) or lease, all the production from the system to the homeowner or business with which there is a net metering agreement. Third Party Owners (TPOs) of PV solar installations use this ownership code.",
-                ),
-                ("C", "cooperative", "Cooperative. Member-owned organizations."),
-                ("COM", "commercial", "Commercial facility."),
-                (
-                    "D",
-                    "nonutility_dsm_administrator",
-                    "Non-utility DSM Administrator. Only involved with Demand-Side Management activities.",
-                ),
-                (
-                    "F",
-                    "federal",
-                    "Federal. Government agencies with the authority to deliver energy to end-use customers.",
-                ),
-                ("G", "community_choice_aggregator", "Community Choice Aggregator."),
-                (
-                    "I",
-                    "investor_owned",
-                    "Investor-owned Utilities. Entities that are privately owned and provide a public service.",
-                ),
-                ("IND", "industrial", "Industrial facility."),
-                (
-                    "M",
-                    "municipal",
-                    "Municipal: Entities that are organized under authority of state statute to provide a public service to residents of that area.",
-                ),
-                ("O", "other", "Other entity type."),
-                (
-                    "P",
-                    "political_subdivision",
-                    'Political Subdivision. (also called "public utility district"): Independent of city or county government and voted into existence by a majority of the residents of any given area for the specific purpose of providing utility service to the voters. State laws provide for the formation of such districts.',
-                ),
-                ("PO", "power_marketer", "Power marketer."),
-                ("PR", "private", "Private entity."),
-                (
-                    "Q",
-                    "independent_power_producer",
-                    "Independent Power Producer or Qualifying Facility. Entities that own power plants and sell their power into the wholesale market.",
-                ),
-                (
-                    "R",
-                    "retail_power_marketer",
-                    "Retail Power Marketer or Energy Service Provider: Entities that market power to customers in restructured markets.",
-                ),
-                (
-                    "S",
-                    "state",
-                    "State entities that own or operate facilities or provide a public service.",
-                ),
-                (
-                    "T",
-                    "transmission",
-                    "Transmission: Entities that operate or own high voltage transmission wires that provide bulk power services.",
-                ),
-                ("U", "unknown", "Unknown entity type."),
-                (
-                    "W",
-                    "wholesale_power_marketer",
-                    "Wholesale Power Marketer: Entities that buy and sell power in the wholesale market.",
-                ),
-            ],
-        ).convert_dtypes(),
-        "code_fixes": {
-            "Behind the Meter": "B",
-            "Community Choice Aggregator": "G",
-            "Cooperative": "C",
-            "Facility": "Q",
-            "Federal": "F",
-            "Investor Owned": "I",
-            "Municipal": "M",
-            "Political Subdivision": "P",
-            "Power Marketer": "PO",
-            "Retail Power Marketer": "R",
-            "State": "S",
-            "Unregulated": "Q",
-            "Wholesale Power Marketer": "W",
-        },
-        "ignored_codes": [],
-    },
     "core_eia__codes_boiler_generator_assn_types": {
         "df": pd.DataFrame(
             columns=[
@@ -2390,4 +2295,104 @@ CODE_METADATA: dict[str, dict[str, Any]] = {
         "code_fixes": {},
         "ignored_codes": [],
     },
+}
+
+# The entity type codes were never fully reconciled. Preserving this work for reference.
+# See https://github.com/catalyst-cooperative/pudl/issues/1392
+DISABLED_CODE_METADATA = {
+    "core_eia__codes_entity_types": {
+        "df": pd.DataFrame(
+            columns=[
+                "code",
+                "label",
+                "description",
+            ],
+            data=[
+                (
+                    "A",
+                    "municipal_marketing_authority",
+                    "Municipal Marketing Authority. Voted into existence by the residents of a municipality and given authority for creation by the state government. They are nonprofit organizations",
+                ),
+                (
+                    "B",
+                    "behind_the_meter",
+                    "Behind the Meter. Entities that install, own, and/or operate a system (usually photovoltaic), and sell, under a long term power purchase agreement (PPA) or lease, all the production from the system to the homeowner or business with which there is a net metering agreement. Third Party Owners (TPOs) of PV solar installations use this ownership code.",
+                ),
+                ("C", "cooperative", "Cooperative. Member-owned organizations."),
+                ("COM", "commercial", "Commercial facility."),
+                (
+                    "D",
+                    "nonutility_dsm_administrator",
+                    "Non-utility DSM Administrator. Only involved with Demand-Side Management activities.",
+                ),
+                (
+                    "F",
+                    "federal",
+                    "Federal. Government agencies with the authority to deliver energy to end-use customers.",
+                ),
+                ("G", "community_choice_aggregator", "Community Choice Aggregator."),
+                (
+                    "I",
+                    "investor_owned",
+                    "Investor-owned Utilities. Entities that are privately owned and provide a public service.",
+                ),
+                ("IND", "industrial", "Industrial facility."),
+                (
+                    "M",
+                    "municipal",
+                    "Municipal: Entities that are organized under authority of state statute to provide a public service to residents of that area.",
+                ),
+                ("O", "other", "Other entity type."),
+                (
+                    "P",
+                    "political_subdivision",
+                    'Political Subdivision. (also called "public utility district"): Independent of city or county government and voted into existence by a majority of the residents of any given area for the specific purpose of providing utility service to the voters. State laws provide for the formation of such districts.',
+                ),
+                ("PO", "power_marketer", "Power marketer."),
+                ("PR", "private", "Private entity."),
+                (
+                    "Q",
+                    "independent_power_producer",
+                    "Independent Power Producer or Qualifying Facility. Entities that own power plants and sell their power into the wholesale market.",
+                ),
+                (
+                    "R",
+                    "retail_power_marketer",
+                    "Retail Power Marketer or Energy Service Provider: Entities that market power to customers in restructured markets.",
+                ),
+                (
+                    "S",
+                    "state",
+                    "State entities that own or operate facilities or provide a public service.",
+                ),
+                (
+                    "T",
+                    "transmission",
+                    "Transmission: Entities that operate or own high voltage transmission wires that provide bulk power services.",
+                ),
+                ("U", "unknown", "Unknown entity type."),
+                (
+                    "W",
+                    "wholesale_power_marketer",
+                    "Wholesale Power Marketer: Entities that buy and sell power in the wholesale market.",
+                ),
+            ],
+        ).convert_dtypes(),
+        "code_fixes": {
+            "Behind the Meter": "B",
+            "Community Choice Aggregator": "G",
+            "Cooperative": "C",
+            "Facility": "Q",
+            "Federal": "F",
+            "Investor Owned": "I",
+            "Municipal": "M",
+            "Political Subdivision": "P",
+            "Power Marketer": "PO",
+            "Retail Power Marketer": "R",
+            "State": "S",
+            "Unregulated": "Q",
+            "Wholesale Power Marketer": "W",
+        },
+        "ignored_codes": [],
+    }
 }

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -1729,7 +1729,7 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     },
     "operator_name": {
         "type": "string",
-        "descripion": "The name of the EIA operator utility.",
+        "description": "The name of the EIA operator utility.",
     },
     "operator_state": {
         "type": "string",
@@ -1737,7 +1737,7 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     },
     "operator_utility_id_eia": {
         "type": "integer",
-        "descrption": "The EIA utility Identification number for the operator utility.",
+        "description": "The EIA utility Identification number for the operator utility.",
     },
     "opex_allowances": {"type": "number", "description": "Allowances.", "unit": "USD"},
     "opex_boiler": {

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -372,6 +372,7 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     "city": {
         "type": "string",
         # TODO: Disambiguate column. City means different things in different tables.
+        "description": "Name of the city.",
     },
     "co2_mass_measurement_code": {
         "type": "string",
@@ -2581,6 +2582,7 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     "street_address": {
         "type": "string",
         # TODO: Disambiguate as this means different things in different tables.
+        "description": "Physical street address.",
     },
     "subcritical_tech": {
         "type": "boolean",

--- a/src/pudl/metadata/resources/eia.py
+++ b/src/pudl/metadata/resources/eia.py
@@ -444,15 +444,17 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "etl_group": "static_eia",
         "field_namespace": "eia",
     },
-    "entity_types_eia": {
-        "description": "Descriptive labels for EIA entity type and ownership codes, taken from the EIA-861 form instructions, valid through 2023-05-31.",
-        "schema": {"fields": ["code", "label", "description"], "primary_key": ["code"]},
-        "encoder": CODE_METADATA["entity_types_eia"],
-        "sources": ["eia861"],
-        "etl_group": "static_eia_disabled",  # currently not being loaded into the db
-        "field_namespace": "eia",
-        "create_database_schema": False,
-    },
+    # The entity types were never fully reconciled. Preserving for future reference.
+    # See https://github.com/catalyst-cooperative/pudl/issues/1392
+    # "core_eia__codes_entity_types": {
+    #    "description": "Descriptive labels for EIA entity type and ownership codes, taken from the EIA-861 form instructions, valid through 2023-05-31.",
+    #    "schema": {"fields": ["code", "label", "description"], "primary_key": ["code"]},
+    #    "encoder": CODE_METADATA["core_eia__codes_entity_types"],
+    #    "sources": ["eia861"],
+    #    "etl_group": "static_eia_disabled",  # currently not being loaded into the db
+    #    "field_namespace": "eia",
+    #    "create_database_schema": False,
+    # },
     "core_eia__codes_fuel_transportation_modes": {
         "description": "Long descriptions of the fuel transportation modes reported in the EIA-860 and EIA-923.",
         "schema": {

--- a/src/pudl/metadata/resources/pudl.py
+++ b/src/pudl/metadata/resources/pudl.py
@@ -56,6 +56,8 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "sources": ["pudl"],
     },
     "core_pudl__assn_utilities_plants": {
+        "title": "PUDL Utility-Plant Associations",
+        "description": "Associations between PUDL utility IDs and PUDL plant IDs. This table is read in from a spreadsheet stored in the PUDL repository: src/pudl/package_data/glue/pudl_id_mapping.xlsx",
         "schema": {
             "fields": ["utility_id_pudl", "plant_id_pudl"],
             "primary_key": ["utility_id_pudl", "plant_id_pudl"],
@@ -65,6 +67,8 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "sources": ["pudl"],
     },
     "core_pudl__codes_datasources": {
+        "title": "PUDL Data Sources",
+        "description": "Static table defining codes associated with the data sources that PUDL integrates.",
         "schema": {
             "fields": [
                 "datasource",
@@ -79,6 +83,8 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "sources": ["pudl"],
     },
     "out_ferc714__hourly_predicted_state_demand": {
+        "title": "Estimated Hourly State Electricity Demand",
+        "description": "Estimated hourly electricity demand for each state, scaled such that it matches the total electricity sales by state reported in EIA 861.",
         "schema": {
             "fields": [
                 "state_id_fips",

--- a/test/integration/output_test.py
+++ b/test/integration/output_test.py
@@ -1,4 +1,4 @@
-"""PyTest cases related to the integration between FERC1 & EIA 860/923."""
+"""PyTest cases related to generating dervied outputs."""
 import logging
 
 import pandas as pd

--- a/test/unit/metadata_test.py
+++ b/test/unit/metadata_test.py
@@ -1,10 +1,13 @@
 """Tests for metadata not covered elsewhere."""
 import pytest
 
-from pudl.metadata.classes import DataSource, Package
+from pudl.metadata.classes import DataSource, Field, Package
+from pudl.metadata.fields import FIELD_METADATA
 from pudl.metadata.helpers import format_errors
 from pudl.metadata.resources import RESOURCE_METADATA
 from pudl.metadata.sources import SOURCES
+
+PUDL_RESOURCES = {r.name: r for r in Package.from_resource_ids().resources}
 
 
 def test_all_resources_valid() -> None:
@@ -39,3 +42,60 @@ def test_get_etl_group_tables() -> None:
     """Test that a Value error is raised for non existent etl group."""
     with pytest.raises(ValueError):
         Package.get_etl_group_tables("not_an_etl_group")
+
+
+@pytest.mark.parametrize("resource_name", sorted(PUDL_RESOURCES.keys()))
+def test_pyarrow_schemas(resource_name: str):
+    """Verify that we can produce pyarrow schemas for all defined Resources."""
+    _ = PUDL_RESOURCES[resource_name].to_pyarrow()
+
+
+@pytest.mark.parametrize("field_name", sorted(FIELD_METADATA.keys()))
+def test_field_definitions(field_name: str):
+    """Check that all defined fields are valid."""
+    _ = Field(name=field_name, **FIELD_METADATA[field_name])
+
+
+@pytest.mark.xfail(reason="Need to purge unused fields. See issue #3224")
+def test_defined_fields_are_used():
+    """Check that all fields which are defined are actually used."""
+    used_fields = set()
+    for resource in PUDL_RESOURCES.values():
+        used_fields |= {f.name for f in resource.schema.fields}
+    defined_fields = set(FIELD_METADATA.keys())
+    unused_fields = sorted(defined_fields - used_fields)
+    if len(unused_fields) > 0:
+        raise AssertionError(
+            f"Found {len(unused_fields)} unused fields: {unused_fields}"
+        )
+
+
+@pytest.mark.xfail(reason="Incomplete descriptions. See issue #3224")
+def test_fields_have_descriptions():
+    """Check that all fields have a description and report any that do not."""
+    fields_without_description = []
+    for field_name in FIELD_METADATA:
+        field = Field(name=field_name, **FIELD_METADATA[field_name])
+        if field.description is None:
+            fields_without_description.append(field_name)
+    fields_without_description = sorted(fields_without_description)
+    if len(fields_without_description) > 0:
+        raise AssertionError(
+            f"Found {len(fields_without_description)} fields without descriptions: "
+            f"{fields_without_description}"
+        )
+
+
+@pytest.mark.xfail(reason="Incomplete descriptions. See issue #3224")
+def test_resources_have_descriptions():
+    """Check that all resources have a description and report any that do not."""
+    resources_without_description = []
+    for resource_name, resource in PUDL_RESOURCES.items():
+        if resource.description is None:
+            resources_without_description.append(resource_name)
+    resources_without_description = sorted(resources_without_description)
+    if len(resources_without_description) > 0:
+        raise AssertionError(
+            f"Found {len(resources_without_description)} resources without descriptions: "
+            f"{resources_without_description}"
+        )


### PR DESCRIPTION
# Overview

## What problem/need does this address?

Previously, we were unable to use the `Resource.to_pyarrow()` method to generate PyArrow schemas for all of our tables, and had historically only used it for the billion-row EPA CEMS table. It turns out that the issues preventing the schemas for being valid were minor and easy to fix:

- Some tables and fields were missing a `description` field, which we were assuming would be present and trying to write into the Parquet metadata.
- Some tables and fields don't have a `primary_key` but we were assuming one always existed, and trying to write that into the Parquet metadata as well.

## What did you change?

- I added a few missing titles / descriptions and also added a conditional that uses an empty string if the description is `None`.
- I added a conditional that only writes the `primary_key` to the Parquet metadata if it is not `None`.
- Added a unit test ensuring that all Resources can generate their PyArrow schemas.
- Added a unit test ensuring that all defined fields can actually be instantiated (we had some bad ones with typos that were never used)
- Removed the unfinished and problematic `entity_types_eia` table (and renamed its vestigial form `core_eia__codes_entity_types`)
- Added some currently `xfail` tests for: unused fields, fields without descriptions, and resources without descriptions.

Part of #3102
Followup in #3224 

# Testing

I iterated through every `Resource` we generate, and attempted to create a PyArrow schema from it, and then attempted to use that schema to write the table out to a Parquet file successfully.

```[tasklist]
# To-do list
- [x] Disable the confusing `entity_types_eia` table which does not actually exist.
- [x] Add an integration test that attempts to create PyArrow schemas for all resources.
- [x] Review the PR yourself and call out any questions or issues you have
- [x] Make sure full ETL runs locally (especially EPA CEMS)
```
