### PR TITLE
Update expected MCOE row counts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ pytest-jupyter:
 # whose name contains "minmax_rows" so it's important to follow that naming convention.
 .PHONY: pytest-minmax-rows
 pytest-minmax-rows:
-	pytest --live-dbs test/validate -k minmax_rows
+	pytest -n 8 --no-cov --live-dbs test/validate -k minmax_rows
 
 # Build the FERC 1 and PUDL DBs, ignoring foreign key constraints.
 # Identify any plant or utility IDs in the DBs that haven't yet been mapped

--- a/test/validate/mcoe_test.py
+++ b/test/validate/mcoe_test.py
@@ -97,8 +97,8 @@ def test_no_null_rows_mcoe(pudl_out_mcoe, live_dbs, df_name, thresh):
         ("hr_by_unit", 389_530, 32_569),
         ("hr_by_gen", 602_580, 50_327),
         ("fuel_cost", 602_580, 50_327),
-        ("capacity_factor", 5_179_478, 433_336),
-        ("mcoe", 5_179_886, 433_370),
+        ("capacity_factor", 5_179_478, 433_327),
+        ("mcoe", 5_179_886, 433_361),
     ],
 )
 def test_minmax_rows_mcoe(pudl_out_mcoe, live_dbs, monthly_rows, annual_rows, df_name):


### PR DESCRIPTION
# Overview

We lost 9 rows in the annual capacity factor and MCOE outputs, which is almost certainly because we lost 9 rows in the annual `gen_eia923` outputs... which we already knew -- not sure why this didn't trip the validations up before and get included in the initial row count updates. 🤦🏼 

I also changed the `pytest-minmax-rows` make target to run on 8 CPUs instead of one to make doing this check faster and more convenient in the future. It used less than 10 GB of memory at peak, so this should not freeze anybody's computer up.

# Testing

I ran `make pytest-minmax-rows` locally and they all passed.