### PR TITLE
added data access for user cases

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -134,6 +134,9 @@ PUDL currently integrates data from:
 * **US Census Demographic Profile 1 Geodatabase**:
   - `Source Docs <https://www.census.gov/geographies/mapping-files/2010/geo/tiger-data.html>`__
 
+*Please take note that the hyperlinked 'PUDL DOCS'
+lead to our transformed datasets on Readthedocs*
+
 High Priority Target Datasets
 -----------------------------
 

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -13,6 +13,31 @@ tables with the ``out_`` prefix, as these tables contain the most complete and e
 to work with data. For more information about the different types
 of tables, read through :ref:`PUDL's naming conventions <asset-naming>`.
 
+
+Based on our assumptions of having three major users interested in the PUDL data,
+we would like to recommend a one-stop shop for you to get all you need from PUDL.
+
+Listed below are the user cases and the available data:
+
+* Energy Policy Expert and/or Non-Technical User:
+
+  You can download CSV or JSON files that are readily available for analysis in the
+  `PUDL database <https://data.catalyst.coop/pudl>`__.
+
+* Energy Modeler and/or Technical User:
+
+  We have parquet data formats in the AWS Open Data Registry. You can follow our
+  :doc:`nightly data builds tutorial <dev/nightly_data_builds>` on ingesting
+  the data from the registry into your development environment.
+
+* Open-Source Contributor:
+
+  Your contributions to PUDL are very much welcomed. If you're interested in
+  contributing, please refer to our :doc:`contribution guide <dev/dev_setup>`.
+
+If you need more specific user cases on how to access the PUDL data from a
+variety of locations, you can refer to the table below.
+
 .. _access-modes:
 
 ---------------------------------------------------------------------------------------


### PR DESCRIPTION
Overview:
Closes this Google Season of Docs Task:
Reorganize documentation to have better flow through the docs for the three user cases 

What problem does this address?
This addresses the issue of data findability for some specific usercases

Testing
How did you make sure this worked? How can a reviewer verify this?
I ran the command: `make docs-build`

@aesharpe @zaneselvans @e-belfer