### PR TITLE
Remove bad respondent ID 2

### DIFF
--- a/src/pudl/transform/ferc714.py
+++ b/src/pudl/transform/ferc714.py
@@ -359,7 +359,6 @@ def _standardize_offset_codes(df: pd.DataFrame, offset_fixes) -> pd.DataFrame:
 
     Args:
         df: DataFrame containing a utc_offset_code column that needs to be standardized.
-
         offset_fixes: A dictionary with respondent_id_ferc714 values as the keys, and a
             dictionary mapping non-standard UTC offset codes to the standardized UTC
             offset codes as the value.

--- a/src/pudl/transform/ferc714.py
+++ b/src/pudl/transform/ferc714.py
@@ -159,6 +159,7 @@ OFFSET_CODE_FIXES_BY_YEAR = [
 ]
 
 BAD_RESPONDENTS = [
+    2,
     319,
     99991,
     99992,
@@ -357,11 +358,11 @@ def _standardize_offset_codes(df: pd.DataFrame, offset_fixes) -> pd.DataFrame:
     as defined by offset_fixes.
 
     Args:
-        df (pandas.DataFrame): A DataFrame containing a utc_offset_code column
-            that needs to be standardized.
-        offset_fixes (dict): A dictionary with respondent_id_ferc714 values as the
-            keys, and a dictionary mapping non-standard UTC offset codes to
-            the standardized UTC offset codes as the value.
+        df: DataFrame containing a utc_offset_code column that needs to be standardized.
+
+        offset_fixes: A dictionary with respondent_id_ferc714 values as the keys, and a
+            dictionary mapping non-standard UTC offset codes to the standardized UTC
+            offset codes as the value.
 
     Returns:
         Standardized UTC offset codes.


### PR DESCRIPTION
# Overview

The builds failed last night with a FK violation from the new `core_ferc714__yearly_planning_area_demand_forecast` table, because it has 10 records for respondent ID 2, which doesn't show up in the respondent ID table. Half of those records contain only zeros, and the other half have values in only one column, so dropping all 10.

# Testing

Materialized all FERC-714 tables locally and ran the FK checks and they passed.

```[tasklist]
# To-do list
- [ ] Ensure docs build, unit & integration tests, and test coverage pass locally with `make pytest-coverage`
```
