### PR TITLE
Refactor etl/__init__.py to make adding new modules easier.

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -55,9 +55,9 @@ You'll need to fork this repository and get the
 **Work on it!**
 
 * Make a branch on your fork and open a draft pull request (PR) early so we can
-  discuss concrete code! **Set the base branch to ``dev`` unless there's a good
-  reason otherwise.** Please don't wait until it's all polished up - it's much
-  easier for us to help you when we can see the code evolve over time.
+  discuss concrete code! **Set the base branch to ``main``.** Please don't wait
+  until it's all polished up - it's much easier for us to help you when we can
+  see the code evolve over time.
 
 * Please make sure to write tests and documentation for your code - if you run
   into trouble with writing tests, let us know in the comments and we can help!

--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -46,86 +46,83 @@ logger = pudl.logging_helpers.get_logger(__name__)
 # everywhere.
 warnings.filterwarnings("ignore", category=ExperimentalWarning)
 
-default_assets = (
-    *load_assets_from_modules([eia_bulk_elec_assets], group_name="core_eia_bulk_elec"),
-    *load_assets_from_modules([epacems_assets], group_name="core_epacems"),
-    *load_assets_from_modules([pudl.extract.eia176], group_name="raw_eia176"),
-    *load_assets_from_modules([pudl.extract.eia191], group_name="raw_eia191"),
-    *load_assets_from_modules([pudl.extract.eia757a], group_name="raw_eia757a"),
-    *load_assets_from_modules(
-        [pudl.extract.gridpathratoolkit], group_name="raw_gridpathratoolkit"
-    ),
-    *load_assets_from_modules(
-        [pudl.transform.gridpathratoolkit], group_name="core_gridpathratoolkit"
-    ),
-    *load_assets_from_modules([pudl.extract.phmsagas], group_name="raw_phmsagas"),
-    *load_assets_from_modules([pudl.extract.nrelatb], group_name="raw_nrelatb"),
-    *load_assets_from_modules([pudl.extract.eia860m], group_name="raw_eia860m"),
-    *load_assets_from_modules([pudl.extract.eia860], group_name="raw_eia860"),
-    *load_assets_from_modules([pudl.transform.eia860], group_name="_core_eia860"),
-    *load_assets_from_modules([pudl.transform.eia860m], group_name="core_eia860m"),
-    *load_assets_from_modules([pudl.extract.eia861], group_name="raw_eia861"),
-    *load_assets_from_modules(
-        [pudl.transform.eia861], group_name="core_eia861"
-    ),  # TODO: move one _core asset to separate module?
-    *load_assets_from_modules([pudl.extract.eia923], group_name="raw_eia923"),
-    *load_assets_from_modules([pudl.transform.eia923], group_name="_core_eia923"),
-    *load_assets_from_modules([pudl.extract.eia930], group_name="raw_eia930"),
-    *load_assets_from_modules([pudl.transform.eia], group_name="core_eia"),
-    *load_assets_from_modules([pudl.extract.ferc1], group_name="raw_ferc1"),
-    *load_assets_from_modules([pudl.transform.ferc1], group_name="core_ferc1"),
-    *load_assets_from_modules([pudl.extract.ferc714], group_name="raw_ferc714"),
-    *load_assets_from_modules([pudl.transform.ferc714], group_name="core_ferc714"),
-    *load_assets_from_modules(
-        [pudl.output.ferc714], group_name="out_respondents_ferc714"
-    ),
-    *load_assets_from_modules(
-        [pudl.convert.censusdp1tract_to_sqlite, pudl.output.censusdp1tract],
-        group_name="core_censusdp1tract",
-    ),
-    *load_assets_from_modules([glue_assets], group_name="core_assn"),
-    *load_assets_from_modules([static_assets], group_name="core_codes"),
-    *load_assets_from_modules(
-        [
-            pudl.output.eia,
-            pudl.output.eia860,
-            pudl.output.eia923,
-            pudl.output.eia_bulk_elec,
-        ],
-        group_name="out_eia",
-    ),
-    *load_assets_from_modules(
-        [pudl.analysis.allocate_gen_fuel], group_name="out_allocate_gen_fuel"
-    ),
-    *load_assets_from_modules(
-        [pudl.analysis.mcoe], group_name="out_derived_gen_attributes"
-    ),
-    *load_assets_from_modules([pudl.output.ferc1], group_name="out_ferc1"),
-    *load_assets_from_modules(
-        [pudl.analysis.service_territory], group_name="out_service_territory_eia861"
-    ),
-    *load_assets_from_modules(
-        [pudl.analysis.state_demand], group_name="out_state_demand_ferc714"
-    ),
-    *load_assets_from_modules(
-        [pudl.analysis.record_linkage.classify_plants_ferc1],
-        group_name="out_ferc1",
-    ),
-    *load_assets_from_modules(
-        [
-            pudl.analysis.plant_parts_eia,
-            pudl.analysis.record_linkage.eia_ferc1_record_linkage,
-        ],
-        group_name="eia_ferc1_record_linkage",
-    ),
+raw_module_groups = {
+    "raw_eia176": [pudl.extract.eia176],
+    "raw_eia191": [pudl.extract.eia191],
+    "raw_eia757a": [pudl.extract.eia757a],
+    "raw_eia860": [pudl.extract.eia860],
+    "raw_eia860m": [pudl.extract.eia860m],
+    "raw_eia861": [pudl.extract.eia861],
+    "raw_eia923": [pudl.extract.eia923],
+    "raw_eia930": [pudl.extract.eia930],
+    "raw_ferc1": [pudl.extract.ferc1],
+    "raw_ferc714": [pudl.extract.ferc714],
+    "raw_gridpathratoolkit": [pudl.extract.gridpathratoolkit],
+    "raw_phmsagas": [pudl.extract.phmsagas],
+    "raw_nrelatb": [pudl.extract.nrelatb],
+}
+
+
+core_module_groups = {
+    "_core_eia860": [pudl.transform.eia860],
+    "_core_eia923": [pudl.transform.eia923],
+    "core_censusdp1tract": [
+        pudl.convert.censusdp1tract_to_sqlite,
+        pudl.output.censusdp1tract,
+    ],
+    "core_assn": [glue_assets],
+    "core_codes": [static_assets],
+    "core_eia": [pudl.transform.eia],
+    "core_eia_bulk_elec": [eia_bulk_elec_assets],
+    "core_eia860m": [pudl.transform.eia860m],
+    "core_eia861": [pudl.transform.eia861],
+    "core_epacems": [epacems_assets],
+    "core_ferc1": [pudl.transform.ferc1],
+    "core_ferc714": [pudl.transform.ferc714],
+    "core_gridpathratoolkit": [pudl.transform.gridpathratoolkit],
+}
+
+out_module_groups = {
+    "eia_ferc1_record_linkage": [
+        pudl.analysis.plant_parts_eia,
+        pudl.analysis.record_linkage.eia_ferc1_record_linkage,
+    ],
+    "out_allocate_gen_fuel": [pudl.analysis.allocate_gen_fuel],
+    "out_derived_gen_attributes": [pudl.analysis.mcoe],
+    "out_eia": [
+        pudl.output.eia,
+        pudl.output.eia860,
+        pudl.output.eia923,
+        pudl.output.eia_bulk_elec,
+    ],
+    "out_ferc1": [
+        pudl.output.ferc1,
+        pudl.analysis.record_linkage.classify_plants_ferc1,
+    ],
+    "out_respondents_ferc714": [pudl.output.ferc714],
+    "out_service_territory_eia861": [pudl.analysis.service_territory],
+    "out_state_demand_ferc714": [pudl.analysis.state_demand],
+}
+
+all_asset_modules = raw_module_groups | core_module_groups | out_module_groups
+default_assets = list(
+    itertools.chain.from_iterable(
+        load_assets_from_modules(
+            modules,
+            group_name=group_name,
+        )
+        for group_name, modules in all_asset_modules.items()
+    )
 )
 
-asset_check_modules = [
-    pudl.transform.eia860,
-    pudl.transform.eia923,
-    pudl.transform.gridpathratoolkit,
-]
-default_asset_checks = list(load_asset_checks_from_modules(asset_check_modules))
+default_asset_checks = list(
+    itertools.chain.from_iterable(
+        load_asset_checks_from_modules(
+            modules,
+        )
+        for modules in all_asset_modules.values()
+    )
+)
 
 
 def asset_check_from_schema(


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

This changes how we add new modules to the ETL so we only have to add them in one place. Also it organizes them slightly.

Finally, there's a tiny opportunistic change to the docs to remove a reference to `dev`.

# Testing

How did you make sure this worked? How can a reviewer verify this?

* Checked to see that all modules on the left do indeed show up on the right.
* Loaded up Dagster UI and saw that the ETL appears to still be there

```[tasklist]
# To-do list
- [x] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage` (otherwise the merge queue may reject your PR)
- [x] Review the PR yourself and call out any questions or issues you have
```
