### PR TITLE
Add EIA Thermoelectric Cooling Water dataset DOI to datastore.

### DIFF
--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -192,6 +192,7 @@ class ZenodoDoiSettings(BaseSettings):
     eia860m: ZenodoDoi = "10.5281/zenodo.10603998"
     eia861: ZenodoDoi = "10.5281/zenodo.10204708"
     eia923: ZenodoDoi = "10.5281/zenodo.10603997"
+    eiawater: ZenodoDoi = "10.5281/zenodo.10806016"
     eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.10603995"
     epacamd_eia: ZenodoDoi = "10.5281/zenodo.7900974"
     epacems: ZenodoDoi = "10.5281/zenodo.10603994"


### PR DESCRIPTION
# Overview

Added the new DOI for the EIA Thermoelectric Cooling Water dataset to the PUDL datastore, since it's available for download now, even though we haven't started processing it yet.

# Testing

I ran
```console
pudl_datastore -d eiawater
```

and it successfully downloaded all years of EIA water spreadsheets.

```[tasklist]
# To-do list
- [x] Review the PR yourself and call out any questions or issues you have
```
