### PR TITLE
Fix `release.yml` fork behaviors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,15 @@
 ---
 name: release
 
-on: push
+on:
+  pull_request:
+  push:
 
 jobs:
   build-distribution:
     name: Build catalystcoop.pudl distribution for PyPI
     runs-on: ubuntu-latest
-    if: github.repository == 'catalyst-cooperative/pudl'
+    if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
# Overview

What problem does this address?
Our `release.yml` workflow doesn't currently trigger from PRs merging in for a fork.

What did you change?
- Updated `on` condition to include `pull_request`
- Updated conditional to correctly identify forks vs non-forked repos