### PR TITLE
Update gas price upper bound; Enable null-row check for MCOE.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -31,8 +31,13 @@ v2024.01.XX
 Data Coverage
 ^^^^^^^^^^^^^
 * Updated :doc:`data_sources/epacems` to switch to pulling the quarterly updates of
-  CEMS instead of the annual files. Integrates CEMS through 2023q3. See issue
+  CEMS instead of the annual files. Integrates CEMS through 2023Q3. See issue
   :issue:`2973` & PR :pr:`3096`.
+* Updated the EIA Bulk Electricity data archive so that the available data now to runs
+  through 2023-10-01. See :pr:`3252`.  Also added this dataset to the set of data that
+  will automatically generate archives each month. See `This PUDL Archiver PR
+  <https://github.com/catalyst-cooperative/pudl-archiver/pull/257>`__ and `this Zenodo
+  archive <https://doi.org/10.5281/zenodo.10525348>`__
 
 Data Cleaning
 ^^^^^^^^^^^^^

--- a/src/pudl/validate.py
+++ b/src/pudl/validate.py
@@ -2733,7 +2733,6 @@ mcoe_fuel_cost_per_mwh = [
         "weight_col": "net_generation_mwh",
     },
     {  # EIA natural gas reporting really only becomes usable in 2015.
-        # Adjusted hi_bound for extra high gas prices in 2022.
         "title": "Natural Gas Fuel Costs (tails, 2015+)",
         "query": "fuel_type_code_pudl=='gas' and report_date>='2015-01-01'",
         "low_q": 0.05,
@@ -2778,13 +2777,12 @@ mcoe_fuel_cost_per_mmbtu = [
         "weight_col": "total_mmbtu",
     },
     {  # EIA natural gas reporting really only becomes usable in 2015.
-        # Adjusted the hi_bound for extra high gas prices in 2022.
         "title": "Natural Gas Fuel Costs (tails, 2015+)",
         "query": "fuel_type_code_pudl=='gas' and report_date>='2015-01-01'",
         "low_q": 0.05,
         "low_bound": 1.65,
         "hi_q": 0.95,
-        "hi_bound": 7.8,
+        "hi_bound": 8.0,
         "data_col": "fuel_cost_per_mmbtu",
         "weight_col": "total_mmbtu",
     },
@@ -2796,7 +2794,7 @@ mcoe_fuel_cost_per_mmbtu = [
 # them to be most useful
 mcoe_self_fuel_cost_per_mmbtu = [
     {  # EIA natural gas reporting really only becomes usable in 2015.
-        "title": "Nautral Gas Fuel Cost (2015+)",
+        "title": "Nautral Gas Fuel Costs (2015+)",
         "query": "fuel_type_code_pudl=='gas' and report_date>='2015-01-01'",
         "low_q": 0.05,
         "mid_q": 0.50,

--- a/test/validate/mcoe_test.py
+++ b/test/validate/mcoe_test.py
@@ -70,20 +70,7 @@ def test_no_null_cols_mcoe(pudl_out_mcoe, live_dbs, df_name):
     pv.no_null_cols(df, cols=cols, df_name=df_name)
 
 
-@pytest.mark.parametrize(
-    "df_name,thresh",
-    [
-        pytest.param(
-            "mcoe",
-            0.8,
-            marks=pytest.mark.xfail(
-                reason="The net generation allocation is now integrated into MCOE. The "
-                "allocated fuel still needs to be integrated - without it we'll have "
-                "nulls. See #2033"
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("df_name,thresh", [("mcoe", 0.8)])
 def test_no_null_rows_mcoe(pudl_out_mcoe, live_dbs, df_name, thresh):
     """Verify that output DataFrames have no overly NULL rows.
 


### PR DESCRIPTION
# Overview

- Bumped the upper bound on natural gas prices per MMBTU to accommodate the integration of the new EIA Bulk Electricity data, which includes more high prices from 2022.
- Found an XPASSing test related to using the allocated fuel in MCOE which... should actualy be passing, so removed the XFAIL mark.

Closes #2033 
Closes #3250 

# Testing

Re-ran the failing tests with `--live-dbs` locally on my full ETL outputs locally and they passed.

```[tasklist]
# To-do list
- [x] Make sure full ETL runs
- [x] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [x] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
```
