### PR TITLE
Add --build-only flag to datasette deploy script.

### DIFF
--- a/devtools/datasette/publish.py
+++ b/devtools/datasette/publish.py
@@ -110,7 +110,12 @@ def metadata(pudl_out: Path) -> str:
     flag_value="metadata",
     help="Generate the Datasette metadata.yml in current directory, but do not deploy.",
 )
-def deploy_datasette(deploy: str) -> int:
+@click.option(
+    "--build-only",
+    is_flag=True,
+    help="Only for fly.io deployments - try building the image without actually deploying.",
+)
+def deploy_datasette(deploy: str, build_only: bool) -> int:
     """Generate deployment files and run the deploy."""
     pudl_out = PudlPaths().pudl_output
     metadata_yml = metadata(pudl_out)
@@ -148,7 +153,10 @@ def deploy_datasette(deploy: str) -> int:
         )
 
         logging.info("Running fly deploy...")
-        check_call(["/usr/bin/env", "flyctl", "deploy"], cwd=fly_dir)  # noqa: S603
+        cmd = ["/usr/bin/env", "flyctl", "deploy"]
+        if build_only:
+            cmd.append("--build-only")
+        check_call(cmd, cwd=fly_dir)  # noqa: S603
         logging.info("Deploy finished!")
 
     elif deploy == "local":


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #3229 .

We had what appeared to be a transient issue while deploying to fly.io. To test that out, I wanted to try running the Docker build on the `fly.io` builders, since that was the failing step. `flyctl deploy` provides this functionality, so I added the `--build-only` flag to our `publish.py` to configure that behavior.

# Testing

I ran this with the `--build-only` and checked on https://fly.io/apps/catalyst-coop-pudl/activity for any new releases. No new releases, but I did get a "finished building docker image" log from `flyctl`. So that seems like it works!

```[tasklist]
# To-do list
- [ ] Review the PR yourself and call out any questions or issues you have
```
