### PR TITLE
Add EIA Forms 191 and 757 to sources in PUDL metadata

### DIFF
--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -61,6 +61,68 @@ SOURCES: dict[str, Any] = {
         "license_raw": LICENSES["us-govt"],
         "license_pudl": LICENSES["cc-by-4.0"],
     },
+    "eia191": {
+        "title": "EIA Form 191 -- Monthly Underground Natural Gas Storage Report",
+        "path": "https://www.eia.gov/naturalgas/ngqs/",
+        "description": (
+            "The EIA Form 191, also known as the Monthly Underground Natural Gas "
+            "Storage Report, describes the working and base gas in reservoirs, "
+            "injections, withdrawals, and location of reservoirs by field monthly."
+        ),
+        "source_file_dict": {
+            "respondents": (
+                "All companies that operate underground natural gas storage fields in "
+                "the United States."
+            ),
+            "source_format": "JSON",
+        },
+        "field_namespace": "eia",
+        "contributors": [CONTRIBUTORS["catalyst-cooperative"]],
+        "keywords": sorted(
+            set(
+                [
+                    "eia191",
+                    "form 191",
+                    "natural gas",
+                ]
+                + KEYWORDS["eia"]
+                + KEYWORDS["us_govt"]
+            )
+        ),
+        "license_raw": LICENSES["us-govt"],
+        "license_pudl": LICENSES["cc-by-4.0"],
+    },
+    "eia757a": {
+        "title": "EIA Form 757A -- Natural Gas Processing Plant Survey",
+        "path": "https://www.eia.gov/naturalgas/ngqs/",
+        "description": (
+            "The EIA Form 757A, also known as the Natural Gas Processing Plant Survey "
+            "Schedule A provides detailed plant-level information on the capacity, "
+            "status, operations and connecting infrastructure of natural gas processing "
+            "plants. The form is completed tri-anually."
+        ),
+        "source_file_dict": {
+            "respondents": ("Natural gas processing plants."),
+            "source_format": "JSON",
+        },
+        "field_namespace": "eia",
+        "contributors": [CONTRIBUTORS["catalyst-cooperative"]],
+        "keywords": sorted(
+            set(
+                [
+                    "eia757",
+                    "eia757a",
+                    "form 757",
+                    "form 757 schedule a",
+                    "natural gas",
+                ]
+                + KEYWORDS["eia"]
+                + KEYWORDS["us_govt"]
+            )
+        ),
+        "license_raw": LICENSES["us-govt"],
+        "license_pudl": LICENSES["cc-by-4.0"],
+    },
     "eia860": {
         "title": "EIA Form 860 -- Annual Electric Generator Report",
         "path": "https://www.eia.gov/electricity/data/eia860",


### PR DESCRIPTION
# Overview

A subset of the archiver changes tracked in https://github.com/catalyst-cooperative/pudl-archiver/issues/262.

What problem does this address?

Adds EIA Forms 191 and 757, which are both available from the EIA NGQS, to PUDL metadata so we can archive (and then integrate) them.

What did you change?

Added metadata for these two forms into `pudl.metadata.sources.py` based on information available [here](https://www.eia.gov/Survey/index.php) and PDF instructions for each form.

```[tasklist]
# To-do list
- [x] Review the PR yourself and call out any questions or issues you have
```
