### PR TITLE
add two new correction records into plant_in_service table

### DIFF
--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -87,7 +87,7 @@ def test_no_null_cols_ferc1(pudl_out_ferc1, live_dbs, cols, df_name):
     [
         ("fbp_ferc1", 26_188),
         ("fuel_ferc1", 50_039),
-        ("plant_in_service_ferc1", 335_750),
+        ("plant_in_service_ferc1", 335_752),
         ("plants_all_ferc1", 56_409),
         ("plants_hydro_ferc1", 6_979),
         ("plants_pumped_storage_ferc1", 562),


### PR DESCRIPTION
# Overview
these two new records are a result of adding corrections when either the reported or calculated value is null. this change did not add a ton of extra records to a ton of tables because most of the tables that get their calculations reconciled/corrected are not the orignal ferc1 tables that are in the PudlTabl. These calculation-reconciled tables are mostly new and are mostly not being tested in our test_minmax_rows tests.

What problem does this address?
- fixes a nightly build failure introduced via #3450
 

# Testing

How did you make sure this worked? How can a reviewer verify this?
i used the `sqlite-table-diff` notebook to ensure that the two new records are indeed correction records. also verified that there were no unexpected other changes in this table

```[tasklist]
# To-do list
- [x] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g.,  `test_minmax_rows()`)
```
