### PR TITLE
Update expected row counts in service territory tables.

### DIFF
--- a/test/validate/service_territory_test.py
+++ b/test/validate/service_territory_test.py
@@ -16,9 +16,9 @@ logger = logging.getLogger(__name__)
     "df_name,expected_rows",
     [
         ("summarized_demand_ferc714", 3_195),
-        ("fipsified_respondents_ferc714", 135_627),
-        ("compiled_geometry_balancing_authority_eia861", 112_853),
-        ("compiled_geometry_utility_eia861", 248_987),
+        ("fipsified_respondents_ferc714", 136_011),
+        ("compiled_geometry_balancing_authority_eia861", 113_142),
+        ("compiled_geometry_utility_eia861", 256_949),
     ],
 )
 def test_minmax_rows(


### PR DESCRIPTION
# Overview

Update row counts for the service territory tables, which now have additional utilities in them that were only found in the EIA-861 short form tables.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [x] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g.,  `test_minmax_rows()`)
```
