### PR TITLE
Very minor but widespread formatting changes from ruff 0.3.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
   # Formatters: hooks that re-write Python & documentation files
   ####################################################################################
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.2.2
+    rev: v0.3.0
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/devtools/print_requirements.py
+++ b/devtools/print_requirements.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 """Print out install requirements from setup.py for use with pip install."""
+
 import distutils.core
 
 setup = distutils.core.run_setup("setup.py")

--- a/devtools/sqlite_to_duckdb.py
+++ b/devtools/sqlite_to_duckdb.py
@@ -1,5 +1,6 @@
 #! /usr/bin/env python
 """A naive script for converting SQLite to DuckDB."""
+
 import logging
 from pathlib import Path
 

--- a/devtools/zenodo/zenodo_data_release.py
+++ b/devtools/zenodo/zenodo_data_release.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Script to sync a directory up to Zenodo."""
+
 import datetime
 import logging
 import os

--- a/src/pudl/analysis/__init__.py
+++ b/src/pudl/analysis/__init__.py
@@ -5,6 +5,7 @@ systematic analyses using the data compiled by PUDL. Over time this should grow 
 rich library of tools that show how the data can be put to use. We may also generate
 post-ETL derived database tables for distribution at some point.
 """
+
 from . import (
     allocate_gen_fuel,
     epacamd_eia,

--- a/src/pudl/analysis/mcoe.py
+++ b/src/pudl/analysis/mcoe.py
@@ -1,4 +1,5 @@
 """A module with functions to aid generating MCOE."""
+
 from typing import Literal
 
 import pandas as pd

--- a/src/pudl/analysis/ml_tools/__init__.py
+++ b/src/pudl/analysis/ml_tools/__init__.py
@@ -1,4 +1,5 @@
 """Implements shared tooling for machine learning models in PUDL."""
+
 from . import models
 
 

--- a/src/pudl/analysis/ml_tools/experiment_tracking.py
+++ b/src/pudl/analysis/ml_tools/experiment_tracking.py
@@ -8,6 +8,7 @@ mlflow run. The following command will launch the mlflow UI to view model result
 to a file named 'experiments.sqlite' in the base directory of your PUDL repo, but
 this is a configurable value, which can be found in the dagster UI.
 """
+
 from collections.abc import Callable
 from pathlib import Path
 

--- a/src/pudl/analysis/ml_tools/models.py
+++ b/src/pudl/analysis/ml_tools/models.py
@@ -17,6 +17,7 @@ dagster UI. To provide configuration this way, click `Open Launchpad` in the UI,
 values can be edited here. This configuration will override both default values and
 yaml configuration, but will only be used for a single run.
 """
+
 import importlib
 
 import yaml

--- a/src/pudl/analysis/plant_parts_eia.py
+++ b/src/pudl/analysis/plant_parts_eia.py
@@ -176,6 +176,7 @@ OR make the table via objects in this module:
     parts_compiler = MakePlantParts(pudl_out)
     plant_parts_eia = parts_compiler.execute(gens_mega=gens_mega)
 """
+
 from collections import OrderedDict
 from copy import deepcopy
 from importlib import resources

--- a/src/pudl/analysis/record_linkage/__init__.py
+++ b/src/pudl/analysis/record_linkage/__init__.py
@@ -1,4 +1,5 @@
 """This module implements models for various forms of record linkage."""
+
 from . import (
     classify_plants_ferc1,
     eia_ferc1_model_config,

--- a/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
+++ b/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
@@ -393,7 +393,6 @@ def get_false_pos(pred_df, train_df):
         shared_preds[shared_preds.record_id_eia_true != shared_preds.record_id_eia_pred]
     )
 
-
 # FERC record is in training data but no prediction made
 def get_false_neg(pred_df, train_df):
     """Get the number of matches from the training data where no prediction is made."""

--- a/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
+++ b/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
@@ -202,9 +202,9 @@ def get_training_data_df(inputs):
     )
     train_df.loc[:, "source_dataset_r"] = "ferc_df"
     train_df.loc[:, "source_dataset_l"] = "eia_df"
-    train_df.loc[
-        :, "clerical_match_score"
-    ] = 1  # this column shows that all these labels are positive labels
+    train_df.loc[:, "clerical_match_score"] = (
+        1  # this column shows that all these labels are positive labels
+    )
     return train_df
 
 
@@ -392,6 +392,7 @@ def get_false_pos(pred_df, train_df):
     return len(
         shared_preds[shared_preds.record_id_eia_true != shared_preds.record_id_eia_pred]
     )
+
 
 # FERC record is in training data but no prediction made
 def get_false_neg(pred_df, train_df):
@@ -615,9 +616,9 @@ def override_bad_predictions(
     override_df.loc[:, "match_type"] = "prediction; not in training data"
     override_df.loc[override_rows, "match_type"] = "incorrect prediction; overwritten"
     override_df.loc[correct_rows, "match_type"] = "correct match"
-    override_df.loc[
-        incorrect_rows, "match_type"
-    ] = "incorrect prediction; no predicted match"
+    override_df.loc[incorrect_rows, "match_type"] = (
+        "incorrect prediction; no predicted match"
+    )
     # print out stats
     percent_correct = len(override_df[override_df.match_type == "correct match"]) / len(
         train_df

--- a/src/pudl/analysis/record_linkage/eia_ferc1_train.py
+++ b/src/pudl/analysis/record_linkage/eia_ferc1_train.py
@@ -116,9 +116,9 @@ def _pct_diff(df, col) -> pd.DataFrame:
     # Fed in the _pct_diff column so make sure it is neutral for this analysis
     col = col.replace("_pct_diff", "")
     # Fill in the _pct_diff column with the actual percent difference value
-    df.loc[
-        (df[f"{col}_eia"] > 0) & (df[f"{col}_ferc1"] > 0), f"{col}_pct_diff"
-    ] = round(((df[f"{col}_ferc1"] - df[f"{col}_eia"]) / df[f"{col}_ferc1"] * 100), 2)
+    df.loc[(df[f"{col}_eia"] > 0) & (df[f"{col}_ferc1"] > 0), f"{col}_pct_diff"] = (
+        round(((df[f"{col}_ferc1"] - df[f"{col}_eia"]) / df[f"{col}_ferc1"] * 100), 2)
+    )
 
     return df
 

--- a/src/pudl/analysis/record_linkage/link_cross_year.py
+++ b/src/pudl/analysis/record_linkage/link_cross_year.py
@@ -1,4 +1,5 @@
 """Define a record linkage model interface and implement common functionality."""
+
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -61,9 +62,9 @@ class DistanceMatrix:
         year_inds = original_df.groupby("report_year").indices
         for inds in year_inds.values():
             matching_year_inds = np.array(np.meshgrid(inds, inds)).T.reshape(-1, 2)
-            self.distance_matrix[
-                matching_year_inds[:, 0], matching_year_inds[:, 1]
-            ] = config.distance_penalty
+            self.distance_matrix[matching_year_inds[:, 0], matching_year_inds[:, 1]] = (
+                config.distance_penalty
+            )
 
         np.fill_diagonal(self.distance_matrix, 0)
         self.distance_matrix.flush()

--- a/src/pudl/analysis/service_territory.py
+++ b/src/pudl/analysis/service_territory.py
@@ -5,6 +5,7 @@ within the EIA 861, in conjunction with the US Census geometries for counties, t
 the historical spatial extent of utility and balancing area territories. Output the
 resulting geometries for use in other applications.
 """
+
 import math
 import pathlib
 import sys

--- a/src/pudl/analysis/spatial.py
+++ b/src/pudl/analysis/spatial.py
@@ -1,4 +1,5 @@
 """Spatial operations for demand allocation."""
+
 import itertools
 import warnings
 from collections.abc import Callable, Iterable

--- a/src/pudl/analysis/state_demand.py
+++ b/src/pudl/analysis/state_demand.py
@@ -16,6 +16,7 @@ manual and could certainly be improved, but overall the results seem reasonable.
 Additional predictive spatial variables will be required to obtain more granular
 electricity demand estimates (e.g. at the county level).
 """
+
 import datetime
 from collections.abc import Iterable
 from typing import Any
@@ -280,9 +281,9 @@ def load_hourly_demand_matrix_ferc714(
         of each `respondent_id_ferc714` and reporting `year` (int).
     """
     # Convert UTC to local time (ignoring daylight savings)
-    out_ferc714__hourly_planning_area_demand[
-        "utc_offset"
-    ] = out_ferc714__hourly_planning_area_demand["timezone"].map(STANDARD_UTC_OFFSETS)
+    out_ferc714__hourly_planning_area_demand["utc_offset"] = (
+        out_ferc714__hourly_planning_area_demand["timezone"].map(STANDARD_UTC_OFFSETS)
+    )
     out_ferc714__hourly_planning_area_demand["datetime"] = utc_to_local(
         out_ferc714__hourly_planning_area_demand["utc_datetime"],
         out_ferc714__hourly_planning_area_demand["utc_offset"],
@@ -292,9 +293,9 @@ def load_hourly_demand_matrix_ferc714(
         index="datetime", columns="respondent_id_ferc714", values="demand_mwh"
     )
     # List timezone by year for each respondent
-    out_ferc714__hourly_planning_area_demand[
-        "year"
-    ] = out_ferc714__hourly_planning_area_demand["report_date"].dt.year
+    out_ferc714__hourly_planning_area_demand["year"] = (
+        out_ferc714__hourly_planning_area_demand["report_date"].dt.year
+    )
     utc_offset = out_ferc714__hourly_planning_area_demand.groupby(
         ["respondent_id_ferc714", "year"], as_index=False
     )["utc_offset"].first()

--- a/src/pudl/analysis/timeseries_cleaning.py
+++ b/src/pudl/analysis/timeseries_cleaning.py
@@ -28,6 +28,7 @@ And described at:
 * https://arxiv.org/abs/2008.03194
 * https://github.com/xinychen/tensor-learning
 """
+
 import functools
 import warnings
 from collections.abc import Iterable, Sequence

--- a/src/pudl/convert/__init__.py
+++ b/src/pudl/convert/__init__.py
@@ -4,6 +4,7 @@ It's often useful to be able to convert entire datasets in bulk from one format
 to another, both independent of and within the context of the ETL pipeline.
 This subpackage collects those tools together in one place.
 """
+
 from . import (
     censusdp1tract_to_sqlite,
     metadata_to_rst,

--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -1,4 +1,5 @@
 """Dagster definitions for the PUDL ETL and Output tables."""
+
 import importlib.resources
 import itertools
 import warnings

--- a/src/pudl/etl/check_foreign_keys.py
+++ b/src/pudl/etl/check_foreign_keys.py
@@ -1,4 +1,5 @@
 """Check that foreign key constraints in the PUDL database are respected."""
+
 import pathlib
 import sys
 

--- a/src/pudl/etl/cli.py
+++ b/src/pudl/etl/cli.py
@@ -1,4 +1,5 @@
 """A command line interface (CLI) to the main PUDL ETL functionality."""
+
 import pathlib
 import sys
 from collections.abc import Callable

--- a/src/pudl/etl/eia_bulk_elec_assets.py
+++ b/src/pudl/etl/eia_bulk_elec_assets.py
@@ -1,4 +1,5 @@
 """EIA Bulk Electricty Aggregate assets."""
+
 from dagster import asset
 
 import pudl

--- a/src/pudl/etl/epacems_assets.py
+++ b/src/pudl/etl/epacems_assets.py
@@ -8,6 +8,7 @@ from a graph of ops. The dynamic graph will allow dagster to dynamically generat
 for processing each year of EPA CEMS data and execute these ops in parallel. For more information
 see: https://docs.dagster.io/concepts/ops-jobs-graphs/dynamic-graphs and https://docs.dagster.io/concepts/assets/graph-backed-assets.
 """
+
 from collections import namedtuple
 from pathlib import Path
 

--- a/src/pudl/etl/glue_assets.py
+++ b/src/pudl/etl/glue_assets.py
@@ -1,4 +1,5 @@
 """FERC and EIA and EPA CAMD glue assets."""
+
 import networkx as nx
 import pandas as pd
 from dagster import AssetOut, Output, asset, multi_asset

--- a/src/pudl/etl/static_assets.py
+++ b/src/pudl/etl/static_assets.py
@@ -1,4 +1,5 @@
 """Dagster assets of static data tables."""
+
 from typing import Literal
 
 import pandas as pd
@@ -51,9 +52,9 @@ def static_pudl_tables(context):
     dataset_settings = context.resources.dataset_settings
 
     static_pudl_tables_dict = {"core_pudl__codes_subdivisions": POLITICAL_SUBDIVISIONS}
-    static_pudl_tables_dict[
-        "core_pudl__codes_datasources"
-    ] = dataset_settings.make_datasources_table(ds)
+    static_pudl_tables_dict["core_pudl__codes_datasources"] = (
+        dataset_settings.make_datasources_table(ds)
+    )
     return (
         Output(output_name=table_name, value=df)
         for table_name, df in static_pudl_tables_dict.items()

--- a/src/pudl/extract/__init__.py
+++ b/src/pudl/extract/__init__.py
@@ -7,6 +7,7 @@ the :mod:`pudl.workspace` subpackage, and ends with a dictionary of "raw"
 are ready for normalization and data cleaning by the data source specific modules in the
 :mod:`pudl.transform` subpackage.
 """
+
 from . import (
     eia176,
     eia860,

--- a/src/pudl/extract/csv.py
+++ b/src/pudl/extract/csv.py
@@ -1,4 +1,5 @@
 """Extractor for CSV data."""
+
 from csv import DictReader
 from importlib import resources
 from zipfile import ZipFile

--- a/src/pudl/extract/dbf.py
+++ b/src/pudl/extract/dbf.py
@@ -1,4 +1,5 @@
 """Generalized DBF extractor for FERC data."""
+
 import contextlib
 import csv
 import importlib.resources

--- a/src/pudl/extract/eia860.py
+++ b/src/pudl/extract/eia860.py
@@ -4,6 +4,7 @@ This modules pulls data from EIA's published Excel spreadsheets.
 
 This code is for use analyzing EIA Form 860 data.
 """
+
 import pandas as pd
 from dagster import AssetOut, Output, multi_asset
 

--- a/src/pudl/extract/eia861.py
+++ b/src/pudl/extract/eia861.py
@@ -4,6 +4,7 @@ This modules pulls data from EIA's published Excel spreadsheets.
 
 This code is for use analyzing EIA Form 861 data.
 """
+
 import warnings
 
 import pandas as pd

--- a/src/pudl/extract/eia923.py
+++ b/src/pudl/extract/eia923.py
@@ -5,6 +5,7 @@ This modules pulls data from EIA's published Excel spreadsheets.
 This code is for use analyzing EIA Form 923 data. Currenly only years 2009-2016 work, as
 they share nearly identical file formatting.
 """
+
 import pandas as pd
 from dagster import AssetOut, Output, multi_asset
 

--- a/src/pudl/extract/eia_bulk_elec.py
+++ b/src/pudl/extract/eia_bulk_elec.py
@@ -11,6 +11,7 @@ of timestamp/value pairs. This structure leads to a natural normalization into t
 tables: one of metadata and one of timeseries. That is the format delivered by this
 module.
 """
+
 import warnings
 from io import BytesIO
 from pathlib import Path

--- a/src/pudl/extract/epacems.py
+++ b/src/pudl/extract/epacems.py
@@ -19,6 +19,7 @@ entirely accurate. The core_epa__assn_eia_epacamd crosswalk will show that the m
 Hence, we've called it `plant_id_epa` until it gets transformed into `plant_id_eia`
 during the transform process with help from the crosswalk.
 """
+
 from pathlib import Path
 from typing import Annotated
 
@@ -173,9 +174,12 @@ class EpaCemsDatastore:
 
     def get_data_frame(self, partition: EpaCemsPartition) -> pd.DataFrame:
         """Constructs dataframe from a zipfile for a given (year_quarter) partition."""
-        with self.datastore.get_zipfile_resource(
-            "epacems", **partition.get_filters()
-        ) as zf, zf.open(str(partition.get_quarterly_file()), "r") as csv_file:
+        with (
+            self.datastore.get_zipfile_resource(
+                "epacems", **partition.get_filters()
+            ) as zf,
+            zf.open(str(partition.get_quarterly_file()), "r") as csv_file,
+        ):
             df = self._csv_to_dataframe(
                 csv_file,
                 ignore_cols=API_IGNORE_COLS,

--- a/src/pudl/extract/excel.py
+++ b/src/pudl/extract/excel.py
@@ -1,4 +1,5 @@
 """Load excel metadata CSV files form a python data package."""
+
 import importlib.resources
 import pathlib
 import re

--- a/src/pudl/extract/ferc.py
+++ b/src/pudl/extract/ferc.py
@@ -1,6 +1,5 @@
 """Hooks to integrate ferc to sqlite functionality into dagster graph."""
 
-
 import pudl
 from pudl.extract.ferc1 import Ferc1DbfExtractor
 from pudl.extract.ferc2 import Ferc2DbfExtractor

--- a/src/pudl/extract/ferc1.py
+++ b/src/pudl/extract/ferc1.py
@@ -66,6 +66,7 @@ database online at:
 
 https://data.catalyst.coop/ferc1
 """
+
 import json
 from itertools import chain
 from pathlib import Path

--- a/src/pudl/extract/ferc714.py
+++ b/src/pudl/extract/ferc714.py
@@ -1,4 +1,5 @@
 """Routines used for extracting the raw FERC 714 data."""
+
 from collections import OrderedDict
 
 import pandas as pd
@@ -84,9 +85,10 @@ def generate_raw_ferc714_asset(table_name: str) -> AssetsDefinition:
         logger.info(
             f"Extracting {table_name} from CSV into pandas DataFrame (years: {years})."
         )
-        with ds.get_zipfile_resource("ferc714", name="ferc714.zip") as zf, zf.open(
-            FERC714_FILES[table_name]["name"]
-        ) as csv_file:
+        with (
+            ds.get_zipfile_resource("ferc714", name="ferc714.zip") as zf,
+            zf.open(FERC714_FILES[table_name]["name"]) as csv_file,
+        ):
             df = pd.read_csv(
                 csv_file,
                 encoding=FERC714_FILES[table_name]["encoding"],

--- a/src/pudl/extract/phmsagas.py
+++ b/src/pudl/extract/phmsagas.py
@@ -3,7 +3,6 @@
 This modules pulls data from PHMSA's published Excel spreadsheets.
 """
 
-
 import pandas as pd
 from dagster import AssetOut, Output, multi_asset
 

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -1,4 +1,5 @@
 """Generic extractor for all FERC XBRL data."""
+
 import io
 from collections.abc import Callable
 from datetime import date

--- a/src/pudl/ferc_to_sqlite/__init__.py
+++ b/src/pudl/ferc_to_sqlite/__init__.py
@@ -1,4 +1,5 @@
 """Dagster definitions for the FERC to SQLite process."""
+
 import importlib.resources
 
 from dagster import Definitions, graph

--- a/src/pudl/ferc_to_sqlite/cli.py
+++ b/src/pudl/ferc_to_sqlite/cli.py
@@ -1,4 +1,5 @@
 """A script using Dagster to convert FERC data fom DBF and XBRL to SQLite databases."""
+
 import pathlib
 import sys
 import time

--- a/src/pudl/glue/__init__.py
+++ b/src/pudl/glue/__init__.py
@@ -13,4 +13,5 @@ In general we try to enable each dataset to be processed independently, and
 optionally apply the glue to connect them to each other when both datasets for
 which glue exists are being processed together.
 """
+
 from . import ferc1_eia

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -6,6 +6,7 @@ designed to be used as a general purpose tool, applicable in multiple scenarios,
 should probably live here. There are lost of transform type functions in here that help
 with cleaning and restructing dataframes.
 """
+
 import importlib.resources
 import itertools
 import json
@@ -265,9 +266,9 @@ def clean_eia_counties(
     df = df.explode(county_col)
     df[county_col] = df[county_col].str.strip()
     # Yellowstone county is in MT, not WY
-    df.loc[
-        (df[state_col] == "WY") & (df[county_col] == "Yellowstone"), state_col
-    ] = "MT"
+    df.loc[(df[state_col] == "WY") & (df[county_col] == "Yellowstone"), state_col] = (
+        "MT"
+    )
     # Replace individual bad county names with identified correct names in fixes:
     for fix in fixes.itertuples():
         state_mask = df[state_col] == fix.state

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -1,4 +1,5 @@
 """Dagster IO Managers."""
+
 import json
 import re
 from pathlib import Path

--- a/src/pudl/logging_helpers.py
+++ b/src/pudl/logging_helpers.py
@@ -1,4 +1,5 @@
 """Configure logging for the PUDL package."""
+
 import logging
 
 import coloredlogs

--- a/src/pudl/metadata/__init__.py
+++ b/src/pudl/metadata/__init__.py
@@ -1,4 +1,5 @@
 """Metadata constants and methods."""
+
 from . import (
     classes,
     codes,

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1,4 +1,5 @@
 """Metadata data classes."""
+
 import copy
 import datetime
 import json
@@ -258,14 +259,17 @@ class FieldConstraints(PudlMeta):
     minimum: StrictInt | StrictFloat | datetime.date | datetime.datetime | None = None
     maximum: StrictInt | StrictFloat | datetime.date | datetime.datetime | None = None
     pattern: re.Pattern | None = None
-    enum: StrictList[
-        String
-        | StrictInt
-        | StrictFloat
-        | StrictBool
-        | datetime.date
-        | datetime.datetime
-    ] | None = None
+    enum: (
+        StrictList[
+            String
+            | StrictInt
+            | StrictFloat
+            | StrictBool
+            | datetime.date
+            | datetime.datetime
+        ]
+        | None
+    ) = None
 
     _check_unique = _validator("enum", fn=_check_unique)
 
@@ -853,9 +857,9 @@ class Contributor(PudlMeta):
     title: String
     path: AnyHttpUrl | None = None
     email: EmailStr | None = None
-    role: Literal[
-        "author", "contributor", "maintainer", "publisher", "wrangler"
-    ] = "contributor"
+    role: Literal["author", "contributor", "maintainer", "publisher", "wrangler"] = (
+        "contributor"
+    )
     zenodo_role: Literal[
         "contact person",
         "data collector",
@@ -1246,36 +1250,42 @@ class Resource(PudlMeta):
     sources: list[DataSource] = []
     keywords: list[String] = []
     encoder: Encoder | None = None
-    field_namespace: Literal[
-        "eia",
-        "epacems",
-        "ferc1",
-        "ferc714",
-        "glue",
-        "pudl",
-        "ppe",
-        "eia_bulk_elec",
-    ] | None = None
-    etl_group: Literal[
-        "eia860",
-        "eia861",
-        "eia861_disabled",
-        "eia923",
-        "entity_eia",
-        "epacems",
-        "ferc1",
-        "ferc1_disabled",
-        "ferc714",
-        "glue",
-        "outputs",
-        "static_ferc1",
-        "static_eia",
-        "static_eia_disabled",
-        "eia_bulk_elec",
-        "state_demand",
-        "static_pudl",
-        "service_territories",
-    ] | None = None
+    field_namespace: (
+        Literal[
+            "eia",
+            "epacems",
+            "ferc1",
+            "ferc714",
+            "glue",
+            "pudl",
+            "ppe",
+            "eia_bulk_elec",
+        ]
+        | None
+    ) = None
+    etl_group: (
+        Literal[
+            "eia860",
+            "eia861",
+            "eia861_disabled",
+            "eia923",
+            "entity_eia",
+            "epacems",
+            "ferc1",
+            "ferc1_disabled",
+            "ferc714",
+            "glue",
+            "outputs",
+            "static_ferc1",
+            "static_eia",
+            "static_eia_disabled",
+            "eia_bulk_elec",
+            "state_demand",
+            "static_pudl",
+            "service_territories",
+        ]
+        | None
+    ) = None
     create_database_schema: bool = True
 
     _check_unique = _validator(

--- a/src/pudl/metadata/constants.py
+++ b/src/pudl/metadata/constants.py
@@ -1,4 +1,5 @@
 """Metadata and operational constants."""
+
 import datetime
 from collections.abc import Callable
 

--- a/src/pudl/metadata/dfs.py
+++ b/src/pudl/metadata/dfs.py
@@ -1,4 +1,5 @@
 """Static database tables."""
+
 from io import StringIO
 
 import pandas as pd

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -1,4 +1,5 @@
 """Field metadata."""
+
 from copy import deepcopy
 from typing import Any
 

--- a/src/pudl/metadata/helpers.py
+++ b/src/pudl/metadata/helpers.py
@@ -1,4 +1,5 @@
 """Functions for manipulating metadata constants."""
+
 import re
 from collections import defaultdict
 from collections.abc import Callable, Iterable

--- a/src/pudl/metadata/resources/allocate_gen_fuel.py
+++ b/src/pudl/metadata/resources/allocate_gen_fuel.py
@@ -1,4 +1,5 @@
 """Resource metadata for the allocate_gen_fuel tables."""
+
 from typing import Any
 
 AGG_FREQS = ["yearly", "monthly"]

--- a/src/pudl/metadata/resources/eia.py
+++ b/src/pudl/metadata/resources/eia.py
@@ -1,4 +1,5 @@
 """Definitions of data tables primarily coming from EIA 860/861/923."""
+
 from typing import Any
 
 from pudl.metadata.codes import CODE_METADATA

--- a/src/pudl/metadata/resources/eia860.py
+++ b/src/pudl/metadata/resources/eia860.py
@@ -1,4 +1,5 @@
 """Definitions of data tables primarily coming from EIA-860."""
+
 from typing import Any
 
 RESOURCE_METADATA: dict[str, dict[str, Any]] = {

--- a/src/pudl/metadata/resources/eia861.py
+++ b/src/pudl/metadata/resources/eia861.py
@@ -1,4 +1,5 @@
 """Definitions of data tables primarily coming from EIA-861."""
+
 from typing import Any
 
 RESOURCE_METADATA: dict[str, dict[str, Any]] = {

--- a/src/pudl/metadata/resources/eia923.py
+++ b/src/pudl/metadata/resources/eia923.py
@@ -1,4 +1,5 @@
 """Definitions of data tables primarily coming from EIA-923."""
+
 from typing import Any
 
 TABLE_DESCRIPTIONS: dict[str, str] = {

--- a/src/pudl/metadata/resources/epacems.py
+++ b/src/pudl/metadata/resources/epacems.py
@@ -1,4 +1,5 @@
 """Table definitions for the EPA CEMS data group."""
+
 from typing import Any
 
 RESOURCE_METADATA: dict[str, dict[str, Any]] = {

--- a/src/pudl/metadata/resources/ferc1.py
+++ b/src/pudl/metadata/resources/ferc1.py
@@ -1,4 +1,5 @@
 """Table definitions for the FERC Form 1 data group."""
+
 from typing import Any
 
 from pudl.metadata.codes import CODE_METADATA

--- a/src/pudl/metadata/resources/ferc1_eia_record_linkage.py
+++ b/src/pudl/metadata/resources/ferc1_eia_record_linkage.py
@@ -1,4 +1,5 @@
 """Definitions for the connection between FERC1 and EIA."""
+
 from typing import Any
 
 RESOURCE_METADATA: dict[str, dict[str, Any]] = {

--- a/src/pudl/metadata/resources/glue.py
+++ b/src/pudl/metadata/resources/glue.py
@@ -1,4 +1,5 @@
 """Definitions for the glue/crosswalk tables that connect data groups."""
+
 from typing import Any
 
 RESOURCE_METADATA: dict[str, dict[str, Any]] = {

--- a/src/pudl/metadata/resources/mcoe.py
+++ b/src/pudl/metadata/resources/mcoe.py
@@ -1,4 +1,5 @@
 """Resource metadata for the generator table with derived attributes."""
+
 from typing import Any
 
 AGG_FREQS = ["yearly", "monthly"]

--- a/src/pudl/metadata/resources/pudl.py
+++ b/src/pudl/metadata/resources/pudl.py
@@ -2,6 +2,7 @@
 
 Most of this is compiled from handmapping records.
 """
+
 from typing import Any
 
 RESOURCE_METADATA: dict[str, dict[str, Any]] = {

--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -1,4 +1,5 @@
 """Metadata and operational constants."""
+
 from typing import Any
 
 import pandas as pd

--- a/src/pudl/output/__init__.py
+++ b/src/pudl/output/__init__.py
@@ -10,6 +10,7 @@ This subpackage compiles a bunch of outputs we found we were commonly generating
 that they can be done automatically and uniformly. They are encapsulated within the
 :class:`pudl.output.pudltabl.PudlTabl` class.
 """
+
 from . import (
     censusdp1tract,
     eia,

--- a/src/pudl/output/eia.py
+++ b/src/pudl/output/eia.py
@@ -1050,18 +1050,18 @@ def assign_cc_unit_ids(gens_df: pd.DataFrame) -> pd.DataFrame:
     assert (tmp_df.loc[tmp_df.bga_source == "orphan_ca", "CA"] > 0).all()  # nosec: B101
 
     # Assign flags for various arrangements of CA and CT generators
-    tmp_df.loc[
-        ((tmp_df.CT == 1) & (tmp_df.CA == 1)), "bga_source"
-    ] = "one_ct_one_ca_inferred"
-    tmp_df.loc[
-        ((tmp_df.CT == 1) & (tmp_df.CA > 1)), "bga_source"
-    ] = "one_ct_many_ca_inferred"
-    tmp_df.loc[
-        ((tmp_df.CT > 1) & (tmp_df.CA == 1)), "bga_source"
-    ] = "many_ct_one_ca_inferred"
-    tmp_df.loc[
-        ((tmp_df.CT > 1) & (tmp_df.CA > 1)), "bga_source"
-    ] = "many_ct_many_ca_inferred"
+    tmp_df.loc[((tmp_df.CT == 1) & (tmp_df.CA == 1)), "bga_source"] = (
+        "one_ct_one_ca_inferred"
+    )
+    tmp_df.loc[((tmp_df.CT == 1) & (tmp_df.CA > 1)), "bga_source"] = (
+        "one_ct_many_ca_inferred"
+    )
+    tmp_df.loc[((tmp_df.CT > 1) & (tmp_df.CA == 1)), "bga_source"] = (
+        "many_ct_one_ca_inferred"
+    )
+    tmp_df.loc[((tmp_df.CT > 1) & (tmp_df.CA > 1)), "bga_source"] = (
+        "many_ct_many_ca_inferred"
+    )
 
     # Align the indices of the two dataframes so we can assign directly
     tmp_df = tmp_df.set_index(["plant_id_eia", "generator_id", "report_date"])

--- a/src/pudl/output/eia860.py
+++ b/src/pudl/output/eia860.py
@@ -1,4 +1,5 @@
 """Denormalized versions of the EIA 860 tables."""
+
 import pandas as pd
 from dagster import asset
 

--- a/src/pudl/output/eia923.py
+++ b/src/pudl/output/eia923.py
@@ -1,4 +1,5 @@
 """Denormalized, aggregated, and filled versions of the basic EIA-923 tables."""
+
 from typing import Literal
 
 import numpy as np

--- a/src/pudl/output/eia_bulk_elec.py
+++ b/src/pudl/output/eia_bulk_elec.py
@@ -1,4 +1,5 @@
 """Interim and output tables derived from the EIA Bulk Electricity data."""
+
 import pandas as pd
 from dagster import asset
 

--- a/src/pudl/output/epacems.py
+++ b/src/pudl/output/epacems.py
@@ -1,4 +1,5 @@
 """Routines that provide user-friendly access to the partitioned EPA CEMS dataset."""
+
 from collections.abc import Iterable, Sequence
 from itertools import product
 from pathlib import Path

--- a/src/pudl/output/ferc1.py
+++ b/src/pudl/output/ferc1.py
@@ -953,9 +953,9 @@ def out_ferc1__yearly_steam_plants_fuel_by_plant_sched402(
     # The existing function expects `fuel_type_code_pudl` to be an object, rather than
     # a category. This is a legacy of pre-dagster code, and we convert here to prevent
     # further retooling in the code-base.
-    core_ferc1__yearly_steam_plants_fuel_sched402[
-        "fuel_type_code_pudl"
-    ] = core_ferc1__yearly_steam_plants_fuel_sched402["fuel_type_code_pudl"].astype(str)
+    core_ferc1__yearly_steam_plants_fuel_sched402["fuel_type_code_pudl"] = (
+        core_ferc1__yearly_steam_plants_fuel_sched402["fuel_type_code_pudl"].astype(str)
+    )
 
     fuel_categories = list(
         pudl.transform.ferc1.SteamPlantsFuelTableTransformer()

--- a/src/pudl/output/ferc714.py
+++ b/src/pudl/output/ferc714.py
@@ -1,4 +1,5 @@
 """Functions & classes for compiling derived aspects of the FERC Form 714 data."""
+
 from typing import Any
 
 import geopandas as gpd

--- a/src/pudl/output/sql/helpers.py
+++ b/src/pudl/output/sql/helpers.py
@@ -1,4 +1,5 @@
 """Helper functions for creating output assets."""
+
 import importlib.resources
 
 from dagster import AssetsDefinition, asset

--- a/src/pudl/settings.py
+++ b/src/pudl/settings.py
@@ -1,4 +1,5 @@
 """Module for validating pudl etl settings."""
+
 import json
 from enum import Enum, unique
 from typing import Any, ClassVar, Self

--- a/src/pudl/transform/__init__.py
+++ b/src/pudl/transform/__init__.py
@@ -59,6 +59,7 @@ denormalized columns may also be part of the primary key. This information is im
 for the step after the intra-table transformations during which the collection of EIA
 tables is normalized as a whole.
 """
+
 from . import (
     classes,
     eia,

--- a/src/pudl/transform/classes.py
+++ b/src/pudl/transform/classes.py
@@ -63,6 +63,7 @@ Specific :class:`TransformParams` classes are instantiated using dictionaries of
 defined in the per-dataset modules under :mod:`pudl.transform.params` e.g.
 :mod:`pudl.transform.params.ferc1`.
 """
+
 import enum
 import re
 from abc import ABC, abstractmethod

--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -15,6 +15,7 @@ The boiler generator association inferrence (bga) takes the associations
 provided by the EIA 860, and expands on it using several methods which can be
 found in :func:`pudl.transform.eia._boiler_generator_assn`.
 """
+
 import importlib.resources
 from collections import namedtuple
 from enum import StrEnum, auto

--- a/src/pudl/transform/eia861.py
+++ b/src/pudl/transform/eia861.py
@@ -3,6 +3,7 @@
 All transformations include:
 - Replace . values with NA.
 """
+
 import pandas as pd
 from dagster import AssetIn, AssetOut, Output, asset, multi_asset
 

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -7,6 +7,7 @@ documented in that module.
 See :mod:`pudl.transform.params.ferc1` for the values that parameterize many of these
 transformations.
 """
+
 import enum
 import importlib.resources
 import itertools
@@ -4266,12 +4267,12 @@ class SmallPlantsTableTransformer(Ferc1AbstractTableTransformer):
         )
 
         # Fill NA and "other" fields
-        df.loc[
-            df["plant_type"].isin([pd.NA, "other"]), "plant_type"
-        ] = df.plant_type_from_header
-        df.loc[
-            df["fuel_type"].isin([pd.NA, "other"]), "fuel_type"
-        ] = df.fuel_type_from_header
+        df.loc[df["plant_type"].isin([pd.NA, "other"]), "plant_type"] = (
+            df.plant_type_from_header
+        )
+        df.loc[df["fuel_type"].isin([pd.NA, "other"]), "fuel_type"] = (
+            df.fuel_type_from_header
+        )
 
         # Remove _from_header fields
         df = df.drop(columns=["plant_type_from_header", "fuel_type_from_header"])

--- a/src/pudl/transform/ferc714.py
+++ b/src/pudl/transform/ferc714.py
@@ -1,4 +1,5 @@
 """Transformation of the FERC Form 714 data."""
+
 import re
 
 import numpy as np

--- a/src/pudl/transform/params/__init__.py
+++ b/src/pudl/transform/params/__init__.py
@@ -19,4 +19,5 @@ that's been identified.
 These dictionaries are used by :class:`pudl.transform.classes.AbstractTableTransformer`
 to look up the parameters to be used in transforming a table based on the table name.
 """
+
 from . import ferc1

--- a/src/pudl/validate.py
+++ b/src/pudl/validate.py
@@ -9,6 +9,7 @@ What defines a data validation?
     * A processed version of itself (aggregation or derived values)
     * A hard-coded external standard (e.g. heat rates, fuel heat content)
 """
+
 import warnings
 
 import numpy as np

--- a/src/pudl/workspace/__init__.py
+++ b/src/pudl/workspace/__init__.py
@@ -7,4 +7,5 @@ to that collection of raw inputs, which we refer to as the PUDL datastore.
 These tools are available both as a library module, and via a command line
 interface installed as an entrypoint script called ``pudl_datastore``.
 """
+
 from . import datastore, resource_cache, setup

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -1,4 +1,5 @@
 """Datastore manages file retrieval for PUDL datasets."""
+
 import hashlib
 import io
 import json

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -1,4 +1,5 @@
 """Tools for setting up and managing PUDL workspaces."""
+
 import os
 from pathlib import Path
 from typing import Self

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,6 +2,7 @@
 
 Right now this "package" really only exists to create a test specific logger.
 """
+
 # Create a parent logger for all test loggers to inherit from
 import logging
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -2,6 +2,7 @@
 
 Defines useful fixtures, command line args.
 """
+
 import logging
 from pathlib import Path
 from typing import Any

--- a/test/integration/console_scripts_test.py
+++ b/test/integration/console_scripts_test.py
@@ -1,4 +1,5 @@
 """Test the PUDL console scripts from within PyTest."""
+
 from pathlib import Path
 
 import geopandas as gpd

--- a/test/integration/datasette_metadata_test.py
+++ b/test/integration/datasette_metadata_test.py
@@ -1,4 +1,5 @@
 """Test the metadata.yml file that is output generated for Datasette."""
+
 import logging
 
 import sqlalchemy as sa

--- a/test/integration/epacems_test.py
+++ b/test/integration/epacems_test.py
@@ -1,4 +1,5 @@
 """Tests for pudl/output/epacems.py loading functions."""
+
 from pathlib import Path
 
 import dask.dataframe as dd

--- a/test/integration/etl_test.py
+++ b/test/integration/etl_test.py
@@ -4,6 +4,7 @@ This module also contains fixtures for returning connections to the databases. T
 connections can be either to the live databases for post-ETL testing or to new temporary
 databases, which are created from scratch and dropped after the tests have completed.
 """
+
 import logging
 
 import pandas as pd

--- a/test/integration/glue_test.py
+++ b/test/integration/glue_test.py
@@ -1,4 +1,5 @@
 """PyTest cases related to the integration between FERC1 & EIA 860/923."""
+
 import logging
 from pathlib import Path
 

--- a/test/integration/output_test.py
+++ b/test/integration/output_test.py
@@ -1,4 +1,5 @@
 """PyTest cases related to generating dervied outputs."""
+
 import logging
 
 import pandas as pd

--- a/test/unit/analysis/ml_tools_test.py
+++ b/test/unit/analysis/ml_tools_test.py
@@ -1,4 +1,5 @@
 """Test record linkage models and utilities."""
+
 import mlflow
 import pandas as pd
 import pytest

--- a/test/unit/analysis/plant_parts_eia_test.py
+++ b/test/unit/analysis/plant_parts_eia_test.py
@@ -1,4 +1,5 @@
 """Tests for timeseries anomalies detection and imputation."""
+
 from importlib import resources
 
 import pandas as pd

--- a/test/unit/analysis/state_demand_test.py
+++ b/test/unit/analysis/state_demand_test.py
@@ -1,4 +1,5 @@
 """Tests for timeseries anomalies detection and imputation."""
+
 import numpy as np
 import pandas as pd
 import pytest

--- a/test/unit/extract/csv_test.py
+++ b/test/unit/extract/csv_test.py
@@ -1,4 +1,5 @@
 """Unit tests for pudl.extract.csv module."""
+
 from unittest.mock import MagicMock, patch
 
 from pudl.extract.csv import CsvExtractor, get_table_file_map, open_csv_resource

--- a/test/unit/extract/eia_bulk_elec_test.py
+++ b/test/unit/extract/eia_bulk_elec_test.py
@@ -1,4 +1,5 @@
 """Tests for eia_bulk_data module."""
+
 from io import BytesIO
 from zipfile import ZipFile
 

--- a/test/unit/extract/excel_test.py
+++ b/test/unit/extract/excel_test.py
@@ -1,4 +1,5 @@
 """Unit tests for pudl.extract.excel module."""
+
 import unittest
 from unittest import mock as mock
 from unittest.mock import patch

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -1,6 +1,5 @@
 """Tests for xbrl extraction module."""
 
-
 import pytest
 from dagster import ResourceDefinition, build_op_context
 

--- a/test/unit/harvest_test.py
+++ b/test/unit/harvest_test.py
@@ -1,4 +1,5 @@
 """Tests for Resource harvesting methods."""
+
 from typing import Any
 
 import numpy as np

--- a/test/unit/helpers_test.py
+++ b/test/unit/helpers_test.py
@@ -1,4 +1,5 @@
 """Unit tests for the :mod:`pudl.helpers` module."""
+
 from io import StringIO
 
 import numpy as np

--- a/test/unit/io_managers_test.py
+++ b/test/unit/io_managers_test.py
@@ -1,4 +1,5 @@
 """Test Dagster IO Managers."""
+
 import datetime
 import json
 from pathlib import Path

--- a/test/unit/metadata_test.py
+++ b/test/unit/metadata_test.py
@@ -1,4 +1,5 @@
 """Tests for metadata not covered elsewhere."""
+
 import pandas as pd
 import pandera as pr
 import pytest

--- a/test/unit/output/epacems_test.py
+++ b/test/unit/output/epacems_test.py
@@ -1,4 +1,5 @@
 """Test helper functions associated with the EPA CEMS outputs."""
+
 import logging
 
 import pytest

--- a/test/unit/transform/eia_bulk_elec_test.py
+++ b/test/unit/transform/eia_bulk_elec_test.py
@@ -1,4 +1,5 @@
 """Tests for pudl.transform.eia_bulk_elec functions."""
+
 from io import BytesIO
 
 import pandas as pd

--- a/test/unit/workspace/resource_cache_test.py
+++ b/test/unit/workspace/resource_cache_test.py
@@ -1,4 +1,5 @@
 """Unit tests for resource_cache."""
+
 import shutil
 import tempfile
 import unittest

--- a/test/validate/bf_eia923_test.py
+++ b/test/validate/bf_eia923_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL Boiler Fuel data from EIA 923."""
+
 import logging
 
 import pytest

--- a/test/validate/eia860_test.py
+++ b/test/validate/eia860_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL EIA 860 data and the associated derived outputs."""
+
 import logging
 
 import pandas as pd

--- a/test/validate/eia_test.py
+++ b/test/validate/eia_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL EIA 860 data and the associated derived outputs."""
+
 import logging
 from test.conftest import skip_table_if_null_freq_table
 

--- a/test/validate/epacamd_eia_test.py
+++ b/test/validate/epacamd_eia_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL EPACAMD-EIA Crosswalk data."""
+
 import logging
 
 import pytest

--- a/test/validate/fbp_ferc1_test.py
+++ b/test/validate/fbp_ferc1_test.py
@@ -3,6 +3,7 @@
 These tests depend on a FERC Form 1 specific PudlTabl output object, which is a
 parameterized fixture that has session scope.
 """
+
 import logging
 
 import numpy as np

--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -3,6 +3,7 @@
 These tests depend on a FERC Form 1 specific PudlTabl output object, which is a
 parameterized fixture that has session scope.
 """
+
 import logging
 
 import pandas as pd

--- a/test/validate/frc_eia923_test.py
+++ b/test/validate/frc_eia923_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL Fuel Receipts and Costs data from EIA 923."""
+
 import logging
 
 import pytest

--- a/test/validate/fuel_ferc1_test.py
+++ b/test/validate/fuel_ferc1_test.py
@@ -3,6 +3,7 @@
 These tests depend on a FERC Form 1 specific PudlTabl output object, which is a
 parameterized fixture that has session scope.
 """
+
 import logging
 
 import pandas as pd

--- a/test/validate/gens_eia860_test.py
+++ b/test/validate/gens_eia860_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL Generators data from EIA 860."""
+
 import logging
 
 import pytest

--- a/test/validate/gf_eia923_test.py
+++ b/test/validate/gf_eia923_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL Generation Fuel data from EIA 923."""
+
 import logging
 
 import pytest

--- a/test/validate/mcoe_test.py
+++ b/test/validate/mcoe_test.py
@@ -9,6 +9,7 @@ generators.
 For now, these calculations are only using the EIA fuel cost data. FERC Form 1 non-fuel
 production costs have yet to be integrated.
 """
+
 import logging
 
 import pytest

--- a/test/validate/plant_parts_eia_test.py
+++ b/test/validate/plant_parts_eia_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL Generators data from EIA 860."""
+
 import logging
 
 import numpy as np

--- a/test/validate/plants_steam_ferc1_test.py
+++ b/test/validate/plants_steam_ferc1_test.py
@@ -3,6 +3,7 @@
 These tests depend on a FERC Form 1 specific PudlTabl output object, which is a
 parameterized fixture that has session scope.
 """
+
 import logging
 
 import pandas as pd

--- a/test/validate/service_territory_test.py
+++ b/test/validate/service_territory_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL FERC 714 outputs and associated service territory analyses."""
+
 import logging
 
 import pytest

--- a/test/validate/state_demand_test.py
+++ b/test/validate/state_demand_test.py
@@ -1,4 +1,5 @@
 """Validate post-ETL state demand analysis output."""
+
 import logging
 
 import pytest


### PR DESCRIPTION
# Overview

- Apply `ruff` formatting using the newly released v0.3.0 to all files.
- Doing this as a standalone PR to keep all the tiny one-line autoformatting changes in a single commit that we can ignore for change attribution, but adding the appropriate commit to the `.git-blame-ignore-revs` file can only happen after this hits `main` because of our `squash-merge-queue`.

# Testing

- `pre-commit` checks have passed.
- I skimmed all of the changes and mostly it's the insertion of a blank line after module-level docstrings, plus a handful of reformatted assignment statements, which are a bit more readable.

```[tasklist]
# To-do list
- [ ] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage` (otherwise the merge queue may reject your PR)
- [ ] For significant ETL changes, ensure the full ETL runs locally
- [ ] For major data coverage & analysis changes, [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation)
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Review the PR yourself and call out any questions or issues you have
```
