### PR TITLE
Disable rolling avg to fill missing fuel prices in EIA923 FRC table

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -30,8 +30,17 @@ EIA 860
 Data Cleaning
 ^^^^^^^^^^^^^
 * When ``generator_operating_date`` values are too inconsistent to be harvested
-  successfully, we now take the last reported date in EIA 860 and 860M. See
-  :issue:`423` and PR :pr:`3967`.
+  successfully, we now take the last reported date in EIA 860 and 860M. See :issue:`423`
+  and PR :pr:`3967`.
+
+Bug Fixes
+^^^^^^^^^
+
+* Disabled filling of missing values using rolling averages for the
+  ``fuel_cost_per_mmbtu`` column in the :ref:`out_eia923__fuel_receipts_costs` table, as
+  it was resulting in some anomlously high fuel prices. See :pr:`3716`. This results in
+  about 2% more records in the table being left ``NA`` after filling with the average
+  prices for that fuel type for the state and month found in the bulk EIA API data.
 
 .. _release-v2024.5.0:
 

--- a/src/pudl/output/eia923.py
+++ b/src/pudl/output/eia923.py
@@ -272,7 +272,7 @@ def out_eia923__boiler_fuel(
         ),
         "roll": Field(
             bool,
-            default_value=True,
+            default_value=False,
             description=("If True, use rolling averages to fill missing fuel prices."),
         ),
     },


### PR DESCRIPTION
# Overview

* Something appears to be wrong with the way we have been filling in gaps in fuel prices in the `out_eia923__fuel_receipts_costs` table using rolling averages. This was resulting in anomalously high fuel prices in some cases, identified first in deliveries of `BIT` to plants with `plant_id_eia` `8102` and `2832`.
* It's not clear whether the issue is resulting from the filling step, or the calculation of the rolling averages.
* If it's in the calculation of the rolling averages, then the `out_ferc1__yearly_steam_plants_sched402` table could also be affected, as the same routine is used there to calculate a smoothed estimate of ongoing capital additions.
* For now I have simply disabled the use of rolling averages to fill in the fuel prices until we can figure out exactly what's going on here.

# Testing

After disabling the rolling average filling, I compared the filled vs. unfilled outputs as below.

It looks like this:
* Affects about 2% of all records in the Fuel Receipts & Costs output table.
* Only affects the `fuel_cost_per_mmbtu` and `total_fuel_cost` columns.
* Only affects records with `<NA>` original values for `fuel_cost_per_mmbtu`.

```py
frc923_fill = pd.read_parquet("frc923_fill.parquet", dtype_backend="pyarrow")
frc923_nofill = pd.read_parquet("frc923_nofill.parquet", dtype_backend="pyarrow")

# How many more records are have null fuel prices now than before? (about 2%)
print(f"Percentage of records filled: {(frc923_fill.fuel_cost_per_mmbtu.notna().sum() - frc923_nofill.fuel_cost_per_mmbtu.notna().sum()) / len(frc923_fill):.2%}")

# Boolean mask to select filled / unfilled records:
filled_mask = frc923_fill.fuel_cost_per_mmbtu.notna() & frc923_nofill.fuel_cost_per_mmbtu.isna()

# Are all unfilled records exactly the same?
pd.testing.assert_frame_equal(frc923_fill[~filled_mask], frc923_nofill[~filled_mask])

# Are all fields other than the one filled identical between the two dataframes?
affected_cols = [
    "fuel_cost_per_mmbtu",
    "total_fuel_cost",
]
pd.testing.assert_frame_equal(
    frc923_fill[filled_mask].drop(columns=affected_cols),
    frc923_nofill[filled_mask].drop(columns=affected_cols),
)
```

```[tasklist]
# To-do list
- [x] Update release notes.
```
