### PR TITLE
Update EIA Bulk Electricity archive/DOI.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -48,6 +48,9 @@ New Data Coverage
 * Added hourly generation, demand, and interchange tables from the EIA-930. See issues
   :issue:`3486,3505` PR :pr:`3584` and `this issue in the PUDL archiver repo
   <https://github.com/catalyst-cooperative/pudl-archiver/issues/295>`__
+* Updated the EIA Bulk Electricity data archive to include data that was available as of
+  2024-05-01, which covers up through 2024-02-01 (3 months more than the previously
+  used archive). See PR :pr:`3615`.
 
 Data Cleaning
 ^^^^^^^^^^^^^

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -196,7 +196,7 @@ class ZenodoDoiSettings(BaseSettings):
     eia930: ZenodoDoi = "10.5281/zenodo.10840078"
     eiawater: ZenodoDoi = "10.5281/zenodo.10806016"
     eiaaeo: ZenodoDoi = "10.5281/zenodo.10838488"
-    eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.10603995"
+    eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.11111208"
     epacamd_eia: ZenodoDoi = "10.5281/zenodo.7900974"
     epacems: ZenodoDoi = "10.5281/zenodo.10603994"
     ferc1: ZenodoDoi = "10.5281/zenodo.8326634"


### PR DESCRIPTION
# Overview

* Update to use May, 2024 archives for the EIA Bulk Electricity data (used to fill in missing fuel prices in the EIA-923 fuel receipts and costs table).
* This data contains prices through February, 2024 (3 more months than the previous archive, which ran through November, 2023)

# Testing

* Materialized the `core_eia__yearly_fuel_receipts_costs_aggs` assets locally and verified that they include new months of data, compared to the most recent nightly build outputs.

```[tasklist]
# To-do list
- [x] Update the release notes and reference the PR and related issues.
- [x] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage`
```
