### PR TITLE
Speed up nb-output-clear step in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,11 +68,11 @@ repos:
         stages: [commit]
         language: system
         verbose: false
-        pass_filenames: false
-        always_run: true
-        entry:
-          find devtools \( -name \*.ipynb -not -name \*checkpoint.ipynb \) -type
-          f -exec jupyter nbconvert --clear-output {} \;
+        files: ".*\\.ipynb"
+        pass_filenames: true
+        always_run: false
+        entry: jupyter nbconvert --clear-output
+
       - id: unit-tests
         name: unit-tests
         stages: [commit]


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

I finally got fed up waiting several seconds for `nb-output-clear` to do its thing and made it only clear ipynbs that actually changed.

# Testing

How did you make sure this worked? How can a reviewer verify this?

1. made some trivial changes to ipynbs in devtools, set `verbose: true` on the hook
2. staged one ipynb change for commit
3. committed, saw that only the changed ipynb was passed through `nbconvert`
4. `git reset HEAD^`
5. only stage the precommit hook
6. commit, see that we skip the `nb-output-clear` step

```[tasklist]
# To-do list
- [ ] Review the PR yourself and call out any questions or issues you have
```
