### PR TITLE
Close out PUDL v2024.11.0 release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/versioned_release.md
+++ b/.github/ISSUE_TEMPLATE/versioned_release.md
@@ -18,7 +18,8 @@ assignees: ""
 - [ ] Update our CITATION.cff file with the new release date and current Catalyst membership.
 - [ ] Update our .zenodo.json file with current Catalyst membership.
 - [ ] Close out the [PUDL Release Notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html) with an overview of the changes in this release
-- [ ] Push vYYYY.M.x tag (4-digit year, month with no leading zero, and patch version)
+- [ ] Merge those changes into `main`
+- [ ] Push vYYYY.M.x tag (4-digit year, month with no leading zero, and patch version) to `main`
 - [ ] Verify that the new [GitHub (software) release](https://github.com/catalyst-cooperative/pudl/releases) has been published
 - [ ] Verify [`catalystcoop.pudl` PyPI (software) release](https://pypi.org/project/catalystcoop.pudl/)
 - [ ] Verify that [PUDL repo archive on Zenodo](https://zenodo.org/doi/10.5281/zenodo.3404014) has been updated w/ new version

--- a/.github/ISSUE_TEMPLATE/versioned_release.md
+++ b/.github/ISSUE_TEMPLATE/versioned_release.md
@@ -1,7 +1,7 @@
 ---
-name: Versioned Release Checklist
-about: The process for creating a new release.
-title: Release vYYYY.MM.DD Checklist
+name: PUDL Data Release
+about: Create a new versioned PUDL data release for distribution.
+title: PUDL Data Release vYYYY.MM.x
 labels:
   - metadata
   - packaging

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ authors:
     given-names: Dazhong
 
 title: "The Public Utility Data Liberation (PUDL) Project"
-version: 2024.10.0
+version: 2024.11.0
 doi: 10.5281/zenodo.3404014
-date-released: 2024-10-20
+date-released: 2024-11-14

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,25 @@ v2024.XX.x (2024-MM-DD)
 New Data Coverage
 ^^^^^^^^^^^^^^^^^
 
+Bug Fixes
+^^^^^^^^^
+
+Major Dependency Updates
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _release-v2024.11.0:
+
+---------------------------------------------------------------------------------------
+v2024.11.0 (2024-11-14)
+---------------------------------------------------------------------------------------
+
+PUDL v2024.11.0 is a regularly scheduled quarterly release, incorporating a few updates
+to the following datasets that have come out since the special release we did in
+October.
+
+New Data Coverage
+^^^^^^^^^^^^^^^^^
+
 EIA 930
 ~~~~~~~
 * Added EIA 930 hourly data through the end of October as part of the Q3 quarterly


### PR DESCRIPTION
# Overview

Wrap up the release notes for PUDL v2024.11.0 in preparation for release.

# Testing

I rebuilt the docs locally and inspected them.