### PR TITLE
Attempt to limit `_out_ferc714__hourly_demand_matrix` concurrency

### DIFF
--- a/src/pudl/analysis/plant_parts_eia.py
+++ b/src/pudl/analysis/plant_parts_eia.py
@@ -368,6 +368,7 @@ PPE_COLS = [
 @asset(
     io_manager_key="pudl_io_manager",
     compute_kind="Python",
+    op_tags={"memory-use": "high"},
 )
 def out_eia__yearly_generators_by_ownership(
     out_eia__yearly_generators: pd.DataFrame, out_eia860__yearly_ownership: pd.DataFrame
@@ -382,6 +383,7 @@ def out_eia__yearly_generators_by_ownership(
 @asset(
     io_manager_key="pudl_io_manager",
     compute_kind="Python",
+    op_tags={"memory-use": "high"},
 )
 def out_eia__yearly_plant_parts(
     out_eia__yearly_generators_by_ownership: pd.DataFrame,

--- a/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
+++ b/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
@@ -289,7 +289,7 @@ def get_best_matches(
         "out_pudl__yearly_assn_eia_ferc1_plant_parts": Out(
             io_manager_key="pudl_io_manager"
         )
-    }
+    },
 )
 def get_full_records_with_overrides(best_match_df, inputs, experiment_tracker):
     """Join full dataframe onto matches to make usable and get stats.

--- a/src/pudl/analysis/state_demand.py
+++ b/src/pudl/analysis/state_demand.py
@@ -473,10 +473,7 @@ def _out_ferc714__hourly_demand_matrix(
     return df
 
 
-@asset(
-    compute_kind="Python",
-    op_tags={"memory-use": "high"},
-)
+@asset(compute_kind="Python")
 def _out_ferc714__hourly_imputed_demand(
     _out_ferc714__hourly_demand_matrix: pd.DataFrame,
     _out_ferc714__utc_offset: pd.DataFrame,

--- a/src/pudl/analysis/state_demand.py
+++ b/src/pudl/analysis/state_demand.py
@@ -449,7 +449,7 @@ def melt_ferc714_hourly_demand_matrix(
             ),
         ),
     },
-    op_tags={"datasource": "ferc714"},
+    op_tags={"memory-use": "high"},
 )
 def _out_ferc714__hourly_demand_matrix(
     context, _out_ferc714__hourly_pivoted_demand_matrix: pd.DataFrame
@@ -473,7 +473,10 @@ def _out_ferc714__hourly_demand_matrix(
     return df
 
 
-@asset(compute_kind="Python")
+@asset(
+    compute_kind="Python",
+    op_tags={"memory-use": "high"},
+)
 def _out_ferc714__hourly_imputed_demand(
     _out_ferc714__hourly_demand_matrix: pd.DataFrame,
     _out_ferc714__utc_offset: pd.DataFrame,

--- a/src/pudl/analysis/state_demand.py
+++ b/src/pudl/analysis/state_demand.py
@@ -449,6 +449,7 @@ def melt_ferc714_hourly_demand_matrix(
             ),
         ),
     },
+    op_tags={"datasource": "ferc714"},
 )
 def _out_ferc714__hourly_demand_matrix(
     context, _out_ferc714__hourly_pivoted_demand_matrix: pd.DataFrame

--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -206,17 +206,12 @@ default_resources = {
     "epacems_io_manager": epacems_io_manager,
 }
 
-# By default, limit CEMS and FERC 714 processing concurrency to prevent memory overload.
+# Limit the number of concurrent workers when launch assets that use a lot of memory.
 default_tag_concurrency_limits = [
     {
-        "key": "datasource",
-        "value": "epacems",
+        "key": "memory-use",
+        "value": "high",
         "limit": 2,
-    },
-    {
-        "key": "datasource",
-        "value": "ferc714",
-        "limit": 1,
     },
 ]
 default_config = pudl.helpers.get_dagster_execution_config(

--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -206,13 +206,18 @@ default_resources = {
     "epacems_io_manager": epacems_io_manager,
 }
 
-# By default, limit CEMS year processing concurrency to prevent memory overload.
+# By default, limit CEMS and FERC 714 processing concurrency to prevent memory overload.
 default_tag_concurrency_limits = [
     {
         "key": "datasource",
         "value": "epacems",
         "limit": 2,
-    }
+    },
+    {
+        "key": "datasource",
+        "value": "ferc714",
+        "limit": 1,
+    },
 ]
 default_config = pudl.helpers.get_dagster_execution_config(
     tag_concurrency_limits=default_tag_concurrency_limits

--- a/src/pudl/etl/cli.py
+++ b/src/pudl/etl/cli.py
@@ -78,15 +78,6 @@ def pudl_etl_job_factory(
     help="Max number of processes Dagster can launch. Defaults to the number of CPUs.",
 )
 @click.option(
-    "--epacems-workers",
-    default=2,
-    type=int,
-    help=(
-        "Max number of processes Dagster can launch for EPA CEMS assets. Defaults "
-        "to max number of processes our typical local machines can handle."
-    ),
-)
-@click.option(
     "--gcs-cache-path",
     type=str,
     default="",
@@ -118,7 +109,6 @@ def pudl_etl_job_factory(
 def pudl_etl(
     etl_settings_yml: pathlib.Path,
     dagster_workers: int,
-    epacems_workers: int,
     gcs_cache_path: str,
     logfile: pathlib.Path,
     loglevel: str,
@@ -158,12 +148,18 @@ def pudl_etl(
         },
     }
 
+    # By default, limit CEMS and FERC 714 processing concurrency to prevent memory overload.
     tag_concurrency_limits = [
         {
             "key": "datasource",
             "value": "epacems",
-            "limit": epacems_workers,
-        }
+            "limit": 2,
+        },
+        {
+            "key": "datasource",
+            "value": "ferc714",
+            "limit": 1,
+        },
     ]
 
     run_config.update(

--- a/src/pudl/etl/cli.py
+++ b/src/pudl/etl/cli.py
@@ -148,17 +148,12 @@ def pudl_etl(
         },
     }
 
-    # By default, limit CEMS and FERC 714 processing concurrency to prevent memory overload.
+    # Limit the number of concurrent workers when launch assets that use a lot of memory.
     tag_concurrency_limits = [
         {
-            "key": "datasource",
-            "value": "epacems",
+            "key": "memory-use",
+            "value": "high",
             "limit": 2,
-        },
-        {
-            "key": "datasource",
-            "value": "ferc714",
-            "limit": 1,
         },
     ]
 

--- a/src/pudl/etl/epacems_assets.py
+++ b/src/pudl/etl/epacems_assets.py
@@ -58,7 +58,7 @@ def get_years_from_settings(context):
 
 @op(
     required_resource_keys={"datastore", "dataset_settings"},
-    tags={"datasource": "epacems"},
+    tags={"memory-use": "high"},
 )
 def process_single_year(
     context,

--- a/src/pudl/extract/gridpathratoolkit.py
+++ b/src/pudl/extract/gridpathratoolkit.py
@@ -60,11 +60,15 @@ def raw_gridpathratoolkit_asset_factory(part: str) -> AssetsDefinition:
     into the ``aggregation_group`` field, indicating which generators were aggregated to
     produce the time series based on the wind and solar capacity aggregation tables.
     """
+    asset_kwargs = {
+        "name": f"raw_gridpathratoolkit__{part}",
+        "required_resource_keys": {"datastore", "dataset_settings"},
+        "compute_kind": "Python",
+    }
+    if part == "aggregated_extended_solar_capacity":
+        asset_kwargs["op_tags"] = {"memory-use": "high"}
 
-    @asset(
-        name=f"raw_gridpathratoolkit__{part}",
-        required_resource_keys={"datastore", "dataset_settings"},
-    )
+    @asset(**asset_kwargs)
     def _extract(context):
         """Extract raw GridPath RA Toolkit renewable energy generation profiles.
 

--- a/src/pudl/output/ferc714.py
+++ b/src/pudl/output/ferc714.py
@@ -566,7 +566,10 @@ def out_ferc714__respondents_with_fips(
     return fipsified
 
 
-@asset(compute_kind="Python")
+@asset(
+    compute_kind="Python",
+    op_tags={"memory-use": "high"},
+)
 def _out_ferc714__georeferenced_counties(
     out_ferc714__respondents_with_fips: pd.DataFrame,
     _core_censusdp1tract__counties: gpd.GeoDataFrame,
@@ -619,7 +622,11 @@ def _out_ferc714__georeferenced_respondents(
     return respondents_gdf
 
 
-@asset(compute_kind="Python", io_manager_key="pudl_io_manager")
+@asset(
+    compute_kind="Python",
+    io_manager_key="pudl_io_manager",
+    op_tags={"memory-use": "high"},
+)
 def out_ferc714__summarized_demand(
     _out_ferc714__annualized_respondents: pd.DataFrame,
     out_ferc714__hourly_planning_area_demand: pd.DataFrame,

--- a/src/pudl/transform/eia860m.py
+++ b/src/pudl/transform/eia860m.py
@@ -8,7 +8,11 @@ import pudl
 logger = pudl.logging_helpers.get_logger(__name__)
 
 
-@asset(io_manager_key="pudl_io_manager")
+@asset(
+    io_manager_key="pudl_io_manager",
+    compute_kind="Python",
+    op_tags={"memory-use": "high"},
+)
 def core_eia860m__changelog_generators(
     raw_eia860m__generator_proposed,
     raw_eia860m__generator_existing,

--- a/src/pudl/transform/gridpathratoolkit.py
+++ b/src/pudl/transform/gridpathratoolkit.py
@@ -40,7 +40,11 @@ def _transform_capacity_factors(
     return capacity_factors
 
 
-@asset(io_manager_key="pudl_io_manager")
+@asset(
+    io_manager_key="pudl_io_manager",
+    compute_kind="Python",
+    op_tags={"memory-use": "high"},
+)
 def out_gridpathratoolkit__hourly_available_capacity_factor(
     raw_gridpathratoolkit__aggregated_extended_solar_capacity: pd.DataFrame,
     raw_gridpathratoolkit__aggregated_extended_wind_capacity: pd.DataFrame,
@@ -120,7 +124,10 @@ def _transform_aggs(raw_agg: pd.DataFrame) -> pd.DataFrame:
     return agg
 
 
-@asset(io_manager_key="pudl_io_manager")
+@asset(
+    io_manager_key="pudl_io_manager",
+    compute_kind="Python",
+)
 def core_gridpathratoolkit__assn_generator_aggregation_group(
     raw_gridpathratoolkit__wind_capacity_aggregations: pd.DataFrame,
     raw_gridpathratoolkit__solar_capacity_aggregations: pd.DataFrame,


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #3533.

Attempts to limit max concurrency to 1 when the `_out_ferc714__hourly_demand_matrix` asset is running in an attempt to reduce memory usage on the nightly build VM. 

I'm still a little confused about how dagster's concurrency limiting with tags works, see me [comment here](https://github.com/catalyst-cooperative/pudl/issues/3533#issuecomment-2035791127).

Also, if we keep needing to limit concurrency when certain assets are run because of memory issues, we should come up with a more generalization method so we can restrict the concurrency for any asset. This PR just adds some hard coded values to the an asset decorator and the ETL scripts.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g.,  `test_minmax_rows()`)
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage` (otherwise the merge queue may reject your PR)
- [ ] Review the PR yourself and call out any questions or issues you have
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For significant ETL, data coverage or analysis changes, once `make pytest-coverage` passes, ensure the full ETL runs locally and [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation) using `make pytest-validate` (a ~10 hour run). If you can't run this locally, run the `build-deploy-pudl` GitHub Action (or ask someone with permissions to). Then, check the logs on the `#pudl-deployments` Slack channel or `gs://builds.catalyst.coop`.
```
