### PR TITLE
Fix nightly build failure on EIA plant parts asset reindex problem.

### DIFF
--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -1513,7 +1513,9 @@ def weighted_average(
         A table with ``by`` columns as the index and the weighted ``data_col``.
     """
     df["_data_times_weight"] = df[data_col] * df[weight_col]
-    df["_weight_where_notnull"] = df.loc[df[data_col].notnull(), weight_col]
+    df.loc[df[data_col].notnull(), "_weight_where_notnull"] = df.loc[
+        df[data_col].notnull(), weight_col
+    ]
     g = df.groupby(by, observed=True)
     result = g["_data_times_weight"].sum(min_count=1) / g["_weight_where_notnull"].sum(
         min_count=1
@@ -1551,10 +1553,8 @@ def sum_and_weighted_average_agg(
     """
     logger.debug(f"grouping by {by}")
     # we are keeping the index here for easy merging of the weighted cols below
-    df_out = (
-        df_in.reset_index(drop=True)
-        .groupby(by=by, as_index=True, observed=True)[sum_cols]
-        .sum(min_count=1)
+    df_out = df_in.groupby(by=by, as_index=True, observed=True)[sum_cols].sum(
+        min_count=1
     )
     for data_col, weight_col in wtavg_dict.items():
         df_out.loc[:, data_col] = weighted_average(

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -1551,8 +1551,10 @@ def sum_and_weighted_average_agg(
     """
     logger.debug(f"grouping by {by}")
     # we are keeping the index here for easy merging of the weighted cols below
-    df_out = df_in.groupby(by=by, as_index=True, observed=True)[sum_cols].sum(
-        min_count=1
+    df_out = (
+        df_in.reset_index(drop=True)
+        .groupby(by=by, as_index=True, observed=True)[sum_cols]
+        .sum(min_count=1)
     )
     for data_col, weight_col in wtavg_dict.items():
         df_out.loc[:, data_col] = weighted_average(


### PR DESCRIPTION
# Overview

Closes #3333.

### What problem does this address?
full error over in #3333
we got a `cannot reindex on an axis with duplicate labels` error from this line:
```
  File \"/home/mambauser/pudl/src/pudl/helpers.py\", line 1516, in weighted_average
    df[\"_weight_where_notnull\"] = df.loc[df[data_col].notnull(), weight_col]
```

### What did you change?
basically just used a df.loc[mask] on both sides of the assign inside of just one.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] Make sure full ETL runs & `make pytest-integration-full` passes locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
