### PR TITLE
Enumerate all AEO table 54 schemas.

### DIFF
--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1268,6 +1268,7 @@ class Resource(PudlMeta):
     field_namespace: (
         Literal[
             "eia",
+            "eiaaeo",
             "eia_bulk_elec",
             "epacems",
             "ferc1",
@@ -1285,6 +1286,7 @@ class Resource(PudlMeta):
             "eia861",
             "eia861_disabled",
             "eia923",
+            "eiaaeo",
             "entity_eia",
             "epacems",
             "ferc1",

--- a/src/pudl/metadata/resources/eiaaeo.py
+++ b/src/pudl/metadata/resources/eiaaeo.py
@@ -13,7 +13,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "technology_description_eiaaeo",
@@ -25,7 +25,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "technology_description_eiaaeo",
@@ -50,7 +50,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "fuel_type_eiaaeo",
@@ -59,7 +59,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "fuel_type_eiaaeo",
@@ -77,7 +77,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "gross_generation_mwh",
@@ -86,7 +86,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
             ],
@@ -110,7 +110,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "gross_generation_mwh",
@@ -119,7 +119,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
             ],
@@ -133,7 +133,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "customer_class",
@@ -141,7 +141,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "customer_class",
@@ -156,15 +156,15 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "generation_source_or_sink_type_eiaaeo",
-                "net_energy_for_load_mwh",
+                "net_load_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "generation_source_or_sink_type_eiaaeo",
@@ -179,7 +179,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "customer_class",
@@ -188,7 +188,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "customer_class",
@@ -205,7 +205,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "service_category_eiaaeo",
@@ -214,7 +214,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "service_category_eiaaeo",
@@ -233,7 +233,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "fuel_type_eiaaeo",
@@ -241,7 +241,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "fuel_type_eiaaeo",
@@ -260,7 +260,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "fuel_type_eiaaeo",
@@ -269,7 +269,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "fuel_type_eiaaeo",
@@ -288,7 +288,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
                 "carbon_mass_tons",
@@ -299,7 +299,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "emm_region_eiaaeo",
+                "electricity_market_module_region_eiaaeo",
                 "model_case_eiaaeo",
                 "projection_year",
             ],
@@ -342,7 +342,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Total carbon emissions in short tons.",
         "unit": "short_tons",
     },
-    "emm_region_eiaaeo": {
+    "electricity_market_module_region_eiaaeo": {
         "type": "string",
         "description": "AEO projection region.",
         "constraints": {

--- a/src/pudl/metadata/resources/eiaaeo.py
+++ b/src/pudl/metadata/resources/eiaaeo.py
@@ -1,0 +1,514 @@
+"""Table definitions for EIA AEO resources."""
+
+from typing import Any
+
+# 2024-04-24: workaround so we can *define* a bunch of schemas without
+# documenting them or expecting assets to exist
+_STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
+    "core_eiaaeo__generation_electric_sector": {
+        "description": (
+            "Projected generation capacity & total generation in the electric "
+            "sector."
+        ),
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_electricity_sector_fuel_type",
+                "net_summer_capacity_mw",  # should this be capacity_mw_eia?
+                # should we include "first modeled year" as a field, to help interpret all the cumulative fields?
+                "net_summer_capacity_cumulative_planned_additions_mw",
+                "net_summer_capacity_cumulative_unplanned_additions_mw",
+                "net_summer_capacity_cumulative_total_additions_mw",  # this is just planned + unplanned - do we even care about publishing this?
+                "net_summer_capacity_cumulative_retirements_mw",
+                "gross_generation_mwh",  # chose gross bc the numbers add up to "total generation" which then equals "sales to customers + generation for own use" - but... is that right?
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_electricity_sector_fuel_type",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__generation_end_use_sector": {
+        "description": (
+            "Projected generation capacity & total generation in the end-use "
+            "sector.\n"
+            "Includes combined-heat-and-power plants and electricity-only "
+            "plants in the commercial and industrial sectors; and small on-site "
+            "generating systems in the residential, commercial, and industrial "
+            "sectors used primarily for own-use generation, but which may also "
+            "sell some power to the grid. Solar photovoltaic capacity portion of "
+            "Renewable Sources in gigawatts direct current; other technologies "
+            "in gigawatts alternating current."
+        ),
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_end_use_sector_fuel_type",
+                "net_summer_capacity_mw",  # should this be capacity_mw_eia?
+                "gross_generation_mwh",
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_end_use_sector_fuel_type",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__electricity_sales": {
+        "description": "Projected electricity sales.",
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_sales_sector",
+                "sales_mwh",
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_sales_sector",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__net_energy_for_load": {
+        "description": "Projected net energy for load.",
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_net_energy_for_load_sector",
+                "net_energy_for_load_mwh",
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_net_energy_for_load_sector",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__end_use_prices_by_sector": {
+        "description": "Projected electricity cost to the end user by sector.",
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_sales_sector",
+                "real_value_base_year",
+                "end_use_price_per_mwh",
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_sales_sector",
+                "real_value_base_year",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__end_use_prices_by_service_category": {
+        "description": (
+            "Projected electricity cost to the end user by service category."
+        ),
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_service_category",
+                "real_value_base_year",
+                "end_use_price_per_mwh",
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_service_category",
+                "real_value_base_year",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__fuel_consumption_by_type": {
+        "description": (
+            "Projected fuel consumption by the electric power sector, "
+            "including electricity-only and combined-heat-and-power plants "
+            "that have a regulatory status."
+        ),
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_fuel_consumption_type",
+                "fuel_consumed_mmbtu",
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_fuel_consumption_type",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__electric_sector_fuel_cost_by_type": {
+        "description": (
+            "Projected fuel prices to the electric power sector, including "
+            "electricity-only and combined-heat-and-power plants that have a "
+            "regulatory status."
+        ),
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_fuel_cost_type",
+                "real_value_base_year",
+                "fuel_cost_mmbtu",  # this is *nominal* dollars, but we probably want to standardize to some sort of constant-dollar value?
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "aeo_fuel_cost_type",
+                "real_value_base_year",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__electric_power_sector_emissions": {
+        "description": (
+            "Projected emissions from the electric power sector, including "
+            "electricity-only and combined-heat-and-power plants that have a "
+            "regulatory status."
+        ),
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+                "carbon_mass_tons",
+                "co2_mass_tons",
+                "hg_mass_lb",
+                "nox_mass_lb",
+                "so2_mass_lb",
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region",
+                "aeo_case",
+                "projection_date",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+}
+
+# 2024-04-24: A holding pen so it's easy to see what the field definitions are.
+# Once we "promote" schemas we need to move the fields to the real
+# pudl.metadata.fields.FIELD_METADATA dictionary. What a frickin pain.
+_STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
+    "report_year": {
+        "type": "integer",
+        "description": "ALREADY EXISTS, HERE FOR CONVENIENCE!",
+    },
+    "projection_date": {
+        "type": "date",
+        "description": "Date at which this data is projected to be true.",
+    },
+    "real_value_base_year": {
+        "type": "integer",
+        "description": "Nominal monetary values are converted to values from this year.",
+    },
+    "electricity_market_module_region": {
+        "type": "string",
+        "description": "AEO projection region. Maybe the same as NERC region?",
+        "constraints": {
+            "enum": [
+                "florida_reliability_coordinating_council",
+                "midcontinent_central",
+                "midcontinent_east",
+                "midcontinent_south",
+                "midcontinent_west",
+                "northeast_power_coordinating_council_new_england",
+                "northeast_power_coordinating_council_new_york_city_and_long_island",
+                "northeast_power_coordinating_council_upstate_new_york",
+                "pjm_commonwealth_edison",
+                "pjm_dominion",
+                "pjm_east",
+                "pjm_west",
+                "serc_reliability_corporation_central",
+                "serc_reliability_corporation_east",
+                "serc_reliability_corporation_southeastern",
+                "southwest_power_pool_central",
+                "southwest_power_pool_north",
+                "southwest_power_pool_south",
+                "texas_reliability_entity",
+                "united_states",
+                "western_electricity_coordinating_council_basin",
+                "western_electricity_coordinating_council_california_north",
+                "western_electricity_coordinating_council_california_south",
+                "western_electricity_coordinating_council_northwest_power_pool_area",
+                "western_electricity_coordinating_council_rockies",
+                "western_electricity_coordinating_council_southwest",
+            ]
+        },
+    },
+    "aeo_case": {
+        "type": "string",
+        "description": "AEO modelling case.",
+        "constraints": {
+            "enum": [
+                "aeo2022",
+                "high_economic_growth",
+                "high_macro_and_high_zero_carbon_technology_cost",
+                "high_macro_and_low_zero_carbon_technology_cost",
+                "high_oil_and_gas_supply",
+                "high_oil_price",
+                "high_uptake_of_inflation_reduction_act",
+                "high_zero_carbon_technology_cost",
+                "low_economic_growth",
+                "low_macro_and_high_zero_carbon_technology_cost",
+                "low_macro_and_low_zero_carbon_technology_cost",
+                "low_oil_and_gas_supply",
+                "low_oil_price",
+                "low_uptake_of_inflation_reduction_act",
+                "low_zero_carbon_technology_cost",
+                "no_inflation_reduction_act",
+                "reference",
+            ]
+        },
+    },
+    "aeo_electricity_sector_fuel_type": {
+        "type": "string",
+        "description": "Fuel type reported for AEO electricity sector generation data.",
+        "constraints": {
+            "enum": [
+                "coal",
+                "combined_cycle",
+                "combustion_turbine_diesel",
+                "distributed_generation",
+                "diurnal_storage",
+                "fuel_cells",
+                "nuclear",
+                "oil_and_natural_gas_steam",
+                "pumped_storage",
+                "renewable_sources",
+                "total",  # this one isn't *really* a fuel type - should we even keep it around?
+                "sales_to_customers",  # this is only used for *total* generation, not *capacity*. And also isn't *really* a fuel type...
+                "generation_for_own_use",  # this is only used for *total* generation, not *capacity*. And also isn't *really* a fuel type...
+            ]
+        },
+    },
+    "aeo_end_use_sector_fuel_type": {
+        "type": "string",
+        "description": ("Fuel type reported for AEO end-use sector generation data."),
+        "constraints": {
+            "enum": [
+                "coal",
+                "petroleum",
+                "natural_gas",
+                "other_gaseous_fuels",
+                "renewable_sources",
+                "other",
+                "total",  # this one isn't *really* a fuel type - should we even keep it around?
+                "sales_to_the_grid",  # this is only used for *total* generation, not *capacity*. And also isn't *really* a fuel type...
+                "generation_for_own_use",  # this is only used for *total* generation, not *capacity*. And also isn't *really* a fuel type...
+            ]
+        },
+    },
+    "aeo_fuel_consumption_type": {
+        "type": "string",
+        "description": ("Fuel type reported for AEO fuel consumption data."),
+        "constraints": {
+            "enum": [
+                "coal",
+                "natural_gas",
+                "oil",
+                "total",  # this one isn't *really* a fuel type - should we even keep it around?
+            ]
+        },
+    },
+    "aeo_fuel_cost_type": {
+        "type": "string",
+        "description": ("Fuel type reported for AEO fuel consumption data."),
+        "constraints": {
+            "enum": [
+                "coal",
+                "natural_gas",
+                "distillate_fuel_oil",
+                "residual_fuel_oil",
+            ]
+        },
+    },
+    "aeo_net_energy_for_load_sector": {
+        "type": "string",
+        "description": ("Sector reported for net energy for load."),
+        "constraints": {
+            "enum": [
+                "gross_international_imports",
+                "gross_international_exports",
+                "gross_interregional_electricity_imports",
+                "gross_interregional_electricty_exports",
+                "purchases_from_combined_heat_and_power",
+                "electric_power_sector_generation_for_customer",
+                "total",  # not a real sector / calculatable from everything else, should we keep this?
+            ]
+        },
+    },
+    "aeo_sales_sector": {
+        "type": "string",
+        "description": ("Sector reported for electricity sales & end-use prices."),
+        "constraints": {
+            "enum": [
+                "residential",
+                "commercial",
+                "industrial",
+                "transportation",
+                "average",  # not a real sector, and only present for prices
+                "total",  # not a real sector, only present for sales
+            ]
+        },
+    },
+    "aeo_service_category": {
+        "type": "string",
+        "description": ("Service category reported for electricity end-use prices."),
+        "constraints": {
+            "enum": [
+                "generation",
+                "transmission",
+                "distribution",
+            ]
+        },
+    },
+    "carbon_mass_tons": {
+        "type": "number",
+        "description": "Total carbon emissions in short tons.",
+        "unit": "short_tons",
+    },
+    "co2_mass_tons": {
+        "type": "number",
+        "description": "ALREADY EXISTS, HERE FOR CONVENIENCE!",
+    },
+    "hg_mass_lbs": {
+        "type": "number",
+        "description": "Total mercury emissions in pounds.",
+        "unit": "lb",
+    },
+    "nox_mass_lbs": {
+        "type": "number",
+        "description": "ALREADY EXISTS, HERE FOR CONVENIENCE!",
+    },
+    "so2_mass_lbs": {
+        "type": "number",
+        "description": "ALREADY EXISTS, HERE FOR CONVENIENCE!",
+    },
+    "end_use_price_per_mwh": {
+        "type": "number",
+        "description": (
+            "End-use sector electricity prices (standardized to the year "
+            "``real_value_base_year``)."
+        ),
+        "unit": "USD/MWh",
+    },
+    "sales_mwh": {
+        "type": "number",
+        "description": "ALREADY EXISTS, JUST HERE FOR CONVENIENCE",
+        "unit": "MWh",
+    },
+    "net_summer_capacity_mw": {
+        "type": "number",
+        "description": "The steady hourly output that generating equipment is expected to apply to system load.",
+        "unit": "mw",
+    },  # should this be capacity_mw_eia?
+    "net_summer_capacity_cumulative_planned_additions_mw": {
+        "type": "number",
+        "description": (
+            "The total planned additions to generating capacity since the "
+            "beginning of the AEO period."
+        ),
+        "unit": "mw",
+    },
+    "net_summer_capacity_cumulative_unplanned_additions_mw": {
+        "type": "number",
+        "description": (
+            "The total unplanned additions to generating capacity since the "
+            "beginning of the AEO period."
+        ),
+        "unit": "mw",
+    },
+    "net_summer_capacity_cumulative_total_additions_mw": {  # this is just planned + unplanned - do we even care about publishing this?
+        "type": "number",
+        "description": (
+            "The total additions to generating capacity since the beginning "
+            "of the AEO period."
+        ),
+        "unit": "mw",
+    },
+    "net_summer_capacity_cumulative_retirements_mw": {
+        "type": "number",
+        "description": (
+            "The total retirements from generating capacity since the beginning "
+            "of the AEO period."
+        ),
+        "unit": "mw",
+    },
+}  # noqa:W0612
+
+# 2024-04-24: to "promote" the schemas, we can add them to this set and move
+# the field definitions
+RESOURCE_METADATA = {
+    key: value for key, value in _STAGING_RESOURCE_METADATA.items() if key in {}
+}

--- a/src/pudl/metadata/resources/eiaaeo.py
+++ b/src/pudl/metadata/resources/eiaaeo.py
@@ -5,7 +5,7 @@ from typing import Any
 # 2024-04-24: workaround so we can *define* a bunch of schemas without
 # documenting them or expecting assets to exist
 _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
-    "core_eiaaeo__electric_sector_generation_by_technology": {
+    "core_eiaaeo__yearly_projection_electric_sector_generation_by_technology": {
         "description": (
             "Projected generation capacity & total generation in the electric "
             "sector, broken out by technology."
@@ -35,7 +35,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__end_use_sectors_generation_by_fuel_type": {
+    "core_eiaaeo__yearly_projection_end_use_sectors_generation_by_fuel_type": {
         "description": (
             "Projected generation capacity & total generation in the end-use "
             "sector, broken out by fuel type.\n"
@@ -69,7 +69,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__electric_sector_generation": {
+    "core_eiaaeo__yearly_projection_electric_sector_generation": {
         "description": (
             "Projected total generation in the electric sector, across all "
             "technologies."
@@ -95,7 +95,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__end_use_sectors_generation": {
+    "core_eiaaeo__yearly_projection_end_use_sectors_generation": {
         "description": (
             "Projected total generation in the end-use sector, across all "
             "fuel types.\n"
@@ -128,7 +128,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__electricity_sales": {
+    "core_eiaaeo__yearly_projection_electricity_sales": {
         "description": "Projected electricity sales.",
         "schema": {
             "fields": [
@@ -151,7 +151,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__net_energy_for_load": {
+    "core_eiaaeo__yearly_projection_net_energy_for_load": {
         "description": "Projected net energy for load.",
         "schema": {
             "fields": [
@@ -174,7 +174,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__end_use_prices_by_sector": {
+    "core_eiaaeo__yearly_projection_end_use_prices_by_sector": {
         "description": "Projected electricity cost to the end user by sector.",
         "schema": {
             "fields": [
@@ -184,6 +184,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "projection_year",
                 "customer_class",
                 "nominal_price_per_mwh",
+                "real_price_per_mwh",
             ],
             "primary_key": [
                 "report_year",
@@ -197,7 +198,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__end_use_prices_by_service_category": {
+    "core_eiaaeo__yearly_projection_end_use_prices_by_service_category": {
         "description": (
             "Projected electricity cost to the end user by service category."
         ),
@@ -209,6 +210,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "projection_year",
                 "service_category_aeo",
                 "nominal_price_per_mwh",
+                "real_price_per_mwh",
             ],
             "primary_key": [
                 "report_year",
@@ -222,7 +224,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__fuel_consumption_by_type": {
+    "core_eiaaeo__yearly_projection_fuel_consumption_by_type": {
         "description": (
             "Projected fuel consumption by the electric power sector, "
             "including electricity-only and combined-heat-and-power plants "
@@ -249,7 +251,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__electric_sector_fuel_cost_by_type": {
+    "core_eiaaeo__yearly_projection_electric_sector_fuel_cost_by_type": {
         "description": (
             "Projected fuel prices to the electric power sector, including "
             "electricity-only and combined-heat-and-power plants that have a "
@@ -262,7 +264,8 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "modeling_case_aeo",
                 "projection_year",
                 "fuel_type_aeo",
-                "fuel_cost_mmbtu",  # this is *nominal* dollars, but we probably want to standardize to some sort of constant-dollar value?
+                "fuel_cost_per_mmbtu",
+                "fuel_cost_real_per_mmbtu_aeo",
             ],
             "primary_key": [
                 "report_year",
@@ -276,7 +279,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__electric_power_sector_emissions": {
+    "core_eiaaeo__yearly_projection_electric_power_sector_emissions": {
         "description": (
             "Projected emissions from the electric power sector, including "
             "electricity-only and combined-heat-and-power plants that have a "
@@ -386,6 +389,15 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
                 "other",
             ]
         },
+    },
+    "fuel_cost_real_per_mmbtu_aeo": {
+        "type": "number",
+        "description": (
+            "Average fuel cost per mmBTU of heat content in real USD, "
+            "standardized to the value of a USD in the year before the report "
+            "year."
+        ),
+        "unit": "USD_per_MMBtu",
     },
     "generation_for_own_use_mwh": {
         "type": "number",

--- a/src/pudl/metadata/resources/eiaaeo.py
+++ b/src/pudl/metadata/resources/eiaaeo.py
@@ -5,42 +5,40 @@ from typing import Any
 # 2024-04-24: workaround so we can *define* a bunch of schemas without
 # documenting them or expecting assets to exist
 _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
-    "core_eiaaeo__generation_electric_sector": {
+    "core_eiaaeo__electric_sector_generation_by_technology": {
         "description": (
             "Projected generation capacity & total generation in the electric "
-            "sector."
+            "sector, broken out by technology."
         ),
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_electricity_sector_fuel_type",
-                "net_summer_capacity_mw",  # should this be capacity_mw_eia?
-                # should we include "first modeled year" as a field, to help interpret all the cumulative fields?
-                "net_summer_capacity_cumulative_planned_additions_mw",
-                "net_summer_capacity_cumulative_unplanned_additions_mw",
-                "net_summer_capacity_cumulative_total_additions_mw",  # this is just planned + unplanned - do we even care about publishing this?
-                "net_summer_capacity_cumulative_retirements_mw",
-                "gross_generation_mwh",  # chose gross bc the numbers add up to "total generation" which then equals "sales to customers + generation for own use" - but... is that right?
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "technology_description_aeo",
+                "summer_capacity_mw",
+                "summer_capacity_planned_additions_mw",
+                "summer_capacity_unplanned_additions_mw",
+                "summer_capacity_retirements_mw",
+                "gross_generation_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_electricity_sector_fuel_type",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "technology_description_aeo",
             ],
         },
         "sources": ["eiaaeo"],
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__generation_end_use_sector": {
+    "core_eiaaeo__end_use_sectors_generation_by_fuel_type": {
         "description": (
             "Projected generation capacity & total generation in the end-use "
-            "sector.\n"
+            "sector, broken out by fuel type.\n"
             "Includes combined-heat-and-power plants and electricity-only "
             "plants in the commercial and industrial sectors; and small on-site "
             "generating systems in the residential, commercial, and industrial "
@@ -52,19 +50,78 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_end_use_sector_fuel_type",
-                "net_summer_capacity_mw",  # should this be capacity_mw_eia?
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "fuel_type_aeo",
+                "summer_capacity_mw",  # should this be capacity_mw_eia?
                 "gross_generation_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_end_use_sector_fuel_type",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "fuel_type_aeo",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__electric_sector_generation": {
+        "description": (
+            "Projected total generation in the electric sector, across all "
+            "technologies."
+        ),
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "gross_generation_mwh",
+                "sales_mwh",
+                "generation_for_own_use_mwh",
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+            ],
+        },
+        "sources": ["eiaaeo"],
+        "field_namespace": "eiaaeo",
+        "etl_group": "eiaaeo",
+    },
+    "core_eiaaeo__end_use_sectors_generation": {
+        "description": (
+            "Projected total generation in the end-use sector, across all "
+            "fuel types.\n"
+            "Includes combined-heat-and-power plants and electricity-only "
+            "plants in the commercial and industrial sectors; and small on-site "
+            "generating systems in the residential, commercial, and industrial "
+            "sectors used primarily for own-use generation, but which may also "
+            "sell some power to the grid. Solar photovoltaic capacity portion of "
+            "Renewable Sources in gigawatts direct current; other technologies "
+            "in gigawatts alternating current."
+        ),
+        "schema": {
+            "fields": [
+                "report_year",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "gross_generation_mwh",
+                "sales_mwh",
+                "generation_for_own_use_mwh",
+            ],
+            "primary_key": [
+                "report_year",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
             ],
         },
         "sources": ["eiaaeo"],
@@ -76,18 +133,18 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_sales_sector",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "customer_class",
                 "sales_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_sales_sector",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "customer_class",
             ],
         },
         "sources": ["eiaaeo"],
@@ -99,18 +156,18 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_net_energy_for_load_sector",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "generation_source_or_sink_type_aeo",
                 "net_energy_for_load_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_net_energy_for_load_sector",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "generation_source_or_sink_type_aeo",
             ],
         },
         "sources": ["eiaaeo"],
@@ -122,20 +179,18 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_sales_sector",
-                "real_value_base_year",
-                "end_use_price_per_mwh",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "customer_class",
+                "nominal_price_per_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_sales_sector",
-                "real_value_base_year",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "customer_class",
             ],
         },
         "sources": ["eiaaeo"],
@@ -149,20 +204,18 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_service_category",
-                "real_value_base_year",
-                "end_use_price_per_mwh",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "service_category_aeo",
+                "nominal_price_per_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_service_category",
-                "real_value_base_year",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "service_category_aeo",
             ],
         },
         "sources": ["eiaaeo"],
@@ -178,18 +231,18 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_fuel_consumption_type",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "fuel_type_aeo",
                 "fuel_consumed_mmbtu",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_fuel_consumption_type",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "fuel_type_aeo",
             ],
         },
         "sources": ["eiaaeo"],
@@ -205,20 +258,18 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_fuel_cost_type",
-                "real_value_base_year",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "fuel_type_aeo",
                 "fuel_cost_mmbtu",  # this is *nominal* dollars, but we probably want to standardize to some sort of constant-dollar value?
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
-                "aeo_fuel_cost_type",
-                "real_value_base_year",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
+                "fuel_type_aeo",
             ],
         },
         "sources": ["eiaaeo"],
@@ -234,9 +285,9 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
                 "carbon_mass_tons",
                 "co2_mass_tons",
                 "hg_mass_lb",
@@ -245,9 +296,9 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region",
-                "aeo_case",
-                "projection_date",
+                "electricity_market_module_region_aeo",
+                "modeling_case_aeo",
+                "projection_year",
             ],
         },
         "sources": ["eiaaeo"],
@@ -260,21 +311,37 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
 # Once we "promote" schemas we need to move the fields to the real
 # pudl.metadata.fields.FIELD_METADATA dictionary. What a frickin pain.
 _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
-    "report_year": {
-        "type": "integer",
-        "description": "ALREADY EXISTS, HERE FOR CONVENIENCE!",
-    },
-    "projection_date": {
-        "type": "date",
-        "description": "Date at which this data is projected to be true.",
-    },
-    "real_value_base_year": {
-        "type": "integer",
-        "description": "Nominal monetary values are converted to values from this year.",
-    },
-    "electricity_market_module_region": {
+    "aeo_fuel_consumption_type": {  # TODO: turn this into a resource-specific enum for fuel_type_aeo when promoting.
         "type": "string",
-        "description": "AEO projection region. Maybe the same as NERC region?",
+        "description": ("Fuel type reported for AEO fuel consumption data."),
+        "constraints": {
+            "enum": [
+                "coal",
+                "natural_gas",
+                "oil",
+            ]
+        },
+    },
+    "aeo_fuel_cost_type": {  # TODO: turn this into a resource-specific enum for fuel_type_aeo when promoting.
+        "type": "string",
+        "description": ("Fuel type reported for AEO fuel consumption data."),
+        "constraints": {
+            "enum": [
+                "coal",
+                "natural_gas",
+                "distillate_fuel_oil",
+                "residual_fuel_oil",
+            ]
+        },
+    },
+    "carbon_mass_tons": {
+        "type": "number",
+        "description": "Total carbon emissions in short tons.",
+        "unit": "short_tons",
+    },
+    "electricity_market_module_region_aeo": {
+        "type": "string",
+        "description": "AEO projection region.",
         "constraints": {
             "enum": [
                 "florida_reliability_coordinating_council",
@@ -306,9 +373,47 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
             ]
         },
     },
-    "aeo_case": {
+    "fuel_type_aeo": {
         "type": "string",
-        "description": "AEO modelling case.",
+        "description": ("Fuel type reported for AEO end-use sector generation data."),
+        "constraints": {
+            "enum": [
+                "coal",
+                "petroleum",
+                "natural_gas",
+                "other_gaseous_fuels",
+                "renewable_sources",
+                "other",
+            ]
+        },
+    },
+    "generation_for_own_use_mwh": {
+        "type": "number",
+        "description": "Amount of generation that is used for generation instead of sold.",
+        "unit": "MWh",
+    },
+    "generation_source_or_sink_type_aeo": {
+        "type": "string",
+        "description": ("Sector reported for net energy for load."),
+        "constraints": {
+            "enum": [
+                "gross_international_imports",
+                "gross_international_exports",
+                "gross_interregional_electricity_imports",
+                "gross_interregional_electricty_exports",
+                "purchases_from_combined_heat_and_power",
+                "electric_power_sector_generation_for_customer",
+            ]
+        },
+    },
+    "hg_mass_lbs": {
+        "type": "number",
+        "description": "Total mercury emissions in pounds.",
+        "unit": "lb",
+    },
+    "modeling_case_aeo": {
+        "type": "string",
+        "description": "AEO modeling case.",
         "constraints": {
             "enum": [
                 "aeo2022",
@@ -331,7 +436,56 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
             ]
         },
     },
-    "aeo_electricity_sector_fuel_type": {
+    "nominal_price_per_mwh": {
+        "type": "number",
+        "description": ("Nominal electricity price per MWh."),
+        "unit": "USD/MWh",
+    },
+    "projection_year": {
+        "type": "date",
+        "description": "Date at which this data is projected to be true.",
+    },
+    "real_price_per_mwh": {
+        "type": "number",
+        "description": (
+            "Real electricity price per MWh, standardized to "
+            "the year before the ``report_year``."
+        ),
+        "unit": "USD/MWh",
+    },
+    "service_category_aeo": {
+        "type": "string",
+        "description": ("Service category reported for electricity end-use prices."),
+        "constraints": {
+            "enum": [
+                "generation",
+                "transmission",
+                "distribution",
+            ]
+        },
+    },
+    "summer_capacity_planned_additions_mw": {
+        "type": "number",
+        "description": (
+            "The total planned additions to net summer generating capacity."
+        ),
+        "unit": "mw",
+    },
+    "summer_capacity_retirements_mw": {
+        "type": "number",
+        "description": (
+            "The total retirements from to net summer generating capacity."
+        ),
+        "unit": "mw",
+    },
+    "summer_capacity_unplanned_additions_mw": {
+        "type": "number",
+        "description": (
+            "The total unplanned additions to net summer generating capacity."
+        ),
+        "unit": "mw",
+    },
+    "technology_description_aeo": {
         "type": "string",
         "description": "Fuel type reported for AEO electricity sector generation data.",
         "constraints": {
@@ -346,164 +500,8 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
                 "oil_and_natural_gas_steam",
                 "pumped_storage",
                 "renewable_sources",
-                "total",  # this one isn't *really* a fuel type - should we even keep it around?
-                "sales_to_customers",  # this is only used for *total* generation, not *capacity*. And also isn't *really* a fuel type...
-                "generation_for_own_use",  # this is only used for *total* generation, not *capacity*. And also isn't *really* a fuel type...
             ]
         },
-    },
-    "aeo_end_use_sector_fuel_type": {
-        "type": "string",
-        "description": ("Fuel type reported for AEO end-use sector generation data."),
-        "constraints": {
-            "enum": [
-                "coal",
-                "petroleum",
-                "natural_gas",
-                "other_gaseous_fuels",
-                "renewable_sources",
-                "other",
-                "total",  # this one isn't *really* a fuel type - should we even keep it around?
-                "sales_to_the_grid",  # this is only used for *total* generation, not *capacity*. And also isn't *really* a fuel type...
-                "generation_for_own_use",  # this is only used for *total* generation, not *capacity*. And also isn't *really* a fuel type...
-            ]
-        },
-    },
-    "aeo_fuel_consumption_type": {
-        "type": "string",
-        "description": ("Fuel type reported for AEO fuel consumption data."),
-        "constraints": {
-            "enum": [
-                "coal",
-                "natural_gas",
-                "oil",
-                "total",  # this one isn't *really* a fuel type - should we even keep it around?
-            ]
-        },
-    },
-    "aeo_fuel_cost_type": {
-        "type": "string",
-        "description": ("Fuel type reported for AEO fuel consumption data."),
-        "constraints": {
-            "enum": [
-                "coal",
-                "natural_gas",
-                "distillate_fuel_oil",
-                "residual_fuel_oil",
-            ]
-        },
-    },
-    "aeo_net_energy_for_load_sector": {
-        "type": "string",
-        "description": ("Sector reported for net energy for load."),
-        "constraints": {
-            "enum": [
-                "gross_international_imports",
-                "gross_international_exports",
-                "gross_interregional_electricity_imports",
-                "gross_interregional_electricty_exports",
-                "purchases_from_combined_heat_and_power",
-                "electric_power_sector_generation_for_customer",
-                "total",  # not a real sector / calculatable from everything else, should we keep this?
-            ]
-        },
-    },
-    "aeo_sales_sector": {
-        "type": "string",
-        "description": ("Sector reported for electricity sales & end-use prices."),
-        "constraints": {
-            "enum": [
-                "residential",
-                "commercial",
-                "industrial",
-                "transportation",
-                "average",  # not a real sector, and only present for prices
-                "total",  # not a real sector, only present for sales
-            ]
-        },
-    },
-    "aeo_service_category": {
-        "type": "string",
-        "description": ("Service category reported for electricity end-use prices."),
-        "constraints": {
-            "enum": [
-                "generation",
-                "transmission",
-                "distribution",
-            ]
-        },
-    },
-    "carbon_mass_tons": {
-        "type": "number",
-        "description": "Total carbon emissions in short tons.",
-        "unit": "short_tons",
-    },
-    "co2_mass_tons": {
-        "type": "number",
-        "description": "ALREADY EXISTS, HERE FOR CONVENIENCE!",
-    },
-    "hg_mass_lbs": {
-        "type": "number",
-        "description": "Total mercury emissions in pounds.",
-        "unit": "lb",
-    },
-    "nox_mass_lbs": {
-        "type": "number",
-        "description": "ALREADY EXISTS, HERE FOR CONVENIENCE!",
-    },
-    "so2_mass_lbs": {
-        "type": "number",
-        "description": "ALREADY EXISTS, HERE FOR CONVENIENCE!",
-    },
-    "end_use_price_per_mwh": {
-        "type": "number",
-        "description": (
-            "End-use sector electricity prices (standardized to the year "
-            "``real_value_base_year``)."
-        ),
-        "unit": "USD/MWh",
-    },
-    "sales_mwh": {
-        "type": "number",
-        "description": "ALREADY EXISTS, JUST HERE FOR CONVENIENCE",
-        "unit": "MWh",
-    },
-    "net_summer_capacity_mw": {
-        "type": "number",
-        "description": "The steady hourly output that generating equipment is expected to apply to system load.",
-        "unit": "mw",
-    },  # should this be capacity_mw_eia?
-    "net_summer_capacity_cumulative_planned_additions_mw": {
-        "type": "number",
-        "description": (
-            "The total planned additions to generating capacity since the "
-            "beginning of the AEO period."
-        ),
-        "unit": "mw",
-    },
-    "net_summer_capacity_cumulative_unplanned_additions_mw": {
-        "type": "number",
-        "description": (
-            "The total unplanned additions to generating capacity since the "
-            "beginning of the AEO period."
-        ),
-        "unit": "mw",
-    },
-    "net_summer_capacity_cumulative_total_additions_mw": {  # this is just planned + unplanned - do we even care about publishing this?
-        "type": "number",
-        "description": (
-            "The total additions to generating capacity since the beginning "
-            "of the AEO period."
-        ),
-        "unit": "mw",
-    },
-    "net_summer_capacity_cumulative_retirements_mw": {
-        "type": "number",
-        "description": (
-            "The total retirements from generating capacity since the beginning "
-            "of the AEO period."
-        ),
-        "unit": "mw",
     },
 }  # noqa:W0612
 

--- a/src/pudl/metadata/resources/eiaaeo.py
+++ b/src/pudl/metadata/resources/eiaaeo.py
@@ -5,7 +5,7 @@ from typing import Any
 # 2024-04-24: workaround so we can *define* a bunch of schemas without
 # documenting them or expecting assets to exist
 _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
-    "core_eiaaeo__yearly_projection_electric_sector_generation_by_technology": {
+    "core_eiaaeo__yearly_projected_generation_in_electric_sector_by_technology": {
         "description": (
             "Projected generation capacity & total generation in the electric "
             "sector, broken out by technology."
@@ -13,10 +13,10 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "technology_description_aeo",
+                "technology_description_eiaaeo",
                 "summer_capacity_mw",
                 "summer_capacity_planned_additions_mw",
                 "summer_capacity_unplanned_additions_mw",
@@ -25,17 +25,17 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "technology_description_aeo",
+                "technology_description_eiaaeo",
             ],
         },
         "sources": ["eiaaeo"],
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_end_use_sectors_generation_by_fuel_type": {
+    "core_eiaaeo__yearly_projected_generation_in_end_use_sectors_by_fuel_type": {
         "description": (
             "Projected generation capacity & total generation in the end-use "
             "sector, broken out by fuel type.\n"
@@ -50,26 +50,26 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "fuel_type_aeo",
+                "fuel_type_eiaaeo",
                 "summer_capacity_mw",  # should this be capacity_mw_eia?
                 "gross_generation_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "fuel_type_aeo",
+                "fuel_type_eiaaeo",
             ],
         },
         "sources": ["eiaaeo"],
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_electric_sector_generation": {
+    "core_eiaaeo__yearly_projected_generation_in_electric_sector": {
         "description": (
             "Projected total generation in the electric sector, across all "
             "technologies."
@@ -77,8 +77,8 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
                 "gross_generation_mwh",
                 "sales_mwh",
@@ -86,8 +86,8 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
             ],
         },
@@ -95,7 +95,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_end_use_sectors_generation": {
+    "core_eiaaeo__yearly_projected_generation_in_end_use_sectors": {
         "description": (
             "Projected total generation in the end-use sector, across all "
             "fuel types.\n"
@@ -110,8 +110,8 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
                 "gross_generation_mwh",
                 "sales_mwh",
@@ -119,8 +119,8 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
             ],
         },
@@ -128,21 +128,21 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_electricity_sales": {
+    "core_eiaaeo__yearly_projected_generation_electric_sales": {
         "description": "Projected electricity sales.",
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
                 "customer_class",
                 "sales_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
                 "customer_class",
             ],
@@ -151,36 +151,36 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_net_energy_for_load": {
+    "core_eiaaeo__yearly_projected_net_energy_for_load": {
         "description": "Projected net energy for load.",
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "generation_source_or_sink_type_aeo",
+                "generation_source_or_sink_type_eiaaeo",
                 "net_energy_for_load_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "generation_source_or_sink_type_aeo",
+                "generation_source_or_sink_type_eiaaeo",
             ],
         },
         "sources": ["eiaaeo"],
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_end_use_prices_by_sector": {
+    "core_eiaaeo__yearly_projected_end_use_prices_by_sector": {
         "description": "Projected electricity cost to the end user by sector.",
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
                 "customer_class",
                 "nominal_price_per_mwh",
@@ -188,8 +188,8 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
                 "customer_class",
             ],
@@ -198,33 +198,33 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_end_use_prices_by_service_category": {
+    "core_eiaaeo__yearly_projected_end_use_prices_by_service_category": {
         "description": (
             "Projected electricity cost to the end user by service category."
         ),
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "service_category_aeo",
+                "service_category_eiaaeo",
                 "nominal_price_per_mwh",
                 "real_price_per_mwh",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "service_category_aeo",
+                "service_category_eiaaeo",
             ],
         },
         "sources": ["eiaaeo"],
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_fuel_consumption_by_type": {
+    "core_eiaaeo__yearly_projected_fuel_consumption_by_type": {
         "description": (
             "Projected fuel consumption by the electric power sector, "
             "including electricity-only and combined-heat-and-power plants "
@@ -233,25 +233,25 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "fuel_type_aeo",
+                "fuel_type_eiaaeo",
                 "fuel_consumed_mmbtu",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "fuel_type_aeo",
+                "fuel_type_eiaaeo",
             ],
         },
         "sources": ["eiaaeo"],
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_electric_sector_fuel_cost_by_type": {
+    "core_eiaaeo__yearly_projected_fuel_cost_in_electric_sector_by_type": {
         "description": (
             "Projected fuel prices to the electric power sector, including "
             "electricity-only and combined-heat-and-power plants that have a "
@@ -260,26 +260,26 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "fuel_type_aeo",
+                "fuel_type_eiaaeo",
                 "fuel_cost_per_mmbtu",
-                "fuel_cost_real_per_mmbtu_aeo",
+                "fuel_cost_real_per_mmbtu_eiaaeo",
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
-                "fuel_type_aeo",
+                "fuel_type_eiaaeo",
             ],
         },
         "sources": ["eiaaeo"],
         "field_namespace": "eiaaeo",
         "etl_group": "eiaaeo",
     },
-    "core_eiaaeo__yearly_projection_electric_power_sector_emissions": {
+    "core_eiaaeo__yearly_projected_emissions_in_electric_sector": {
         "description": (
             "Projected emissions from the electric power sector, including "
             "electricity-only and combined-heat-and-power plants that have a "
@@ -288,8 +288,8 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "schema": {
             "fields": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
                 "carbon_mass_tons",
                 "co2_mass_tons",
@@ -299,8 +299,8 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
             ],
             "primary_key": [
                 "report_year",
-                "electricity_market_module_region_aeo",
-                "modeling_case_aeo",
+                "emm_region_eiaaeo",
+                "model_case_eiaaeo",
                 "projection_year",
             ],
         },
@@ -314,7 +314,7 @@ _STAGING_RESOURCE_METADATA: dict[str, dict[str, Any]] = {
 # Once we "promote" schemas we need to move the fields to the real
 # pudl.metadata.fields.FIELD_METADATA dictionary. What a frickin pain.
 _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
-    "aeo_fuel_consumption_type": {  # TODO: turn this into a resource-specific enum for fuel_type_aeo when promoting.
+    "aeo_fuel_consumption_type": {  # TODO: turn this into a resource-specific enum for fuel_type_eiaaeo when promoting.
         "type": "string",
         "description": ("Fuel type reported for AEO fuel consumption data."),
         "constraints": {
@@ -325,7 +325,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
             ]
         },
     },
-    "aeo_fuel_cost_type": {  # TODO: turn this into a resource-specific enum for fuel_type_aeo when promoting.
+    "aeo_fuel_cost_type": {  # TODO: turn this into a resource-specific enum for fuel_type_eiaaeo when promoting.
         "type": "string",
         "description": ("Fuel type reported for AEO fuel consumption data."),
         "constraints": {
@@ -342,7 +342,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Total carbon emissions in short tons.",
         "unit": "short_tons",
     },
-    "electricity_market_module_region_aeo": {
+    "emm_region_eiaaeo": {
         "type": "string",
         "description": "AEO projection region.",
         "constraints": {
@@ -376,7 +376,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
             ]
         },
     },
-    "fuel_type_aeo": {
+    "fuel_type_eiaaeo": {
         "type": "string",
         "description": ("Fuel type reported for AEO end-use sector generation data."),
         "constraints": {
@@ -390,7 +390,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
             ]
         },
     },
-    "fuel_cost_real_per_mmbtu_aeo": {
+    "fuel_cost_real_per_mmbtu_eiaaeo": {
         "type": "number",
         "description": (
             "Average fuel cost per mmBTU of heat content in real USD, "
@@ -404,7 +404,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Amount of generation that is used for generation instead of sold.",
         "unit": "MWh",
     },
-    "generation_source_or_sink_type_aeo": {
+    "generation_source_or_sink_type_eiaaeo": {
         "type": "string",
         "description": ("Sector reported for net energy for load."),
         "constraints": {
@@ -423,7 +423,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Total mercury emissions in pounds.",
         "unit": "lb",
     },
-    "modeling_case_aeo": {
+    "model_case_eiaaeo": {
         "type": "string",
         "description": "AEO modeling case.",
         "constraints": {
@@ -448,7 +448,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
             ]
         },
     },
-    "nominal_price_per_mwh": {
+    "price_per_mwh": {
         "type": "number",
         "description": ("Nominal electricity price per MWh."),
         "unit": "USD/MWh",
@@ -457,7 +457,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
         "type": "date",
         "description": "Date at which this data is projected to be true.",
     },
-    "real_price_per_mwh": {
+    "price_real_per_mwh": {
         "type": "number",
         "description": (
             "Real electricity price per MWh, standardized to "
@@ -465,7 +465,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
         ),
         "unit": "USD/MWh",
     },
-    "service_category_aeo": {
+    "service_category_eiaaeo": {
         "type": "string",
         "description": ("Service category reported for electricity end-use prices."),
         "constraints": {
@@ -497,7 +497,7 @@ _STAGING_FIELD_METADATA: dict[str, dict[str, Any]] = {
         ),
         "unit": "mw",
     },
-    "technology_description_aeo": {
+    "technology_description_eiaaeo": {
         "type": "string",
         "description": "Fuel type reported for AEO electricity sector generation data.",
         "constraints": {


### PR DESCRIPTION


<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

doesn't really close #3581, but sure helps!

Table 54 has a bunch of confusingly heterogeneous data, here I'm sorting them and organizing them in some way.

Also, I'm introducing a new pattern of defining schemas in a 'staging area' that can be reviewed + checked in, but don't get published or expect there to be an asset involved. This enables the following flow:

1. figure out some resource designs ahead of time - often we'll want to design multiple resources at once due to interdependencies
2. merge that
3. work on new assets that generate those resources, maybe even in parallel!
4. promote and merge new assets as they become complete, so we don't have to wait for *all* assets to be done to use *any* assets

# Testing

How did you make sure this worked? How can a reviewer verify this?

Nothing seems to have broken because the `RESOURCE_METADATA` dictionary is actually empty right now. Once we start promoting assets, then we'll have to make sure *those* assets actually get pulled in, etc.

```[tasklist]
# To-do list
- [ ] Review the PR yourself and call out any questions or issues you have
```
