### PR TITLE
Add Q3 2024 CEMS data to ETL

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,6 +14,10 @@ EIA 930
 * Added EIA 930 hourly data through the end of October as part of the Q3 quarterly
   release. See :issue:`3942` and :pr:`3946`.
 
+EPA CEMS
+~~~~~~~~
+* Added 2024 Q3 of CEMS data. See :issue:`3943` and :pr:`3948`.
+
 .. _release-v2024.10.0:
 
 ---------------------------------------------------------------------------------------

--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -426,7 +426,7 @@ SOURCES: dict[str, Any] = {
         "working_partitions": {
             "year_quarters": [
                 str(q).lower()
-                for q in pd.period_range(start="1995q1", end="2024q2", freq="Q")
+                for q in pd.period_range(start="1995q1", end="2024q3", freq="Q")
             ]
         },
         "contributors": [

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -199,7 +199,7 @@ class ZenodoDoiSettings(BaseSettings):
     eiaaeo: ZenodoDoi = "10.5281/zenodo.10838488"
     eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.13149083"
     epacamd_eia: ZenodoDoi = "10.5281/zenodo.7900974"
-    epacems: ZenodoDoi = "10.5281/zenodo.13240556"
+    epacems: ZenodoDoi = "10.5281/zenodo.14037184"
     ferc1: ZenodoDoi = "10.5281/zenodo.13149094"
     ferc2: ZenodoDoi = "10.5281/zenodo.13149082"
     ferc6: ZenodoDoi = "10.5281/zenodo.13149089"


### PR DESCRIPTION
# Overview

Closes #3943.

## What problem does this address?
Adds Q3 2024 CEMS data to the ETL.

## What did you change?

- Updated the `working_partitions` to include the new quarter
- Updated the DOI

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [x] Review and update any other aspects of the documentation that might be affected by this PR.
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [x] Review the PR yourself and call out any questions or issues you have.
- [x] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
```
