### PR TITLE
EIA bulk elec q3 2024 integration

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,6 +14,13 @@ EIA 930
 * Added EIA 930 hourly data through the end of October as part of the Q3 quarterly
   release. See :issue:`3942` and :pr:`3946`.
 
+EIA Bulk Electricity Data
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+* Updated the EIA Bulk Electricity data archive to include data that was available as of
+  2024-11-01, which covers up through 2024-08-01 (3 months more than the previously
+  used archive). See :issue:`3944` and PR :pr:`3951`.
+
 .. _release-v2024.10.0:
 
 ---------------------------------------------------------------------------------------

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -16,9 +16,9 @@ EIA 930
 
 EIA Bulk Electricity Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-* Updated the EIA Bulk Electricity data archive to include data that was available as of
-  2024-11-01, which covers up through 2024-08-01 (3 months more than the previously
-  used archive). See :issue:`3944` and PR :pr:`3951`.
+* Updated the EIA Bulk Electricity data archive to include data that was available
+  as of 2024-11-01, which covers up through 2024-08-01 (3 months more than the
+  previously used archive). See :issue:`3944` and PR :pr:`3951`.
 
 EPA CEMS
 ~~~~~~~~

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -6,6 +6,14 @@ PUDL Release Notes
 v2024.XX.x (2024-MM-DD)
 ---------------------------------------------------------------------------------------
 
+New Data Coverage
+^^^^^^^^^^^^^^^^^
+
+EIA 930
+~~~~~~~
+* Added EIA 930 hourly data through the end of October as part of the Q3 quarterly
+  release. See :issue:`3942` and :pr:`3946`.
+
 .. _release-v2024.10.0:
 
 ---------------------------------------------------------------------------------------

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -197,7 +197,7 @@ class ZenodoDoiSettings(BaseSettings):
     eia930: ZenodoDoi = "10.5281/zenodo.14026427"
     eiawater: ZenodoDoi = "10.5281/zenodo.10806016"
     eiaaeo: ZenodoDoi = "10.5281/zenodo.10838488"
-    eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.13149083"
+    eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.14026418"
     epacamd_eia: ZenodoDoi = "10.5281/zenodo.7900974"
     epacems: ZenodoDoi = "10.5281/zenodo.13240556"
     ferc1: ZenodoDoi = "10.5281/zenodo.13149094"

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -194,7 +194,7 @@ class ZenodoDoiSettings(BaseSettings):
     eia860m: ZenodoDoi = "10.5281/zenodo.12656895"
     eia861: ZenodoDoi = "10.5281/zenodo.13907096"
     eia923: ZenodoDoi = "10.5281/zenodo.13884405"
-    eia930: ZenodoDoi = "10.5281/zenodo.13149087"
+    eia930: ZenodoDoi = "10.5281/zenodo.14026427"
     eiawater: ZenodoDoi = "10.5281/zenodo.10806016"
     eiaaeo: ZenodoDoi = "10.5281/zenodo.10838488"
     eia_bulk_elec: ZenodoDoi = "10.5281/zenodo.13149083"


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #3944.

## What problem does this address?

Add three more months of EIA bulk elec data (2024-06 through 2024-08)

## What did you change?

- Update DOI
- Update release notes

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
```
