### PR TITLE
Remove unused resource keys from asset definitions

### DIFF
--- a/src/pudl/extract/eia176.py
+++ b/src/pudl/extract/eia176.py
@@ -39,9 +39,7 @@ class Extractor(CsvExtractor):
 raw_eia176__all_dfs = raw_df_factory(Extractor, name="eia176")
 
 
-@asset(
-    required_resource_keys={"datastore", "dataset_settings"},
-)
+@asset
 def raw_eia176__data(raw_eia176__all_dfs):
     """Extract raw EIA company data from CSV sheets into dataframes.
 

--- a/src/pudl/extract/eia191.py
+++ b/src/pudl/extract/eia191.py
@@ -39,9 +39,7 @@ class Extractor(CsvExtractor):
 raw_eia191__all_dfs = raw_df_factory(Extractor, name="eia191")
 
 
-@asset(
-    required_resource_keys={"datastore", "dataset_settings"},
-)
+@asset
 def raw_eia191__data(raw_eia191__all_dfs):
     """Extract raw EIA company data from CSV sheets into dataframes.
 

--- a/src/pudl/extract/eia757a.py
+++ b/src/pudl/extract/eia757a.py
@@ -39,9 +39,7 @@ class Extractor(CsvExtractor):
 raw_eia757a__all_dfs = raw_df_factory(Extractor, name="eia757a")
 
 
-@asset(
-    required_resource_keys={"datastore", "dataset_settings"},
-)
+@asset
 def raw_eia757a__data(raw_eia757a__all_dfs):
     """Extract raw EIA company data from CSV sheets into dataframes.
 

--- a/src/pudl/extract/eia860m.py
+++ b/src/pudl/extract/eia860m.py
@@ -92,9 +92,7 @@ def append_eia860m(
     return eia860_raw_dfs
 
 
-@asset(
-    required_resource_keys={"datastore", "dataset_settings"},
-)
+@asset(required_resource_keys={"datastore", "dataset_settings"})
 def raw_eia860m__all_dfs(context):
     """Extract raw EIA 860M data from excel sheets into dict of dataframes."""
     eia_settings = context.resources.dataset_settings.eia
@@ -116,7 +114,6 @@ raw_table_names = (
 
 @multi_asset(
     outs={table_name: AssetOut() for table_name in sorted(raw_table_names)},
-    required_resource_keys={"datastore", "dataset_settings"},
 )
 def extract_eia860m(raw_eia860m__all_dfs: dict[str, pd.DataFrame]):
     """Extract raw EIA data from excel sheets into dataframes.

--- a/src/pudl/extract/eia860m.py
+++ b/src/pudl/extract/eia860m.py
@@ -105,25 +105,20 @@ def raw_eia860m__all_dfs(context):
     return raw_eia860m__all_dfs
 
 
-raw_table_names = (
-    "raw_eia860m__generator_existing",
-    "raw_eia860m__generator_proposed",
-    "raw_eia860m__generator_retired",
-)
-
-
 @multi_asset(
-    outs={table_name: AssetOut() for table_name in sorted(raw_table_names)},
+    outs={
+        table_name: AssetOut()
+        for table_name in sorted(
+            (
+                "raw_eia860m__generator_existing",
+                "raw_eia860m__generator_proposed",
+                "raw_eia860m__generator_retired",
+            )
+        )
+    },
 )
 def extract_eia860m(raw_eia860m__all_dfs: dict[str, pd.DataFrame]):
-    """Extract raw EIA data from excel sheets into dataframes.
-
-    Args:
-        context: dagster keyword that provides access to resources and config.
-
-    Returns:
-        A tuple of extracted EIA dataframes.
-    """
+    """Extract raw EIA data from excel sheets into dataframes."""
     # create descriptive table_names
     raw_eia860m__all_dfs = {
         "raw_eia860m__" + table_name: df

--- a/src/pudl/extract/eia861.py
+++ b/src/pudl/extract/eia861.py
@@ -105,15 +105,8 @@ raw_eia861__all_dfs = raw_df_factory(Extractor, name="eia861")
         )
     },
 )
-def extract_eia861(context, raw_eia861__all_dfs):
-    """Extract raw EIA-861 data from Excel sheets into dataframes.
-
-    Args:
-        context: dagster keyword that provides access to resources and config.
-
-    Returns:
-        A tuple of extracted EIA-861 dataframes.
-    """
+def extract_eia861(raw_eia861__all_dfs):
+    """Extract raw EIA-861 data from Excel sheets into dataframes."""
     raw_eia861__all_dfs = {
         "raw_eia861__" + table_name.replace("_eia861", ""): df
         for table_name, df in raw_eia861__all_dfs.items()

--- a/src/pudl/extract/eia861.py
+++ b/src/pudl/extract/eia861.py
@@ -104,7 +104,6 @@ raw_eia861__all_dfs = raw_df_factory(Extractor, name="eia861")
             )
         )
     },
-    required_resource_keys={"datastore", "dataset_settings"},
 )
 def extract_eia861(context, raw_eia861__all_dfs):
     """Extract raw EIA-861 data from Excel sheets into dataframes.

--- a/src/pudl/extract/eia923.py
+++ b/src/pudl/extract/eia923.py
@@ -95,40 +95,33 @@ class Extractor(excel.ExcelExtractor):
         }
 
 
-# TODO (bendnorman): Add this information to the metadata
-eia_raw_table_names = (
-    "raw_eia923__boiler_fuel",
-    "raw_eia923__energy_storage",
-    "raw_eia923__fuel_receipts_costs",
-    "raw_eia923__generation_fuel",
-    "raw_eia923__generator",
-    "raw_eia923__stocks",
-    "raw_eia923__emissions_control",
-    "raw_eia923__byproduct_disposition",
-    "raw_eia923__byproduct_expenses_and_revenues",
-    "raw_eia923__fgd_operation_maintenance",
-    "raw_eia923__cooling_system_information",
-    "raw_eia923__boiler_nox_operation",
-    "raw_eia923__fgp_operation",
-)
-
-
 raw_eia923__all_dfs = raw_df_factory(Extractor, name="eia923")
 
 
-# TODO (bendnorman): Figure out type hint for context keyword and mutli_asset return
 @multi_asset(
-    outs={table_name: AssetOut() for table_name in sorted(eia_raw_table_names)},
+    outs={
+        table_name: AssetOut()
+        for table_name in sorted(
+            (
+                "raw_eia923__boiler_fuel",
+                "raw_eia923__energy_storage",
+                "raw_eia923__fuel_receipts_costs",
+                "raw_eia923__generation_fuel",
+                "raw_eia923__generator",
+                "raw_eia923__stocks",
+                "raw_eia923__emissions_control",
+                "raw_eia923__byproduct_disposition",
+                "raw_eia923__byproduct_expenses_and_revenues",
+                "raw_eia923__fgd_operation_maintenance",
+                "raw_eia923__cooling_system_information",
+                "raw_eia923__boiler_nox_operation",
+                "raw_eia923__fgp_operation",
+            )
+        )
+    },
 )
-def extract_eia923(context, raw_eia923__all_dfs):
-    """Extract raw EIA-923 data from excel sheets into dataframes.
-
-    Args:
-        context: dagster keyword that provides access to resources and config.
-
-    Returns:
-        A tuple of extracted EIA dataframes.
-    """
+def extract_eia923(raw_eia923__all_dfs):
+    """Extract raw EIA-923 data from excel sheets into dataframes."""
     # create descriptive table_names
     raw_eia923__all_dfs = {
         "raw_eia923__" + table_name: df

--- a/src/pudl/extract/eia923.py
+++ b/src/pudl/extract/eia923.py
@@ -119,7 +119,6 @@ raw_eia923__all_dfs = raw_df_factory(Extractor, name="eia923")
 # TODO (bendnorman): Figure out type hint for context keyword and mutli_asset return
 @multi_asset(
     outs={table_name: AssetOut() for table_name in sorted(eia_raw_table_names)},
-    required_resource_keys={"datastore", "dataset_settings"},
 )
 def extract_eia923(context, raw_eia923__all_dfs):
     """Extract raw EIA-923 data from excel sheets into dataframes.

--- a/src/pudl/extract/extractor.py
+++ b/src/pudl/extract/extractor.py
@@ -328,7 +328,7 @@ def partition_extractor_factory(
     """
 
     @op(
-        required_resource_keys={"datastore", "dataset_settings"},
+        required_resource_keys={"datastore"},
         name=f"extract_single_{name}_partition",
         ins={"part_dict": In(dagster_type=dagster_dict_str_strint)},
     )

--- a/src/pudl/extract/nrelatb.py
+++ b/src/pudl/extract/nrelatb.py
@@ -22,9 +22,7 @@ class Extractor(ParquetExtractor):
 raw_nrelatb__all_dfs = raw_df_factory(Extractor, name="nrelatb")
 
 
-@asset(
-    required_resource_keys={"datastore", "dataset_settings"},
-)
+@asset
 def raw_nrelatb__data(raw_nrelatb__all_dfs):
     """Extract raw NREL ATB data from annual parquet files to one dataframe.
 

--- a/src/pudl/extract/phmsagas.py
+++ b/src/pudl/extract/phmsagas.py
@@ -55,41 +55,35 @@ class Extractor(excel.ExcelExtractor):
         return newdata
 
 
-# TODO (bendnorman): Add this information to the metadata
-raw_table_names = (
-    "raw_phmsagas__yearly_distribution",
-    "raw_phmsagas__yearly_transmission_gathering_summary_by_commodity",
-    "raw_phmsagas__yearly_gathering_pipe_miles_by_nps",
-    "raw_phmsagas__yearly_transmission_pipe_miles_by_nps",
-    "raw_phmsagas__yearly_transmission_gathering_inspections_assessments",
-    "raw_phmsagas__yearly_transmission_gathering_pipe_miles_by_class_location",
-    "raw_phmsagas__yearly_transmission_material_verification",
-    "raw_phmsagas__yearly_transmission_hca_miles_by_determination_method_and_risk_model",
-    "raw_phmsagas__yearly_transmission_miles_by_pressure_test_range_and_internal_inspection",
-    "raw_phmsagas__yearly_transmission_gathering_preparer_certification",
-    "raw_phmsagas__yearly_transmission_pipe_miles_by_smys",
-    "raw_phmsagas__yearly_transmission_gathering_failures_leaks_repairs",
-    "raw_phmsagas__yearly_transmission_miles_by_maop",
-    "raw_phmsagas__yearly_transmission_gathering_pipe_miles_by_decade_installed",
-    "raw_phmsagas__yearly_transmission_gathering_pipe_miles_by_material",
-)
-
 raw_phmsagas__all_dfs = raw_df_factory(Extractor, name="phmsagas")
 
 
-# # TODO (bendnorman): Figure out type hint for context keyword and multi_asset return
 @multi_asset(
-    outs={table_name: AssetOut() for table_name in sorted(raw_table_names)},
+    outs={
+        table_name: AssetOut()
+        for table_name in sorted(
+            (
+                "raw_phmsagas__yearly_distribution",
+                "raw_phmsagas__yearly_gathering_pipe_miles_by_nps",
+                "raw_phmsagas__yearly_transmission_gathering_summary_by_commodity",
+                "raw_phmsagas__yearly_transmission_pipe_miles_by_nps",
+                "raw_phmsagas__yearly_transmission_gathering_inspections_assessments",
+                "raw_phmsagas__yearly_transmission_gathering_pipe_miles_by_class_location",
+                "raw_phmsagas__yearly_transmission_material_verification",
+                "raw_phmsagas__yearly_transmission_hca_miles_by_determination_method_and_risk_model",
+                "raw_phmsagas__yearly_transmission_miles_by_pressure_test_range_and_internal_inspection",
+                "raw_phmsagas__yearly_transmission_gathering_preparer_certification",
+                "raw_phmsagas__yearly_transmission_pipe_miles_by_smys",
+                "raw_phmsagas__yearly_transmission_gathering_failures_leaks_repairs",
+                "raw_phmsagas__yearly_transmission_miles_by_maop",
+                "raw_phmsagas__yearly_transmission_gathering_pipe_miles_by_decade_installed",
+                "raw_phmsagas__yearly_transmission_gathering_pipe_miles_by_material",
+            )
+        )
+    }
 )
-def extract_phmsagas(context, raw_phmsagas__all_dfs):
-    """Extract raw PHMSA gas data from excel sheets into dataframes.
-
-    Args:
-        context: dagster keyword that provides access to resources and config.
-
-    Returns:
-        A tuple of extracted PHMSA gas dataframes.
-    """
+def extract_phmsagas(raw_phmsagas__all_dfs):
+    """Extract raw PHMSA gas data from excel sheets into dataframes."""
     # create descriptive table_names
     raw_phmsagas__all_dfs = {
         "raw_phmsagas__" + table_name: df

--- a/src/pudl/extract/phmsagas.py
+++ b/src/pudl/extract/phmsagas.py
@@ -80,7 +80,6 @@ raw_phmsagas__all_dfs = raw_df_factory(Extractor, name="phmsagas")
 # # TODO (bendnorman): Figure out type hint for context keyword and multi_asset return
 @multi_asset(
     outs={table_name: AssetOut() for table_name in sorted(raw_table_names)},
-    required_resource_keys={"datastore", "dataset_settings"},
 )
 def extract_phmsagas(context, raw_phmsagas__all_dfs):
     """Extract raw PHMSA gas data from excel sheets into dataframes.


### PR DESCRIPTION
# Overview

When debugging the 2024-04-27 nightly build failure #3593 I noticed that there were a bunch of asset definitions annotated with required resource keys that were not being used. My guess is that this was due to cut-and-paste without understanding how Dagster resources work, but maybe I'm the one misunderstanding them?  If you don't actually use a resource within the asset being defined, are there good reasons to nevertheless supply it with these resources?

# Testing

```[tasklist]
# To-do list
- [x] Run `make pytest-integration` locally
- [ ] Review the PR yourself and call out any questions or issues you have
```
