### PR TITLE
Try to fix CodeCov report uploads in pytest workflow.

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -210,9 +210,9 @@ jobs:
   ci-coverage:
     runs-on: ubuntu-latest
     needs:
-      # - ci-docs
+      - ci-docs
       - ci-unit
-    # - ci-integration
+      - ci-integration
     steps:
       - uses: actions/checkout@v4
       - name: Download coverage

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -210,9 +210,9 @@ jobs:
   ci-coverage:
     runs-on: ubuntu-latest
     needs:
-      - ci-docs
+      # - ci-docs
       - ci-unit
-      - ci-integration
+    # - ci-integration
     steps:
       - uses: actions/checkout@v4
       - name: Download coverage
@@ -238,9 +238,11 @@ jobs:
       - name: Upload XML coverage report to CodeCov
         uses: codecov/codecov-action@v4
         with:
+          disable_search: true
           file: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true # optional (default = false)
+          plugin: pycoverage
           verbose: true
       - name: Display coverage report and ensure it meets required minimum
         # Required coverage is set in pyproject.toml section [tool.coverage.report]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -242,7 +242,7 @@ jobs:
           file: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true # optional (default = false)
-          plugin: pycoverage
+          plugin: noop
           verbose: true
       - name: Display coverage report and ensure it meets required minimum
         # Required coverage is set in pyproject.toml section [tool.coverage.report]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -223,11 +223,6 @@ jobs:
       - name: List downloaded files
         run: |
           find coverage -type f
-      - name: Upload test coverage report to CodeCov
-        uses: codecov/codecov-action@v4
-        with:
-          directory: coverage
-          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Install Micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
@@ -236,9 +231,18 @@ jobs:
           create-args: >-
             python=3.12
             coverage>=7.6.1
-      - name: Combine coverage data and check that we have required coverage
-        # Required coverage is set in pyproject.toml section [tool.coverage.report]
+      - name: Combine coverage data and output XML report
         run: |
           micromamba run -n coverage coverage combine coverage/*/.coverage
           micromamba run -n coverage coverage xml --fail-under=0
+      - name: Upload XML coverage report to CodeCov
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true
+      - name: Display coverage report and ensure it meets required minimum
+        # Required coverage is set in pyproject.toml section [tool.coverage.report]
+        run: |
           micromamba run -n coverage coverage report


### PR DESCRIPTION
# Overview

After merging #3823 I saw that the upload of coverage data to CodeCov was broken by some of the changes in that PR. This gets it back to working again.

# Testing

I did some `workflow_dispatch` testing of the modified workflow with the integration & docs tests turned off, until I was able to get rid of the upload errors,and had the data showing up on CodeCov for the branch again with each push.

I've also told the CodeCov action to fail the check if the upload fails, so this kind of thing should get caught if it happens again.