### PR TITLE
Allow beta service accounts to access Parquet bucket

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -92,6 +92,8 @@ resource "google_storage_bucket_iam_binding" "binding" {
   role   = "roles/storage.objectViewer"
   members = [
     "serviceAccount:rmi-beta-access@catalyst-cooperative-pudl.iam.gserviceaccount.com",
+    "serviceAccount:zerolab-beta-access@catalyst-cooperative-pudl.iam.gserviceaccount.com",
+    "serviceAccount:gridpath-beta-access@catalyst-cooperative-pudl.iam.gserviceaccount.com",
     "serviceAccount:dgm-github-action@dbcp-dev-350818.iam.gserviceaccount.com",
     "user:aengel@rmi.org",
   ]


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?

I forgot to actually give the beta service accounts any permissions in #3577 .

What did you change?

Did that ^

# Testing

How did you make sure this worked? How can a reviewer verify this?

`terraform plan` output: 

```
Terraform will perform the following actions:                                                                                   
                                                                                                                                
  # google_storage_bucket_iam_binding.binding will be updated in-place                                                          
  ~ resource "google_storage_bucket_iam_binding" "binding" {                                                                    
        id      = "b/parquet.catalyst.coop/roles/storage.objectViewer"                                                          
      ~ members = [                                                                                                             
          + "serviceAccount:gridpath-beta-access@catalyst-cooperative-pudl.iam.gserviceaccount.com",                            
          + "serviceAccount:zerolab-beta-access@catalyst-cooperative-pudl.iam.gserviceaccount.com",                             
            # (3 unchanged elements hidden)                                                                                     
        ]                                                                                                                       
        # (3 unchanged attributes hidden)                                                                                       
    }                                                                                                                           
                                                                                                                                
Plan: 0 to add, 1 to change, 0 to destroy.  
```

That looked good so I `terraform apply`ed it. Verified that someone was able to use one of these SAs to access the parquet files.

```[tasklist]
# To-do list
- [x] Review the PR yourself and call out any questions or issues you have
```
