### PR TITLE
Get last non-null value instead of latest XBRL filing.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -47,6 +47,11 @@ Data Cleaning
   :issue:`3340` and PR :pr:`3419`. This change also fixed a bug that was preventing
   other columns harvested with a special process from being saved.
 
+* When ingesting FERC 1 XBRL filings, we now take the most recent non-null
+  value instead of the value from the latest filing that applies for a specific
+  row. This means that we no longer lose data if a utility posts a FERC filing
+  with only a small number of updated values.
+
 EIA - FERC1 Record Linkage Model Update
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 We merged in a refactor of the EIA plant parts to FERC1 plants record linkage

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -715,11 +715,13 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
             duped_groups: pd.core.groupby.DataFrameGroupBy,
         ) -> pd.DataFrame:
             """Take the row that has most non-null values out of each group."""
+            # Ignore errors when dropping the "count" column since empty
+            # groupby won't have this column.
             return duped_groups.apply(
                 lambda df: df.assign(count=df.count(axis="columns"))
                 .sort_values(by="count", ascending=True)
                 .tail(1)
-            ).drop(columns="count")
+            ).drop(columns="count", errors="ignore")
 
         def __compare_dedupe_methodologies(
             apply_diffs: pd.DataFrame, best_snapshot: pd.DataFrame

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -702,7 +702,7 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
         This means that if a utility reports a non-null value, then later
         either reports a null value for it or simply omits it from the report,
         we keep the old non-null value, which may be erroneous. This appears to
-        be fairly rare.
+        be fairly rare, affecting < 0.005% of reported values.
         """
         filing_metadata_cols = {"publication_time", "filing_name"}
         xbrl_context_cols = [c for c in primary_key if c not in filing_metadata_cols]

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -704,15 +704,78 @@ class FercXBRLSQLiteIOManager(FercSQLiteIOManager):
         we keep the old non-null value, which may be erroneous. This appears to
         be fairly rare, affecting < 0.005% of reported values.
         """
+
+        def __apply_diffs(
+            duped_groups: pd.core.groupby.DataFrameGroupBy,
+        ) -> pd.DataFrame:
+            """Take the latest reported non-null value for each group."""
+            return duped_groups.last()
+
+        def __best_snapshot(
+            duped_groups: pd.core.groupby.DataFrameGroupBy,
+        ) -> pd.DataFrame:
+            """Take the row that has most non-null values out of each group."""
+            return duped_groups.apply(
+                lambda df: df.assign(count=df.count(axis="columns"))
+                .sort_values(by="count", ascending=True)
+                .tail(1)
+            ).drop(columns="count")
+
+        def __compare_dedupe_methodologies(
+            apply_diffs: pd.DataFrame, best_snapshot: pd.DataFrame
+        ):
+            """Compare deduplication methodologies.
+
+            By cross-referencing these we can make sure that the apply-diff
+            methodology isn't doing something unexpected.
+
+            The main thing we want to keep tabs on is apply-diff adding new
+            non-null values compared to best-snapshot, because some of those
+            are instances of a value correctly being reported as `null`.
+
+            Instead of stacking the two datasets, merging by context, and then
+            looking for left_only or right_only values, we just count non-null
+            values. This is because we would want to use the report_year as a
+            merge key, but that isn't available until after we pipe the
+            dataframe through `refine_report_year`.
+            """
+            n_diffs = apply_diffs.count().sum()
+            n_best = best_snapshot.count().sum()
+
+            if n_diffs < n_best:
+                raise ValueError(
+                    f"Found {n_diffs} non-null values with apply-diffs"
+                    f"methodology, and {n_best} with best-snapshot. "
+                    "apply-diffs should be >= best-snapshot."
+                )
+
+            # 2024-04-10: this threshold set by looking at existing values for FERC
+            # <=2022.
+            threshold_pct = 0.3
+            if n_diffs / n_best > (1 + threshold_pct / 100):
+                raise ValueError(
+                    f"Found {n_diffs} non-null values with apply-diffs"
+                    f"methodology, and {n_best} with best-snapshot. "
+                    f"apply-diffs shouldn't be more than {threshold_pct}% "
+                    "greater than best-snapshot."
+                )
+
         filing_metadata_cols = {"publication_time", "filing_name"}
         xbrl_context_cols = [c for c in primary_key if c not in filing_metadata_cols]
         original = table.sort_values("publication_time")
         dupe_mask = original.duplicated(subset=xbrl_context_cols, keep=False)
         duped_groups = original.loc[dupe_mask].groupby(
-            xbrl_context_cols, as_index=False
+            xbrl_context_cols, as_index=False, dropna=True
         )
         never_duped = original.loc[~dupe_mask]
-        return pd.concat([never_duped, duped_groups.last()], ignore_index=True)
+        apply_diffs = __apply_diffs(duped_groups)
+        best_snapshot = __best_snapshot(duped_groups)
+        __compare_dedupe_methodologies(
+            apply_diffs=apply_diffs, best_snapshot=best_snapshot
+        )
+
+        deduped = pd.concat([never_duped, apply_diffs], ignore_index=True)
+        return deduped
 
     @staticmethod
     def refine_report_year(df: pd.DataFrame, xbrl_years: list[int]) -> pd.DataFrame:

--- a/src/pudl/transform/params/ferc1.py
+++ b/src/pudl/transform/params/ferc1.py
@@ -4129,7 +4129,7 @@ TRANSFORM_PARAMS = {
             "group_metric_checks": {
                 "group_metric_tolerances": {
                     "ungrouped": {
-                        "error_frequency": 0.058,
+                        "error_frequency": 0.06,
                         "relative_error_magnitude": 0.045,
                     },
                     "report_year": {

--- a/test/unit/io_managers_test.py
+++ b/test/unit/io_managers_test.py
@@ -513,12 +513,6 @@ def test_filter_for_freshest_data(df):
     hypothesis.note(f"Paired by context:\n{paired_by_context}")
     assert (paired_by_context._merge == "both").all()
 
-    # for every row in the output - its publication time is greater than or equal to all of the other ones for that [entity_id, utility_type, date] in the input data
-    assert (
-        paired_by_context["publication_time_out"]
-        >= paired_by_context["publication_time_in"]
-    ).all()
-
 
 def test_report_year_fixing_instant():
     instant_df = pd.DataFrame.from_records(


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #3309.

What problem does this address?

A bunch of utilities sent diff-only reports to update their 2021 data, which led to some important XBRL tables being mostly-null.

What did you change?

After much debate and investigation, we decided to change the XBRL deduplication to take the latest non-null value (across multiple filings) instead of taking the value from the latest single filing.

# Testing

How did you make sure this worked? How can a reviewer verify this?

@cmgosnell I'd love if you could take a look and see if this affects rate base table in the expected way.

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g.,  `test_minmax_rows()`)
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage` (otherwise the merge queue may reject your PR)
- [ ] Review the PR yourself and call out any questions or issues you have
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For significant ETL, data coverage or analysis changes, once `make pytest-coverage` passes, ensure the full ETL runs locally and [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation) using `make pytest-validate` (a ~10 hour run). If you can't run this locally, run the `build-deploy-pudl` GitHub Action (or ask someone with permissions to). Then, check the logs on the `#pudl-deployments` Slack channel or `gs://builds.catalyst.coop`.
```
