### PR TITLE
FERC 714: Fix defensive check

### DIFF
--- a/src/pudl/transform/ferc714.py
+++ b/src/pudl/transform/ferc714.py
@@ -1158,7 +1158,7 @@ class YearlyPlanningAreaDemandForecast:
             & (df["forecast_year"] == 2014)
             & (df["net_demand_forecast_mwh"] == 0)
         )
-        if (len_dupes := len(df[error_mask])) >= 1:
+        if (len_dupes := len(df[error_mask])) > 1:
             raise AssertionError(
                 f"We found {len_dupes} duplicate errors, but expected 1 or less:\n{df[error_mask]}"
             )


### PR DESCRIPTION
# Overview

## What problem does this address?
The 714 data got pushed (via #3842) and failed the nightly builds bc of this silly silly error:

```python
The above exception was caused by the following exception:
AssertionError: We found 1 duplicate errors, but expected 1 or less:
       respondent_id_ferc714_csv  report_year  forecast_year  summer_peak_demand_forecast_mw  winter_peak_demand_forecast_mw  net_demand_forecast_mwh  respondent_id_ferc714
10801                        211         2013           2014                               0                               0                        0                    100
```
bc i had it as if len(baddies) >= 1 instead of if len(baddies) > 1.

(side personal note that I am continuously surprised that I've been doing this for this long but still regularly have to look up which one is > vs < and do baby tests of >= or <= or whatever)

## What did you change?

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [x] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually. (I just kicked this off here: https://github.com/catalyst-cooperative/pudl/actions/runs/11053532115
```
