### PR TITLE
Fix Issue #3484: Updated 'four' to 'six'

### DIFF
--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -19,7 +19,7 @@ of tables, read through :ref:`PUDL's naming conventions <asset-naming>`.
 How Should You Access PUDL Data?
 ---------------------------------------------------------------------------------------
 
-We provide four primary ways of interacting with PUDL data. Here's how to find out
+We provide six primary ways of interacting with PUDL data. Here's how to find out
 which one is right for you and your use case.
 
 .. list-table::


### PR DESCRIPTION
# Overview

Closes #3484.

This PR addresses the issue of changing the number of ways to access the PUDL data from 'four' to 'six' in the data_access.rst documentation.