### PR TITLE
Add Q4 CEMS data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ PUDL currently integrates data from:
 * **EIA Form 923**: 2001-2023
   - `Source Docs <https://www.eia.gov/electricity/data/eia923/>`__
   - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/eia923.html>`__
-* **EPA Continuous Emissions Monitoring System (CEMS)**: 1995Q1-2023Q3
+* **EPA Continuous Emissions Monitoring System (CEMS)**: 1995Q1-2023Q4
   - `Source Docs <https://campd.epa.gov/>`__
   - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/epacems.html>`__
 * **FERC Form 1**: 1994-2022

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -110,7 +110,7 @@ AWS CLI, or programmatically via the S3 API. They can also be downloaded directl
 HTTPS using the following links:
 
 * `PUDL SQLite DB <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/pudl.sqlite.gz>`__
-* `EPA CEMS Hourly Emissions Parquet (1995Q1-2023Q3) <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_epacems__hourly_emissions.parquet>`__
+* `EPA CEMS Hourly Emissions Parquet (1995Q1-2023Q4) <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_epacems__hourly_emissions.parquet>`__
 * `Census DP1 SQLite DB (2010) <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/censusdp1tract.sqlite.gz>`__
 
 * Raw FERC Form 1:

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,7 +9,7 @@ v2024.XX.XX
 New Data Coverage
 ^^^^^^^^^^^^^^^^^
 * Add EIA860M data through December 2023 :issue:`3313`, :pr:`3367`.
-* Add 2023 Q4 of CEMS data. See :issue:`3315`, :pr:``
+* Add 2023 Q4 of CEMS data. See :issue:`3315`, :pr:`3379`.
 
 
 .. _release-v2024.02.05:

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,7 @@ v2024.XX.XX
 New Data Coverage
 ^^^^^^^^^^^^^^^^^
 * Add EIA860M data through December 2023 :issue:`3313`, :pr:`3367`.
+* Add 2023 Q4 of CEMS data. See :issue:`3315`, :pr:``
 
 
 .. _release-v2024.02.05:

--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -337,7 +337,7 @@ SOURCES: dict[str, Any] = {
         "working_partitions": {
             "year_quarters": [
                 str(q).lower()
-                for q in pd.period_range(start="1995q1", end="2023q3", freq="Q")
+                for q in pd.period_range(start="1995q1", end="2023q4", freq="Q")
             ]
         },
         "contributors": [

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -191,7 +191,7 @@ class ZenodoDoiSettings(BaseSettings):
     eia923: ZenodoDoi = "10.5281/zenodo.10067550"
     eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.10603995"
     epacamd_eia: ZenodoDoi = "10.5281/zenodo.7900974"
-    epacems: ZenodoDoi = "10.5281/zenodo.10425497"
+    epacems: ZenodoDoi = "10.5281/zenodo.10603994"
     ferc1: ZenodoDoi = "10.5281/zenodo.8326634"
     ferc2: ZenodoDoi = "10.5281/zenodo.8326697"
     ferc6: ZenodoDoi = "10.5281/zenodo.8326696"


### PR DESCRIPTION
# Overview

Closes #3315 

What problem does this address?
Adds Q4 2023 CEMS data.

What did you change?
Added Q4 data to extraction, updated docs.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Materialize the EPA CEMS dagster assets.

```[tasklist]
# To-do list
- [x] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage` (otherwise the merge queue may reject your PR)
- [x] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [x] Review the PR yourself and call out any questions or issues you have
```
