### PR TITLE
Automate issue creation for Quarterly Updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/quarterly_updates.md
+++ b/.github/ISSUE_TEMPLATE/quarterly_updates.md
@@ -1,0 +1,23 @@
+---
+name: Quarterly Update
+about: Check-list for integrating the quarterly updates into PUDL
+title: ""
+labels: data-update
+assignees: ""
+---
+
+### Quarterly Update Check-list
+
+Once the new archives have been vetted and published, you can begin the process of integrating the new quarterly update data into PUDL.
+
+Follow the steps in [Existing Data Updates Docs](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/existing_data_updates.html)
+
+<!-- Update the quarter number and year -->
+
+```[tasklist]
+- [ ] EIA 860m QX-YYYY Update
+- [ ] EIA 923 QX-YYYY Update
+- [ ] EIA 930 QX-YYYY Update
+- [ ] CEMS QX-YYYY Update
+- [ ] EIA Bulk API QX-YYYY Update
+```

--- a/.github/workflows/q-update-issue-scheduler.yml
+++ b/.github/workflows/q-update-issue-scheduler.yml
@@ -1,0 +1,21 @@
+---
+name: quarterly-update-issues
+on:
+  schedule:
+    - cron: "21 8 2 2,5,8,11 *" # 8:21 AM UTC, second of feb, may, aug, nov
+
+jobs:
+  create_issue:
+    name: Create quarterly update issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Create quarterly update issue
+        uses: JasonEtco/create-an-issue@v2.9.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        with:
+          filename: .github/ISSUE_TEMPLATE/quarterly_updates.md


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #XXXX.

What problem does this address?

What did you change?

# Testing

How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g.,  `test_minmax_rows()`)
- [ ] Update the [release notes](../docs/release_notes.rst): reference the PR and related issues.
- [ ] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage` (otherwise the merge queue may reject your PR)
- [ ] Review the PR yourself and call out any questions or issues you have
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For significant ETL, data coverage or analysis changes, once `make pytest-coverage` passes, ensure the full ETL runs locally and [run data validation tests](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/testing.html#data-validation) using `make pytest-validate` (a ~10 hour run). If you can't run this locally, run the `build-deploy-pudl` GitHub Action (or ask someone with permissions to). Then, check the logs on the `#pudl-deployments` Slack channel or `gs://builds.catalyst.coop`.
```
