### PR TITLE
Skip batch job if build was skipped as a whole.

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -156,9 +156,11 @@ jobs:
 
       # Start the batch job
       - name: Kick off batch job
+        if: ${{ env.SKIP_BUILD != 'true' }}
         run: gcloud batch jobs submit run-etl-${{ env.BATCH_JOB_ID }} --config ${{ env.BATCH_JOB_JSON }} --location us-west1
 
       - name: Post to a pudl-deployments channel
+        if: always()
         id: slack
         uses: slackapi/slack-github-action@v1
         with:


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?

The [2024-02-11](https://github.com/catalyst-cooperative/pudl/actions/runs/7860068155) and [2024-02-12](https://github.com/catalyst-cooperative/pudl/actions/runs/7867868547) builds were skipped, but we didn't get a Slack notification because the GHA itself failed.

What did you change?

We had forgotten to skip the "kick off a batch job" step when the build was skipped, so it was trying to do that, failing, and then not sending any notification.

I added the skip condition + force the slack notif to always run.

# Testing

How did you make sure this worked? How can a reviewer verify this?

We'll see if it works the next time we have a skip!

```[tasklist]
# To-do list
- [ ] Review the PR yourself and call out any questions or issues you have
```
