### PR TITLE
Trigger CI on merge group; only trigger integration on merge group.

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -3,6 +3,9 @@ name: docker-build-test
 on:
   workflow_dispatch:
   pull_request:
+  merge_group:
+    types:
+      - checks_requested
 
 jobs:
   pudl_docker_build:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,13 +3,10 @@ name: pytest
 
 on:
   pull_request:
-    types:
-      - opened
-      - synchronize
-      - ready_for_review
   merge_group:
     types:
       - checks_requested
+  workflow_dispatch:
 
 env:
   PUDL_OUTPUT: /home/runner/pudl-work/output/
@@ -110,7 +107,7 @@ jobs:
     runs-on:
       group: large-runner-group
       labels: ubuntu-22.04-4core
-    if: github.event.merge_group
+    if: github.event.merge_group || github.event.workflow_dispatch
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,10 +4,12 @@ name: pytest
 on:
   pull_request:
     types:
-      - created
       - opened
       - synchronize
       - ready_for_review
+  merge_group:
+    types:
+      - checks_requested
 
 env:
   PUDL_OUTPUT: /home/runner/pudl-work/output/
@@ -108,7 +110,7 @@ jobs:
     runs-on:
       group: large-runner-group
       labels: ubuntu-22.04-4core
-    if: github.event.pull_request.draft == false
+    if: github.event.merge_group
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #3317.

This makes our PR checks also run on merge_group triggers, so that our required checks can actually pass when PRs are added to the merge queue.

# Testing

How did you make sure this worked? How can a reviewer verify this?

We'll have to turn on the merge queues & test it out manually.

```[tasklist]
# To-do list
- [x] Review the PR yourself and call out any questions or issues you have
```
