### PR TITLE
Add pudl usage metrics gcp infrastructure

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -426,8 +426,9 @@ resource "google_storage_bucket_iam_member" "usage_metrics_archiver_gcs_iam" {
 }
 
 resource "google_storage_bucket_iam_member" "usage_metrics_etl_gcs_iam" {
+  for_each = toset(["roles/storage.legacyBucketReader", "roles/storage.objectViewer"])
 
   bucket = google_storage_bucket.pudl_usage_metrics_archive_bucket.name
-  role = "roles/storage.legacyBucketReader"
+  role = each.key
   member = "serviceAccount:pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -432,3 +432,11 @@ resource "google_storage_bucket_iam_member" "usage_metrics_etl_gcs_iam" {
   role = each.key
   member = "serviceAccount:pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
 }
+
+resource "google_storage_bucket_iam_member" "usage_metrics_etl_s3_logs_gcs_iam" {
+  for_each = toset(["roles/storage.legacyBucketReader", "roles/storage.objectViewer"])
+
+  bucket = "pudl-s3-logs.catalyst.coop"
+  role = each.key
+  member = "serviceAccount:pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -424,3 +424,10 @@ resource "google_storage_bucket_iam_member" "usage_metrics_archiver_gcs_iam" {
   role = each.key
   member = "serviceAccount:${google_service_account.usage_metrics_archiver.email}"
 }
+
+resource "google_storage_bucket_iam_member" "usage_metrics_etl_gcs_iam" {
+
+  bucket = google_storage_bucket.pudl_usage_metrics_archive_bucket.name
+  role = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -228,7 +228,7 @@ resource "google_cloud_run_v2_service" "pudl-superset" {
     volumes {
       name = "cloudsql"
       cloud_sql_instance {
-        instances = ["catalyst-cooperative-pudl:us-central1:superset-database"]
+        instances = ["catalyst-cooperative-pudl:us-central1:superset-database", "catalyst-cooperative-pudl:us-central1:pudl-usage-metrics-db"]
       }
     }
   }
@@ -395,4 +395,32 @@ resource "google_service_account_iam_member" "gce-default-account-iam" {
   service_account_id = data.google_compute_default_service_account.google_compute_default_service_account_data.name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:345950277072@cloudbuild.gserviceaccount.com"
+}
+
+resource "google_secret_manager_secret" "pudl_usage_metrics_db_connection_string" {
+  secret_id = "pudl-usage-metrics-db-connection-string"
+  replication {
+    auto {}
+  }
+}
+
+resource "google_storage_bucket" "pudl_usage_metrics_archive_bucket" {
+  name          = "pudl-usage-metrics-archives.catalyst.coop"
+  location      = "US"
+  storage_class = "STANDARD"
+
+  uniform_bucket_level_access = true
+}
+
+resource "google_service_account" "usage_metrics_archiver" {
+  account_id   = "usage-metrics-archiver"
+  display_name = "PUDL usage metrics archiver github action service account"
+}
+
+resource "google_storage_bucket_iam_member" "usage_metrics_archiver_gcs_iam" {
+  for_each = toset(["roles/storage.objectCreator", "roles/storage.objectViewer"])
+
+  bucket = google_storage_bucket.pudl_usage_metrics_archive_bucket.name
+  role = each.key
+  member = "serviceAccount:${google_service_account.usage_metrics_archiver.email}"
 }


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

- Mount the Cloud SQL `pudl-usage-metrics-db` to Superset cloud run instance
- Create a new bucket for raw usage metrics archives
- Give github action service account permission to write to the bucket

# Testing

The usage metrics data can be viewed in superset and the github metrics are being saved to the new bucket.

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`)
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
```
