### PR TITLE
Manage concurrency of high-memory processes

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -145,6 +145,7 @@ jobs:
             --container-env GCP_BILLING_PROJECT=${{ secrets.GCP_BILLING_PROJECT }} \
             --container-env GITHUB_ACTION_TRIGGER=${{ github.event_name }} \
             --container-env NIGHTLY_TAG=${{ env.NIGHTLY_TAG }} \
+            --container-env OMP_NUM_THREADS=4 \
             --container-env PUDL_BOT_PAT=${{ secrets.PUDL_BOT_PAT }} \
             --container-env PUDL_GCS_OUTPUT=${{ env.PUDL_GCS_OUTPUT }} \
             --container-env PUDL_SETTINGS_YML="/home/mambauser/pudl/src/pudl/package_data/settings/etl_full.yml" \

--- a/src/pudl/analysis/record_linkage/classify_plants_ferc1.py
+++ b/src/pudl/analysis/record_linkage/classify_plants_ferc1.py
@@ -90,7 +90,7 @@ def plants_steam_validate_ids(
     ferc1_steam_df: pd.DataFrame,
     label_df: pd.DataFrame,
 ) -> pd.DataFrame:
-    """Tests that plant_id_ferc1 times series includes one record per year.
+    """Tests that plant_id_ferc1 timeseries includes one record per year.
 
     Args:
         ferc1_steam_df: A DataFrame of the data from the FERC 1 Steam table.

--- a/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
+++ b/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
@@ -290,6 +290,7 @@ def get_best_matches(
             io_manager_key="pudl_io_manager"
         )
     },
+    tags={"memory-use": "high"},
 )
 def get_full_records_with_overrides(best_match_df, inputs, experiment_tracker):
     """Join full dataframe onto matches to make usable and get stats.

--- a/src/pudl/analysis/record_linkage/link_cross_year.py
+++ b/src/pudl/analysis/record_linkage/link_cross_year.py
@@ -115,7 +115,7 @@ def get_average_distance_matrix(
     return average_dist_matrix
 
 
-@op
+@op(tags={"memory-use": "high"})
 def compute_distance_with_year_penalty(
     config: PenalizeReportYearDistanceConfig,
     feature_matrix: FeatureMatrix,
@@ -245,7 +245,7 @@ class MatchOrphanedRecordsConfig(Config):
     distance_threshold: float = 0.5
 
 
-@op
+@op(tags={"memory-use": "high"})
 def match_orphaned_records(
     config: MatchOrphanedRecordsConfig,
     distance_matrix: DistanceMatrix,

--- a/src/pudl/analysis/state_demand.py
+++ b/src/pudl/analysis/state_demand.py
@@ -581,6 +581,7 @@ def total_state_sales_eia861(
             ),
         ),
     },
+    op_tags={"memory-use": "high"},
 )
 def out_ferc714__hourly_estimated_state_demand(
     context,

--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -211,7 +211,7 @@ default_tag_concurrency_limits = [
     {
         "key": "memory-use",
         "value": "high",
-        "limit": 2,
+        "limit": 4,
     },
 ]
 default_config = pudl.helpers.get_dagster_execution_config(

--- a/src/pudl/etl/cli.py
+++ b/src/pudl/etl/cli.py
@@ -153,7 +153,7 @@ def pudl_etl(
         {
             "key": "memory-use",
             "value": "high",
-            "limit": 2,
+            "limit": 4,
         },
     ]
 


### PR DESCRIPTION
# Overview

This PR follows on #3541 

* Tag additional high memory (>4GB peak) processes
* Dial down the parallelism of Numpy's linear algebra
* Increase the allowed concurrency of high memory processes, since we can be more confident about limiting their overall number with more complete tagging.

## Limiting concurrency of high memory ops

The nightly build machine has no swap, and 4GB of memory per CPU (16 CPUs, 64 GB of memory, as on all "highmem" instances). Some of the assets in our DAG use significantly more memory that that, and sometimes a few of them stack on top of each other and they run out of memory, crashing the process and causing the ETL to fail.

After a lot of time running individual assets and watching the per-process memory consumption while the ETL was running locally, it seems like there aren't *that* many assets / ops using significantly more than 4GB of memory peak. Here's a checklist of the ones I identified, with the highest memory usage I observed. The ones checked off have been tagged as high memory usage:

- [x] 11.0 GB, `raw_eia930__all_dfs.concat_pages` (just the concatenation is big!)
- [x] 7.9 GB, `core_eia860m__generators`
- [x] 7.2 GB, `_out_ferc714__georeferenced_counties`
- [x] 7.2 GB, `out_ferc714__summarized_demand`
- [x] 7.2 GB,  `compute_distance_with_year_penalty` (in FERC to FERC matching)
- [x] 6.0 GB, `out_ferc714__hourly_planning_area_demand`
- [x] 5.7 GB, `out_eia__yearly_plant_parts`
- [x] 5.0 GB, `out_eia__yearly_generators_by_ownership`
- [x] 4.8 GB, `raw_gridpathratoolkit__aggregated_extended_solar_capacity`
- [x] 4.7 GB, `out_gridpathratoolkit__hourly_available_capacity_factor`
- [x] 4.7 GB, `out_ferc714__hourly_estimated_state_demand`
- [x] 4.6 GB,  `out_pudl__yearly_assn_eia_ferc1_plant_parts`
- [x] 4.6 GB, `match_orphaned_records` (in FERC to FERC matching)
- [x] 4.0 GB, `_out_ferc714__hourly_demand_matrix`
- [x] 4.0 GB, `core_epacems__hourly_emissions.process_single_year`

The peak memory usage of the EIA930 extraction is very high, but also very brief -- it's only high during the concatenation of the dataframes after they've all been extracted. But that op is buried inside the `raw_df_factory` that's used for many of our CSV / Excel extractors, so we would need a way to selectively pass in the highmem tag, and ideally be able to apply it only to the concatenation step if appropriate.

## Numpy CPU contention

The other resource contention that we're maybe dealing with happens when we're imputing the hourly demand timeseries in the FERC-714 data. This process makes heavy use of Numpy's linear algebra functionality, which in turn depend on the BLAS and LAPACK libraries, which are multi-threaded and by default use all available CPUs. This behavior can be modulated by setting an environment variable `$OMP_NUM_THREADS` which might reduce the contention between that asset and all the other things running at the same time. Note that the linear algebra is not memory intensive, so this is a separate issue from the above high memory usage.

For reasons I don't understand, setting $OMP_NUM_THREADS=4` locally seems to cut the time to impute the hourly demand in half! At least when run in isolation. It cuts the observed CPU usage for that op from 400-600% down to 150-200%. I'll run the full ETL with this limit changed and see what overall impact it has on the runtime.

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g.,  `test_minmax_rows()`)
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage` (otherwise the merge queue may reject your PR)
- [ ] Review the PR yourself and call out any questions or issues you have
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For significant ETL, data coverage or analysis changes, once `make pytest-coverage` passes, ensure the full ETL runs locally and [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation) using `make pytest-validate` (a ~10 hour run). If you can't run this locally, run the `build-deploy-pudl` GitHub Action (or ask someone with permissions to). Then, check the logs on the `#pudl-deployments` Slack channel or `gs://builds.catalyst.coop`.
```
