### PR TITLE
Add mozilla repo to wif pool

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,6 +66,10 @@ module "gh_oidc" {
       sa_name   = "projects/${var.project_id}/serviceAccounts/gce-github-action-test@catalyst-cooperative-pudl.iam.gserviceaccount.com"
       attribute = "attribute.repository/catalyst-cooperative/gce-build-test"
     }
+    "sec-extraction-test-github-action" = {
+      sa_name   = "projects/catalyst-cooperative-mozilla/serviceAccounts/mozilla-dev-sa@catalyst-cooperative-mozilla.iam.gserviceaccount.com"
+      attribute = "attribute.repository/catalyst-cooperative/mozilla-sec-eia"
+    }
   }
 }
 


### PR DESCRIPTION
# Overview

This PR updates our terraform config to include the mozilla development repo in our gcloud WIF pool.

## Questions
* My understanding is that I just need this update to `main.tf`, then update the workflow file to use the workload identity pool with the appropriate service account. Is there anything else we need to do?
* When I run `terraform plan` there's a bunch of new superset resources that would be deleted because they haven't been migrated into terraform yet. Is there an easy/clean way to avoid that?