### PR TITLE
Add logline that tells us more about BadZipFile.

### DIFF
--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -419,7 +419,14 @@ class Datastore:
 
     def get_zipfile_resource(self, dataset: str, **filters: Any) -> zipfile.ZipFile:
         """Retrieves unique resource and opens it as a ZipFile."""
-        return zipfile.ZipFile(io.BytesIO(self.get_unique_resource(dataset, **filters)))
+        resource_bytes = self.get_unique_resource(dataset, **filters)
+        resource = io.BytesIO(resource_bytes)
+        md5sum = hashlib.file_digest(resource, "md5").hexdigest()
+        logger.info(
+            f"Got resource {dataset=}, {filters=}, {md5sum=}, "
+            f"{len(resource_bytes)} bytes; turning into ZipFile"
+        )
+        return zipfile.ZipFile(resource)
 
     def get_zipfile_resources(
         self, dataset: str, **filters: Any


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Related to #3453 .

What problem does this address?

We keep getting these BadZipFile errors but don't really have much to go on - so we should log out some information about the ZipFiles.

What did you change?

Add a logline.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Ran `raw_phmsagas__all_dfs` asset in dagster and verified that these logs showed up in the terminal:

```
2024-03-21 16:45:22 [    INFO] catalystcoop.pudl.workspace.datastore:425 Got resource dataset='phmsagas', filters={'year': 2008, 'form': 'gas_distribution'}, md5sum='4ef276c35808fd8ea0feddf6e2881511', 8513846 bytes; turning into ZipFile    
```

