### PR TITLE
Add Q2 2024 CEMS data

### DIFF
--- a/docs/dev/existing_data_updates.rst
+++ b/docs/dev/existing_data_updates.rst
@@ -298,10 +298,10 @@ script in the terminal. From within the pudl repo directory, run:
 C. EPA CEMS
 ^^^^^^^^^^^
 
-**4.C.1)** Use dagster to materialize the ``epacems`` asset group and debug. The most
-common errors will occur when new CEMS plants lack timezone data in the EIA database.
-See section 6.B.1 for instructions on how to fix this. Once you've updated the
-spreadsheet tracking these errors, reload the ``epacems`` assets in Dagster.
+**4.C.1)** Use dagster to materialize the ``core_epacems`` asset group and debug. The
+most common errors will occur when new CEMS plants lack timezone data in the EIA
+database. See section 6.B.1 for instructions on how to fix this. Once you've updated the
+spreadsheet tracking these errors, reload the ``core_epacems`` assets in Dagster.
 
 D. NREL ATB
 ^^^^^^^^^^^^
@@ -399,9 +399,11 @@ B. Missing EIA Plant Locations from CEMS
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 **6.B.1)** If there are any plants that appear in the EPA CEMS dataset that do not
 appear in the ``core_eia__entity_plants`` table, or that are missing latitude and
-longitude values, you'll get a warning when you try and materialize the ``core_epacamd``
-asset group in Dagster. You'll need to manually compile the missing information and add
-it to ``src/pudl/package_data/epacems/additional_epacems_plants.csv`` to enable accurate
+longitude values, you'll get a warning when you try and materialize assets downstream
+from ``core_epacems`` (``_core_epacems__emissions_unit_ids`` and
+``core_epa__assn_eia_epacamd_subplant_ids``). You'll need to manually compile the
+missing information and add it to
+``src/pudl/package_data/epacems/additional_epacems_plants.csv`` to enable accurate
 adjustment of the EPA CEMS timestamps to UTC. Using the Plant ID from the warning, look
 up the plant coordinates in the
 `EPA FACT API <https://www.epa.gov/airmarkets/field-audit-checklist-tool-fact-api>`__.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -45,6 +45,10 @@ EIA 923
 ~~~~~~~
 * Added EIA 923 early release data from 2023. See :issue:`3719` and PR :pr:`3721`.
 
+EPA CEMS
+~~~~~~~~
+* Added 2024 Q2 of CEMS data. See :issue:`3762` and :pr:`3769`.
+
 FERC 714
 ~~~~~~~~
 * Added :ref:`core_ferc714__yearly_planning_area_demand_forecast` based on FERC
@@ -78,7 +82,7 @@ Bug Fixes
   about 2% more records in the table being left ``NA`` after filling with the average
   prices for that fuel type for the state and month found in the bulk EIA API data.
 
-Qualtiy of Life Improvements
+Quality of Life Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * The full ETL settings are now read directly from ``etl_full.yml`` instead of using
   default values defined in the settings classes.  This also results in the settings

--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -426,7 +426,7 @@ SOURCES: dict[str, Any] = {
         "working_partitions": {
             "year_quarters": [
                 str(q).lower()
-                for q in pd.period_range(start="1995q1", end="2024q1", freq="Q")
+                for q in pd.period_range(start="1995q1", end="2024q2", freq="Q")
             ]
         },
         "contributors": [

--- a/src/pudl/package_data/settings/etl_fast.yml
+++ b/src/pudl/package_data/settings/etl_fast.yml
@@ -88,7 +88,7 @@ datasets:
     # Note that the CEMS data relies on EIA 860 data for plant locations,
     # so if you're loading CEMS data for a particular year, you should
     # also load the EIA 860 data for that year if possible
-    year_quarters: ["2022q1"]
+    year_quarters: ["2023q1"]
   phmsagas:
     years: [2022]
   nrelatb:

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -199,7 +199,7 @@ class ZenodoDoiSettings(BaseSettings):
     eiaaeo: ZenodoDoi = "10.5281/zenodo.10838488"
     eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.11111208"
     epacamd_eia: ZenodoDoi = "10.5281/zenodo.7900974"
-    epacems: ZenodoDoi = "10.5281/zenodo.13149102"
+    epacems: ZenodoDoi = "10.5281/zenodo.13240556"
     ferc1: ZenodoDoi = "10.5281/zenodo.12549172"
     ferc2: ZenodoDoi = "10.5281/zenodo.11408175"
     ferc6: ZenodoDoi = "10.5281/zenodo.11408164"

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -199,7 +199,7 @@ class ZenodoDoiSettings(BaseSettings):
     eiaaeo: ZenodoDoi = "10.5281/zenodo.10838488"
     eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.11111208"
     epacamd_eia: ZenodoDoi = "10.5281/zenodo.7900974"
-    epacems: ZenodoDoi = "10.5281/zenodo.11111203"
+    epacems: ZenodoDoi = "10.5281/zenodo.13149102"
     ferc1: ZenodoDoi = "10.5281/zenodo.12549172"
     ferc2: ZenodoDoi = "10.5281/zenodo.11408175"
     ferc6: ZenodoDoi = "10.5281/zenodo.11408164"

--- a/test/integration/epacems_test.py
+++ b/test/integration/epacems_test.py
@@ -69,12 +69,12 @@ def test_epacems_parallel(pudl_engine, epacems_parquet_path):
     # monolithic outputs.
     df = dd.read_parquet(
         epacems_parquet_path,
-        filters=year_state_filter(years=[2022], states=["ME"]),
+        filters=year_state_filter(years=[2023], states=["ME"]),
         index=False,
         engine="pyarrow",
         split_row_groups=True,
     ).compute()
-    assert df.year.unique() == [2022]
+    assert df.year.unique() == [2023]
     assert df.state.unique() == ["ME"]
 
 


### PR DESCRIPTION
# Overview

Closes #3762.

What problem does this address?
Adds Q2 of CEMS data into PUDL.

What did you change?
- Updated the Zenodo DOI for datastore.
- Updated docs to remove reference to non-existent asset groups

# Testing

How did you make sure this worked? How can a reviewer verify this?
Generated the CEMS assets and all downstream outputs. Double checked to make sure that no validation tests are impacted, and ran minmax row tests.

```[tasklist]
# To-do list
- [x] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`)
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [x] Review the PR yourself and call out any questions or issues you have
- [x] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
```
