### PR TITLE
FERC 714: Integrate the XBRL data Respondent ID table 

### DIFF
--- a/src/pudl/package_data/glue/respondent_id_ferc714.csv
+++ b/src/pudl/package_data/glue/respondent_id_ferc714.csv
@@ -45,7 +45,7 @@ respondent_id_ferc714,respondent_id_ferc714_xbrl,respondent_id_ferc714_csv,Sourc
 44,,150,,
 45,,151,,
 46,,152,,
-47,,153,,
+47,C011377,153,,
 48,,154,,
 49,,155,,
 50,,156,,
@@ -216,3 +216,4 @@ respondent_id_ferc714,respondent_id_ferc714_xbrl,respondent_id_ferc714_csv,Sourc
 215,C000136,,,
 216,C011420,,,
 217,C011454,,,
+218,C002732,,,

--- a/src/pudl/transform/ferc714.py
+++ b/src/pudl/transform/ferc714.py
@@ -378,6 +378,7 @@ class RespondentId:
         Process and combine the CSV and XBRL based data.
 
         There are two main threads of transforms happening here:
+
         * Table compatibility: The CSV raw table is static (does not even report years)
           while the xbrl table is reported annually. A lot of the downstream analysis
           expects this table to be static. So the first step was to check whether or not


### PR DESCRIPTION
# Overview

Closes #3839 and #3858

What problem does this address?

What did you change?
There were two main threads that needed pulling to get this table updates:
* **Table compatibility**: The csv table is static while the xbrl table is reported annually. A lot of the downstream analysis expects this table to be static. So the first step was to check whether or not the columns that we have in the CSV years had consistent data over the few XBRL years that we have. There were a small number of `eia_code`'s we needed to clean up, but besides that it was static. I then converted the XBRL data into a static table, then I concat-ed the tables and checked the static-ness again.
* **eia_code cleaning**: Not a ton but some cleaning necessary. Done all in `spot_fix_eia_codes` & `EIA_CODE_FIXES`

still todo that I'd rather finish in `transform-714-xbrl` [3842](https://github.com/catalyst-cooperative/pudl/pull/3842):
* metadata/schema updates: add csv and xbrl respondent id's into table.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`)
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
- [x] Materialize the assets locally
```
