### PR TITLE
Add template that includes overview/success criteria/tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -18,9 +18,7 @@ How will we know that we're done?
 * [ ] ...
 
 
-### Tasks
-What are the next steps to take?
-
 ```[tasklist]
+### Next steps
 * [ ] ...
 ```

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,26 @@
+---
+name: Task
+about: A simple template that includes an overview, success criteria, and a todo list.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+### Overview
+
+What is the problem we're solving? For very simple items, this can be encapsulated in the success criteria.
+
+### Success Criteria
+
+How will we know that we're done?
+
+* [ ] ...
+
+
+### Tasks
+What are the next steps to take?
+
+```[tasklist]
+* [ ] ...
+```


### PR DESCRIPTION

# Overview

What problem does this address?

It's kind of annoying to keep typing the same sections over and over again when creating generic issues.

What did you change?

Added a template.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Copied the template text into an issue and hit the 'preview' tab.
