### PR TITLE
Update nightly build script to quietly publish public Parquet outputs.

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -215,12 +215,12 @@ function clean_up_outputs_for_distribution() {
         rm "$file"
     done
     popd && \
-    # Copy all parquet outputs to the top level output directory
-    cp "$PUDL_OUTPUT"/parquet/*.parquet "$PUDL_OUTPUT" && \
     # Create a zip file of all the parquet outputs for distribution on Kaggle
     # Don't try to compress the already compressed Parquet files with Zip.
-    pushd "$PUDL_OUTPUT" && \
-    zip -0 pudl_parquet.zip ./*.parquet && \
+    pushd "$PUDL_OUTPUT/parquet" && \
+    zip -0 "$PUDL_OUTPUT/pudl_parquet.zip" ./*.parquet && \
+    # Move the individual parquet outputs to the output directory for direct access
+    mv ./*.parquet "$PUDL_OUTPUT" && \
     popd && \
     # Remove any remaiining files and directories we don't want to distribute
     rm -rf "$PUDL_OUTPUT/parquet" && \

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -208,20 +208,20 @@ function merge_tag_into_branch() {
 
 function clean_up_outputs_for_distribution() {
     # Compress the SQLite DBs for easier distribution
-    cd "$PUDL_OUTPUT" && \
+    pushd "$PUDL_OUTPUT" && \
     for file in *.sqlite; do
         echo "Compressing $file" && \
         zip "$file.zip" "$file" && \
         rm "$file"
     done
-    cd "$HOME" && \
+    popd && \
     # Copy all parquet outputs to the top level output directory
     cp "$PUDL_OUTPUT"/parquet/*.parquet "$PUDL_OUTPUT" && \
     # Create a zip file of all the parquet outputs for distribution on Kaggle
     # Don't try to compress the already compressed Parquet files with Zip.
-    cd "$PUDL_OUTPUT" && \
+    pushd "$PUDL_OUTPUT" && \
     zip -0 pudl_parquet.zip ./*.parquet && \
-    cd "$HOME" && \
+    popd && \
     # Remove any remaiining files and directories we don't want to distribute
     rm -rf "$PUDL_OUTPUT/parquet" && \
     rm -f "$PUDL_OUTPUT/metadata.yml"

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -220,7 +220,7 @@ function clean_up_outputs_for_distribution() {
     # Create a zip file of all the parquet outputs for distribution on Kaggle
     # Don't try to compress the already compressed Parquet files with Zip.
     cd "$PUDL_OUTPUT" && \
-    zip -0 "$PUDL_OUTPUT/pudl_parquet.zip" ./*.parquet && \
+    zip -0 pudl_parquet.zip ./*.parquet && \
     cd "$HOME" && \
     # Remove all other parquet output, which we are not yet distributing.
     rm -rf "$PUDL_OUTPUT/parquet" && \

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -288,8 +288,9 @@ if [[ $ETL_SUCCESS == 0 ]]; then
         # Copy cleaned up outputs to the S3 and GCS distribution buckets
         copy_outputs_to_distribution_bucket | tee -a "$LOGFILE"
         DISTRIBUTION_BUCKET_SUCCESS=${PIPESTATUS[0]}
-        # TODO: this currently just makes a sandbox release, for testing. Should be
-        # switched to production and only run on push of a version tag eventually.
+        # Remove individual parquet outputs and distribute just the zipped parquet
+        # archives on Zenodo, due to their number of files limit
+        rm -f "$PUDL_OUTPUT"/*.parquet && \
         # Push a data release to Zenodo for long term accessiblity
         zenodo_data_release "$ZENODO_TARGET_ENV" 2>&1 | tee -a "$LOGFILE"
         ZENODO_SUCCESS=${PIPESTATUS[0]}

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -222,7 +222,7 @@ function clean_up_outputs_for_distribution() {
     cd "$PUDL_OUTPUT" && \
     zip -0 pudl_parquet.zip ./*.parquet && \
     cd "$HOME" && \
-    # Remove all other parquet output, which we are not yet distributing.
+    # Remove any remaiining files and directories we don't want to distribute
     rm -rf "$PUDL_OUTPUT/parquet" && \
     rm -f "$PUDL_OUTPUT/metadata.yml"
 }


### PR DESCRIPTION
# Overview

* Publish Parquet files to the public GCS & S3 buckets when the builds succeed.
* Create a `pudl_parquet.zip` archive containing all the Parquet outputs that we can point Kaggle at.
* Switch to using `zip` instead of `gzip` to compress SQLite files because Windows can only open `zip` archives and we don't want Windows users to have to download a 3rd party archive/compression utility.

Closes #3678

# Testing

* Is there an easy way to give this a test besides doing a whole deployment?

```[tasklist]
# To-do list
- [x] Review the PR yourself and call out any questions or issues you have
- [x] Update Zenodo data release process to only archive the zipped parquet files (due to file number limit)
- [ ] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage`
```
