### PR TITLE
Stop using live DB in unit tests!!

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -321,11 +321,18 @@ def pudl_engine(pudl_io_manager: PudlMixedFormatIOManager) -> sa.Engine:
 def configure_paths_for_tests(tmp_path_factory, request):
     """Configures PudlPaths for tests.
 
-    Typically PUDL_INPUT and PUDL_OUTPUT will be read from the environment.
-    If we are running in GitHub Actions and they are NOT set, we'll use temp dirs.
-    If we are NOT running in GitHub Actions (e.g. we're running locally) then we always
-    want to use a temporary output directory, so we don't overwrite a user's existing
-    databases.
+    Default behavior:
+
+    PUDL_INPUT is read from the environment.
+    PUDL_OUTPUT is set to a tmp path, to avoid clobbering existing databases.
+
+    Set ``--tmp-data`` to force PUDL_INPUT to a temporary directory, causing
+    re-downloads of all raw inputs.
+
+    Set ``--live-dbs`` to force PUDL_OUTPUT to *NOT* be a temporary directory
+    and instead inherit from environment.
+
+    ``--live--dbs`` flag is ignored in unit tests, see pudl/test/unit/conftest.py.
     """
     # Just in case we need this later...
     pudl_tmpdir = tmp_path_factory.mktemp("pudl")

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,0 +1,53 @@
+import logging
+from pathlib import Path
+
+import pydantic
+import pytest
+
+from pudl.workspace.setup import PudlPaths
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_paths_for_tests(tmp_path_factory, request):
+    """Configures PudlPaths for tests.
+
+    Default behavior:
+
+    PUDL_INPUT is read from the environment.
+    PUDL_OUTPUT is set to a tmp path, to avoid clobbering existing databases.
+
+    Set ``--tmp-data`` to force PUDL_INPUT to a temporary directory, causing
+    re-downloads of all raw inputs.
+
+    Ignores the ``--live-dbs`` flag; always forces PUDL_OUTPUT to a temp dir so
+    unit test can never mess with the outputs.
+
+    See pudl/test/conftest.py for the non-unit test counterpart.
+    """
+    pudl_tmpdir = tmp_path_factory.mktemp("pudl")
+
+    # We only use a temporary input directory when explicitly requested.
+    # This will force a re-download of raw inputs from Zenodo or the GCS cache.
+    if request.config.getoption("--tmp-data"):
+        in_tmp = pudl_tmpdir / "input"
+        in_tmp.mkdir()
+        PudlPaths.set_path_overrides(
+            input_dir=str(Path(in_tmp).resolve()),
+        )
+        logger.info(f"Using temporary PUDL_INPUT: {in_tmp}")
+
+    out_tmp = pudl_tmpdir / "output"
+    out_tmp.mkdir()
+    PudlPaths.set_path_overrides(
+        output_dir=str(Path(out_tmp).resolve()),
+    )
+    logger.info(f"Using temporary PUDL_OUTPUT: {out_tmp}")
+
+    try:
+        return PudlPaths()
+    except pydantic.ValidationError as err:
+        pytest.exit(
+            f"Set PUDL_INPUT, PUDL_OUTPUT env variables, or use --tmp-path, --live-dbs flags. Error: {err}."
+        )

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -1,6 +1,5 @@
 """Tests for xbrl extraction module."""
 
-import os
 
 import pytest
 from dagster import ResourceDefinition, build_op_context
@@ -110,8 +109,6 @@ def test_xbrl2sqlite(settings, forms, mocker, tmp_path):
         if op.tags.get("data_format") == "xbrl"
     ]
 
-    # always use tmp path here so that we don't clobber the live DB when --live-dbs is passed
-    mocker.patch.dict(os.environ, {"PUDL_OUTPUT": tmp_path})
     ferc_to_sqlite.execute_in_process(
         op_selection=op_selection,
         resources={
@@ -140,9 +137,6 @@ def test_xbrl2sqlite(settings, forms, mocker, tmp_path):
 
 
 def test_xbrl2sqlite_db_exists_no_clobber(mocker, tmp_path):
-    # always use tmp path here so that we don't clobber the live DB when --live-dbs is passed
-    mocker.patch.dict(os.environ, {"PUDL_OUTPUT": tmp_path})
-
     convert_form_mock = mocker.MagicMock()
     mocker.patch("pudl.extract.xbrl.convert_form", new=convert_form_mock)
 
@@ -174,9 +168,6 @@ def test_xbrl2sqlite_db_exists_no_clobber(mocker, tmp_path):
 
 
 def test_xbrl2sqlite_db_exists_yes_clobber(mocker, tmp_path):
-    # always use tmp path here so that we don't clobber the live DB when --live-dbs is passed
-    mocker.patch.dict(os.environ, {"PUDL_OUTPUT": tmp_path})
-
     convert_form_mock = mocker.MagicMock()
     mocker.patch("pudl.extract.xbrl.convert_form", new=convert_form_mock)
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #3376 .

What problem does this address?

When merging #3098 we ended up merging a change that inadvertently clobbered the XBRL SQLite DBs in unit test, when `--live-dbs` was passed. This is not the first time tests of our clobbering logic have actually clobbered our hard-won data.

What did you change?

Make it so that the unit tests have their own conftest.py which ignores `--live-dbs`. Unit tests should never rely on live dbs, ever, so let's make that impossible.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Ran the unit tests with `--live-dbs` on `main` and saw it clobber all my XBRL dbs; then `touch $PUDL_OUTPUT/ferc1_xbrl.sqlite` etc and re-ran the unit tests on this branch, with `--live-dbs`, and saw that the DBs survived unscathed.

```[tasklist]
# To-do list
- [x] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage` (otherwise the merge queue may reject your PR)
- [x] Review the PR yourself and call out any questions or issues you have
```
