### PR TITLE
Bump mamba docker image version to 1.5.9

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:1.5.8
+FROM mambaorg/micromamba:1.5.9
 
 ENV PGDATA=${CONTAINER_HOME}/pgdata
 


### PR DESCRIPTION
# Overview

A new version of mamba came out, but I didn't catch it and failed to update the docker image when I was doing the other version updates so... yet another one-liner.  