### PR TITLE
Force --no-cov in nightly build

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -59,11 +59,13 @@ function run_pudl_etl() {
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         --etl-settings "$PUDL_SETTINGS_YML" \
         --live-dbs test/integration test/unit \
+        --no-cov \
     && pytest \
         -n auto \
         --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
         --etl-settings "$PUDL_SETTINGS_YML" \
         --live-dbs test/validate \
+        --no-cov \
     && touch "$PUDL_OUTPUT/success"
 }
 


### PR DESCRIPTION
Since we don't run docs build in nightly, coverage is necessarily lower and fails our thresholds.

<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #3381.

We added a "fail-under" threshold to our coverage configuration - which is useful to capture coverage drops. But, since we don't build the docs in nightly build, our unit/integration tests will always fail that threshold, thus failing the build.


We already calculate the coverage in CI, we don't need to do it in the nightly build.

Alternatives:
- build docs in nightly build also
- set `--cov-fail-under=0` which effectively stops us from failing the threshold, but also is more confusing

# Testing

How did you make sure this worked? How can a reviewer verify this?

I'm going to run a build on this branch via GHA and see if we still fail on coverage.

```[tasklist]
# To-do list
- [ ] Review the PR yourself and call out any questions or issues you have
```
