### PR TITLE
Update build ref

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -137,7 +137,7 @@ jobs:
             --container-env AWS_DEFAULT_REGION=${{ secrets.AWS_DEFAULT_REGION }} \
             --container-env AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
             --container-env BUILD_ID=${{ env.BUILD_ID }} \
-            --container-env BUILD_REF=${{ env.BUILD_REF }} \
+            --container-env BUILD_REF=${{ github.ref_name }} \
             --container-env FLY_ACCESS_TOKEN=${{ secrets.FLY_ACCESS_TOKEN }} \
             --container-env GCE_INSTANCE=${{ env.GCE_INSTANCE }} \
             --container-env GCE_INSTANCE_ZONE=${{ env.GCE_INSTANCE_ZONE }} \


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #3320 .

What problem does this address?

The `BUILD_REF` env var wasn't being set correctly ([GHA logs](https://github.com/catalyst-cooperative/pudl/actions/runs/7706962258/job/21003361867)), which lead to the nightly build not publishing any of last night's outputs.

What did you change?

I set it to the `github.ref_name` value which worked for `nightly-2024-01-27`. 

# Testing

How did you make sure this worked? How can a reviewer verify this?

We can kick off an ad-hoc run with workflow_dispatch and verify that BUILD_REF is indeed being set properly.

```[tasklist]
# To-do list
- [x] Manual testing
- [x] Review the PR yourself and call out any questions or issues you have
```
