### PR TITLE
Create directory for local only notebooks

### DIFF
--- a/notebooks/.gitignore
+++ b/notebooks/.gitignore
@@ -6,3 +6,5 @@
 *.zip
 ef_nat_gas/
 /**/*.jpg
+local/**
+!local/README.md

--- a/notebooks/local/README.md
+++ b/notebooks/local/README.md
@@ -1,0 +1,2 @@
+## Local Notebooks
+This directory is a placeholder directory to store notebooks you might want to keep locally but shouldn't be tracked in git.


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

I have some untracked local notebooks that probably don't belong in git but are still things I'd like to save. This PR creates a new directory called `notebooks/local/` that only contains a `.gitignore` file so folks can stash old notebooks in their pudl directory but not have them tracked in git.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
