### PR TITLE
Fix nightly builds 2024-01-31

### DIFF
--- a/devtools/generate_batch_config.py
+++ b/devtools/generate_batch_config.py
@@ -19,6 +19,7 @@ from pathlib import Path
 logging.basicConfig()
 logger = logging.getLogger()
 
+MIB_PER_GB = 1e9 / 2**20
 
 def _flat(ls: list[list]) -> list:
     return list(itertools.chain.from_iterable(ls))
@@ -55,7 +56,7 @@ def to_config(
                     ],
                     "computeResource": {
                         "cpuMilli": 8000,
-                        "memoryMib": 60 * 1024,
+                        "memoryMib": int(63 * MIB_PER_GB),
                         "bootDiskMib": 80 * 1024,
                     },
                     "maxRunDuration": f"{60 * 60 * 12}s",

--- a/devtools/generate_batch_config.py
+++ b/devtools/generate_batch_config.py
@@ -55,7 +55,7 @@ def to_config(
                     ],
                     "computeResource": {
                         "cpuMilli": 8000,
-                        "memoryMib": 32 * 1024,
+                        "memoryMib": 64 * 1024,
                         "bootDiskMib": 80 * 1024,
                     },
                     "maxRunDuration": f"{60 * 60 * 12}s",

--- a/devtools/generate_batch_config.py
+++ b/devtools/generate_batch_config.py
@@ -21,6 +21,7 @@ logger = logging.getLogger()
 
 MIB_PER_GB = 1e9 / 2**20
 
+
 def _flat(ls: list[list]) -> list:
     return list(itertools.chain.from_iterable(ls))
 

--- a/devtools/generate_batch_config.py
+++ b/devtools/generate_batch_config.py
@@ -55,7 +55,7 @@ def to_config(
                     ],
                     "computeResource": {
                         "cpuMilli": 8000,
-                        "memoryMib": 64 * 1024,
+                        "memoryMib": 60 * 1024,
                         "bootDiskMib": 80 * 1024,
                     },
                     "maxRunDuration": f"{60 * 60 * 12}s",

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -125,7 +125,7 @@ function zenodo_data_release() {
 function notify_slack() {
     # Notify pudl-deployment slack channel of deployment status
     echo "Notifying Slack about deployment status"
-    message='# `${BUILD_ID}` status\n\n'
+    message="# `${BUILD_ID}` status\n\n"
     if [[ "$1" == "success" ]]; then
         message+=":large_green_circle: :sunglasses: :unicorn_face: :rainbow: deployment succeeded!! :partygritty: :database_parrot: :blob-dance: :large_green_circle:\n\n"
     elif [[ "$1" == "failure" ]]; then

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -64,7 +64,6 @@ function run_pudl_etl() {
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         --etl-settings "$PUDL_SETTINGS_YML" \
         --live-dbs test/validate \
-    && pg_ctlcluster 15 dagster stop \
     && touch "$PUDL_OUTPUT/success"
 }
 
@@ -198,6 +197,9 @@ ZENODO_SUCCESS=0
 # 2>&1 redirects stderr to stdout.
 run_pudl_etl 2>&1 | tee "$LOGFILE"
 ETL_SUCCESS=${PIPESTATUS[0]}
+
+# This needs to happen regardless of the ETL outcome:
+pg_ctlcluster 15 dagster stop 2>&1 | tee "$LOGFILE"
 
 save_outputs_to_gcs 2>&1 | tee -a "$LOGFILE"
 SAVE_OUTPUTS_SUCCESS=${PIPESTATUS[0]}


### PR DESCRIPTION
# Overview

Closes #3328

Fixes issues surfaced in the build failure for 2024-01-31

- Increase Google Batch instance memory to 64GB
- Fix a Slack notification formatting error so we can see the `$BUILD_ID`
- The actual build failure (Locked SQLite DB) seems like it's probably stochastic and can hopefully be ignored
- pulled the postgres shutdown command out of the chained PUDL ETL command so it's run no matter what happens in the ETL.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [x] Make instance shutdown-on-failure more robust.
- [ ] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
