### PR TITLE
Push to prod Zenodo sometimes, fix pypi release flow, update docs

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -154,6 +154,7 @@ jobs:
             --container-env PUDL_BOT_PAT=${{ secrets.PUDL_BOT_PAT }} \
             --container-env ZENODO_SANDBOX_TOKEN_PUBLISH=${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }} \
             --container-env ZENODO_TARGET_ENV=${{ (startsWith(github.ref_name, 'v20') && 'production') || 'sandbox' }} \
+            --container-env ZENODO_TOKEN_UPLOAD=${{ secrets.ZENODO_TOKEN_UPLOAD }} \
             --container-env PUDL_SETTINGS_YML="/home/mambauser/pudl/src/pudl/package_data/settings/etl_full.yml" \
             --container-env PUDL_GCS_OUTPUT=${{ env.PUDL_GCS_OUTPUT }}
 

--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -153,6 +153,7 @@ jobs:
             --container-env FLY_ACCESS_TOKEN=${{ secrets.FLY_ACCESS_TOKEN }} \
             --container-env PUDL_BOT_PAT=${{ secrets.PUDL_BOT_PAT }} \
             --container-env ZENODO_SANDBOX_TOKEN_PUBLISH=${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }} \
+            --container-env ZENODO_TARGET_ENV=${{ (startsWith(github.ref_name, 'v20') && 'production') || 'sandbox' }} \
             --container-env PUDL_SETTINGS_YML="/home/mambauser/pudl/src/pudl/package_data/settings/etl_full.yml" \
             --container-env PUDL_GCS_OUTPUT=${{ env.PUDL_GCS_OUTPUT }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,6 @@ jobs:
     name: Upload release to PyPI - only if test release is successful!
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')
     needs:
-      - build-distribution
       - publish-test-pypi
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,10 +49,11 @@ jobs:
           repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
-    name: Upload release to PyPI
+    name: Upload release to PyPI - only if test release is successful!
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v20')
     needs:
       - build-distribution
+      - publish-test-pypi
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/devtools/zenodo/zenodo_data_release.py
+++ b/devtools/zenodo/zenodo_data_release.py
@@ -71,18 +71,18 @@ class ZenodoClient:
         """
         if env == SANDBOX:
             self.base_url = "https://sandbox.zenodo.org/api"
-            self.auth_headers = {
-                "Authorization": f"Bearer {os.environ['ZENODO_SANDBOX_TOKEN_PUBLISH']}"
-            }
+            token = os.environ["ZENODO_SANDBOX_TOKEN_PUBLISH"]
         elif env == PRODUCTION:
             self.base_url = "https://zenodo.org/api"
-            self.auth_headers = {
-                "Authorization": f"Bearer {os.environ['ZENODO_TOKEN_PUBLISH']}"
-            }
+            token = os.environ["ZENODO_TOKEN_UPLOAD"]
         else:
             raise ValueError(
                 f"Got unexpected {env=}, expected {SANDBOX} or {PRODUCTION}"
             )
+
+        self.auth_headers = {"Authorization": f"Bearer {token}"}
+
+        logger.info(f"Using Zenodo token: {token[:4]}...{token[-4:]}")
 
     def get_deposition(self, deposition_id: int) -> _LegacyDeposition:
         """LEGACY API: Get JSON describing a deposition.

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -101,8 +101,13 @@ function copy_outputs_to_distribution_bucket() {
 }
 
 function zenodo_data_release() {
-    echo "Creating a new PUDL data release on Zenodo." && \
-    ~/pudl/devtools/zenodo/zenodo_data_release.py --publish --env "$1" --source-dir "$PUDL_OUTPUT"
+    echo "Creating a new PUDL data release on Zenodo."
+
+    if [[ "$1" == "production" ]]; then
+        ~/pudl/devtools/zenodo/zenodo_data_release.py --no-publish --env "$1" --source-dir "$PUDL_OUTPUT"
+    else
+        ~/pudl/devtools/zenodo/zenodo_data_release.py --publish --env "$1" --source-dir "$PUDL_OUTPUT"
+    fi
 }
 
 function notify_slack() {
@@ -195,7 +200,7 @@ if [[ $ETL_SUCCESS == 0 ]]; then
         # TODO: this currently just makes a sandbox release, for testing. Should be
         # switched to production and only run on push of a version tag eventually.
         # Push a data release to Zenodo for long term accessiblity
-        zenodo_data_release sandbox 2>&1 | tee -a "$LOGFILE"
+        zenodo_data_release "$ZENODO_TARGET_ENV" 2>&1 | tee -a "$LOGFILE"
         ZENODO_SUCCESS=${PIPESTATUS[0]}
     fi
 fi

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -65,8 +65,8 @@ function save_outputs_to_gcs() {
 }
 
 function upload_to_dist_path() {
-    GCS_PATH="gs://pudl.catalyst.coop/$1"
-    AWS_PATH="s3://pudl.catalyst.coop/$1"
+    GCS_PATH="gs://pudl.catalyst.coop/$1/"
+    AWS_PATH="s3://pudl.catalyst.coop/$1/"
 
     # If the old outputs don't exist, these will exit with status 1, so we
     # don't && them with the rest of the commands.
@@ -77,7 +77,7 @@ function upload_to_dist_path() {
 
     echo "Copying outputs to $GCS_PATH:" && \
     gsutil -m -u "$GCP_BILLING_PROJECT" cp -r "$PUDL_OUTPUT/*" "$GCS_PATH" && \
-    echo "Copying outputs to AWS distribution bucket" && \
+    echo "Copying outputs to $AWS_PATH" && \
     aws s3 cp "$PUDL_OUTPUT/" "$AWS_PATH" --recursive
 }
 

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -64,6 +64,23 @@ function save_outputs_to_gcs() {
     rm "$PUDL_OUTPUT/success"
 }
 
+function upload_to_dist_path() {
+    GCS_PATH="gs://pudl.catalyst.coop/$1"
+    AWS_PATH="s3://pudl.catalyst.coop/$1"
+
+    # If the old outputs don't exist, these will exit with status 1, so we
+    # don't && them with the rest of the commands.
+    echo "Removing old outputs from $GCS_PATH."
+    gsutil -m -u "$GCP_BILLING_PROJECT" rm -r "$GCS_PATH"
+    echo "Removing old outputs from $AWS_PATH."
+    aws s3 rm "$AWS_PATH" --recursive
+
+    echo "Copying outputs to $GCS_PATH:" && \
+    gsutil -m -u "$GCP_BILLING_PROJECT" cp -r "$PUDL_OUTPUT/*" "$GCS_PATH" && \
+    echo "Copying outputs to AWS distribution bucket" && \
+    aws s3 cp "$PUDL_OUTPUT/" "$AWS_PATH" --recursive
+}
+
 function copy_outputs_to_distribution_bucket() {
     # Only attempt to update outputs if we have a real value of BUILD_REF
     # This avoids accidentally blowing away the whole bucket if it's not set.
@@ -76,26 +93,11 @@ function copy_outputs_to_distribution_bucket() {
             # Otherwise we want to copy them to a directory named after the tag/ref
             DIST_PATH="$BUILD_REF"
         fi
-        echo "Removing old $DIST_PATH outputs from GCS distributon bucket." && \
-        gsutil -m -u "$GCP_BILLING_PROJECT" rm -r "gs://pudl.catalyst.coop/$DIST_PATH" && \
-        echo "Copying outputs to GCS distribution bucket" && \
-        gsutil -m -u "$GCP_BILLING_PROJECT" cp -r "$PUDL_OUTPUT/*" "gs://pudl.catalyst.coop/$DIST_PATH" && \
-        echo "Removing old $DIST_PATH outputs from AWS distributon bucket." && \
-        aws s3 rm "s3://pudl.catalyst.coop/$DIST_PATH" --recursive && \
-        echo "Copying outputs to AWS distribution bucket" && \
-        aws s3 cp "$PUDL_OUTPUT/" "s3://pudl.catalyst.coop/$DIST_PATH" --recursive
+        upload_to_dist_path "$DIST_PATH"
 
         # If running a tagged release, ALSO update the stable distribution bucket path:
         if [[ "$GITHUB_ACTION_TRIGGER" == "push" && "$BUILD_REF" == v20* ]]; then
-            echo "Removing old stable outputs from GCS distributon bucket." && \
-            gsutil -m -u "$GCP_BILLING_PROJECT" rm -r "gs://pudl.catalyst.coop/stable" && \
-            echo "Copying tagged version outputs to stable GCS distribution bucket" && \
-            gsutil -m -u "$GCP_BILLING_PROJECT" cp -r "$PUDL_OUTPUT/*" "gs://pudl.catalyst.coop/stable" && \
-            echo "Removing old stable outputs from AWS S3 distributon bucket." && \
-            aws s3 rm "s3://pudl.catalyst.coop/stable" --recursive && \
-            echo "Copying tagged version outputs to stable AWS S3 distribution bucket" && \
-            aws s3 cp "$PUDL_OUTPUT/" "s3://pudl.catalyst.coop/stable" --recursive
-
+            upload_to_dist_path "stable"
         fi
     fi
 }
@@ -114,13 +116,23 @@ function notify_slack() {
     # Notify pudl-deployment slack channel of deployment status
     echo "Notifying Slack about deployment status"
     if [[ "$1" == "success" ]]; then
-        message=":large_green_circle: :sunglasses: :unicorn_face: :rainbow: The deployment succeeded!! :partygritty: :database_parrot: :blob-dance: :large_green_circle:\n\n "
+        message=":large_green_circle: :sunglasses: :unicorn_face: :rainbow: The deployment succeeded!! :partygritty: :database_parrot: :blob-dance: :large_green_circle:\n\n"
     elif [[ "$1" == "failure" ]]; then
-        message=":x: Oh bummer the deployment failed :fiiiiine: :sob: :cry_spin: :x:\n\n "
+        message=":x: Oh bummer the deployment failed :fiiiiine: :sob: :cry_spin: :x:\n\n"
     else
         echo "Invalid deployment status"
         exit 1
     fi
+
+    message+="Stage status (0 means success):\n"
+    message+="ETL_SUCCESS: $ETL_SUCCESS\n"
+    message+="SAVE_OUTPUTS_SUCCESS: $SAVE_OUTPUTS_SUCCESS\n"
+    message+="UPDATE_NIGHTLY_SUCCESS: $UPDATE_NIGHTLY_SUCCESS\n"
+    message+="DATASETTE_SUCCESS: $DATASETTE_SUCCESS\n"
+    message+="CLEAN_UP_OUTPUTS_SUCCESS: $CLEAN_UP_OUTPUTS_SUCCESS\n"
+    message+="DISTRIBUTION_BUCKET_SUCCESS: $DISTRIBUTION_BUCKET_SUCCESS\n"
+    message+="ZENODO_SUCCESS: $ZENODO_SUCCESS\n\n"
+
     message+="See https://console.cloud.google.com/storage/browser/builds.catalyst.coop/$BUILD_ID for logs and outputs."
 
     send_slack_msg "$message"

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -47,6 +47,9 @@ which one is right for you and your use case.
      - Researcher, Database User, Notebook Analyst
      - Use a stable, citable, fully processed version of the PUDL on your own computer.
        Access the SQLite DB and Parquet files directly using any toolset.
+   * - :ref:`access-raw`
+     - Researcher, Data Wrangler
+     - Access the data that feeds into PUDL, unmodified from its original source.
    * - :ref:`access-development`
      - Python Developer, Data Wrangler
      - Run the PUDL data processing pipeline on your own computer.
@@ -165,25 +168,39 @@ Stable Builds
 
 If you want a specific, immutable version of our data for any reason, you can
 find them all `here on Zenodo
-<https://zenodo.org/doi/10.5281/zenodo.3653158>`__. The documentation for the
-latest such stable build is `here
+<https://zenodo.org/doi/10.5281/zenodo.3653158>`__. Zenodo assigns long-lived
+DOIs to each archive, suitable for citation in academic journals and other
+publications. The most recent versioned PUDL data release can be found using
+this Concept DOI: https://doi.org/10.5281/zenodo.3653158
+
+The documentation for the latest such stable build is `here
 <https://catalystcoop-pudl.readthedocs.io/en/stable/>`__. You can access the
 documentation for a specific version by hovering over the version selector at
 the bottom left of the page.
-
-We use Zenodo to archive and version our raw data inputs, the fully processed
-outputs, and the PUDL software repositories. You can find all of our archives
-in `the Catalyst Cooperative Community
-<https://zenodo.org/communities/catalyst-cooperative/>`__. Zenodo assigns
-long-lived DOIs to each archive, suitable for citation in academic journals and
-other publications. The most recent versioned PUDL data release can be found
-using this Concept DOI: https://doi.org/10.5281/zenodo.3653158
 
 If you're not after a *specific* version, but rather the *latest stable
 version*, you can find them `AWS Open Data Registry
 <https://registry.opendata.aws/catalyst-cooperative-pudl/>`__, in the
 ``stable/`` namespace. You can run ``aws s3 ls --no-sign-request
 s3://pudl.catalyst.coop/stable/`` to see what's available.
+
+.. _access-raw:
+
+---------------------------------------------------------------------------------------
+Raw Data
+---------------------------------------------------------------------------------------
+
+Sometimes you want to see the raw data that is published by the government, but
+it's hard to find or difficult to download.
+
+We use Zenodo to archive and version our raw data inputs. You can find all of
+our archives in `the Catalyst Cooperative Community
+<https://zenodo.org/communities/catalyst-cooperative/>`__.
+
+These have been minimally processed - in some cases we've compressed them or
+grouped them into ZIP archives to fit the Zenodo repository requirements. In
+all cases we've added some metadata to help identify the resources you're
+looking for. But, apart from that, these datasets are unmodified.
 
 .. _access-development:
 

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -43,7 +43,7 @@ which one is right for you and your use case.
      - Cloud Developer, Database User, Beta Tester
      - Get the freshest data that has passed all of our data validations, updated most
        weekday mornings. Fast, free downloads from AWS S3 storage buckets.
-   * - :ref:`access-zenodo`
+   * - :ref:`access-stable`
      - Researcher, Database User, Notebook Analyst
      - Use a stable, citable, fully processed version of the PUDL on your own computer.
        Access the SQLite DB and Parquet files directly using any toolset.
@@ -157,18 +157,33 @@ can also be installed using the conda package manager).
 If you're not familiar with using Unix command line tools in Windows you can also use a
 3rd party tool like `7zip <https://www.7-zip.org/download.html>`__.
 
-.. _access-zenodo:
+.. _access-stable:
 
 ---------------------------------------------------------------------------------------
-Zenodo
+Stable Builds
 ---------------------------------------------------------------------------------------
 
-We use Zenodo to archive and version our raw data inputs, the fully processed outputs,
-and the PUDL software repositories. You can find all of our archives in
-`the Catalyst Cooperative Community <https://zenodo.org/communities/catalyst-cooperative/>`__.
-Zenodo assigns long-lived DOIs to each archive, suitable for citation in academic
-journals and other publications. The most recent versioned PUDL data release can be
-found using this Concept DOI: https://doi.org/10.5281/zenodo.3653158
+If you want a specific, immutable version of our data for any reason, you can
+find them all `here on Zenodo
+<https://zenodo.org/doi/10.5281/zenodo.3653158>`__. The documentation for the
+latest such stable build is `here
+<https://catalystcoop-pudl.readthedocs.io/en/stable/>`__. You can access the
+documentation for a specific version by hovering over the version selector at
+the bottom left of the page.
+
+We use Zenodo to archive and version our raw data inputs, the fully processed
+outputs, and the PUDL software repositories. You can find all of our archives
+in `the Catalyst Cooperative Community
+<https://zenodo.org/communities/catalyst-cooperative/>`__. Zenodo assigns
+long-lived DOIs to each archive, suitable for citation in academic journals and
+other publications. The most recent versioned PUDL data release can be found
+using this Concept DOI: https://doi.org/10.5281/zenodo.3653158
+
+If you're not after a *specific* version, but rather the *latest stable
+version*, you can find them `AWS Open Data Registry
+<https://registry.opendata.aws/catalyst-cooperative-pudl/>`__, in the
+``stable/`` namespace. You can run ``aws s3 ls --no-sign-request
+s3://pudl.catalyst.coop/stable/`` to see what's available.
 
 .. _access-development:
 

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -191,7 +191,8 @@ Raw Data
 ---------------------------------------------------------------------------------------
 
 Sometimes you want to see the raw data that is published by the government, but
-it's hard to find or difficult to download.
+it's hard to find or difficult to download, or you want to see what an older version of
+the published data looked like prior to being revised or deleted.
 
 We use Zenodo to archive and version our raw data inputs. You can find all of
 our archives in `the Catalyst Cooperative Community

--- a/docs/dev/index.rst
+++ b/docs/dev/index.rst
@@ -14,6 +14,7 @@ Development
   datastore
   clone_ferc1
   existing_data_updates
+  run_a_release
   pudl_id_mapping
   naming_conventions
   data_guidelines

--- a/docs/dev/run_a_release.rst
+++ b/docs/dev/run_a_release.rst
@@ -46,7 +46,9 @@ Here's how to do it!
 
 8. Publish the Zenodo deposition! Wahoo! You're now done!
 
-9. Except... 24 hours after the PyPI version is updated, we'll get a PR from
-   the ``conda-forge`` bot updating our ``conda`` package. If the direct
-   dependencies have changed in this release, we need to update them in that
-   PR.
+9. Except... within 24 hours after the PyPI version is updated, we'll get [a PR
+   in the PUDL conda-forge feedstock
+   repo](https://github.com/conda-forge/catalystcoop.pudl-feedstock/pulls) from
+   the :user:`regro-cf-autotick-bot` updating our ``conda`` packaging. If
+   PUDL's direct dependencies have changed in this release, we need to update
+   them in the conda packaging recipe in that PR.

--- a/docs/dev/run_a_release.rst
+++ b/docs/dev/run_a_release.rst
@@ -1,0 +1,48 @@
+===============================================================================
+Run a Versioned Release
+===============================================================================
+
+So the time has come and we would like to release a ``stable`` version of our
+data/code out into the world. By the end of this, we'd like for:
+
+* the release notes to have a fully dated release
+* the git tag ``vYYYY.MM.DD`` to identify a specific version
+* the ``stable`` Git branch to refer to the same commit as that tag
+* Our data outputs corresponding to that tag on Zenodo,
+  ``pudl.catalyst.coop/stable`` buckets in GCS/AWS, and Kaggle
+* Our code corresponding to that tag on PyPI
+* Updated ``stable`` and ``vYYYY.MM.DD`` documentation on ReadTheDocs
+
+
+Here's how to do it!
+
+1. Tell the rest of the team you're planning on releasing a new version of the
+   code in #team. Remind them that any changes to the release notes *after* the
+   next nightly build has passed need to go into a new version.
+
+2. The night before you plan to release, update the release notes with a
+   paragraph or two explaining what this new release is, and attach a specific
+   date to the release.
+
+3. Wait for the nightly build to pass with your release notes updates.
+
+4. If the nightly build passes, push a git tag ``vYYYY.MM.DD`` that points at
+   the commit which just passed the nightly build. This will kick off another build.
+
+5. If *that* build passes, verify the following:
+
+   * GCS/AWS distribution buckets have the appropriate data
+   * ``stable`` and ``vYYYY.MM.DD`` point at the same Git ref
+   * ReadTheDocs for ``stable`` and ``vYYYY.MM.DD`` versions have the latest
+     changes in the release notes
+   * PyPI has the most current version of our code
+
+6. Update the Kaggle dataset.
+
+7. Verify that the Zenodo draft deposition has all the expected data (raw FERC
+   databases, PUDL database, everything the right size).
+
+8. Update the Zenodo metadata to include the description from the release
+   notes, and update the various links.
+
+9. Publish the Zenodo deposition! Wahoo! You're now done!

--- a/docs/dev/run_a_release.rst
+++ b/docs/dev/run_a_release.rst
@@ -11,6 +11,7 @@ data/code out into the world. By the end of this, we'd like for:
 * Our data outputs corresponding to that tag on Zenodo,
   ``pudl.catalyst.coop/stable`` buckets in GCS/AWS, and Kaggle
 * Our code corresponding to that tag on PyPI
+* The conda package to be updated with the newest code
 * Updated ``stable`` and ``vYYYY.MM.DD`` documentation on ReadTheDocs
 
 
@@ -37,12 +38,15 @@ Here's how to do it!
      changes in the release notes
    * PyPI has the most current version of our code
 
-6. Update the Kaggle dataset.
-
-7. Verify that the Zenodo draft deposition has all the expected data (raw FERC
+6. Verify that the Zenodo draft deposition has all the expected data (raw FERC
    databases, PUDL database, everything the right size).
 
-8. Update the Zenodo metadata to include the description from the release
+7. Update the Zenodo metadata to include the description from the release
    notes, and update the various links.
 
-9. Publish the Zenodo deposition! Wahoo! You're now done!
+8. Publish the Zenodo deposition! Wahoo! You're now done!
+
+9. Except... 24 hours after the PyPI version is updated, we'll get a PR from
+   the ``conda-forge`` bot updating our ``conda`` package. If the direct
+   dependencies have changed in this release, we need to update them in that
+   PR.


### PR DESCRIPTION
# Overview

Closes #3175:

- Tries to upload draft to Zenodo prod
- Doesn't run PyPI release unless test PyPI release goes through
- added docs

Side-note:

It *really* doesn't seem like it would be that hard to grab the outputs from GCS & just upload to Zenodo that way:

- use `git tag --points-at {{ github.ref_name }}` to figure out which nightly build to access on `builds.catalyst.coop`
- auth into GCP - we could add another WIF identity, or just use the one we use in `build-deploy-pudl.yml`
- sync the directory down to some location on the runner
- check out repo + install deps
- run zenodo_data_release.py

Some clean-up we'd have to do:
- stop running build-deploy-pudl on tag
- run `release.yml` on pushes to `nightly` as well as `vYYYY.MM.DD`, with the appropriate conditionals (e.g., never running prod PyPI release for nightly, always pushing to sandbox for nightly)
- rip out the zenodo publication logic in gcp_pudl_etl.sh 🎉 

So maybe it's worth doing that here? Would make testing this go a bit more smoothly I think.


# Testing

Here's the testing plan:

1. push `v2024.01.25.a1` tag
2. `release.yml` goes:
   - [x] doesn't publish to PyPI production - that one short-circuits
   - [x] does publish to PyPI test
   - [x] We should be able to click through the workflow and see the deps work correctly - e.g., pypi depending on test-pypi.
3. `build-deploy-pudl.yml` gets kicked off:
   - [x] `run_pudl_etl` gets short-circuited
   - [x] we don't publish `stable` to distribution buckets
   - [x] we *do* publish `v20204.01.25.test` in private/public buckets
   - [x] there's a draft record in Zenodo with some bogus files - log, test file

After verifying the behavior of the Test PyPI release I short-circuited so that we wouldn't repeatedly attempt to release v2024.1.25.


```[tasklist]
# To-do list
- [x] update with prod Zenodo token - not a publish token! 😅
- [x] Review the PR yourself and call out any questions or issues you have
```

If we put the Zenodo publication logic in the release workflow, we can comment out the prod PyPI stuff and just push some `vYYYY.MM.DD_rcX` tags, avoiding the whole "short-circuit `gcp_pudl_etl.sh`" step - but, let's first try to get this working for now.