### PR TITLE
Create beta access SA's for gridpath and zerolab.

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -69,9 +69,22 @@ module "gh_oidc" {
   }
 }
 
+# 2024-04-18: separate from the others because this was the first one - if we
+# combined the two, this would delete and recreate the service account
 resource "google_service_account" "service_account" {
   account_id   = "rmi-beta-access"
-  display_name = "RMI Beta Access"
+  display_name = "rmi_beta_access"
+}
+
+# 2024-04-18: after creating a new SA you will have to also create a keypair
+# for the user.
+resource "google_service_account" "beta_access_service_accounts" {
+  for_each = tomap({
+    zerolab_beta_access  = "zerolab-beta-access"
+    gridpath_beta_access = "gridpath-beta-access"
+  })
+  account_id   = each.value
+  display_name = each.key
 }
 
 resource "google_storage_bucket_iam_binding" "binding" {
@@ -79,5 +92,7 @@ resource "google_storage_bucket_iam_binding" "binding" {
   role   = "roles/storage.objectViewer"
   members = [
     "serviceAccount:rmi-beta-access@catalyst-cooperative-pudl.iam.gserviceaccount.com",
+    "serviceAccount:dgm-github-action@dbcp-dev-350818.iam.gserviceaccount.com",
+    "user:aengel@rmi.org",
   ]
 }


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

1. Adds a few beta users for our parquet access.
2. Updates our google storage permission configuration to match the manually-added folks.


# Testing

How did you make sure this worked?

Ran `terraform plan` and saw that we added two SA's, renamed one, and no other changes were planned.

```
random_id.bucket_prefix: Refreshing state... [id=80QeQV5uXn0]
module.gh_oidc.google_iam_workload_identity_pool.main: Refreshing state... [id=projects/catalyst-cooperative-pudl/locations/global/workloadIdentityPools/gh-actions-pool]
google_service_account.service_account: Refreshing state... [id=projects/catalyst-cooperative-pudl/serviceAccounts/rmi-beta-access@catalyst-cooperative-pudl.iam.gserviceaccount.com]
google_storage_bucket_iam_binding.binding: Refreshing state... [id=b/parquet.catalyst.coop/roles/storage.objectViewer]
google_storage_bucket.tfstate: Refreshing state... [id=f3441e415e6e5e7d-bucket-tfstate]
module.gh_oidc.google_iam_workload_identity_pool_provider.main: Refreshing state... [id=projects/catalyst-cooperative-pudl/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider]
module.gh_oidc.google_service_account_iam_member.wif-sa["pudl-catalog-tox-pytest-github-action"]: Refreshing state... [id=projects/catalyst-cooperative-pudl/serviceAccounts/tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com/roles/iam.workloadIdentityUser/principalSet://iam.googleapis.com/projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/attribute.repository/catalyst-cooperative/pudl-catalog]
module.gh_oidc.google_service_account_iam_member.wif-sa["pudl-usage-metrics-pudl-usage-metrics-etl"]: Refreshing state... [id=projects/catalyst-cooperative-pudl/serviceAccounts/pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com/roles/iam.workloadIdentityUser/principalSet://iam.googleapis.com/projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/attribute.repository/catalyst-cooperative/pudl-usage-metrics]
module.gh_oidc.google_service_account_iam_member.wif-sa["gce-build-test-gce-github-action-test"]: Refreshing state... [id=projects/catalyst-cooperative-pudl/serviceAccounts/gce-github-action-test@catalyst-cooperative-pudl.iam.gserviceaccount.com/roles/iam.workloadIdentityUser/principalSet://iam.googleapis.com/projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/attribute.repository/catalyst-cooperative/gce-build-test]
module.gh_oidc.google_service_account_iam_member.wif-sa["pudl-deploy-pudl-github-action"]: Refreshing state... [id=projects/catalyst-cooperative-pudl/serviceAccounts/deploy-pudl-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com/roles/iam.workloadIdentityUser/principalSet://iam.googleapis.com/projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/attribute.repository/catalyst-cooperative/pudl]
module.gh_oidc.google_service_account_iam_member.wif-sa["pudl-tox-pytest-github-action"]: Refreshing state... [id=projects/catalyst-cooperative-pudl/serviceAccounts/tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com/roles/iam.workloadIdentityUser/principalSet://iam.googleapis.com/projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/attribute.repository/catalyst-cooperative/pudl]
module.gh_oidc.google_service_account_iam_member.wif-sa["pudl-zenodo-cache-manager"]: Refreshing state... [id=projects/catalyst-cooperative-pudl/serviceAccounts/zenodo-cache-manager@catalyst-cooperative-pudl.iam.gserviceaccount.com/roles/iam.workloadIdentityUser/principalSet://iam.googleapis.com/projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/attribute.repository/catalyst-cooperative/pudl]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
  ~ update in-place

Terraform will perform the following actions:

  # google_service_account.beta_access_service_accounts["gridpath_beta_access"] will be created
  + resource "google_service_account" "beta_access_service_accounts" {
      + account_id   = "gridpath-beta-access"
      + disabled     = false
      + display_name = "gridpath_beta_access"
      + email        = (known after apply)
      + id           = (known after apply)
      + member       = (known after apply)
      + name         = (known after apply)
      + project      = (known after apply)
      + unique_id    = (known after apply)
    }

  # google_service_account.beta_access_service_accounts["zerolab_beta_access"] will be created
  + resource "google_service_account" "beta_access_service_accounts" {
      + account_id   = "zerolab-beta-access"
      + disabled     = false
      + display_name = "zerolab_beta_access"
      + email        = (known after apply)
      + id           = (known after apply)
      + member       = (known after apply)
      + name         = (known after apply)
      + project      = (known after apply)
      + unique_id    = (known after apply)
    }

  # google_service_account.service_account will be updated in-place
  ~ resource "google_service_account" "service_account" {
      ~ display_name = "RMI Beta Access" -> "rmi_beta_access"
        id           = "projects/catalyst-cooperative-pudl/serviceAccounts/rmi-beta-access@catalyst-cooperative-pudl.iam.gserviceaccount.com"
        name         = "projects/catalyst-cooperative-pudl/serviceAccounts/rmi-beta-access@catalyst-cooperative-pudl.iam.gserviceaccount.com"
        # (6 unchanged attributes hidden)
    }

Plan: 2 to add, 1 to change, 0 to destroy.

─────────────────────────────────────────────────────────────────────────────

Note: You didn't use the -out option to save this plan, so Terraform can't
guarantee to take exactly these actions if you run "terraform apply" now.

```

```[tasklist]
# To-do list
- [ ] Review the PR yourself and call out any questions or issues you have
```
