### PR TITLE
Increase nightly build VM disk from 80GB to 100GB

### DIFF
--- a/devtools/generate_batch_config.py
+++ b/devtools/generate_batch_config.py
@@ -58,7 +58,7 @@ def to_config(
                     "computeResource": {
                         "cpuMilli": 8000,
                         "memoryMib": int(63 * MIB_PER_GB),
-                        "bootDiskMib": 80 * 1024,
+                        "bootDiskMib": 100 * 1024,
                     },
                     "maxRunDuration": f"{60 * 60 * 12}s",
                 }


### PR DESCRIPTION
# Overview

Increase the disk allocated to the nightly build machine from 80GB to 100GB since we're getting an error about running out of disk when we start zipping the output SQLite DBs.

Closes #3852 (hopefully)

# Testing

Can't test this short of running the nightly builds.

```[tasklist]
# To-do list
- [ ] Cause `clean_up_outputs_for_distribution()` to fail if the zip command fails?
```
