### PR TITLE
Update to micromamba 2.0.2 Docker image.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
 
   # Lint Dockerfiles for errors and to ensure best practices
   - repo: https://github.com/AleksaC/hadolint-py
-    rev: v2.12.0.3
+    rev: v2.12.1b3
     hooks:
       - id: hadolint
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM mambaorg/micromamba:2.0.2
 
+ENV CONTAINER_HOME=/home/$MAMBA_USER
 ENV PGDATA=${CONTAINER_HOME}/pgdata
 
 USER root
@@ -29,7 +30,6 @@ RUN pg_createcluster 15 dagster -u "$MAMBA_USER" -- -A trust
 
 # Switch back to being non-root user and get into the home directory
 USER $MAMBA_USER
-ENV CONTAINER_HOME=/home/$MAMBA_USER
 WORKDIR ${CONTAINER_HOME}
 
 ENV CONDA_PREFIX=${CONTAINER_HOME}/env

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:1.5.10
+FROM mambaorg/micromamba:2.0.2
 
 ENV PGDATA=${CONTAINER_HOME}/pgdata
 

--- a/environments/conda-linux-64.lock.yml
+++ b/environments/conda-linux-64.lock.yml
@@ -36,7 +36,7 @@ dependencies:
   - aws-c-compression=0.2.19=h756ea98_1
   - aws-c-event-stream=0.4.3=h29ce20c_2
   - aws-c-http=0.8.10=h5e77a74_0
-  - aws-c-io=0.14.18=h4e6ae90_11
+  - aws-c-io=0.14.18=h2af50b2_12
   - aws-c-mqtt=0.10.7=h02abb05_0
   - aws-c-s3=0.6.6=h834ce55_0
   - aws-c-sdkutils=0.1.19=h756ea98_3
@@ -58,7 +58,7 @@ dependencies:
   - bleach=6.1.0=pyhd8ed1ab_0
   - blinker=1.8.2=pyhd8ed1ab_0
   - blosc=1.21.6=hef167b5_0
-  - boto3=1.35.36=pyhd8ed1ab_0
+  - boto3=1.35.37=pyhd8ed1ab_0
   - botocore=1.35.37=pyge310_1234567_0
   - bottleneck=1.4.0=py312hc0a28a1_2
   - branca=0.7.2=pyhd8ed1ab_0
@@ -66,7 +66,7 @@ dependencies:
   - brotli-bin=1.1.0=hb9d3cd8_2
   - brotli-python=1.1.0=py312h2ec8cdc_2
   - bzip2=1.0.8=h4bc722e_7
-  - c-ares=1.33.1=heb4867d_0
+  - c-ares=1.34.1=heb4867d_0
   - ca-certificates=2024.8.30=hbcca054_0
   - cachecontrol=0.14.0=pyhd8ed1ab_1
   - cachecontrol-with-filecache=0.14.0=pyhd8ed1ab_1
@@ -113,7 +113,7 @@ dependencies:
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - deprecated=1.2.14=pyh1a96a4e_0
-  - distlib=0.3.8=pyhd8ed1ab_0
+  - distlib=0.3.9=pyhd8ed1ab_0
   - dnspython=2.7.0=pyhff2d567_0
   - doc8=1.1.2=pyhd8ed1ab_1
   - docker-py=7.1.0=pyhd8ed1ab_0
@@ -196,7 +196,7 @@ dependencies:
   - humanize=4.11.0=pyhd8ed1ab_0
   - hupper=1.12.1=pyhd8ed1ab_0
   - hyperframe=6.0.1=pyhd8ed1ab_0
-  - hypothesis=6.114.0=pyha770c72_0
+  - hypothesis=6.114.1=pyha770c72_0
   - icu=75.1=he02047a_0
   - identify=2.6.1=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_0
@@ -396,6 +396,7 @@ dependencies:
   - prometheus_flask_exporter=0.23.1=pyhd8ed1ab_0
   - prompt-toolkit=3.0.48=pyha770c72_0
   - prompt_toolkit=3.0.48=hd8ed1ab_0
+  - propcache=0.2.0=py312h66e93f0_2
   - proto-plus=1.23.0=pyhd8ed1ab_0
   - protobuf=4.25.3=py312h83439f5_1
   - psutil=5.9.8=py312h98912ed_0
@@ -470,7 +471,7 @@ dependencies:
   - ruamel.yaml.clib=0.2.8=py312h98912ed_0
   - ruff=0.6.9=py312hd18ad41_0
   - ruff-lsp=0.0.57=pyhd8ed1ab_0
-  - s2n=1.5.4=h1380c3d_0
+  - s2n=1.5.5=h3931f03_0
   - s3transfer=0.10.3=pyhd8ed1ab_0
   - scikit-learn=1.5.2=py312h7a48858_1
   - scipy=1.14.1=py312h7d485d2_0
@@ -541,8 +542,8 @@ dependencies:
   - uri-template=1.3.0=pyhd8ed1ab_0
   - uriparser=0.9.8=hac33072_0
   - urllib3=1.26.19=pyhd8ed1ab_0
-  - uvicorn=0.31.0=py312h7900ff3_0
-  - uvicorn-standard=0.31.0=h7900ff3_0
+  - uvicorn=0.31.1=py312h7900ff3_0
+  - uvicorn-standard=0.31.1=h7900ff3_0
   - uvloop=0.20.0=py312h66e93f0_0
   - validators=0.34.0=pyhd8ed1ab_0
   - virtualenv=20.26.6=pyhd8ed1ab_0
@@ -570,7 +571,7 @@ dependencies:
   - xyzservices=2024.9.0=pyhd8ed1ab_0
   - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
-  - yarl=1.13.1=py312h66e93f0_0
+  - yarl=1.14.0=py312h66e93f0_0
   - zeromq=4.3.5=h3b0a872_6
   - zip=3.0=hd590300_3
   - zipp=3.20.2=pyhd8ed1ab_0

--- a/environments/conda-linux-64.lock.yml
+++ b/environments/conda-linux-64.lock.yml
@@ -10,7 +10,7 @@ dependencies:
   - addfips=0.4.2=pyhd8ed1ab_0
   - aiofiles=24.1.0=pyhd8ed1ab_0
   - aiohappyeyeballs=2.4.3=pyhd8ed1ab_0
-  - aiohttp=3.10.8=py312h66e93f0_0
+  - aiohttp=3.10.9=py312h66e93f0_0
   - aiosignal=1.3.1=pyhd8ed1ab_0
   - alabaster=1.0.0=pyhd8ed1ab_0
   - alembic=1.13.3=pyhd8ed1ab_0
@@ -19,7 +19,7 @@ dependencies:
   - annotated-types=0.7.0=pyhd8ed1ab_0
   - anyio=4.4.0=pyhd8ed1ab_0
   - appdirs=1.4.4=pyh9f0ad1d_0
-  - arelle-release=2.31.4=pyhd8ed1ab_0
+  - arelle-release=2.31.6=pyhd8ed1ab_0
   - argon2-cffi=23.1.0=pyhd8ed1ab_0
   - argon2-cffi-bindings=21.2.0=py312h66e93f0_5
   - arrow=1.3.0=pyhd8ed1ab_0
@@ -37,11 +37,11 @@ dependencies:
   - aws-c-event-stream=0.4.3=h29ce20c_2
   - aws-c-http=0.8.10=h5e77a74_0
   - aws-c-io=0.14.18=h4e6ae90_11
-  - aws-c-mqtt=0.10.6=h02abb05_0
+  - aws-c-mqtt=0.10.7=h02abb05_0
   - aws-c-s3=0.6.6=h834ce55_0
   - aws-c-sdkutils=0.1.19=h756ea98_3
   - aws-checksums=0.1.20=h756ea98_0
-  - aws-crt-cpp=0.28.3=h469002c_5
+  - aws-crt-cpp=0.28.3=h3e6eb3e_6
   - aws-sdk-cpp=1.11.407=h9f1560d_0
   - azure-core-cpp=1.13.0=h935415a_0
   - azure-identity-cpp=1.8.0=hd126650_2
@@ -58,8 +58,8 @@ dependencies:
   - bleach=6.1.0=pyhd8ed1ab_0
   - blinker=1.8.2=pyhd8ed1ab_0
   - blosc=1.21.6=hef167b5_0
-  - boto3=1.35.34=pyhd8ed1ab_0
-  - botocore=1.35.34=pyge310_1234567_0
+  - boto3=1.35.36=pyhd8ed1ab_0
+  - botocore=1.35.37=pyge310_1234567_0
   - bottleneck=1.4.0=py312hc0a28a1_2
   - branca=0.7.2=pyhd8ed1ab_0
   - brotli=1.1.0=hb9d3cd8_2
@@ -82,7 +82,7 @@ dependencies:
   - cffi=1.17.1=py312h06ac9bb_0
   - cfgv=3.3.1=pyhd8ed1ab_0
   - chardet=5.2.0=py312h7900ff3_2
-  - charset-normalizer=3.3.2=pyhd8ed1ab_0
+  - charset-normalizer=3.4.0=pyhd8ed1ab_0
   - click=8.1.7=unix_pyh707e725_0
   - click-default-group=1.2.4=pyhd8ed1ab_0
   - clikit=0.6.2=pyhd8ed1ab_2
@@ -92,7 +92,7 @@ dependencies:
   - comm=0.2.2=pyhd8ed1ab_0
   - conda-lock=2.5.7=pyhd8ed1ab_0
   - contourpy=1.3.0=py312h68727a3_2
-  - coverage=7.6.1=py312h66e93f0_1
+  - coverage=7.6.2=py312h66e93f0_0
   - crashtest=0.4.1=pyhd8ed1ab_0
   - croniter=3.0.3=pyhd8ed1ab_0
   - cryptography=43.0.1=py312hda17c39_0
@@ -106,8 +106,8 @@ dependencies:
   - dagster-webserver=1.8.10=pyhd8ed1ab_0
   - dask-core=2024.9.1=pyhd8ed1ab_0
   - dask-expr=1.1.15=pyhd8ed1ab_0
-  - databricks-sdk=0.33.0=pyhd8ed1ab_0
-  - datasette=0.64.8=pyhd8ed1ab_0
+  - databricks-sdk=0.34.0=pyhd8ed1ab_0
+  - datasette=0.65=pyhd8ed1ab_0
   - dbus=1.13.6=h5008d03_3
   - debugpy=1.8.6=py312h2ec8cdc_0
   - decorator=5.1.1=pyhd8ed1ab_0
@@ -160,11 +160,11 @@ dependencies:
   - gitdb=4.0.11=pyhd8ed1ab_0
   - gitpython=3.1.43=pyhd8ed1ab_0
   - glog=0.7.1=hbabe93e_0
-  - google-api-core=2.20.0=pyhd8ed1ab_0
+  - google-api-core=2.21.0=pyhd8ed1ab_0
   - google-auth=2.35.0=pyhff2d567_0
   - google-auth-oauthlib=1.2.1=pyhd8ed1ab_0
   - google-cloud-core=2.4.1=pyhd8ed1ab_0
-  - google-cloud-sdk=495.0.0=py312h7900ff3_0
+  - google-cloud-sdk=496.0.0=py312h7900ff3_0
   - google-cloud-storage=2.18.2=pyhff2d567_0
   - google-crc32c=1.1.2=py312hb42adb9_6
   - google-resumable-media=2.7.2=pyhd8ed1ab_1
@@ -196,7 +196,7 @@ dependencies:
   - humanize=4.11.0=pyhd8ed1ab_0
   - hupper=1.12.1=pyhd8ed1ab_0
   - hyperframe=6.0.1=pyhd8ed1ab_0
-  - hypothesis=6.112.4=pyha770c72_0
+  - hypothesis=6.114.0=pyha770c72_0
   - icu=75.1=he02047a_0
   - identify=2.6.1=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_0
@@ -208,7 +208,7 @@ dependencies:
   - ipykernel=6.29.5=pyh3099207_0
   - ipython=8.28.0=pyh707e725_0
   - ipywidgets=8.1.5=pyhd8ed1ab_0
-  - isodate=0.6.1=pyhd8ed1ab_0
+  - isodate=0.7.2=pyhd8ed1ab_0
   - isoduration=20.11.0=pyhd8ed1ab_0
   - itsdangerous=2.2.0=pyhd8ed1ab_0
   - janus=1.0.0=pyhd8ed1ab_0
@@ -225,7 +225,7 @@ dependencies:
   - json5=0.9.25=pyhd8ed1ab_0
   - jsonpointer=3.0.0=py312h7900ff3_1
   - jsonschema=4.23.0=pyhd8ed1ab_0
-  - jsonschema-specifications=2023.12.1=pyhd8ed1ab_0
+  - jsonschema-specifications=2024.10.1=pyhd8ed1ab_0
   - jsonschema-with-format-nongpl=4.23.0=hd8ed1ab_0
   - jupyter=1.1.1=pyhd8ed1ab_0
   - jupyter-lsp=2.2.5=pyhd8ed1ab_0
@@ -324,7 +324,7 @@ dependencies:
   - markdown=3.6=pyhd8ed1ab_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_0
   - marko=2.1.2=pyhd8ed1ab_0
-  - markupsafe=2.1.5=py312h66e93f0_1
+  - markupsafe=3.0.1=py312h178313f_1
   - matplotlib-base=3.9.2=py312hd3ec401_1
   - matplotlib-inline=0.1.7=pyhd8ed1ab_0
   - mdurl=0.1.2=pyhd8ed1ab_0
@@ -340,7 +340,7 @@ dependencies:
   - multimethod=1.9.1=pyhd8ed1ab_0
   - munkres=1.1.4=pyh9f0ad1d_0
   - mypy_extensions=1.0.0=pyha770c72_0
-  - narwhals=1.9.1=pyhd8ed1ab_0
+  - narwhals=1.9.2=pyhd8ed1ab_0
   - nbclient=0.10.0=pyhd8ed1ab_0
   - nbconvert=7.16.4=hd8ed1ab_1
   - nbconvert-core=7.16.4=pyhd8ed1ab_1
@@ -383,14 +383,13 @@ dependencies:
   - pexpect=4.9.0=pyhd8ed1ab_0
   - pickleshare=0.7.5=py_1003
   - pillow=10.4.0=py312h56024de_1
-  - pint=0.24.3=pyhd8ed1ab_0
   - pip=24.2=pyh8b19718_1
   - pixman=0.43.2=h59595ed_0
   - pkginfo=1.11.1=pyhd8ed1ab_0
   - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_1
   - platformdirs=4.3.6=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
-  - pre-commit=4.0.0=pyha770c72_0
+  - pre-commit=4.0.1=pyha770c72_0
   - prettier=3.3.3=hdfa8007_0
   - proj=9.5.0=h12925eb_0
   - prometheus_client=0.21.0=pyhd8ed1ab_0
@@ -472,7 +471,7 @@ dependencies:
   - ruff=0.6.9=py312hd18ad41_0
   - ruff-lsp=0.0.57=pyhd8ed1ab_0
   - s2n=1.5.4=h1380c3d_0
-  - s3transfer=0.10.2=pyhd8ed1ab_0
+  - s3transfer=0.10.3=pyhd8ed1ab_0
   - scikit-learn=1.5.2=py312h7a48858_1
   - scipy=1.14.1=py312h7d485d2_0
   - secretstorage=3.3.3=py312h7900ff3_3
@@ -502,7 +501,7 @@ dependencies:
   - sphinxcontrib-serializinghtml=1.1.10=pyhd8ed1ab_0
   - splink=4.0.3=pyhd8ed1ab_0
   - sqlalchemy=2.0.35=py312h66e93f0_0
-  - sqlglot=25.24.4=pyhd8ed1ab_0
+  - sqlglot=25.24.5=pyhd8ed1ab_0
   - sqlite=3.46.1=h9eae976_0
   - sqlparse=0.5.1=pyhd8ed1ab_0
   - stack_data=0.6.2=pyhd8ed1ab_0
@@ -572,7 +571,7 @@ dependencies:
   - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
   - yarl=1.13.1=py312h66e93f0_0
-  - zeromq=4.3.5=ha4adb4c_5
+  - zeromq=4.3.5=h3b0a872_6
   - zip=3.0=hd590300_3
   - zipp=3.20.2=pyhd8ed1ab_0
   - zlib=1.3.1=hb9d3cd8_2

--- a/environments/conda-lock.yml
+++ b/environments/conda-lock.yml
@@ -1343,11 +1343,11 @@ package:
       aws-c-cal: ">=0.7.4,<0.7.5.0a0"
       aws-c-common: ">=0.9.28,<0.9.29.0a0"
       libgcc: ">=13"
-      s2n: ">=1.5.4,<1.5.5.0a0"
-    url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h4e6ae90_11.conda
+      s2n: ">=1.5.5,<1.5.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.14.18-h2af50b2_12.conda
     hash:
-      md5: 21fd3e17dab1b20a0acdbc8b406ee7af
-      sha256: a03b3dfdf221592e17fdf4d4e96ecebfab7052e69bc22adc5eb68b2fc54200de
+      md5: 700f1883f5a0a28c30fd98c43d4d946f
+      sha256: ca10865b8e5d16ea9f9ebc14833ef49bc30eed194233539794db887def925390
     category: main
     optional: false
   - name: aws-c-io
@@ -1358,10 +1358,10 @@ package:
       __osx: ">=10.13"
       aws-c-cal: ">=0.7.4,<0.7.5.0a0"
       aws-c-common: ">=0.9.28,<0.9.29.0a0"
-    url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.18-hf9a0f1c_11.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.14.18-hf9a0f1c_12.conda
     hash:
-      md5: ccab53307c565057ad2c954effab34ab
-      sha256: a9683e05898d0622443b2bf0b38945a2599ebbd90b64d2640a21bd514d00ada5
+      md5: 19876b415ede498ca2003ddc304fe2b2
+      sha256: 6daa592fdf623633ab4bd94394d45552bfdc9041bca6af0394a7fb9af6213c14
     category: main
     optional: false
   - name: aws-c-io
@@ -1372,10 +1372,10 @@ package:
       __osx: ">=11.0"
       aws-c-cal: ">=0.7.4,<0.7.5.0a0"
       aws-c-common: ">=0.9.28,<0.9.29.0a0"
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.18-hc3cb426_11.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.14.18-hc3cb426_12.conda
     hash:
-      md5: d8d628e700847cd9668094cb635164f0
-      sha256: 4f8c8a0f9fe6ed02517b21f93e7c425ab39d8786e3ed1ec0e7e49843528306cd
+      md5: efdd67503fa663c31d51b399c8f4cc2e
+      sha256: 59c510b61aad4da05f17756d84e3b138c51a5f27a8466021587504368818f159
     category: main
     optional: false
   - name: aws-c-mqtt
@@ -2334,48 +2334,48 @@ package:
     category: main
     optional: false
   - name: boto3
-    version: 1.35.36
+    version: 1.35.37
     manager: conda
     platform: linux-64
     dependencies:
-      botocore: ">=1.35.36,<1.36.0"
+      botocore: ">=1.35.37,<1.36.0"
       jmespath: ">=0.7.1,<2.0.0"
       python: ">=3.8"
       s3transfer: ">=0.10.0,<0.11.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.36-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.37-pyhd8ed1ab_0.conda
     hash:
-      md5: 7b26bdcabcaf40040430b63635c6446a
-      sha256: ecf08d0aebb72c0c8fd5a7f753b69932fd7c5d9882ebb9142323cddd99f724e9
+      md5: cc55a5b9524f0807e0d05edb177bf4d3
+      sha256: e403b48843df7cb2744c6290942983969130691315bfcfd209d155dd05d6ad78
     category: main
     optional: false
   - name: boto3
-    version: 1.35.36
+    version: 1.35.37
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.8"
       jmespath: ">=0.7.1,<2.0.0"
       s3transfer: ">=0.10.0,<0.11.0"
-      botocore: ">=1.35.36,<1.36.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.36-pyhd8ed1ab_0.conda
+      botocore: ">=1.35.37,<1.36.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.37-pyhd8ed1ab_0.conda
     hash:
-      md5: 7b26bdcabcaf40040430b63635c6446a
-      sha256: ecf08d0aebb72c0c8fd5a7f753b69932fd7c5d9882ebb9142323cddd99f724e9
+      md5: cc55a5b9524f0807e0d05edb177bf4d3
+      sha256: e403b48843df7cb2744c6290942983969130691315bfcfd209d155dd05d6ad78
     category: main
     optional: false
   - name: boto3
-    version: 1.35.36
+    version: 1.35.37
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.8"
       jmespath: ">=0.7.1,<2.0.0"
       s3transfer: ">=0.10.0,<0.11.0"
-      botocore: ">=1.35.36,<1.36.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.36-pyhd8ed1ab_0.conda
+      botocore: ">=1.35.37,<1.36.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.37-pyhd8ed1ab_0.conda
     hash:
-      md5: 7b26bdcabcaf40040430b63635c6446a
-      sha256: ecf08d0aebb72c0c8fd5a7f753b69932fd7c5d9882ebb9142323cddd99f724e9
+      md5: cc55a5b9524f0807e0d05edb177bf4d3
+      sha256: e403b48843df7cb2744c6290942983969130691315bfcfd209d155dd05d6ad78
     category: main
     optional: false
   - name: botocore
@@ -2681,40 +2681,40 @@ package:
     category: main
     optional: false
   - name: c-ares
-    version: 1.33.1
+    version: 1.34.1
     manager: conda
     platform: linux-64
     dependencies:
       __glibc: ">=2.28,<3.0.a0"
-      libgcc-ng: ">=13"
-    url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.33.1-heb4867d_0.conda
+      libgcc: ">=13"
+    url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.1-heb4867d_0.conda
     hash:
-      md5: 0d3c60291342c0c025db231353376dfb
-      sha256: 2cb24f613eaf2850b1a08f28f967b10d8bd44ef623efa0154dc45eb718776be6
+      md5: db792eada25e970c46642f624b029fd7
+      sha256: d7e50b2ce3ef01dfbb11e8f50411b4be91b92c94cd10a83c843f1f2e53832e04
     category: main
     optional: false
   - name: c-ares
-    version: 1.33.1
+    version: 1.34.1
     manager: conda
     platform: osx-64
     dependencies:
       __osx: ">=10.13"
-    url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.33.1-h44e7173_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.1-h44e7173_0.conda
     hash:
-      md5: b31a2de5edfddb308dda802eab2956dc
-      sha256: 98b0ac09472e6737fc4685147d1755028cc650d428369cbe3cb74ab38b327095
+      md5: 611618b0b3949f947da65c96ff9c51fb
+      sha256: 004fea4112ce5a862271265e908a762843390e1870dacfd1a9a38c9aad902e9c
     category: main
     optional: false
   - name: c-ares
-    version: 1.33.1
+    version: 1.34.1
     manager: conda
     platform: osx-arm64
     dependencies:
       __osx: ">=11.0"
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.33.1-hd74edd7_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.1-hd74edd7_0.conda
     hash:
-      md5: 5b69c16ee900aeffcf0103268d708518
-      sha256: ad29a9cffa0504cb4bf7605963816feff3c7833f36b050e1e71912d09c38e3f6
+      md5: 38c2c944d30ca320a8751b214ed5364e
+      sha256: 6b864a213027340fbcf42a04ca67d4f8b908a714a5c6e160e6fb6ad21af795e4
     category: main
     optional: false
   - name: ca-certificates
@@ -4855,39 +4855,39 @@ package:
     category: main
     optional: false
   - name: distlib
-    version: 0.3.8
+    version: 0.3.9
     manager: conda
     platform: linux-64
     dependencies:
       python: 2.7|>=3.6
-    url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_0.conda
     hash:
-      md5: db16c66b759a64dc5183d69cc3745a52
-      sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
+      md5: fe521c1608280cc2803ebd26dc252212
+      sha256: 300b2e714f59403df0560174f5ef6c19db8b4a3b74a7244862cf771f07dee8fb
     category: main
     optional: false
   - name: distlib
-    version: 0.3.8
+    version: 0.3.9
     manager: conda
     platform: osx-64
     dependencies:
       python: 2.7|>=3.6
-    url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_0.conda
     hash:
-      md5: db16c66b759a64dc5183d69cc3745a52
-      sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
+      md5: fe521c1608280cc2803ebd26dc252212
+      sha256: 300b2e714f59403df0560174f5ef6c19db8b4a3b74a7244862cf771f07dee8fb
     category: main
     optional: false
   - name: distlib
-    version: 0.3.8
+    version: 0.3.9
     manager: conda
     platform: osx-arm64
     dependencies:
       python: 2.7|>=3.6
-    url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.8-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/distlib-0.3.9-pyhd8ed1ab_0.conda
     hash:
-      md5: db16c66b759a64dc5183d69cc3745a52
-      sha256: 3ff11acdd5cc2f80227682966916e878e45ced94f59c402efb94911a5774e84e
+      md5: fe521c1608280cc2803ebd26dc252212
+      sha256: 300b2e714f59403df0560174f5ef6c19db8b4a3b74a7244862cf771f07dee8fb
     category: main
     optional: false
   - name: dnspython
@@ -8526,7 +8526,7 @@ package:
     category: main
     optional: false
   - name: hypothesis
-    version: 6.114.0
+    version: 6.114.1
     manager: conda
     platform: linux-64
     dependencies:
@@ -8537,14 +8537,14 @@ package:
       python: ">=3.8"
       setuptools: ""
       sortedcontainers: ">=2.1.0,<3.0.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.114.0-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.114.1-pyha770c72_0.conda
     hash:
-      md5: 0aaf6016546b0201d061899a37c2d72c
-      sha256: a7b06ea0679b1d4afd0beac904fe5b55b05a5cbebe17e3e5cf7f73c34a70514c
+      md5: 381adcd0274e5b1f23564996ad2d2b0c
+      sha256: 33ff341c4eb9e0e51023416f44cdc9a3e29117d88ea5a4af8ec14bbdbb122d77
     category: main
     optional: false
   - name: hypothesis
-    version: 6.114.0
+    version: 6.114.1
     manager: conda
     platform: osx-64
     dependencies:
@@ -8555,14 +8555,14 @@ package:
       sortedcontainers: ">=2.1.0,<3.0.0"
       backports.zoneinfo: ">=0.2.1"
       exceptiongroup: ">=1.0.0rc8"
-    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.114.0-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.114.1-pyha770c72_0.conda
     hash:
-      md5: 0aaf6016546b0201d061899a37c2d72c
-      sha256: a7b06ea0679b1d4afd0beac904fe5b55b05a5cbebe17e3e5cf7f73c34a70514c
+      md5: 381adcd0274e5b1f23564996ad2d2b0c
+      sha256: 33ff341c4eb9e0e51023416f44cdc9a3e29117d88ea5a4af8ec14bbdbb122d77
     category: main
     optional: false
   - name: hypothesis
-    version: 6.114.0
+    version: 6.114.1
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -8573,10 +8573,10 @@ package:
       sortedcontainers: ">=2.1.0,<3.0.0"
       backports.zoneinfo: ">=0.2.1"
       exceptiongroup: ">=1.0.0rc8"
-    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.114.0-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.114.1-pyha770c72_0.conda
     hash:
-      md5: 0aaf6016546b0201d061899a37c2d72c
-      sha256: a7b06ea0679b1d4afd0beac904fe5b55b05a5cbebe17e3e5cf7f73c34a70514c
+      md5: 381adcd0274e5b1f23564996ad2d2b0c
+      sha256: 33ff341c4eb9e0e51023416f44cdc9a3e29117d88ea5a4af8ec14bbdbb122d77
     category: main
     optional: false
   - name: icu
@@ -17259,6 +17259,49 @@ package:
       sha256: a26eed22badba036b35b8f0a3cc4d17130d7e43c80d3aa258b465dd7d69362a0
     category: main
     optional: false
+  - name: propcache
+    version: 0.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=13"
+      python: ">=3.12,<3.13.0a0"
+      python_abi: 3.12.*
+    url: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.2.0-py312h66e93f0_2.conda
+    hash:
+      md5: 2c6c0c68f310bc33972e7c83264d7786
+      sha256: be7aa0056680dd6e528b7992169a20dd525b94f62d37c8ba0fbf69bd4e8df57d
+    category: main
+    optional: false
+  - name: propcache
+    version: 0.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=10.13"
+      python: ">=3.12,<3.13.0a0"
+      python_abi: 3.12.*
+    url: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.2.0-py312hb553811_2.conda
+    hash:
+      md5: 5710d1b099b723d6296f5c2a03a9546a
+      sha256: 0945df828856b73f1005f7339a93a9bd6aabf70e021952270c17aa9243cddd7a
+    category: main
+    optional: false
+  - name: propcache
+    version: 0.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      python: ">=3.12,<3.13.0a0"
+      python_abi: 3.12.*
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.2.0-py312h024a12e_2.conda
+    hash:
+      md5: 6693e523bc43c38508efe14ab3374f0c
+      sha256: 0f3a04675c6c473398f0aaa95c259e0a085d5ec106b4fa89a7efeb7cc73d5dd2
+    category: main
+    optional: false
   - name: proto-plus
     version: 1.23.0
     manager: conda
@@ -20472,17 +20515,17 @@ package:
     category: dev
     optional: true
   - name: s2n
-    version: 1.5.4
+    version: 1.5.5
     manager: conda
     platform: linux-64
     dependencies:
       __glibc: ">=2.17,<3.0.a0"
       libgcc: ">=13"
       openssl: ">=3.3.2,<4.0a0"
-    url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.4-h1380c3d_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.5.5-h3931f03_0.conda
     hash:
-      md5: 4e63e4713ffc9cddc3d5d435b5853b93
-      sha256: b5145c74e781511ea55dad60dbb45e1053be1543d2577b29f4b091c96f93a65a
+      md5: 334dba9982ab9f5d62033c61698a8683
+      sha256: a6fa0afa836f8f26dea0abc180ca2549bb517932d9a88a121e707135d4bcb715
     category: main
     optional: false
   - name: s3transfer
@@ -23315,7 +23358,7 @@ package:
     category: main
     optional: false
   - name: uvicorn
-    version: 0.31.0
+    version: 0.31.1
     manager: conda
     platform: linux-64
     dependencies:
@@ -23323,14 +23366,14 @@ package:
       h11: ">=0.8"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.31.0-py312h7900ff3_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-0.31.1-py312h7900ff3_0.conda
     hash:
-      md5: 069c7bfb27ab05c65fd654c7640a088c
-      sha256: 0abb60995d2a90eb094101188e5be2ebb3495d460afdc101332a06d50f6901d4
+      md5: 07890c755e354e0ca05d7449918f0424
+      sha256: 33c1085abd1b292291acf82fff96d0c02943b6f7dd25ee8a05d2f81cc930ccd5
     category: main
     optional: false
   - name: uvicorn
-    version: 0.31.0
+    version: 0.31.1
     manager: conda
     platform: osx-64
     dependencies:
@@ -23338,14 +23381,14 @@ package:
       h11: ">=0.8"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-64/uvicorn-0.31.0-py312hb401068_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/uvicorn-0.31.1-py312hb401068_0.conda
     hash:
-      md5: d1a3c5f66c082d9cd556d273711d3777
-      sha256: e53b179c7e31490c9fe2e6f7b0630fd89d2e925d2a08e34abd9f22e31d9c0ca2
+      md5: 6b0fba88be3ad1df5bdd2eff46c33c46
+      sha256: 0e387f9e125b8d1a3df751ed13f8ea9a7391ad366a6297718d815c5dfa8ec732
     category: main
     optional: false
   - name: uvicorn
-    version: 0.31.0
+    version: 0.31.1
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -23353,14 +23396,14 @@ package:
       h11: ">=0.8"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-0.31.0-py312h81bd7bf_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-0.31.1-py312h81bd7bf_0.conda
     hash:
-      md5: 25df50debc9c90ac374846f358aa4008
-      sha256: 5ba0deb548755a99cf34f8b4effbe98b99b8c5cf6c7aa18b68a3ec965d6b43c0
+      md5: 4d4241c6eab98951d812a3b1bbb36149
+      sha256: 222076d7bc6d3580379d3e079dcc7b27901d6b470121e5bbacd9a6a4500233cd
     category: main
     optional: false
   - name: uvicorn-standard
-    version: 0.31.0
+    version: 0.31.1
     manager: conda
     platform: linux-64
     dependencies:
@@ -23368,18 +23411,18 @@ package:
       python-dotenv: ">=0.13"
       python_abi: 3.12.*
       pyyaml: ">=5.1"
-      uvicorn: 0.31.0
+      uvicorn: 0.31.1
       uvloop: ">=0.14.0,!=0.15.0,!=0.15.1"
       watchfiles: ">=0.13"
       websockets: ">=10.4"
-    url: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-standard-0.31.0-h7900ff3_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/uvicorn-standard-0.31.1-h7900ff3_0.conda
     hash:
-      md5: eb28d6e9953fc96270619058b600369a
-      sha256: 0d99730e9a95298c1d81d6fc7fd18c36cbbc31152582e82ff813137870bd947e
+      md5: 4ccb7952b464f81adb919ac14e43c19f
+      sha256: 280c6acb6f13534e90ba25a8f8fbd217646342ae84d574809733d1f4f9ea4f7b
     category: dev
     optional: true
   - name: uvicorn-standard
-    version: 0.31.0
+    version: 0.31.1
     manager: conda
     platform: osx-64
     dependencies:
@@ -23387,18 +23430,18 @@ package:
       python-dotenv: ">=0.13"
       python_abi: 3.12.*
       pyyaml: ">=5.1"
-      uvicorn: 0.31.0
+      uvicorn: 0.31.1
       uvloop: ">=0.14.0,!=0.15.0,!=0.15.1"
       watchfiles: ">=0.13"
       websockets: ">=10.4"
-    url: https://conda.anaconda.org/conda-forge/osx-64/uvicorn-standard-0.31.0-hb401068_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/uvicorn-standard-0.31.1-hb401068_0.conda
     hash:
-      md5: b2cb8ab8c6abce239a061a1bdeb75650
-      sha256: 0f83638a47f98167354388e39e33e9e62181dc95fee0383746f0edeca21caa36
+      md5: b9655d8e4d9f3ee3e595029d36667fd8
+      sha256: 3c93718d5604f0170d6956174088cf9eaa8e6909c7939f755abbac40cb9c8318
     category: dev
     optional: true
   - name: uvicorn-standard
-    version: 0.31.0
+    version: 0.31.1
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -23406,14 +23449,14 @@ package:
       python-dotenv: ">=0.13"
       python_abi: 3.12.*
       pyyaml: ">=5.1"
-      uvicorn: 0.31.0
+      uvicorn: 0.31.1
       uvloop: ">=0.14.0,!=0.15.0,!=0.15.1"
       watchfiles: ">=0.13"
       websockets: ">=10.4"
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-standard-0.31.0-h1f38498_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/uvicorn-standard-0.31.1-h1f38498_0.conda
     hash:
-      md5: 9cd7dc425ec750cd710d740361f48031
-      sha256: f0342b1fc3c9a7d57b6a59509afaebdad4f1b3341550cd8371272cdce2f76827
+      md5: a0ec3cb010c4bf035beba11d54040bb6
+      sha256: 42e7e9e6bd35e6924d261cb65de0496d69d5fd3a0efe283f3ca427a1ca872b92
     category: dev
     optional: true
   - name: uvloop
@@ -24315,7 +24358,7 @@ package:
     category: main
     optional: false
   - name: yarl
-    version: 1.13.1
+    version: 1.14.0
     manager: conda
     platform: linux-64
     dependencies:
@@ -24323,44 +24366,47 @@ package:
       idna: ">=2.0"
       libgcc: ">=13"
       multidict: ">=4.0"
+      propcache: ">=0.2.0"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.13.1-py312h66e93f0_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.14.0-py312h66e93f0_0.conda
     hash:
-      md5: 2df2598fb30eaccaf8717bac238d4e49
-      sha256: d184281da96ccaf01d044146b73a50513d554889b1f1efb1f1a40675e74d40df
+      md5: 353fc2bd18626fd943033713c6dd7143
+      sha256: da84dd46b49debd57b43951d7716d70b7860894564dbb1d4b7339d04ed64b90b
     category: main
     optional: false
   - name: yarl
-    version: 1.13.1
+    version: 1.14.0
     manager: conda
     platform: osx-64
     dependencies:
       __osx: ">=10.13"
       idna: ">=2.0"
       multidict: ">=4.0"
+      propcache: ">=0.2.0"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.13.1-py312hb553811_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.14.0-py312hb553811_0.conda
     hash:
-      md5: c98f4fc74c84af69e7c2efae4479c7bf
-      sha256: b78b57baf1cf29cf0da8c9adec917dcd93a1b9085a3df2ef632c9be4977052e7
+      md5: 5d3ffc25bc647f27a601d2cf59f69be2
+      sha256: 71af6f79cd43ccc1b83bf805d1375ddc9ee6f367a3bb65452a477e981d2ad622
     category: main
     optional: false
   - name: yarl
-    version: 1.13.1
+    version: 1.14.0
     manager: conda
     platform: osx-arm64
     dependencies:
       __osx: ">=11.0"
       idna: ">=2.0"
       multidict: ">=4.0"
+      propcache: ">=0.2.0"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.13.1-py312h024a12e_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.14.0-py312h024a12e_0.conda
     hash:
-      md5: 7f735d412c81c48ac9c784004d23ee64
-      sha256: 3dd43c0c56f7ebce7fc1a7458b3677e8bae1ffd3e69de5f33900fad5316a48be
+      md5: 3d476da77fb4fa982f786c9cd5d7ef77
+      sha256: f7cbe182f37d82b7141ef8d71672a52409b9b5d31ff703c671818107b4bbbf55
     category: main
     optional: false
   - name: zeromq

--- a/environments/conda-lock.yml
+++ b/environments/conda-lock.yml
@@ -164,7 +164,7 @@ package:
     category: main
     optional: false
   - name: aiohttp
-    version: 3.10.8
+    version: 3.10.9
     manager: conda
     platform: linux-64
     dependencies:
@@ -178,14 +178,14 @@ package:
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
       yarl: ">=1.12.0,<2.0"
-    url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.8-py312h66e93f0_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/aiohttp-3.10.9-py312h66e93f0_0.conda
     hash:
-      md5: c647e9aea172bbff2f976a11af497fed
-      sha256: e890917377c66464a6f5ff7cdefebdd3569d1617fd25237f4e547f145f2aa1cf
+      md5: 8cd694e68fe7c1561dc1e9629347a866
+      sha256: ddb95a439520958f423ce9aae4d50e67e9dcff65056408ba74528d6fad0fb8ce
     category: main
     optional: false
   - name: aiohttp
-    version: 3.10.8
+    version: 3.10.9
     manager: conda
     platform: osx-64
     dependencies:
@@ -198,14 +198,14 @@ package:
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
       yarl: ">=1.12.0,<2.0"
-    url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.10.8-py312hb553811_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/aiohttp-3.10.9-py312hb553811_0.conda
     hash:
-      md5: e26957f31c426b028b7f5f77c0950198
-      sha256: 9911a59d05dfde86fc5e89047b09e53a4326b5f5b4a9867b7629c8041c61e4b7
+      md5: 24594fc0cd980f43a86ca6f7cf76e124
+      sha256: 00e4e7917ab6a2a383b103ba7cd7011d4ab416102b3a8f06e70ab261152fc245
     category: main
     optional: false
   - name: aiohttp
-    version: 3.10.8
+    version: 3.10.9
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -218,10 +218,10 @@ package:
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
       yarl: ">=1.12.0,<2.0"
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.10.8-py312h024a12e_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/aiohttp-3.10.9-py312h024a12e_0.conda
     hash:
-      md5: b8228160bd0b70341265005eeb720abc
-      sha256: 4a0e548f6e347cd94af68ad9a093903683519132013480200f99ec135b11481b
+      md5: 730cd266f3edfb5113e741bb498bcdcc
+      sha256: 55c70d802535302621043a96448a47df0dd89b6493eea383882c70ddea88e47e
     category: main
     optional: false
   - name: aiosignal
@@ -591,7 +591,7 @@ package:
     category: main
     optional: false
   - name: arelle-release
-    version: 2.31.4
+    version: 2.31.6
     manager: conda
     platform: linux-64
     dependencies:
@@ -606,14 +606,14 @@ package:
       python: ">=3.8"
       python-dateutil: 2.*
       regex: ""
-    url: https://conda.anaconda.org/conda-forge/noarch/arelle-release-2.31.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/arelle-release-2.31.6-pyhd8ed1ab_0.conda
     hash:
-      md5: 46c724b1ccb82c188deed550c0845ed4
-      sha256: f0439ca211c71d062ebcef0932e10be1d38561765afd4885ddd0b66b13443cf8
+      md5: d5809a6cd1f6a41559dafb0de5751d09
+      sha256: 53758109a8757384ca60da0248558789e46c903a314b171683de64133fad6ff1
     category: main
     optional: false
   - name: arelle-release
-    version: 2.31.4
+    version: 2.31.6
     manager: conda
     platform: osx-64
     dependencies:
@@ -628,14 +628,14 @@ package:
       lxml: ">=4,<6"
       numpy: ">=1,<3"
       pillow: 10.*
-    url: https://conda.anaconda.org/conda-forge/noarch/arelle-release-2.31.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/arelle-release-2.31.6-pyhd8ed1ab_0.conda
     hash:
-      md5: 46c724b1ccb82c188deed550c0845ed4
-      sha256: f0439ca211c71d062ebcef0932e10be1d38561765afd4885ddd0b66b13443cf8
+      md5: d5809a6cd1f6a41559dafb0de5751d09
+      sha256: 53758109a8757384ca60da0248558789e46c903a314b171683de64133fad6ff1
     category: main
     optional: false
   - name: arelle-release
-    version: 2.31.4
+    version: 2.31.6
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -650,10 +650,10 @@ package:
       lxml: ">=4,<6"
       numpy: ">=1,<3"
       pillow: 10.*
-    url: https://conda.anaconda.org/conda-forge/noarch/arelle-release-2.31.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/arelle-release-2.31.6-pyhd8ed1ab_0.conda
     hash:
-      md5: 46c724b1ccb82c188deed550c0845ed4
-      sha256: f0439ca211c71d062ebcef0932e10be1d38561765afd4885ddd0b66b13443cf8
+      md5: d5809a6cd1f6a41559dafb0de5751d09
+      sha256: 53758109a8757384ca60da0248558789e46c903a314b171683de64133fad6ff1
     category: main
     optional: false
   - name: argon2-cffi
@@ -1379,7 +1379,7 @@ package:
     category: main
     optional: false
   - name: aws-c-mqtt
-    version: 0.10.6
+    version: 0.10.7
     manager: conda
     platform: linux-64
     dependencies:
@@ -1388,14 +1388,14 @@ package:
       aws-c-http: ">=0.8.10,<0.8.11.0a0"
       aws-c-io: ">=0.14.18,<0.14.19.0a0"
       libgcc: ">=13"
-    url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.6-h02abb05_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.10.7-h02abb05_0.conda
     hash:
-      md5: 73d09018ed22e5208f25d71b1496a853
-      sha256: 9c50cde84bf37debf738ba8f806eddeff88b5c982c9073a2be6161e1a4df0df2
+      md5: b442b985952afe5820da96bb976ee006
+      sha256: dfc23a658ee659b0bf86545bd76d14710bfb6fb1457824b85e49a0e99b0aaea9
     category: main
     optional: false
   - name: aws-c-mqtt
-    version: 0.10.6
+    version: 0.10.7
     manager: conda
     platform: osx-64
     dependencies:
@@ -1403,14 +1403,14 @@ package:
       aws-c-common: ">=0.9.28,<0.9.29.0a0"
       aws-c-http: ">=0.8.10,<0.8.11.0a0"
       aws-c-io: ">=0.14.18,<0.14.19.0a0"
-    url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.6-h9d7d61c_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.10.7-h9d7d61c_0.conda
     hash:
-      md5: 41ede335d3fb845c49043dab04db1576
-      sha256: bd8cc5cdb47f3c6cd953e33269714df466a428e7a16ea30028f68829c4452216
+      md5: cfa8c785abedd8caaf6a58703d215c44
+      sha256: e17efadc9db5b4397f1a2ce8714bf60a2c5269764dd95000c2a2c97f28e663eb
     category: main
     optional: false
   - name: aws-c-mqtt
-    version: 0.10.6
+    version: 0.10.7
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -1418,10 +1418,10 @@ package:
       aws-c-common: ">=0.9.28,<0.9.29.0a0"
       aws-c-http: ">=0.8.10,<0.8.11.0a0"
       aws-c-io: ">=0.14.18,<0.14.19.0a0"
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.6-h3acc7b9_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.10.7-h3acc7b9_0.conda
     hash:
-      md5: 1a8f32a114eac377378a7982c7a363a5
-      sha256: 2ad955c17e01e7309bd44b19d071369f08160c41316fa0e8e4a29429f6db29fc
+      md5: 832123f8f88fc311b0eb86b06890aff4
+      sha256: ffb9600b4fa37dbee242eb300b22757b092943a82b56b9c0e3940ff3a0358809
     category: main
     optional: false
   - name: aws-c-s3
@@ -1572,15 +1572,15 @@ package:
       aws-c-event-stream: ">=0.4.3,<0.4.4.0a0"
       aws-c-http: ">=0.8.10,<0.8.11.0a0"
       aws-c-io: ">=0.14.18,<0.14.19.0a0"
-      aws-c-mqtt: ">=0.10.6,<0.10.7.0a0"
+      aws-c-mqtt: ">=0.10.7,<0.10.8.0a0"
       aws-c-s3: ">=0.6.6,<0.6.7.0a0"
       aws-c-sdkutils: ">=0.1.19,<0.1.20.0a0"
       libgcc: ">=13"
       libstdcxx: ">=13"
-    url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.28.3-h469002c_5.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/aws-crt-cpp-0.28.3-h3e6eb3e_6.conda
     hash:
-      md5: 32c889edce6ee7b9004dfce76c3f23d8
-      sha256: 1477c63867d46c531d771e370c85314885396f13285ee26e4ddeb7a16a218f86
+      md5: a12a25457b517277e15228889e568daa
+      sha256: bf85c7ad2875771d29db7f65a346b1937fc6b4c7f44283b159e6f00c2dac7a2c
     category: main
     optional: false
   - name: aws-crt-cpp
@@ -1595,14 +1595,14 @@ package:
       aws-c-event-stream: ">=0.4.3,<0.4.4.0a0"
       aws-c-http: ">=0.8.10,<0.8.11.0a0"
       aws-c-io: ">=0.14.18,<0.14.19.0a0"
-      aws-c-mqtt: ">=0.10.6,<0.10.7.0a0"
+      aws-c-mqtt: ">=0.10.7,<0.10.8.0a0"
       aws-c-s3: ">=0.6.6,<0.6.7.0a0"
       aws-c-sdkutils: ">=0.1.19,<0.1.20.0a0"
       libcxx: ">=17"
-    url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.28.3-h21c617a_5.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/aws-crt-cpp-0.28.3-hef75ebe_6.conda
     hash:
-      md5: 6de09093d1c0f5aa1f4bd9d91923c9df
-      sha256: 95cc7a027ca0c06c4a77f9e08ea7d8f16d32cad36db9bc4670d5a1e970d15971
+      md5: 831c884adc08e9cb33671f5ae024da65
+      sha256: 540af6454373d89636012578c1d35cffb6fcf997ebb242773f975c13cea3d0f8
     category: main
     optional: false
   - name: aws-crt-cpp
@@ -1617,14 +1617,14 @@ package:
       aws-c-event-stream: ">=0.4.3,<0.4.4.0a0"
       aws-c-http: ">=0.8.10,<0.8.11.0a0"
       aws-c-io: ">=0.14.18,<0.14.19.0a0"
-      aws-c-mqtt: ">=0.10.6,<0.10.7.0a0"
+      aws-c-mqtt: ">=0.10.7,<0.10.8.0a0"
       aws-c-s3: ">=0.6.6,<0.6.7.0a0"
       aws-c-sdkutils: ">=0.1.19,<0.1.20.0a0"
       libcxx: ">=17"
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.28.3-hdde83a9_5.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-crt-cpp-0.28.3-h433f80b_6.conda
     hash:
-      md5: 5d5b17677fab85d9b47bbc8c69e6eae1
-      sha256: 67a28bf8ff0f9d4fd8a7f059503f71c718185cbd65fa0a5688a6b56c944bc1e2
+      md5: e410ea6979eb3a603eb778cb4ba4ee19
+      sha256: 88f08fae202172df62b0ffc370deb464098d9a4aff63039d71189421750455de
     category: main
     optional: false
   - name: aws-sdk-cpp
@@ -2334,52 +2334,52 @@ package:
     category: main
     optional: false
   - name: boto3
-    version: 1.35.34
+    version: 1.35.36
     manager: conda
     platform: linux-64
     dependencies:
-      botocore: ">=1.35.34,<1.36.0"
+      botocore: ">=1.35.36,<1.36.0"
       jmespath: ">=0.7.1,<2.0.0"
       python: ">=3.8"
       s3transfer: ">=0.10.0,<0.11.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.34-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.36-pyhd8ed1ab_0.conda
     hash:
-      md5: 1aa2742c1572abaefeda6e558a935143
-      sha256: fe98648450d7fd28191e10fb388bc40631719afd438fcdb646e89b2f6c5773a4
+      md5: 7b26bdcabcaf40040430b63635c6446a
+      sha256: ecf08d0aebb72c0c8fd5a7f753b69932fd7c5d9882ebb9142323cddd99f724e9
     category: main
     optional: false
   - name: boto3
-    version: 1.35.34
+    version: 1.35.36
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.8"
       jmespath: ">=0.7.1,<2.0.0"
       s3transfer: ">=0.10.0,<0.11.0"
-      botocore: ">=1.35.34,<1.36.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.34-pyhd8ed1ab_0.conda
+      botocore: ">=1.35.36,<1.36.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.36-pyhd8ed1ab_0.conda
     hash:
-      md5: 1aa2742c1572abaefeda6e558a935143
-      sha256: fe98648450d7fd28191e10fb388bc40631719afd438fcdb646e89b2f6c5773a4
+      md5: 7b26bdcabcaf40040430b63635c6446a
+      sha256: ecf08d0aebb72c0c8fd5a7f753b69932fd7c5d9882ebb9142323cddd99f724e9
     category: main
     optional: false
   - name: boto3
-    version: 1.35.34
+    version: 1.35.36
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.8"
       jmespath: ">=0.7.1,<2.0.0"
       s3transfer: ">=0.10.0,<0.11.0"
-      botocore: ">=1.35.34,<1.36.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.34-pyhd8ed1ab_0.conda
+      botocore: ">=1.35.36,<1.36.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.36-pyhd8ed1ab_0.conda
     hash:
-      md5: 1aa2742c1572abaefeda6e558a935143
-      sha256: fe98648450d7fd28191e10fb388bc40631719afd438fcdb646e89b2f6c5773a4
+      md5: 7b26bdcabcaf40040430b63635c6446a
+      sha256: ecf08d0aebb72c0c8fd5a7f753b69932fd7c5d9882ebb9142323cddd99f724e9
     category: main
     optional: false
   - name: botocore
-    version: 1.35.34
+    version: 1.35.37
     manager: conda
     platform: linux-64
     dependencies:
@@ -2387,14 +2387,14 @@ package:
       python: ">=3.10"
       python-dateutil: ">=2.1,<3.0.0"
       urllib3: ">=1.25.4,!=2.2.0,<3"
-    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.34-pyge310_1234567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.37-pyge310_1234567_0.conda
     hash:
-      md5: ff0c99dc06a75ce7cd64520427038ee6
-      sha256: a34099166b88fba4560016954d4600ef6622fe66b9d0239688d8dcfe7a8a7b5c
+      md5: 8a2be5d002f36a7b94f2acfdbc54e160
+      sha256: 72ef796d01503480cbcfba74c884466384255e864659505020037b3e94ec1f36
     category: main
     optional: false
   - name: botocore
-    version: 1.35.34
+    version: 1.35.37
     manager: conda
     platform: osx-64
     dependencies:
@@ -2402,14 +2402,14 @@ package:
       python: ">=3.10"
       jmespath: ">=0.7.1,<2.0.0"
       urllib3: ">=1.25.4,!=2.2.0,<3"
-    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.34-pyge310_1234567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.37-pyge310_1234567_0.conda
     hash:
-      md5: ff0c99dc06a75ce7cd64520427038ee6
-      sha256: a34099166b88fba4560016954d4600ef6622fe66b9d0239688d8dcfe7a8a7b5c
+      md5: 8a2be5d002f36a7b94f2acfdbc54e160
+      sha256: 72ef796d01503480cbcfba74c884466384255e864659505020037b3e94ec1f36
     category: main
     optional: false
   - name: botocore
-    version: 1.35.34
+    version: 1.35.37
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -2417,10 +2417,10 @@ package:
       python: ">=3.10"
       jmespath: ">=0.7.1,<2.0.0"
       urllib3: ">=1.25.4,!=2.2.0,<3"
-    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.34-pyge310_1234567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.37-pyge310_1234567_0.conda
     hash:
-      md5: ff0c99dc06a75ce7cd64520427038ee6
-      sha256: a34099166b88fba4560016954d4600ef6622fe66b9d0239688d8dcfe7a8a7b5c
+      md5: 8a2be5d002f36a7b94f2acfdbc54e160
+      sha256: 72ef796d01503480cbcfba74c884466384255e864659505020037b3e94ec1f36
     category: main
     optional: false
   - name: bottleneck
@@ -3359,39 +3359,39 @@ package:
     category: main
     optional: false
   - name: charset-normalizer
-    version: 3.3.2
+    version: 3.4.0
     manager: conda
     platform: linux-64
     dependencies:
       python: ">=3.7"
-    url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
     hash:
-      md5: 7f4a9e3fcff3f6356ae99244a014da6a
-      sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+      md5: a374efa97290b8799046df7c5ca17164
+      sha256: 1873ac45ea61f95750cb0b4e5e675d1c5b3def937e80c7eebb19297f76810be8
     category: main
     optional: false
   - name: charset-normalizer
-    version: 3.3.2
+    version: 3.4.0
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.7"
-    url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
     hash:
-      md5: 7f4a9e3fcff3f6356ae99244a014da6a
-      sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+      md5: a374efa97290b8799046df7c5ca17164
+      sha256: 1873ac45ea61f95750cb0b4e5e675d1c5b3def937e80c7eebb19297f76810be8
     category: main
     optional: false
   - name: charset-normalizer
-    version: 3.3.2
+    version: 3.4.0
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.7"
-    url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.3.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.0-pyhd8ed1ab_0.conda
     hash:
-      md5: 7f4a9e3fcff3f6356ae99244a014da6a
-      sha256: 20cae47d31fdd58d99c4d2e65fbdcefa0b0de0c84e455ba9d6356a4bdbc4b5b9
+      md5: a374efa97290b8799046df7c5ca17164
+      sha256: 1873ac45ea61f95750cb0b4e5e675d1c5b3def937e80c7eebb19297f76810be8
     category: main
     optional: false
   - name: click
@@ -3822,7 +3822,7 @@ package:
     category: main
     optional: false
   - name: coverage
-    version: 7.6.1
+    version: 7.6.2
     manager: conda
     platform: linux-64
     dependencies:
@@ -3831,14 +3831,14 @@ package:
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
       tomli: ""
-    url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.1-py312h66e93f0_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/coverage-7.6.2-py312h66e93f0_0.conda
     hash:
-      md5: 5dc6e358ee0af388564bd0eba635cf9e
-      sha256: 1ad422ed302e3630b26e23238bd1d047674b153c4f0a99e7773faa591aa7eab9
+      md5: fa85b4b778217fbeb88425985f001497
+      sha256: a48fd12d3a2b021998fff3588cbd811386c64528111d5d284a73dfc9a552495b
     category: main
     optional: false
   - name: coverage
-    version: 7.6.1
+    version: 7.6.2
     manager: conda
     platform: osx-64
     dependencies:
@@ -3846,14 +3846,14 @@ package:
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
       tomli: ""
-    url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.6.1-py312hb553811_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/coverage-7.6.2-py312h3d0f464_0.conda
     hash:
-      md5: 49f066bb9337fd34a4c9c09f576ce136
-      sha256: fd0f5c84ef943618b378592e74010831a7962127e2759ea75437117ad3f00eee
+      md5: 8e87296799e87fa5de5e82f4473cf764
+      sha256: 892c9a4dc830d4ab1b4a4abd10c079338a0a80d81adf0940e45ad2762db8315a
     category: main
     optional: false
   - name: coverage
-    version: 7.6.1
+    version: 7.6.2
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -3861,10 +3861,10 @@ package:
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
       tomli: ""
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.6.1-py312h024a12e_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/coverage-7.6.2-py312h0bf5046_0.conda
     hash:
-      md5: 6b98fe7947dbc5a91c1e995cf3352002
-      sha256: 984f0e7b2ae7fdbb7c34d581c33f049c17aa5ac982246f1f2e63c56b17b50e52
+      md5: d010d8c119755729bf24992e0875db25
+      sha256: 61eda206266ab9e6eb3e283fa8fdddaa5fd47a54397c073f927ee818ff9611e5
     category: main
     optional: false
   - name: crashtest
@@ -4546,49 +4546,49 @@ package:
     category: main
     optional: false
   - name: databricks-sdk
-    version: 0.33.0
+    version: 0.34.0
     manager: conda
     platform: linux-64
     dependencies:
       google-auth: ">=2.0,<3"
       python: ">=3.7"
       requests: ">=2.28.1,<3"
-    url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.33.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.34.0-pyhd8ed1ab_0.conda
     hash:
-      md5: e5622f39fa90d4118e4da45b41756dc5
-      sha256: 9c53957cfc4e780308356b1e5a8d64fe3743b678a312167ad7d0267997df9c6d
+      md5: fd4135092dfb5b0735c9ebdf61b6d9b7
+      sha256: 6c4bc53d7c38a3d928e24327a43403e633fdad62dfdb44a81f38d9c2dce553eb
     category: main
     optional: false
   - name: databricks-sdk
-    version: 0.33.0
+    version: 0.34.0
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.7"
       requests: ">=2.28.1,<3"
       google-auth: ">=2.0,<3"
-    url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.33.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.34.0-pyhd8ed1ab_0.conda
     hash:
-      md5: e5622f39fa90d4118e4da45b41756dc5
-      sha256: 9c53957cfc4e780308356b1e5a8d64fe3743b678a312167ad7d0267997df9c6d
+      md5: fd4135092dfb5b0735c9ebdf61b6d9b7
+      sha256: 6c4bc53d7c38a3d928e24327a43403e633fdad62dfdb44a81f38d9c2dce553eb
     category: main
     optional: false
   - name: databricks-sdk
-    version: 0.33.0
+    version: 0.34.0
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.7"
       requests: ">=2.28.1,<3"
       google-auth: ">=2.0,<3"
-    url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.33.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/databricks-sdk-0.34.0-pyhd8ed1ab_0.conda
     hash:
-      md5: e5622f39fa90d4118e4da45b41756dc5
-      sha256: 9c53957cfc4e780308356b1e5a8d64fe3743b678a312167ad7d0267997df9c6d
+      md5: fd4135092dfb5b0735c9ebdf61b6d9b7
+      sha256: 6c4bc53d7c38a3d928e24327a43403e633fdad62dfdb44a81f38d9c2dce553eb
     category: main
     optional: false
   - name: datasette
-    version: 0.64.8
+    version: "0.65"
     manager: conda
     platform: linux-64
     dependencies:
@@ -4597,27 +4597,30 @@ package:
       asgiref: ">=3.2.10"
       click: ">=7.1.1"
       click-default-group: ">=1.2.3"
+      flexcache: ">=0.3"
+      flexparser: ">=0.3"
       httpx: ">=0.20"
       hupper: ">=1.9"
       itsdangerous: ">=1.1"
       janus: ">=0.6.2"
       jinja2: ">=2.10.3"
       mergedeep: ">=1.1.1"
-      pint: ">=0.9"
       pip: ""
+      platformdirs: ">=2.1.0"
       pluggy: ">=1.0"
       python: ">=3.7"
       pyyaml: ">=5.3"
       setuptools: ""
+      typing_extensions: ">=4.0.0"
       uvicorn: ">=0.11"
-    url: https://conda.anaconda.org/conda-forge/noarch/datasette-0.64.8-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/datasette-0.65-pyhd8ed1ab_0.conda
     hash:
-      md5: 268ba306ef3bf49d66703fbb4b0b7eaa
-      sha256: c0ee04cc73dd78c5568544eada04919ba8b9d0c50cb454b49ac5fa4c78bfba3c
+      md5: cc8f66b28ae3b042ac20e88d6f715e91
+      sha256: 0da660175b30e16e40293c022846c25edfd9636aeb1dd17f37f689097ca721a2
     category: main
     optional: false
   - name: datasette
-    version: 0.64.8
+    version: "0.65"
     manager: conda
     platform: osx-64
     dependencies:
@@ -4627,7 +4630,7 @@ package:
       pyyaml: ">=5.3"
       jinja2: ">=2.10.3"
       click: ">=7.1.1"
-      pint: ">=0.9"
+      typing_extensions: ">=4.0.0"
       httpx: ">=0.20"
       asgi-csrf: ">=0.9"
       itsdangerous: ">=1.1"
@@ -4639,14 +4642,17 @@ package:
       asgiref: ">=3.2.10"
       janus: ">=0.6.2"
       mergedeep: ">=1.1.1"
-    url: https://conda.anaconda.org/conda-forge/noarch/datasette-0.64.8-pyhd8ed1ab_0.conda
+      flexcache: ">=0.3"
+      flexparser: ">=0.3"
+      platformdirs: ">=2.1.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/datasette-0.65-pyhd8ed1ab_0.conda
     hash:
-      md5: 268ba306ef3bf49d66703fbb4b0b7eaa
-      sha256: c0ee04cc73dd78c5568544eada04919ba8b9d0c50cb454b49ac5fa4c78bfba3c
+      md5: cc8f66b28ae3b042ac20e88d6f715e91
+      sha256: 0da660175b30e16e40293c022846c25edfd9636aeb1dd17f37f689097ca721a2
     category: main
     optional: false
   - name: datasette
-    version: 0.64.8
+    version: "0.65"
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -4656,7 +4662,7 @@ package:
       pyyaml: ">=5.3"
       jinja2: ">=2.10.3"
       click: ">=7.1.1"
-      pint: ">=0.9"
+      typing_extensions: ">=4.0.0"
       httpx: ">=0.20"
       asgi-csrf: ">=0.9"
       itsdangerous: ">=1.1"
@@ -4668,10 +4674,13 @@ package:
       asgiref: ">=3.2.10"
       janus: ">=0.6.2"
       mergedeep: ">=1.1.1"
-    url: https://conda.anaconda.org/conda-forge/noarch/datasette-0.64.8-pyhd8ed1ab_0.conda
+      flexcache: ">=0.3"
+      flexparser: ">=0.3"
+      platformdirs: ">=2.1.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/datasette-0.65-pyhd8ed1ab_0.conda
     hash:
-      md5: 268ba306ef3bf49d66703fbb4b0b7eaa
-      sha256: c0ee04cc73dd78c5568544eada04919ba8b9d0c50cb454b49ac5fa4c78bfba3c
+      md5: cc8f66b28ae3b042ac20e88d6f715e91
+      sha256: 0da660175b30e16e40293c022846c25edfd9636aeb1dd17f37f689097ca721a2
     category: main
     optional: false
   - name: dbus
@@ -6874,7 +6883,7 @@ package:
     category: main
     optional: false
   - name: google-api-core
-    version: 2.20.0
+    version: 2.21.0
     manager: conda
     platform: linux-64
     dependencies:
@@ -6884,14 +6893,14 @@ package:
       protobuf: ">=3.19.5,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5"
       python: ">=3.7"
       requests: ">=2.18.0,<3.0.0.dev0"
-    url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.20.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.21.0-pyhd8ed1ab_0.conda
     hash:
-      md5: fc554f77ede6b9d12acdc6eec1144f70
-      sha256: 234372fa0b0efe41d23e193c7b8c90a43d30e43d0570e003696a7dc8c3f46b64
+      md5: edeea37b608c49ffa472e03ecb54e026
+      sha256: 34558e083b9caa0af561e7ef0428f33ae7453488e41bba1b4af055aef67425cd
     category: main
     optional: false
   - name: google-api-core
-    version: 2.20.0
+    version: 2.21.0
     manager: conda
     platform: osx-64
     dependencies:
@@ -6901,14 +6910,14 @@ package:
       googleapis-common-protos: ">=1.56.2,<2.0.dev0"
       requests: ">=2.18.0,<3.0.0.dev0"
       protobuf: ">=3.19.5,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5"
-    url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.20.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.21.0-pyhd8ed1ab_0.conda
     hash:
-      md5: fc554f77ede6b9d12acdc6eec1144f70
-      sha256: 234372fa0b0efe41d23e193c7b8c90a43d30e43d0570e003696a7dc8c3f46b64
+      md5: edeea37b608c49ffa472e03ecb54e026
+      sha256: 34558e083b9caa0af561e7ef0428f33ae7453488e41bba1b4af055aef67425cd
     category: main
     optional: false
   - name: google-api-core
-    version: 2.20.0
+    version: 2.21.0
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -6918,10 +6927,10 @@ package:
       googleapis-common-protos: ">=1.56.2,<2.0.dev0"
       requests: ">=2.18.0,<3.0.0.dev0"
       protobuf: ">=3.19.5,<6.0.0.dev0,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5"
-    url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.20.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/google-api-core-2.21.0-pyhd8ed1ab_0.conda
     hash:
-      md5: fc554f77ede6b9d12acdc6eec1144f70
-      sha256: 234372fa0b0efe41d23e193c7b8c90a43d30e43d0570e003696a7dc8c3f46b64
+      md5: edeea37b608c49ffa472e03ecb54e026
+      sha256: 34558e083b9caa0af561e7ef0428f33ae7453488e41bba1b4af055aef67425cd
     category: main
     optional: false
   - name: google-auth
@@ -7075,42 +7084,42 @@ package:
     category: main
     optional: false
   - name: google-cloud-sdk
-    version: 495.0.0
+    version: 496.0.0
     manager: conda
     platform: linux-64
     dependencies:
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-495.0.0-py312h7900ff3_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/google-cloud-sdk-496.0.0-py312h7900ff3_0.conda
     hash:
-      md5: bc011083bb5c892ce2bf9d6a27f02e55
-      sha256: dcbec355ea0cc6f4c2de99997dc6c2bdf6656c92628845441c79b488e1cea814
+      md5: b258afd9f4755da0a8427cdb3aae3cad
+      sha256: 75cbacd0ee42a000053011c7c9955bf7dd599c701a10521a76f63f50b6b574a2
     category: main
     optional: false
   - name: google-cloud-sdk
-    version: 495.0.0
+    version: 496.0.0
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-64/google-cloud-sdk-495.0.0-py312hb401068_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/google-cloud-sdk-496.0.0-py312hb401068_0.conda
     hash:
-      md5: 8c3826ef86a986fd18f67c5646e10186
-      sha256: 85b25fc4cf0516a6a88f657eb4eb10aa15da865be484e1dac8bdf854c50ba830
+      md5: a2e158349ca2c979cbe8ccd910f7879b
+      sha256: 91793e2ae593d7e8fff47615f12f6625255ba032735bca3e10a4832a02926527
     category: main
     optional: false
   - name: google-cloud-sdk
-    version: 495.0.0
+    version: 496.0.0
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/google-cloud-sdk-495.0.0-py312h81bd7bf_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/google-cloud-sdk-496.0.0-py312h81bd7bf_0.conda
     hash:
-      md5: 63da65801530ec5cd6a4101eb5164aa3
-      sha256: 170f87ebb0d4f9920755d62a554da84e01ddedf5b186a3dfe6638a30eea15e78
+      md5: a625610dc81859a56d8d4252cac07fb3
+      sha256: 8910443b951de1379de4fc75c405d20a4fbfb2ff39d6b2d40f8ff914b81124db
     category: main
     optional: false
   - name: google-cloud-storage
@@ -8517,7 +8526,7 @@ package:
     category: main
     optional: false
   - name: hypothesis
-    version: 6.112.4
+    version: 6.114.0
     manager: conda
     platform: linux-64
     dependencies:
@@ -8528,14 +8537,14 @@ package:
       python: ">=3.8"
       setuptools: ""
       sortedcontainers: ">=2.1.0,<3.0.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.112.4-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.114.0-pyha770c72_0.conda
     hash:
-      md5: 71609400d964fafab4ee0b5cb921f695
-      sha256: 3ac2d67786a18c9f6b57f77f60e7a886cca4c7e1a7081c48ee22cc334bad9742
+      md5: 0aaf6016546b0201d061899a37c2d72c
+      sha256: a7b06ea0679b1d4afd0beac904fe5b55b05a5cbebe17e3e5cf7f73c34a70514c
     category: main
     optional: false
   - name: hypothesis
-    version: 6.112.4
+    version: 6.114.0
     manager: conda
     platform: osx-64
     dependencies:
@@ -8546,14 +8555,14 @@ package:
       sortedcontainers: ">=2.1.0,<3.0.0"
       backports.zoneinfo: ">=0.2.1"
       exceptiongroup: ">=1.0.0rc8"
-    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.112.4-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.114.0-pyha770c72_0.conda
     hash:
-      md5: 71609400d964fafab4ee0b5cb921f695
-      sha256: 3ac2d67786a18c9f6b57f77f60e7a886cca4c7e1a7081c48ee22cc334bad9742
+      md5: 0aaf6016546b0201d061899a37c2d72c
+      sha256: a7b06ea0679b1d4afd0beac904fe5b55b05a5cbebe17e3e5cf7f73c34a70514c
     category: main
     optional: false
   - name: hypothesis
-    version: 6.112.4
+    version: 6.114.0
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -8564,10 +8573,10 @@ package:
       sortedcontainers: ">=2.1.0,<3.0.0"
       backports.zoneinfo: ">=0.2.1"
       exceptiongroup: ">=1.0.0rc8"
-    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.112.4-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.114.0-pyha770c72_0.conda
     hash:
-      md5: 71609400d964fafab4ee0b5cb921f695
-      sha256: 3ac2d67786a18c9f6b57f77f60e7a886cca4c7e1a7081c48ee22cc334bad9742
+      md5: 0aaf6016546b0201d061899a37c2d72c
+      sha256: a7b06ea0679b1d4afd0beac904fe5b55b05a5cbebe17e3e5cf7f73c34a70514c
     category: main
     optional: false
   - name: icu
@@ -9070,42 +9079,39 @@ package:
     category: main
     optional: false
   - name: isodate
-    version: 0.6.1
+    version: 0.7.2
     manager: conda
     platform: linux-64
     dependencies:
-      python: ">=3.6"
-      six: ""
-    url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.6.1-pyhd8ed1ab_0.tar.bz2
+      python: ">=3.7"
+    url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_0.conda
     hash:
-      md5: 4a62c93c1b5c0b920508ae3fd285eaf5
-      sha256: af8f801e093da52a50ca0ea0510dfaf6898fea37e66d08d335e370235dede9fc
+      md5: d68d25aca67d1a06bf6f5b43aea9430d
+      sha256: 5bf70eb750654eba73d0624a21dccbda982fb77070b3ff457dc2abd67c4e0a27
     category: main
     optional: false
   - name: isodate
-    version: 0.6.1
+    version: 0.7.2
     manager: conda
     platform: osx-64
     dependencies:
-      six: ""
-      python: ">=3.6"
-    url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.6.1-pyhd8ed1ab_0.tar.bz2
+      python: ">=3.7"
+    url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_0.conda
     hash:
-      md5: 4a62c93c1b5c0b920508ae3fd285eaf5
-      sha256: af8f801e093da52a50ca0ea0510dfaf6898fea37e66d08d335e370235dede9fc
+      md5: d68d25aca67d1a06bf6f5b43aea9430d
+      sha256: 5bf70eb750654eba73d0624a21dccbda982fb77070b3ff457dc2abd67c4e0a27
     category: main
     optional: false
   - name: isodate
-    version: 0.6.1
+    version: 0.7.2
     manager: conda
     platform: osx-arm64
     dependencies:
-      six: ""
-      python: ">=3.6"
-    url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.6.1-pyhd8ed1ab_0.tar.bz2
+      python: ">=3.7"
+    url: https://conda.anaconda.org/conda-forge/noarch/isodate-0.7.2-pyhd8ed1ab_0.conda
     hash:
-      md5: 4a62c93c1b5c0b920508ae3fd285eaf5
-      sha256: af8f801e093da52a50ca0ea0510dfaf6898fea37e66d08d335e370235dede9fc
+      md5: d68d25aca67d1a06bf6f5b43aea9430d
+      sha256: 5bf70eb750654eba73d0624a21dccbda982fb77070b3ff457dc2abd67c4e0a27
     category: main
     optional: false
   - name: isoduration
@@ -9714,45 +9720,42 @@ package:
     category: main
     optional: false
   - name: jsonschema-specifications
-    version: 2023.12.1
+    version: 2024.10.1
     manager: conda
     platform: linux-64
     dependencies:
-      importlib_resources: ">=1.4.0"
       python: ">=3.8"
       referencing: ">=0.31.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
     hash:
-      md5: a0e4efb5f35786a05af4809a2fb1f855
-      sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
+      md5: 720745920222587ef942acfbc578b584
+      sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
     category: main
     optional: false
   - name: jsonschema-specifications
-    version: 2023.12.1
+    version: 2024.10.1
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.8"
-      importlib_resources: ">=1.4.0"
       referencing: ">=0.31.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
     hash:
-      md5: a0e4efb5f35786a05af4809a2fb1f855
-      sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
+      md5: 720745920222587ef942acfbc578b584
+      sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
     category: main
     optional: false
   - name: jsonschema-specifications
-    version: 2023.12.1
+    version: 2024.10.1
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.8"
-      importlib_resources: ">=1.4.0"
       referencing: ">=0.31.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2023.12.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2024.10.1-pyhd8ed1ab_0.conda
     hash:
-      md5: a0e4efb5f35786a05af4809a2fb1f855
-      sha256: a9630556ddc3121c0be32f4cbf792dd9102bd380d5cd81d57759d172cf0c2da2
+      md5: 720745920222587ef942acfbc578b584
+      sha256: 82f8bed0f21dc0b3aff40dd4e39d77e85b93b0417bc5659b001e0109341b8b98
     category: main
     optional: false
   - name: jsonschema-with-format-nongpl
@@ -13560,27 +13563,27 @@ package:
     category: main
     optional: false
   - name: llvm-openmp
-    version: 19.1.0
+    version: 19.1.1
     manager: conda
     platform: osx-64
     dependencies:
       __osx: ">=10.13"
-    url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.0-h56322cc_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-19.1.1-h545e0da_0.conda
     hash:
-      md5: a96391a6d7efc331d86f20480f7d555c
-      sha256: 1775b8001a3063e128830d79ec811910ce32edf6914724360d0a3c7191e884b5
+      md5: 3f3e4a599dd2638a945fc5821090db07
+      sha256: 7e15f5ac89e750dadbc6fe81dc2909dd056c7324c72379a8440b57a6174a1146
     category: main
     optional: false
   - name: llvm-openmp
-    version: 19.1.0
+    version: 19.1.1
     manager: conda
     platform: osx-arm64
     dependencies:
       __osx: ">=11.0"
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.0-hba312e6_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-19.1.1-h6cdba0f_0.conda
     hash:
-      md5: 2f97682b9d39cf0cc42bc96d55e543cb
-      sha256: af4b01dbfdba42141c8db6ffd2909da9df35c878654ac0149421459128e037bd
+      md5: e509675b5f2dff8cbd7de8f9362bafac
+      sha256: f325a123dffba3dbf090ced4d8b05fd9f7c7151180f7bdd5952c146017a20f4c
     category: main
     optional: false
   - name: llvmlite
@@ -14044,7 +14047,7 @@ package:
     category: main
     optional: false
   - name: markupsafe
-    version: 2.1.5
+    version: 3.0.1
     manager: conda
     platform: linux-64
     dependencies:
@@ -14052,38 +14055,38 @@ package:
       libgcc: ">=13"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-2.1.5-py312h66e93f0_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.1-py312h178313f_1.conda
     hash:
-      md5: 80b79ce0d3dc127e96002dfdcec0a2a5
-      sha256: 5c88cd6e19437015de16bde30dd25791aca63ac9cbb8d66b65f365ecff1b235b
+      md5: 490afd4d3627a7f999b9d633c4b6c229
+      sha256: d65455297e005c73811848fb3b25a9570d5712c972c7302198ca72698f5f5341
     category: main
     optional: false
   - name: markupsafe
-    version: 2.1.5
+    version: 3.0.1
     manager: conda
     platform: osx-64
     dependencies:
       __osx: ">=10.13"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-2.1.5-py312hb553811_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/markupsafe-3.0.1-py312hca98d7e_1.conda
     hash:
-      md5: 2b9fc64d656299475c648d7508e14943
-      sha256: 2382cc541f3bbe912180861754aceb2ed180004e361a7c66ac2b1a71a7c2fba8
+      md5: 136bab776f3fb3ccc6e11f95cf71e658
+      sha256: 848e8be9b74d20a90c120f0f3332df5baad07514edab44e4e8e561b89fbf261b
     category: main
     optional: false
   - name: markupsafe
-    version: 2.1.5
+    version: 3.0.1
     manager: conda
     platform: osx-arm64
     dependencies:
       __osx: ">=11.0"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-2.1.5-py312h024a12e_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.1-py312h906988d_1.conda
     hash:
-      md5: 66ee733dbdf8a9ca670f167bf5ea36b4
-      sha256: 0e337724d82b19510c457246c319b35944580f31b3859359e1e8b9c53a14bc52
+      md5: 1d5bfcca1e22c01219af6845ec51772f
+      sha256: 6fecbc3da19cabddd870ff51c29f3bc174ee0db564d2e45a1a6490969fc048dd
     category: main
     optional: false
   - name: matplotlib-base
@@ -14830,39 +14833,39 @@ package:
     category: main
     optional: false
   - name: narwhals
-    version: 1.9.1
+    version: 1.9.2
     manager: conda
     platform: linux-64
     dependencies:
       python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.9.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.9.2-pyhd8ed1ab_0.conda
     hash:
-      md5: ad0f9d5eeab82195938bc37b5f4b17ff
-      sha256: b291657ede552379324550c3f8a1490edbe5f33e5fc5ab8ca3463d3455d90694
+      md5: 9d64a8c444eb821ca19d7ea8f7f9f6d1
+      sha256: 0d22cbf34e61a4204fa742d15364a9848810acfa52ae67333733aab4b83b7e60
     category: main
     optional: false
   - name: narwhals
-    version: 1.9.1
+    version: 1.9.2
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.9.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.9.2-pyhd8ed1ab_0.conda
     hash:
-      md5: ad0f9d5eeab82195938bc37b5f4b17ff
-      sha256: b291657ede552379324550c3f8a1490edbe5f33e5fc5ab8ca3463d3455d90694
+      md5: 9d64a8c444eb821ca19d7ea8f7f9f6d1
+      sha256: 0d22cbf34e61a4204fa742d15364a9848810acfa52ae67333733aab4b83b7e60
     category: main
     optional: false
   - name: narwhals
-    version: 1.9.1
+    version: 1.9.2
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.9.1-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.9.2-pyhd8ed1ab_0.conda
     hash:
-      md5: ad0f9d5eeab82195938bc37b5f4b17ff
-      sha256: b291657ede552379324550c3f8a1490edbe5f33e5fc5ab8ca3463d3455d90694
+      md5: 9d64a8c444eb821ca19d7ea8f7f9f6d1
+      sha256: 0d22cbf34e61a4204fa742d15364a9848810acfa52ae67333733aab4b83b7e60
     category: main
     optional: false
   - name: nbclient
@@ -16738,57 +16741,6 @@ package:
       sha256: 980139e8dfc9da20a96a6260c796eb7c77c5c5658ee4032f33ebe0ac980b2e2b
     category: main
     optional: false
-  - name: pint
-    version: 0.24.3
-    manager: conda
-    platform: linux-64
-    dependencies:
-      appdirs: ">=1.4.4"
-      flexcache: ">=0.3"
-      flexparser: ">=0.3"
-      python: ">=3.9"
-      typing-extensions: ""
-      typing_extensions: ""
-    url: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.3-pyhd8ed1ab_0.conda
-    hash:
-      md5: ca12b329038e1a3b73f5f5d73ba99475
-      sha256: b6f2dd095747551ff2ec73b86c7d741720037c31facec845e402e21d35d4a450
-    category: main
-    optional: false
-  - name: pint
-    version: 0.24.3
-    manager: conda
-    platform: osx-64
-    dependencies:
-      typing_extensions: ""
-      typing-extensions: ""
-      python: ">=3.9"
-      appdirs: ">=1.4.4"
-      flexcache: ">=0.3"
-      flexparser: ">=0.3"
-    url: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.3-pyhd8ed1ab_0.conda
-    hash:
-      md5: ca12b329038e1a3b73f5f5d73ba99475
-      sha256: b6f2dd095747551ff2ec73b86c7d741720037c31facec845e402e21d35d4a450
-    category: main
-    optional: false
-  - name: pint
-    version: 0.24.3
-    manager: conda
-    platform: osx-arm64
-    dependencies:
-      typing_extensions: ""
-      typing-extensions: ""
-      python: ">=3.9"
-      appdirs: ">=1.4.4"
-      flexcache: ">=0.3"
-      flexparser: ">=0.3"
-    url: https://conda.anaconda.org/conda-forge/noarch/pint-0.24.3-pyhd8ed1ab_0.conda
-    hash:
-      md5: ca12b329038e1a3b73f5f5d73ba99475
-      sha256: b6f2dd095747551ff2ec73b86c7d741720037c31facec845e402e21d35d4a450
-    category: main
-    optional: false
   - name: pip
     version: "24.2"
     manager: conda
@@ -17013,7 +16965,7 @@ package:
     category: main
     optional: false
   - name: pre-commit
-    version: 4.0.0
+    version: 4.0.1
     manager: conda
     platform: linux-64
     dependencies:
@@ -17023,14 +16975,14 @@ package:
       python: ">=3.9"
       pyyaml: ">=5.1"
       virtualenv: ">=20.10.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.0-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_0.conda
     hash:
-      md5: a635451e05b47b3db00fa91bdb8afab3
-      sha256: 23138d3aa3e58c168f2dd607eb3832cb9d918b9ae35f8280262760d27b7d5723
+      md5: 5971cc64048943605f352f7f8612de6c
+      sha256: 2490b18ec802d8f085f2de8298a3d275451f7db17769353080dfb121fe386675
     category: main
     optional: false
   - name: pre-commit
-    version: 4.0.0
+    version: 4.0.1
     manager: conda
     platform: osx-64
     dependencies:
@@ -17040,14 +16992,14 @@ package:
       nodeenv: ">=0.11.1"
       cfgv: ">=2.0.0"
       virtualenv: ">=20.10.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.0-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_0.conda
     hash:
-      md5: a635451e05b47b3db00fa91bdb8afab3
-      sha256: 23138d3aa3e58c168f2dd607eb3832cb9d918b9ae35f8280262760d27b7d5723
+      md5: 5971cc64048943605f352f7f8612de6c
+      sha256: 2490b18ec802d8f085f2de8298a3d275451f7db17769353080dfb121fe386675
     category: main
     optional: false
   - name: pre-commit
-    version: 4.0.0
+    version: 4.0.1
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -17057,10 +17009,10 @@ package:
       nodeenv: ">=0.11.1"
       cfgv: ">=2.0.0"
       virtualenv: ">=20.10.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.0-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.0.1-pyha770c72_0.conda
     hash:
-      md5: a635451e05b47b3db00fa91bdb8afab3
-      sha256: 23138d3aa3e58c168f2dd607eb3832cb9d918b9ae35f8280262760d27b7d5723
+      md5: 5971cc64048943605f352f7f8612de6c
+      sha256: 2490b18ec802d8f085f2de8298a3d275451f7db17769353080dfb121fe386675
     category: main
     optional: false
   - name: prettier
@@ -20534,42 +20486,42 @@ package:
     category: main
     optional: false
   - name: s3transfer
-    version: 0.10.2
+    version: 0.10.3
     manager: conda
     platform: linux-64
     dependencies:
       botocore: ">=1.33.2,<2.0a.0"
       python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.3-pyhd8ed1ab_0.conda
     hash:
-      md5: 80f00f9033aee2358171207746e09ea0
-      sha256: aea88a1be4be3d71ebb4c10ecdadcfa852115e9071c36c063fa315319fb25cae
+      md5: 0878f8e10cb8b4e069d27db48b95c3b5
+      sha256: a8d6061e31cd4e315b26ab1f6a74c618c930d3e14eb3b7c82e4077a11eae2141
     category: main
     optional: false
   - name: s3transfer
-    version: 0.10.2
+    version: 0.10.3
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.8"
       botocore: ">=1.33.2,<2.0a.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.3-pyhd8ed1ab_0.conda
     hash:
-      md5: 80f00f9033aee2358171207746e09ea0
-      sha256: aea88a1be4be3d71ebb4c10ecdadcfa852115e9071c36c063fa315319fb25cae
+      md5: 0878f8e10cb8b4e069d27db48b95c3b5
+      sha256: a8d6061e31cd4e315b26ab1f6a74c618c930d3e14eb3b7c82e4077a11eae2141
     category: main
     optional: false
   - name: s3transfer
-    version: 0.10.2
+    version: 0.10.3
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.8"
       botocore: ">=1.33.2,<2.0a.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.3-pyhd8ed1ab_0.conda
     hash:
-      md5: 80f00f9033aee2358171207746e09ea0
-      sha256: aea88a1be4be3d71ebb4c10ecdadcfa852115e9071c36c063fa315319fb25cae
+      md5: 0878f8e10cb8b4e069d27db48b95c3b5
+      sha256: a8d6061e31cd4e315b26ab1f6a74c618c930d3e14eb3b7c82e4077a11eae2141
     category: main
     optional: false
   - name: scikit-learn
@@ -21208,8 +21160,8 @@ package:
       colorama: ">=0.4.6"
       sphinxcontrib-htmlhelp: ">=2.0.0"
       packaging: ">=23.0"
-      imagesize: ">=1.3"
       tomli: ">=2.0"
+      imagesize: ">=1.3"
       jinja2: ">=3.1"
       sphinxcontrib-serializinghtml: ">=1.1.9"
       babel: ">=2.13"
@@ -21237,8 +21189,8 @@ package:
       colorama: ">=0.4.6"
       sphinxcontrib-htmlhelp: ">=2.0.0"
       packaging: ">=23.0"
-      imagesize: ">=1.3"
       tomli: ">=2.0"
+      imagesize: ">=1.3"
       jinja2: ">=3.1"
       sphinxcontrib-serializinghtml: ">=1.1.9"
       babel: ">=2.13"
@@ -21804,39 +21756,39 @@ package:
     category: main
     optional: false
   - name: sqlglot
-    version: 25.24.4
+    version: 25.24.5
     manager: conda
     platform: linux-64
     dependencies:
       python: ">=3.7"
-    url: https://conda.anaconda.org/conda-forge/noarch/sqlglot-25.24.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/sqlglot-25.24.5-pyhd8ed1ab_0.conda
     hash:
-      md5: ca9ba8da37b92e65aaf0a7f48448a7f0
-      sha256: 5e690ff8fbc1bcf416ed782872dd6e3c345c3902915749de4d4763913d296f38
+      md5: f932f826399855ca4d03dbbd81cf21a3
+      sha256: c3a63046f7c85a4bf0a7dbf170672a67f64c49e2ad134bd9fc0e7c20618152b0
     category: main
     optional: false
   - name: sqlglot
-    version: 25.24.4
+    version: 25.24.5
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.7"
-    url: https://conda.anaconda.org/conda-forge/noarch/sqlglot-25.24.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/sqlglot-25.24.5-pyhd8ed1ab_0.conda
     hash:
-      md5: ca9ba8da37b92e65aaf0a7f48448a7f0
-      sha256: 5e690ff8fbc1bcf416ed782872dd6e3c345c3902915749de4d4763913d296f38
+      md5: f932f826399855ca4d03dbbd81cf21a3
+      sha256: c3a63046f7c85a4bf0a7dbf170672a67f64c49e2ad134bd9fc0e7c20618152b0
     category: main
     optional: false
   - name: sqlglot
-    version: 25.24.4
+    version: 25.24.5
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.7"
-    url: https://conda.anaconda.org/conda-forge/noarch/sqlglot-25.24.4-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/sqlglot-25.24.5-pyhd8ed1ab_0.conda
     hash:
-      md5: ca9ba8da37b92e65aaf0a7f48448a7f0
-      sha256: 5e690ff8fbc1bcf416ed782872dd6e3c345c3902915749de4d4763913d296f38
+      md5: f932f826399855ca4d03dbbd81cf21a3
+      sha256: c3a63046f7c85a4bf0a7dbf170672a67f64c49e2ad134bd9fc0e7c20618152b0
     category: main
     optional: false
   - name: sqlite
@@ -24421,10 +24373,10 @@ package:
       libgcc: ">=13"
       libsodium: ">=1.0.20,<1.0.21.0a0"
       libstdcxx: ">=13"
-    url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-ha4adb4c_5.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/zeromq-4.3.5-h3b0a872_6.conda
     hash:
-      md5: e8372041ebb377237db9d0d24c7b5962
-      sha256: dd48adc07fcd029c86fbf82e68d0e4818c7744b768e08139379920b56b582814
+      md5: 113506c8d2d558e733f5c38f6bf08c50
+      sha256: e67288b1c98a31ee58a5c07bdd873dbe08e75f752e1ad605d5e8c0697339903e
     category: main
     optional: false
   - name: zeromq
@@ -24436,10 +24388,10 @@ package:
       krb5: ">=1.21.3,<1.22.0a0"
       libcxx: ">=17"
       libsodium: ">=1.0.20,<1.0.21.0a0"
-    url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-hb33e954_5.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/zeromq-4.3.5-he4ceba3_6.conda
     hash:
-      md5: a9735eb372d515c78f8211785406e36f
-      sha256: 7e63a9ec19660666095ea9332a5b226329ff4f499018e8a281d0d160cbb60ca4
+      md5: 00ec9f2a5e21bbbd22ffbbc12b3df286
+      sha256: 0e2a6ced111fd99b66b76ec797804ab798ec190a88a2779060f7a8787c343ee0
     category: main
     optional: false
   - name: zeromq
@@ -24451,10 +24403,10 @@ package:
       krb5: ">=1.21.3,<1.22.0a0"
       libcxx: ">=17"
       libsodium: ">=1.0.20,<1.0.21.0a0"
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h64debc3_5.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/zeromq-4.3.5-h9f5b81c_6.conda
     hash:
-      md5: c29dbe9343a0b55b027fa645644c59d9
-      sha256: b4ba544a04129472651a5df3b8906ed68e7f43bf23e724fd0e368218083c920c
+      md5: 84121ef1717cdfbecedeae70142706cc
+      sha256: 5c5061c976141eccbbb2aec21483ddd10fd1df4fd9bcf638e3fd57b2bd85721f
     category: main
     optional: false
   - name: zip

--- a/environments/conda-osx-64.lock.yml
+++ b/environments/conda-osx-64.lock.yml
@@ -35,7 +35,7 @@ dependencies:
   - aws-c-compression=0.2.19=h8128ea2_1
   - aws-c-event-stream=0.4.3=hcd1ed9e_2
   - aws-c-http=0.8.10=h2f86973_0
-  - aws-c-io=0.14.18=hf9a0f1c_11
+  - aws-c-io=0.14.18=hf9a0f1c_12
   - aws-c-mqtt=0.10.7=h9d7d61c_0
   - aws-c-s3=0.6.6=hd01826e_0
   - aws-c-sdkutils=0.1.19=h8128ea2_3
@@ -57,7 +57,7 @@ dependencies:
   - bleach=6.1.0=pyhd8ed1ab_0
   - blinker=1.8.2=pyhd8ed1ab_0
   - blosc=1.21.6=h7d75f6d_0
-  - boto3=1.35.36=pyhd8ed1ab_0
+  - boto3=1.35.37=pyhd8ed1ab_0
   - botocore=1.35.37=pyge310_1234567_0
   - bottleneck=1.4.0=py312h3a11e2b_2
   - branca=0.7.2=pyhd8ed1ab_0
@@ -65,7 +65,7 @@ dependencies:
   - brotli-bin=1.1.0=h00291cd_2
   - brotli-python=1.1.0=py312h5861a67_2
   - bzip2=1.0.8=hfdf4475_7
-  - c-ares=1.33.1=h44e7173_0
+  - c-ares=1.34.1=h44e7173_0
   - ca-certificates=2024.8.30=h8857fd0_0
   - cachecontrol=0.14.0=pyhd8ed1ab_1
   - cachecontrol-with-filecache=0.14.0=pyhd8ed1ab_1
@@ -111,7 +111,7 @@ dependencies:
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - deprecated=1.2.14=pyh1a96a4e_0
-  - distlib=0.3.8=pyhd8ed1ab_0
+  - distlib=0.3.9=pyhd8ed1ab_0
   - dnspython=2.7.0=pyhff2d567_0
   - doc8=1.1.2=pyhd8ed1ab_1
   - docker-py=7.1.0=pyhd8ed1ab_0
@@ -194,7 +194,7 @@ dependencies:
   - humanize=4.11.0=pyhd8ed1ab_0
   - hupper=1.12.1=pyhd8ed1ab_0
   - hyperframe=6.0.1=pyhd8ed1ab_0
-  - hypothesis=6.114.0=pyha770c72_0
+  - hypothesis=6.114.1=pyha770c72_0
   - icu=75.1=h120a0e1_0
   - identify=2.6.1=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_0
@@ -384,6 +384,7 @@ dependencies:
   - prometheus_flask_exporter=0.23.1=pyhd8ed1ab_0
   - prompt-toolkit=3.0.48=pyha770c72_0
   - prompt_toolkit=3.0.48=hd8ed1ab_0
+  - propcache=0.2.0=py312hb553811_2
   - proto-plus=1.23.0=pyhd8ed1ab_0
   - protobuf=4.25.3=py312hd13efa9_1
   - psutil=5.9.8=py312h41838bb_0
@@ -529,8 +530,8 @@ dependencies:
   - uri-template=1.3.0=pyhd8ed1ab_0
   - uriparser=0.9.8=h6aefe2f_0
   - urllib3=1.26.19=pyhd8ed1ab_0
-  - uvicorn=0.31.0=py312hb401068_0
-  - uvicorn-standard=0.31.0=hb401068_0
+  - uvicorn=0.31.1=py312hb401068_0
+  - uvicorn-standard=0.31.1=hb401068_0
   - uvloop=0.20.0=py312hb553811_0
   - validators=0.34.0=pyhd8ed1ab_0
   - virtualenv=20.26.6=pyhd8ed1ab_0
@@ -552,7 +553,7 @@ dependencies:
   - xyzservices=2024.9.0=pyhd8ed1ab_0
   - xz=5.2.6=h775f41a_0
   - yaml=0.2.5=h0d85af4_2
-  - yarl=1.13.1=py312hb553811_0
+  - yarl=1.14.0=py312hb553811_0
   - zeromq=4.3.5=he4ceba3_6
   - zip=3.0=h0dc2134_3
   - zipp=3.20.2=pyhd8ed1ab_0

--- a/environments/conda-osx-64.lock.yml
+++ b/environments/conda-osx-64.lock.yml
@@ -8,7 +8,7 @@ dependencies:
   - addfips=0.4.2=pyhd8ed1ab_0
   - aiofiles=24.1.0=pyhd8ed1ab_0
   - aiohappyeyeballs=2.4.3=pyhd8ed1ab_0
-  - aiohttp=3.10.8=py312hb553811_0
+  - aiohttp=3.10.9=py312hb553811_0
   - aiosignal=1.3.1=pyhd8ed1ab_0
   - alabaster=1.0.0=pyhd8ed1ab_0
   - alembic=1.13.3=pyhd8ed1ab_0
@@ -18,7 +18,7 @@ dependencies:
   - anyio=4.4.0=pyhd8ed1ab_0
   - appdirs=1.4.4=pyh9f0ad1d_0
   - appnope=0.1.4=pyhd8ed1ab_0
-  - arelle-release=2.31.4=pyhd8ed1ab_0
+  - arelle-release=2.31.6=pyhd8ed1ab_0
   - argon2-cffi=23.1.0=pyhd8ed1ab_0
   - argon2-cffi-bindings=21.2.0=py312hb553811_5
   - arrow=1.3.0=pyhd8ed1ab_0
@@ -36,11 +36,11 @@ dependencies:
   - aws-c-event-stream=0.4.3=hcd1ed9e_2
   - aws-c-http=0.8.10=h2f86973_0
   - aws-c-io=0.14.18=hf9a0f1c_11
-  - aws-c-mqtt=0.10.6=h9d7d61c_0
+  - aws-c-mqtt=0.10.7=h9d7d61c_0
   - aws-c-s3=0.6.6=hd01826e_0
   - aws-c-sdkutils=0.1.19=h8128ea2_3
   - aws-checksums=0.1.20=h8128ea2_0
-  - aws-crt-cpp=0.28.3=h21c617a_5
+  - aws-crt-cpp=0.28.3=hef75ebe_6
   - aws-sdk-cpp=1.11.407=h2e282c2_0
   - azure-core-cpp=1.13.0=hf8dbe3c_0
   - azure-identity-cpp=1.8.0=h60298e3_2
@@ -57,8 +57,8 @@ dependencies:
   - bleach=6.1.0=pyhd8ed1ab_0
   - blinker=1.8.2=pyhd8ed1ab_0
   - blosc=1.21.6=h7d75f6d_0
-  - boto3=1.35.34=pyhd8ed1ab_0
-  - botocore=1.35.34=pyge310_1234567_0
+  - boto3=1.35.36=pyhd8ed1ab_0
+  - botocore=1.35.37=pyge310_1234567_0
   - bottleneck=1.4.0=py312h3a11e2b_2
   - branca=0.7.2=pyhd8ed1ab_0
   - brotli=1.1.0=h00291cd_2
@@ -81,7 +81,7 @@ dependencies:
   - cffi=1.17.1=py312hf857d28_0
   - cfgv=3.3.1=pyhd8ed1ab_0
   - chardet=5.2.0=py312hb401068_2
-  - charset-normalizer=3.3.2=pyhd8ed1ab_0
+  - charset-normalizer=3.4.0=pyhd8ed1ab_0
   - click=8.1.7=unix_pyh707e725_0
   - click-default-group=1.2.4=pyhd8ed1ab_0
   - clikit=0.6.2=pyhd8ed1ab_2
@@ -91,7 +91,7 @@ dependencies:
   - comm=0.2.2=pyhd8ed1ab_0
   - conda-lock=2.5.7=pyhd8ed1ab_0
   - contourpy=1.3.0=py312hc5c4d5f_2
-  - coverage=7.6.1=py312hb553811_1
+  - coverage=7.6.2=py312h3d0f464_0
   - crashtest=0.4.1=pyhd8ed1ab_0
   - croniter=3.0.3=pyhd8ed1ab_0
   - cryptography=43.0.1=py312h840e0bc_0
@@ -105,8 +105,8 @@ dependencies:
   - dagster-webserver=1.8.10=pyhd8ed1ab_0
   - dask-core=2024.9.1=pyhd8ed1ab_0
   - dask-expr=1.1.15=pyhd8ed1ab_0
-  - databricks-sdk=0.33.0=pyhd8ed1ab_0
-  - datasette=0.64.8=pyhd8ed1ab_0
+  - databricks-sdk=0.34.0=pyhd8ed1ab_0
+  - datasette=0.65=pyhd8ed1ab_0
   - debugpy=1.8.6=py312h5861a67_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
@@ -158,11 +158,11 @@ dependencies:
   - gitdb=4.0.11=pyhd8ed1ab_0
   - gitpython=3.1.43=pyhd8ed1ab_0
   - glog=0.7.1=h2790a97_0
-  - google-api-core=2.20.0=pyhd8ed1ab_0
+  - google-api-core=2.21.0=pyhd8ed1ab_0
   - google-auth=2.35.0=pyhff2d567_0
   - google-auth-oauthlib=1.2.1=pyhd8ed1ab_0
   - google-cloud-core=2.4.1=pyhd8ed1ab_0
-  - google-cloud-sdk=495.0.0=py312hb401068_0
+  - google-cloud-sdk=496.0.0=py312hb401068_0
   - google-cloud-storage=2.18.2=pyhff2d567_0
   - google-crc32c=1.1.2=py312hfee8fbb_6
   - google-resumable-media=2.7.2=pyhd8ed1ab_1
@@ -194,7 +194,7 @@ dependencies:
   - humanize=4.11.0=pyhd8ed1ab_0
   - hupper=1.12.1=pyhd8ed1ab_0
   - hyperframe=6.0.1=pyhd8ed1ab_0
-  - hypothesis=6.112.4=pyha770c72_0
+  - hypothesis=6.114.0=pyha770c72_0
   - icu=75.1=h120a0e1_0
   - identify=2.6.1=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_0
@@ -206,7 +206,7 @@ dependencies:
   - ipykernel=6.29.5=pyh57ce528_0
   - ipython=8.28.0=pyh707e725_0
   - ipywidgets=8.1.5=pyhd8ed1ab_0
-  - isodate=0.6.1=pyhd8ed1ab_0
+  - isodate=0.7.2=pyhd8ed1ab_0
   - isoduration=20.11.0=pyhd8ed1ab_0
   - itsdangerous=2.2.0=pyhd8ed1ab_0
   - janus=1.0.0=pyhd8ed1ab_0
@@ -222,7 +222,7 @@ dependencies:
   - json5=0.9.25=pyhd8ed1ab_0
   - jsonpointer=3.0.0=py312hb401068_1
   - jsonschema=4.23.0=pyhd8ed1ab_0
-  - jsonschema-specifications=2023.12.1=pyhd8ed1ab_0
+  - jsonschema-specifications=2024.10.1=pyhd8ed1ab_0
   - jsonschema-with-format-nongpl=4.23.0=hd8ed1ab_0
   - jupyter=1.1.1=pyhd8ed1ab_0
   - jupyter-lsp=2.2.5=pyhd8ed1ab_0
@@ -301,7 +301,7 @@ dependencies:
   - libxml2=2.12.7=heaf3512_4
   - libxslt=1.1.39=h03b04e6_0
   - libzlib=1.3.1=hd23fc13_2
-  - llvm-openmp=19.1.0=h56322cc_0
+  - llvm-openmp=19.1.1=h545e0da_0
   - llvmlite=0.43.0=py312hcc8fd36_1
   - locket=1.0.0=pyhd8ed1ab_0
   - lsprotocol=2023.0.1=pyhd8ed1ab_0
@@ -313,7 +313,7 @@ dependencies:
   - markdown=3.6=pyhd8ed1ab_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_0
   - marko=2.1.2=pyhd8ed1ab_0
-  - markupsafe=2.1.5=py312hb553811_1
+  - markupsafe=3.0.1=py312hca98d7e_1
   - matplotlib-base=3.9.2=py312h30cc4df_1
   - matplotlib-inline=0.1.7=pyhd8ed1ab_0
   - mdurl=0.1.2=pyhd8ed1ab_0
@@ -329,7 +329,7 @@ dependencies:
   - multimethod=1.9.1=pyhd8ed1ab_0
   - munkres=1.1.4=pyh9f0ad1d_0
   - mypy_extensions=1.0.0=pyha770c72_0
-  - narwhals=1.9.1=pyhd8ed1ab_0
+  - narwhals=1.9.2=pyhd8ed1ab_0
   - nbclient=0.10.0=pyhd8ed1ab_0
   - nbconvert=7.16.4=hd8ed1ab_1
   - nbconvert-core=7.16.4=pyhd8ed1ab_1
@@ -371,14 +371,13 @@ dependencies:
   - pexpect=4.9.0=pyhd8ed1ab_0
   - pickleshare=0.7.5=py_1003
   - pillow=10.4.0=py312h683ea77_1
-  - pint=0.24.3=pyhd8ed1ab_0
   - pip=24.2=pyh8b19718_1
   - pixman=0.43.4=h73e2aa4_0
   - pkginfo=1.11.1=pyhd8ed1ab_0
   - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_1
   - platformdirs=4.3.6=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
-  - pre-commit=4.0.0=pyha770c72_0
+  - pre-commit=4.0.1=pyha770c72_0
   - prettier=3.3.3=h2ff3409_0
   - proj=9.5.0=h70d2bda_0
   - prometheus_client=0.21.0=pyhd8ed1ab_0
@@ -461,7 +460,7 @@ dependencies:
   - ruamel.yaml.clib=0.2.8=py312h41838bb_0
   - ruff=0.6.9=py312he6c0bb9_0
   - ruff-lsp=0.0.57=pyhd8ed1ab_0
-  - s3transfer=0.10.2=pyhd8ed1ab_0
+  - s3transfer=0.10.3=pyhd8ed1ab_0
   - scikit-learn=1.5.2=py312h9d777eb_1
   - scipy=1.14.1=py312he82a568_0
   - send2trash=1.8.3=pyh31c8845_0
@@ -490,7 +489,7 @@ dependencies:
   - sphinxcontrib-serializinghtml=1.1.10=pyhd8ed1ab_0
   - splink=4.0.3=pyhd8ed1ab_0
   - sqlalchemy=2.0.35=py312hb553811_0
-  - sqlglot=25.24.4=pyhd8ed1ab_0
+  - sqlglot=25.24.5=pyhd8ed1ab_0
   - sqlite=3.46.1=he26b093_0
   - sqlparse=0.5.1=pyhd8ed1ab_0
   - stack_data=0.6.2=pyhd8ed1ab_0
@@ -554,7 +553,7 @@ dependencies:
   - xz=5.2.6=h775f41a_0
   - yaml=0.2.5=h0d85af4_2
   - yarl=1.13.1=py312hb553811_0
-  - zeromq=4.3.5=hb33e954_5
+  - zeromq=4.3.5=he4ceba3_6
   - zip=3.0=h0dc2134_3
   - zipp=3.20.2=pyhd8ed1ab_0
   - zlib=1.3.1=hd23fc13_2

--- a/environments/conda-osx-arm64.lock.yml
+++ b/environments/conda-osx-arm64.lock.yml
@@ -35,7 +35,7 @@ dependencies:
   - aws-c-compression=0.2.19=h41dd001_1
   - aws-c-event-stream=0.4.3=h40a8fc1_2
   - aws-c-http=0.8.10=hf5a2c8c_0
-  - aws-c-io=0.14.18=hc3cb426_11
+  - aws-c-io=0.14.18=hc3cb426_12
   - aws-c-mqtt=0.10.7=h3acc7b9_0
   - aws-c-s3=0.6.6=hd16c091_0
   - aws-c-sdkutils=0.1.19=h41dd001_3
@@ -57,7 +57,7 @@ dependencies:
   - bleach=6.1.0=pyhd8ed1ab_0
   - blinker=1.8.2=pyhd8ed1ab_0
   - blosc=1.21.6=h5499902_0
-  - boto3=1.35.36=pyhd8ed1ab_0
+  - boto3=1.35.37=pyhd8ed1ab_0
   - botocore=1.35.37=pyge310_1234567_0
   - bottleneck=1.4.0=py312h755e627_2
   - branca=0.7.2=pyhd8ed1ab_0
@@ -65,7 +65,7 @@ dependencies:
   - brotli-bin=1.1.0=hd74edd7_2
   - brotli-python=1.1.0=py312hde4cb15_2
   - bzip2=1.0.8=h99b78c6_7
-  - c-ares=1.33.1=hd74edd7_0
+  - c-ares=1.34.1=hd74edd7_0
   - ca-certificates=2024.8.30=hf0a4a13_0
   - cachecontrol=0.14.0=pyhd8ed1ab_1
   - cachecontrol-with-filecache=0.14.0=pyhd8ed1ab_1
@@ -111,7 +111,7 @@ dependencies:
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
   - deprecated=1.2.14=pyh1a96a4e_0
-  - distlib=0.3.8=pyhd8ed1ab_0
+  - distlib=0.3.9=pyhd8ed1ab_0
   - dnspython=2.7.0=pyhff2d567_0
   - doc8=1.1.2=pyhd8ed1ab_1
   - docker-py=7.1.0=pyhd8ed1ab_0
@@ -194,7 +194,7 @@ dependencies:
   - humanize=4.11.0=pyhd8ed1ab_0
   - hupper=1.12.1=pyhd8ed1ab_0
   - hyperframe=6.0.1=pyhd8ed1ab_0
-  - hypothesis=6.114.0=pyha770c72_0
+  - hypothesis=6.114.1=pyha770c72_0
   - icu=75.1=hfee45f7_0
   - identify=2.6.1=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_0
@@ -384,6 +384,7 @@ dependencies:
   - prometheus_flask_exporter=0.23.1=pyhd8ed1ab_0
   - prompt-toolkit=3.0.48=pyha770c72_0
   - prompt_toolkit=3.0.48=hd8ed1ab_0
+  - propcache=0.2.0=py312h024a12e_2
   - proto-plus=1.23.0=pyhd8ed1ab_0
   - protobuf=4.25.3=py312he4aa971_1
   - psutil=5.9.8=py312he37b823_0
@@ -529,8 +530,8 @@ dependencies:
   - uri-template=1.3.0=pyhd8ed1ab_0
   - uriparser=0.9.8=h00cdb27_0
   - urllib3=1.26.19=pyhd8ed1ab_0
-  - uvicorn=0.31.0=py312h81bd7bf_0
-  - uvicorn-standard=0.31.0=h1f38498_0
+  - uvicorn=0.31.1=py312h81bd7bf_0
+  - uvicorn-standard=0.31.1=h1f38498_0
   - uvloop=0.20.0=py312h024a12e_0
   - validators=0.34.0=pyhd8ed1ab_0
   - virtualenv=20.26.6=pyhd8ed1ab_0
@@ -552,7 +553,7 @@ dependencies:
   - xyzservices=2024.9.0=pyhd8ed1ab_0
   - xz=5.2.6=h57fd34a_0
   - yaml=0.2.5=h3422bc3_2
-  - yarl=1.13.1=py312h024a12e_0
+  - yarl=1.14.0=py312h024a12e_0
   - zeromq=4.3.5=h9f5b81c_6
   - zip=3.0=hb547adb_3
   - zipp=3.20.2=pyhd8ed1ab_0

--- a/environments/conda-osx-arm64.lock.yml
+++ b/environments/conda-osx-arm64.lock.yml
@@ -8,7 +8,7 @@ dependencies:
   - addfips=0.4.2=pyhd8ed1ab_0
   - aiofiles=24.1.0=pyhd8ed1ab_0
   - aiohappyeyeballs=2.4.3=pyhd8ed1ab_0
-  - aiohttp=3.10.8=py312h024a12e_0
+  - aiohttp=3.10.9=py312h024a12e_0
   - aiosignal=1.3.1=pyhd8ed1ab_0
   - alabaster=1.0.0=pyhd8ed1ab_0
   - alembic=1.13.3=pyhd8ed1ab_0
@@ -18,7 +18,7 @@ dependencies:
   - anyio=4.4.0=pyhd8ed1ab_0
   - appdirs=1.4.4=pyh9f0ad1d_0
   - appnope=0.1.4=pyhd8ed1ab_0
-  - arelle-release=2.31.4=pyhd8ed1ab_0
+  - arelle-release=2.31.6=pyhd8ed1ab_0
   - argon2-cffi=23.1.0=pyhd8ed1ab_0
   - argon2-cffi-bindings=21.2.0=py312h024a12e_5
   - arrow=1.3.0=pyhd8ed1ab_0
@@ -36,11 +36,11 @@ dependencies:
   - aws-c-event-stream=0.4.3=h40a8fc1_2
   - aws-c-http=0.8.10=hf5a2c8c_0
   - aws-c-io=0.14.18=hc3cb426_11
-  - aws-c-mqtt=0.10.6=h3acc7b9_0
+  - aws-c-mqtt=0.10.7=h3acc7b9_0
   - aws-c-s3=0.6.6=hd16c091_0
   - aws-c-sdkutils=0.1.19=h41dd001_3
   - aws-checksums=0.1.20=h41dd001_0
-  - aws-crt-cpp=0.28.3=hdde83a9_5
+  - aws-crt-cpp=0.28.3=h433f80b_6
   - aws-sdk-cpp=1.11.407=h0455a66_0
   - azure-core-cpp=1.13.0=hd01fc5c_0
   - azure-identity-cpp=1.8.0=h13ea094_2
@@ -57,8 +57,8 @@ dependencies:
   - bleach=6.1.0=pyhd8ed1ab_0
   - blinker=1.8.2=pyhd8ed1ab_0
   - blosc=1.21.6=h5499902_0
-  - boto3=1.35.34=pyhd8ed1ab_0
-  - botocore=1.35.34=pyge310_1234567_0
+  - boto3=1.35.36=pyhd8ed1ab_0
+  - botocore=1.35.37=pyge310_1234567_0
   - bottleneck=1.4.0=py312h755e627_2
   - branca=0.7.2=pyhd8ed1ab_0
   - brotli=1.1.0=hd74edd7_2
@@ -81,7 +81,7 @@ dependencies:
   - cffi=1.17.1=py312h0fad829_0
   - cfgv=3.3.1=pyhd8ed1ab_0
   - chardet=5.2.0=py312h81bd7bf_2
-  - charset-normalizer=3.3.2=pyhd8ed1ab_0
+  - charset-normalizer=3.4.0=pyhd8ed1ab_0
   - click=8.1.7=unix_pyh707e725_0
   - click-default-group=1.2.4=pyhd8ed1ab_0
   - clikit=0.6.2=pyhd8ed1ab_2
@@ -91,7 +91,7 @@ dependencies:
   - comm=0.2.2=pyhd8ed1ab_0
   - conda-lock=2.5.7=pyhd8ed1ab_0
   - contourpy=1.3.0=py312h6142ec9_2
-  - coverage=7.6.1=py312h024a12e_1
+  - coverage=7.6.2=py312h0bf5046_0
   - crashtest=0.4.1=pyhd8ed1ab_0
   - croniter=3.0.3=pyhd8ed1ab_0
   - cryptography=43.0.1=py312h3ddc590_0
@@ -105,8 +105,8 @@ dependencies:
   - dagster-webserver=1.8.10=pyhd8ed1ab_0
   - dask-core=2024.9.1=pyhd8ed1ab_0
   - dask-expr=1.1.15=pyhd8ed1ab_0
-  - databricks-sdk=0.33.0=pyhd8ed1ab_0
-  - datasette=0.64.8=pyhd8ed1ab_0
+  - databricks-sdk=0.34.0=pyhd8ed1ab_0
+  - datasette=0.65=pyhd8ed1ab_0
   - debugpy=1.8.6=py312hde4cb15_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
@@ -158,11 +158,11 @@ dependencies:
   - gitdb=4.0.11=pyhd8ed1ab_0
   - gitpython=3.1.43=pyhd8ed1ab_0
   - glog=0.7.1=heb240a5_0
-  - google-api-core=2.20.0=pyhd8ed1ab_0
+  - google-api-core=2.21.0=pyhd8ed1ab_0
   - google-auth=2.35.0=pyhff2d567_0
   - google-auth-oauthlib=1.2.1=pyhd8ed1ab_0
   - google-cloud-core=2.4.1=pyhd8ed1ab_0
-  - google-cloud-sdk=495.0.0=py312h81bd7bf_0
+  - google-cloud-sdk=496.0.0=py312h81bd7bf_0
   - google-cloud-storage=2.18.2=pyhff2d567_0
   - google-crc32c=1.1.2=py312h1fa1217_6
   - google-resumable-media=2.7.2=pyhd8ed1ab_1
@@ -194,7 +194,7 @@ dependencies:
   - humanize=4.11.0=pyhd8ed1ab_0
   - hupper=1.12.1=pyhd8ed1ab_0
   - hyperframe=6.0.1=pyhd8ed1ab_0
-  - hypothesis=6.112.4=pyha770c72_0
+  - hypothesis=6.114.0=pyha770c72_0
   - icu=75.1=hfee45f7_0
   - identify=2.6.1=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_0
@@ -206,7 +206,7 @@ dependencies:
   - ipykernel=6.29.5=pyh57ce528_0
   - ipython=8.28.0=pyh707e725_0
   - ipywidgets=8.1.5=pyhd8ed1ab_0
-  - isodate=0.6.1=pyhd8ed1ab_0
+  - isodate=0.7.2=pyhd8ed1ab_0
   - isoduration=20.11.0=pyhd8ed1ab_0
   - itsdangerous=2.2.0=pyhd8ed1ab_0
   - janus=1.0.0=pyhd8ed1ab_0
@@ -222,7 +222,7 @@ dependencies:
   - json5=0.9.25=pyhd8ed1ab_0
   - jsonpointer=3.0.0=py312h81bd7bf_1
   - jsonschema=4.23.0=pyhd8ed1ab_0
-  - jsonschema-specifications=2023.12.1=pyhd8ed1ab_0
+  - jsonschema-specifications=2024.10.1=pyhd8ed1ab_0
   - jsonschema-with-format-nongpl=4.23.0=hd8ed1ab_0
   - jupyter=1.1.1=pyhd8ed1ab_0
   - jupyter-lsp=2.2.5=pyhd8ed1ab_0
@@ -301,7 +301,7 @@ dependencies:
   - libxml2=2.12.7=h01dff8b_4
   - libxslt=1.1.39=h223e5b9_0
   - libzlib=1.3.1=h8359307_2
-  - llvm-openmp=19.1.0=hba312e6_0
+  - llvm-openmp=19.1.1=h6cdba0f_0
   - llvmlite=0.43.0=py312ha9ca408_1
   - locket=1.0.0=pyhd8ed1ab_0
   - lsprotocol=2023.0.1=pyhd8ed1ab_0
@@ -313,7 +313,7 @@ dependencies:
   - markdown=3.6=pyhd8ed1ab_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_0
   - marko=2.1.2=pyhd8ed1ab_0
-  - markupsafe=2.1.5=py312h024a12e_1
+  - markupsafe=3.0.1=py312h906988d_1
   - matplotlib-base=3.9.2=py312h9bd0bc6_1
   - matplotlib-inline=0.1.7=pyhd8ed1ab_0
   - mdurl=0.1.2=pyhd8ed1ab_0
@@ -329,7 +329,7 @@ dependencies:
   - multimethod=1.9.1=pyhd8ed1ab_0
   - munkres=1.1.4=pyh9f0ad1d_0
   - mypy_extensions=1.0.0=pyha770c72_0
-  - narwhals=1.9.1=pyhd8ed1ab_0
+  - narwhals=1.9.2=pyhd8ed1ab_0
   - nbclient=0.10.0=pyhd8ed1ab_0
   - nbconvert=7.16.4=hd8ed1ab_1
   - nbconvert-core=7.16.4=pyhd8ed1ab_1
@@ -371,14 +371,13 @@ dependencies:
   - pexpect=4.9.0=pyhd8ed1ab_0
   - pickleshare=0.7.5=py_1003
   - pillow=10.4.0=py312h8609ca0_1
-  - pint=0.24.3=pyhd8ed1ab_0
   - pip=24.2=pyh8b19718_1
   - pixman=0.43.4=hebf3989_0
   - pkginfo=1.11.1=pyhd8ed1ab_0
   - pkgutil-resolve-name=1.3.10=pyhd8ed1ab_1
   - platformdirs=4.3.6=pyhd8ed1ab_0
   - pluggy=1.5.0=pyhd8ed1ab_0
-  - pre-commit=4.0.0=pyha770c72_0
+  - pre-commit=4.0.1=pyha770c72_0
   - prettier=3.3.3=h0857397_0
   - proj=9.5.0=h61a8e3e_0
   - prometheus_client=0.21.0=pyhd8ed1ab_0
@@ -461,7 +460,7 @@ dependencies:
   - ruamel.yaml.clib=0.2.8=py312he37b823_0
   - ruff=0.6.9=py312h42f095d_0
   - ruff-lsp=0.0.57=pyhd8ed1ab_0
-  - s3transfer=0.10.2=pyhd8ed1ab_0
+  - s3transfer=0.10.3=pyhd8ed1ab_0
   - scikit-learn=1.5.2=py312h387f99c_1
   - scipy=1.14.1=py312heb3a901_0
   - send2trash=1.8.3=pyh31c8845_0
@@ -490,7 +489,7 @@ dependencies:
   - sphinxcontrib-serializinghtml=1.1.10=pyhd8ed1ab_0
   - splink=4.0.3=pyhd8ed1ab_0
   - sqlalchemy=2.0.35=py312h024a12e_0
-  - sqlglot=25.24.4=pyhd8ed1ab_0
+  - sqlglot=25.24.5=pyhd8ed1ab_0
   - sqlite=3.46.1=h3b4c4e4_0
   - sqlparse=0.5.1=pyhd8ed1ab_0
   - stack_data=0.6.2=pyhd8ed1ab_0
@@ -554,7 +553,7 @@ dependencies:
   - xz=5.2.6=h57fd34a_0
   - yaml=0.2.5=h3422bc3_2
   - yarl=1.13.1=py312h024a12e_0
-  - zeromq=4.3.5=h64debc3_5
+  - zeromq=4.3.5=h9f5b81c_6
   - zip=3.0=hb547adb_3
   - zipp=3.20.2=pyhd8ed1ab_0
   - zlib=1.3.1=h8359307_2


### PR DESCRIPTION
# Overview

- Update to the micromamba v2 Docker image.
- Update to the newest version of the `hadolint-py` pre-commit hook since the old one started failing.

Note: [hadolint](https://github.com/hadolint/hadolint) seems to have been abandoned and [the prettier commit hook](https://github.com/pre-commit/mirrors-prettier) has been archived due to incompatible changes in the underlying prettier library, so we should probably try and replace those hooks (Dockerfile linting, and YAML linting/formatting)

# Testing

- Ran a branch deployment using the new Dockerfile

```[tasklist]
# To-do list
- [x] Run the `build-deploy-pudl` GitHub Action manually to make sure the new Docker image works.
```
