### PR TITLE
Fix quoting in hourly parquet deployment command

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -210,7 +210,7 @@ function clean_up_outputs_for_distribution() {
     # Compress the SQLite DBs for easier distribution
     gzip --verbose "$PUDL_OUTPUT"/*.sqlite && \
     # Grab hourly tables which are only written to Parquet for distribution
-    cp "$PUDL_OUTPUT/parquet/*__hourly_*.parquet" "$PUDL_OUTPUT" && \
+    cp "$PUDL_OUTPUT"/parquet/*__hourly_*.parquet "$PUDL_OUTPUT" && \
     # Remove all other parquet output, which we are not yet distributing.
     rm -rf "$PUDL_OUTPUT/parquet" && \
     rm -f "$PUDL_OUTPUT/metadata.yml"


### PR DESCRIPTION
# Overview

Fix quoting in the nightly build script which is attempting to copy all hourly parquet outputs into the distribution directory.

Closes #3601

# Testing

Unfortunately testing this part of the nightly build script is annoying, so I haven't tested it.
