### PR TITLE
Update EIA bulk electricity data archive.

### DIFF
--- a/devtools/debug-ferc1-etl.ipynb
+++ b/devtools/debug-ferc1-etl.ipynb
@@ -320,7 +320,6 @@
    "execution_count": null,
    "id": "08da1d39-6272-435f-8241-8b3879078393",
    "metadata": {
-    "scrolled": true,
     "tags": []
    },
    "outputs": [],

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -186,7 +186,7 @@ class ZenodoDoiSettings(BaseSettings):
     eia860m: ZenodoDoi = "10.5281/zenodo.10423813"
     eia861: ZenodoDoi = "10.5281/zenodo.10204708"
     eia923: ZenodoDoi = "10.5281/zenodo.10067550"
-    eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.7067367"
+    eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.10525348"
     epacamd_eia: ZenodoDoi = "10.5281/zenodo.7900974"
     epacems: ZenodoDoi = "10.5281/zenodo.10425497"
     ferc1: ZenodoDoi = "10.5281/zenodo.8326634"


### PR DESCRIPTION
# Overview

Update to a fresh EIA Bulk Electricity data archive so that fuel price estimates run through most of 2023.

Existing EIA bulk electricity data was only available through mid 2022. Somehow we failed to update in 2023!  Gaby from RMI asked whether the new data could be made available so I created a new archive (which [had some issues](https://github.com/catalyst-cooperative/pudl-archiver/issues/256)... but in the end seemed to work.)

## What did you change?
- Updated the EIA Bulk Electricity data input archive DOI.

## How did you make sure this worked? How can a reviewer verify this?
- Ran integration tests locally
- Ran a full ETL locally, and this bumped the date of the last filled fuel price from 2022-06-01 to 2023-08-01.

```[tasklist]
# To-do list
- [ ] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
```
