### PR TITLE
Add `data` and `other` to EIA 176 raw data extraction

### DIFF
--- a/src/pudl/package_data/eia176/table_file_map.csv
+++ b/src/pudl/package_data/eia176/table_file_map.csv
@@ -1,2 +1,4 @@
 table,filename
 company,all_company_176.csv
+data,all_data_176.csv
+other,all_other_176.csv

--- a/test/unit/extract/csv_test.py
+++ b/test/unit/extract/csv_test.py
@@ -1,13 +1,13 @@
 """Unit tests for pudl.extract.csv module."""
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from pudl.extract.csv import CsvExtractor, get_table_file_map, open_csv_resource
 
 DATASET = "eia176"
 BASE_FILENAME = "table_file_map.csv"
-TABLE_NAME = "company"
-FILENAME = "all_company_176.csv"
-TABLE_FILE_MAP = {TABLE_NAME: FILENAME}
+TABLE_NAME = ["company", "data", "other"]
+FILE_NAME = ["all_company_176.csv", "all_data_176.csv", "all_other_176.csv"]
+TABLE_FILE_MAP = {TABLE_NAME[i]: FILE_NAME[i] for i in range(len(TABLE_NAME))}
 
 
 def get_csv_extractor():
@@ -28,15 +28,15 @@ def test_get_table_file_map():
 def test_get_table_names():
     extractor = get_csv_extractor()
     table_names = extractor.get_table_names()
-    assert [TABLE_NAME] == table_names
+    assert table_names == TABLE_NAME
 
 
 @patch("pudl.extract.csv.pd")
 def test_csv_extractor_read_source(mock_pd):
     extractor = get_csv_extractor()
-    res = extractor.extract_one(TABLE_NAME)
+    res = extractor.extract_one(TABLE_NAME[0])
     mock_zipfile = extractor._zipfile
-    mock_zipfile.open.assert_called_once_with(FILENAME)
+    mock_zipfile.open.assert_called_once_with(FILE_NAME[0])
     f = mock_zipfile.open.return_value.__enter__.return_value
     mock_pd.read_csv.assert_called_once_with(f)
     df = mock_pd.read_csv()
@@ -48,5 +48,7 @@ def test_csv_extractor_extract():
     df = MagicMock()
     with patch.object(CsvExtractor, "extract_one", return_value=df) as mock_read_source:
         raw_dfs = extractor.extract_all()
-    mock_read_source.assert_called_once_with(TABLE_NAME)
-    assert {TABLE_NAME: df} == raw_dfs
+    mock_read_source.assert_has_calls(
+        calls=[call(table_name) for table_name in TABLE_NAME]
+    )
+    assert {table_name: df for table_name in TABLE_NAME} == raw_dfs


### PR DESCRIPTION
# Overview

This PR builds on #3227 and adds `data` and `other` 176 data to the extraction process designed by @davidmudrauskas, transforming the extractor function into a dagster asset factory to enable simple creation of a dagster asset for each table.

What problem does this address?

Extracts raw EIA 176 "data" and "other" tables.

What did you change?

Converted the extractor in `pudl.extract.eia176` to a factory, and added to the `table_file_map.csv`. Updated the unit test to handle multiple files, rather than just one.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Generate the raw assets in dagster and open them to review.

```[tasklist]
# To-do list
- [ ] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [x] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
