### PR TITLE
Parse EIA-930 CSVs during extract to minimize memory use

### DIFF
--- a/src/pudl/extract/csv.py
+++ b/src/pudl/extract/csv.py
@@ -1,5 +1,7 @@
 """Extractor for CSV data."""
 
+from typing import Any
+
 import pandas as pd
 
 import pudl.logging_helpers
@@ -12,6 +14,18 @@ class CsvExtractor(GenericExtractor):
     """Class for extracting dataframes from CSV files.
 
     The extraction logic is invoked by calling extract() method of this class.
+    """
+
+    # TODO[zaneselvans] 2024-04-19: it would be useful to also be able to specify
+    # different CSV reading options for different pages within the same dataset. But
+    # that's not strictly necessary yet.
+    READ_CSV_KWARGS: dict[str, Any] = {}
+    """Keyword arguments that are passed to :meth:`pandas.read_csv`.
+
+    These allow customization of the CSV parsing process. For example, you can specify
+    the column delimeter, data types, date parsing, etc. This can greatly reduce peak
+    memory usage and speed up the extraction process. Unfortunately you must refer to
+    the column headers using their original names as they appear in the CSV.
     """
 
     def source_filename(self, page: str, **partition: PartitionSelection) -> str:
@@ -49,6 +63,6 @@ class CsvExtractor(GenericExtractor):
             self.ds.get_zipfile_resource(self._dataset_name, **partition) as zf,
             zf.open(filename) as f,
         ):
-            df = pd.read_csv(f)
+            df = pd.read_csv(f, **self.READ_CSV_KWARGS)
 
         return df

--- a/src/pudl/extract/eia930.py
+++ b/src/pudl/extract/eia930.py
@@ -3,8 +3,11 @@
 import pandas as pd
 from dagster import asset
 
+import pudl.logging_helpers
 from pudl.extract.csv import CsvExtractor
 from pudl.extract.extractor import GenericMetadata, PartitionSelection, raw_df_factory
+
+logger = pudl.logging_helpers.get_logger(__name__)
 
 
 class Extractor(CsvExtractor):
@@ -60,6 +63,7 @@ class Extractor(CsvExtractor):
             DataFrame containing the CSV data
         """
         filename = self.source_filename(page, **partition)
+        logger.info(f"Loading {filename} from {self._dataset_name}.")
 
         with (
             self.ds.get_zipfile_resource(self._dataset_name, **partition) as zf,


### PR DESCRIPTION
# Overview

Previously almost all numerical columns in the EIA-930 extraction were appearing as type object because in the CSV they show up as quoted strings with commas separating every 3 digits.

This PR ensures that those columns are parsed as numbers, and the datetime columns are parsed as datetimes when the CSVs are first read in, dramatically reducing overall memory usage, and avoiding the need to deal with enormous untyped dataframes in the transform steps.

# Testing

```[tasklist]
# To-do list
- [ ] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage`
- [ ] Review the PR yourself and call out any questions or issues you have
```
