### PR TITLE
Make asset checks matter to integration tests

### DIFF
--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -137,7 +137,7 @@ def asset_check_from_schema(
         return None
     pandera_schema = resource.schema.to_pandera()
 
-    @asset_check(asset=asset_key)
+    @asset_check(asset=asset_key, blocking=True)
     def pandera_schema_check(asset_value) -> AssetCheckResult:
         try:
             pandera_schema.validate(asset_value, lazy=True)

--- a/src/pudl/etl/cli.py
+++ b/src/pudl/etl/cli.py
@@ -2,16 +2,12 @@
 
 import pathlib
 import sys
-from collections.abc import Callable
 
 import click
 import fsspec
 from dagster import (
     DagsterInstance,
-    Definitions,
-    JobDefinition,
     build_reconstructable_job,
-    define_asset_job,
     execute_job,
 )
 
@@ -21,42 +17,6 @@ from pudl.settings import EpaCemsSettings, EtlSettings
 from pudl.workspace.setup import PudlPaths
 
 logger = pudl.logging_helpers.get_logger(__name__)
-
-
-def pudl_etl_job_factory(
-    logfile: str | None = None, loglevel: str = "INFO", process_epacems: bool = True
-) -> Callable[[], JobDefinition]:
-    """Factory for parameterizing a reconstructable pudl_etl job.
-
-    Args:
-        loglevel: The log level for the job's execution.
-        logfile: Path to a log file for the job's execution.
-        process_epacems: Include EPA CEMS assets in the job execution.
-
-    Returns:
-        The job definition to be executed.
-    """
-
-    def get_pudl_etl_job():
-        """Create an pudl_etl_job wrapped by to be wrapped by reconstructable."""
-        pudl.logging_helpers.configure_root_logger(logfile=logfile, loglevel=loglevel)
-        jobs = [define_asset_job("etl_job")]
-        if not process_epacems:
-            jobs = [
-                define_asset_job(
-                    "etl_job",
-                    selection=pudl.etl.create_non_cems_selection(
-                        pudl.etl.default_assets
-                    ),
-                )
-            ]
-        return Definitions(
-            assets=pudl.etl.default_assets,
-            resources=pudl.etl.default_resources,
-            jobs=jobs,
-        ).get_job_def("etl_job")
-
-    return get_pudl_etl_job
 
 
 @click.command(


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #3705 .


What did you change?
* we weren't running asset checks in our ETL when running in integration tests. Instead of making a new, different ETL job for integration tests, we now just run the same job we use everywhere else, but with whatever dataset configuration we have defined for the tests.
* we also weren't asserting that the ETL execution actually succeeded. Asset check failures currently cause `Exception`s, so we don't technically need this, but it seems prudent to assert success anyways.

# Testing

* verified that the `fgd_equipment_null_check` asset check passes, by running the raw_eia860 assets and then the `_core_eia860__fgd_equipment` asset in Dagster
* ran integration tests with `make pytest-coverage` and saw the integration tests pass
* break the `fgd_equipment_null_check` by making it `return AssetCheckResult(passed=False)`
* re-run the `_core_eia860__fgd_equipment` asset in Dagster and see the check fail
* re-run integration tests with `make pytest-coverage` and see that the integration test fails with a bunch of errors about `dagster._core.errors.DagsterAssetCheckFailedError: Blocking check 'fgd_equipment_null_c
heck' for asset '_core_eia860__fgd_e...`


```[tasklist]
# To-do list
- [x] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage` (otherwise the merge queue may reject your PR)
- [x] Review the PR yourself and call out any questions or issues you have
```
