### PR TITLE
Update DOI for NREL ATB to get error corrections

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -62,6 +62,8 @@ NREL ATB
   all technologies, and more detailed nuclear breakdowns of ``fuel_cost_per_mwh``.
   Simultaneously, updated the :mod:`docs.dev.existing_data_updates` documentation to
   make it easier to add future years of data. See :issue:`3706` and :pr:`3719`.
+* Updated NREL ATB data to include `error corrections in the 2024 data <https://atb.nrel.gov/electricity/2024/errata>`__.
+  See :issue:`3777` and PR :pr:`3778`.
 
 Data Cleaning
 ^^^^^^^^^^^^^

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -207,7 +207,7 @@ class ZenodoDoiSettings(BaseSettings):
     ferc714: ZenodoDoi = "10.5281/zenodo.12021228"
     gridpathratoolkit: ZenodoDoi = "10.5281/zenodo.10892394"
     phmsagas: ZenodoDoi = "10.5281/zenodo.10493790"
-    nrelatb: ZenodoDoi = "10.5281/zenodo.12609821"
+    nrelatb: ZenodoDoi = "10.5281/zenodo.12658647"
 
     model_config = SettingsConfigDict(
         env_prefix="pudl_zenodo_doi_", env_file=".env", extra="ignore"


### PR DESCRIPTION
# Overview

Update Zenodo DOI for NREL ATB dataset to get their error corrections.

Closes #3777

# Testing

* I re-ran the ETL for the NREL ATB assets locally.
* I checked whether there are any data validation tests for the ATB, and there aren't, so I didn't re-run the minmax rows.

```[tasklist]
# To-do list
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [x] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
```
