### PR TITLE
Update conda lockfile for week of 2024-11-18

### DIFF
--- a/.github/workflows/build-deploy-pudl.yml
+++ b/.github/workflows/build-deploy-pudl.yml
@@ -163,7 +163,7 @@ jobs:
       - name: Post to a pudl-deployments channel
         if: always()
         id: slack
-        uses: slackapi/slack-github-action@v1
+        uses: slackapi/slack-github-action@v2
         with:
           channel-id: "C03FHB9N0PQ"
           slack-message: "`${{ env.BUILD_ID }}` build-deploy-pudl status: ${{ (env.SKIP_BUILD == 'true') && 'skipped' || job.status }}\n${{ env.GCS_OUTPUT_BUCKET }}/${{ env.BUILD_ID }}"

--- a/.github/workflows/com-dev-notify.yml
+++ b/.github/workflows/com-dev-notify.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Post to a Slack channel user isn't a part of Catalyst
         if: ${{ !steps.is_organization_member.outputs.result }}
         id: slack
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@v2
 
         with:
           # Slack channel id, channel name, or user id to post message.

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -237,7 +237,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           disable_search: true
-          file: ./coverage.xml
+          files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true # optional (default = false)
           plugin: noop

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -240,7 +240,7 @@ jobs:
           files: ./coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true # optional (default = false)
-          plugin: noop
+          plugins: noop
           verbose: true
       - name: Display coverage report and ensure it meets required minimum
         # Required coverage is set in pyproject.toml section [tool.coverage.report]

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -234,7 +234,7 @@ jobs:
           micromamba run -n coverage coverage combine coverage/*/.coverage
           micromamba run -n coverage coverage xml --fail-under=0
       - name: Upload XML coverage report to CodeCov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           disable_search: true
           file: ./coverage.xml

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -43,6 +43,11 @@ EIA 860M
 * Added 2024 EIA 860m data from August, September, and October as part of the Q3
   quarterly release. See :issue:`3940` and PR :pr:`3949`.
 
+EIA 861
+~~~~~~~
+
+* Added final release EIA 861 data. See :issue:`3905` and PR :pr:`3911`.
+
 EIA Bulk Electricity Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 * Updated the EIA Bulk Electricity data to include data published up through

--- a/environments/conda-linux-64.lock.yml
+++ b/environments/conda-linux-64.lock.yml
@@ -339,7 +339,7 @@ dependencies:
   - multimethod=1.9.1=pyhd8ed1ab_0
   - munkres=1.1.4=pyh9f0ad1d_0
   - mypy_extensions=1.0.0=pyha770c72_0
-  - narwhals=1.13.5=pyhff2d567_0
+  - narwhals=1.14.0=pyhff2d567_0
   - nbclassic=1.1.0=pyhd8ed1ab_0
   - nbclient=0.10.0=pyhd8ed1ab_0
   - nbconvert=7.16.4=hd8ed1ab_1
@@ -350,7 +350,7 @@ dependencies:
   - nest-asyncio=1.6.0=pyhd8ed1ab_0
   - networkx=3.4.2=pyh267e887_2
   - nodeenv=1.9.1=pyhd8ed1ab_0
-  - nodejs=22.9.0=hf235a45_0
+  - nodejs=22.11.0=hf235a45_0
   - nomkl=1.0=h5ca1d4c_0
   - notebook=6.5.7=pyha770c72_0
   - notebook-shim=0.2.4=pyhd8ed1ab_0
@@ -435,7 +435,7 @@ dependencies:
   - python=3.12.7=hc5c86c4_0_cpython
   - python-build=1.2.2.post1=pyhff2d567_0
   - python-calamine=0.3.1=py312h12e396e_0
-  - python-dateutil=2.9.0=pyhd8ed1ab_0
+  - python-dateutil=2.9.0.post0=pyhff2d567_0
   - python-dotenv=1.0.1=pyhd8ed1ab_0
   - python-duckdb=1.1.3=py312h2ec8cdc_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
@@ -573,7 +573,7 @@ dependencies:
   - xyzservices=2024.9.0=pyhd8ed1ab_0
   - xz=5.2.6=h166bdaf_0
   - yaml=0.2.5=h7f98852_2
-  - yarl=1.17.1=py312h66e93f0_1
+  - yarl=1.17.2=py312h66e93f0_0
   - zeromq=4.3.5=h3b0a872_7
   - zip=3.0=hd590300_3
   - zipp=3.21.0=pyhd8ed1ab_0

--- a/environments/conda-linux-64.lock.yml
+++ b/environments/conda-linux-64.lock.yml
@@ -57,8 +57,8 @@ dependencies:
   - bleach=6.2.0=pyhd8ed1ab_0
   - blinker=1.9.0=pyhff2d567_0
   - blosc=1.21.6=hef167b5_0
-  - boto3=1.35.62=pyhd8ed1ab_0
-  - botocore=1.35.62=pyge310_1234567_0
+  - boto3=1.35.63=pyhd8ed1ab_0
+  - botocore=1.35.63=pyge310_1234567_0
   - bottleneck=1.4.2=py312hc0a28a1_0
   - branca=0.7.2=pyhd8ed1ab_0
   - brotli=1.1.0=hb9d3cd8_2
@@ -111,7 +111,7 @@ dependencies:
   - debugpy=1.8.8=py312h2ec8cdc_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
-  - deprecated=1.2.14=pyh1a96a4e_0
+  - deprecated=1.2.15=pyhff2d567_0
   - distlib=0.3.9=pyhd8ed1ab_0
   - dnspython=2.7.0=pyhff2d567_0
   - doc8=1.1.2=pyhd8ed1ab_1
@@ -195,7 +195,7 @@ dependencies:
   - humanize=4.11.0=pyhd8ed1ab_0
   - hupper=1.12.1=pyhd8ed1ab_0
   - hyperframe=6.0.1=pyhd8ed1ab_0
-  - hypothesis=6.119.1=pyha770c72_0
+  - hypothesis=6.119.3=pyha770c72_0
   - icu=75.1=he02047a_0
   - identify=2.6.2=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_0
@@ -236,7 +236,7 @@ dependencies:
   - jupyter_events=0.10.0=pyhd8ed1ab_0
   - jupyter_server=2.14.2=pyhd8ed1ab_0
   - jupyter_server_terminals=0.5.3=pyhd8ed1ab_0
-  - jupyterlab=4.3.0=pyhd8ed1ab_0
+  - jupyterlab=4.3.1=pyhff2d567_0
   - jupyterlab-lsp=5.1.0=pyhd8ed1ab_2
   - jupyterlab_pygments=0.3.0=pyhd8ed1ab_1
   - jupyterlab_server=2.27.3=pyhd8ed1ab_0
@@ -318,7 +318,7 @@ dependencies:
   - lxml=5.3.0=py312he28fd5a_2
   - lz4-c=1.9.4=hcb278e6_0
   - lzo=2.10=hd590300_1001
-  - mako=1.3.5=pyhd8ed1ab_0
+  - mako=1.3.6=pyhff2d567_0
   - mapclassify=2.8.1=pyhd8ed1ab_0
   - markdown=3.6=pyhd8ed1ab_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_0
@@ -367,7 +367,7 @@ dependencies:
   - opentelemetry-semantic-conventions=0.37b0=pyhd8ed1ab_0
   - orc=2.0.2=h669347b_0
   - overrides=7.7.0=pyhd8ed1ab_0
-  - packaging=24.2=pyhd8ed1ab_0
+  - packaging=24.2=pyhff2d567_1
   - pandas=2.2.3=py312hf9745cd_1
   - pandera-core=0.20.4=pyhd8ed1ab_0
   - pandoc=3.5=ha770c72_0
@@ -418,7 +418,7 @@ dependencies:
   - pygls=1.3.1=pyhd8ed1ab_0
   - pygments=2.18.0=pyhd8ed1ab_0
   - pygraphviz=1.14=py312h011e53f_0
-  - pyjwt=2.9.0=pyhd8ed1ab_1
+  - pyjwt=2.10.0=pyhff2d567_0
   - pylev=1.4.0=pyhd8ed1ab_0
   - pynacl=1.5.0=py312h66e93f0_4
   - pyogrio=0.10.0=py312he8b4914_0

--- a/environments/conda-lock.yml
+++ b/environments/conda-lock.yml
@@ -2286,52 +2286,52 @@ package:
     category: main
     optional: false
   - name: boto3
-    version: 1.35.62
+    version: 1.35.63
     manager: conda
     platform: linux-64
     dependencies:
-      botocore: ">=1.35.62,<1.36.0"
+      botocore: ">=1.35.63,<1.36.0"
       jmespath: ">=0.7.1,<2.0.0"
       python: ">=3.8"
       s3transfer: ">=0.10.0,<0.11.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.62-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.63-pyhd8ed1ab_0.conda
     hash:
-      md5: f506599c4fcc6d32837f3dd8512a7455
-      sha256: 099c2df49f7f9e50cb121b88308b190c611464eb4a2f842bf840a00c354c0a62
+      md5: 41ac72c902b3ddfa0764328413a06c7d
+      sha256: 1bfed989428f04e4552d3e87b6c53109a7ee5d3cb37b0c3d66c8c9e8d33a9390
     category: main
     optional: false
   - name: boto3
-    version: 1.35.62
+    version: 1.35.63
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.8"
       jmespath: ">=0.7.1,<2.0.0"
       s3transfer: ">=0.10.0,<0.11.0"
-      botocore: ">=1.35.62,<1.36.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.62-pyhd8ed1ab_0.conda
+      botocore: ">=1.35.63,<1.36.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.63-pyhd8ed1ab_0.conda
     hash:
-      md5: f506599c4fcc6d32837f3dd8512a7455
-      sha256: 099c2df49f7f9e50cb121b88308b190c611464eb4a2f842bf840a00c354c0a62
+      md5: 41ac72c902b3ddfa0764328413a06c7d
+      sha256: 1bfed989428f04e4552d3e87b6c53109a7ee5d3cb37b0c3d66c8c9e8d33a9390
     category: main
     optional: false
   - name: boto3
-    version: 1.35.62
+    version: 1.35.63
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.8"
       jmespath: ">=0.7.1,<2.0.0"
       s3transfer: ">=0.10.0,<0.11.0"
-      botocore: ">=1.35.62,<1.36.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.62-pyhd8ed1ab_0.conda
+      botocore: ">=1.35.63,<1.36.0"
+    url: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.63-pyhd8ed1ab_0.conda
     hash:
-      md5: f506599c4fcc6d32837f3dd8512a7455
-      sha256: 099c2df49f7f9e50cb121b88308b190c611464eb4a2f842bf840a00c354c0a62
+      md5: 41ac72c902b3ddfa0764328413a06c7d
+      sha256: 1bfed989428f04e4552d3e87b6c53109a7ee5d3cb37b0c3d66c8c9e8d33a9390
     category: main
     optional: false
   - name: botocore
-    version: 1.35.62
+    version: 1.35.63
     manager: conda
     platform: linux-64
     dependencies:
@@ -2339,14 +2339,14 @@ package:
       python: ">=3.10"
       python-dateutil: ">=2.1,<3.0.0"
       urllib3: ">=1.25.4,!=2.2.0,<3"
-    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.62-pyge310_1234567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.63-pyge310_1234567_0.conda
     hash:
-      md5: 3fab8ee950f3ce61342f629099d532df
-      sha256: e1b315d7f0e2f819a0715db185a6c8a7704b5cbe58f53e191067e19ee15cc4ab
+      md5: f6ca7743a8eb6a2dd26d82395348eff9
+      sha256: c484095c92c86c10209d70c54f07e4311531e1ad2e1fa2a9fdc193b0611b720e
     category: main
     optional: false
   - name: botocore
-    version: 1.35.62
+    version: 1.35.63
     manager: conda
     platform: osx-64
     dependencies:
@@ -2354,14 +2354,14 @@ package:
       python-dateutil: ">=2.1,<3.0.0"
       jmespath: ">=0.7.1,<2.0.0"
       urllib3: ">=1.25.4,!=2.2.0,<3"
-    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.62-pyge310_1234567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.63-pyge310_1234567_0.conda
     hash:
-      md5: 3fab8ee950f3ce61342f629099d532df
-      sha256: e1b315d7f0e2f819a0715db185a6c8a7704b5cbe58f53e191067e19ee15cc4ab
+      md5: f6ca7743a8eb6a2dd26d82395348eff9
+      sha256: c484095c92c86c10209d70c54f07e4311531e1ad2e1fa2a9fdc193b0611b720e
     category: main
     optional: false
   - name: botocore
-    version: 1.35.62
+    version: 1.35.63
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -2369,10 +2369,10 @@ package:
       python-dateutil: ">=2.1,<3.0.0"
       jmespath: ">=0.7.1,<2.0.0"
       urllib3: ">=1.25.4,!=2.2.0,<3"
-    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.62-pyge310_1234567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.63-pyge310_1234567_0.conda
     hash:
-      md5: 3fab8ee950f3ce61342f629099d532df
-      sha256: e1b315d7f0e2f819a0715db185a6c8a7704b5cbe58f53e191067e19ee15cc4ab
+      md5: f6ca7743a8eb6a2dd26d82395348eff9
+      sha256: c484095c92c86c10209d70c54f07e4311531e1ad2e1fa2a9fdc193b0611b720e
     category: main
     optional: false
   - name: bottleneck
@@ -4584,8 +4584,8 @@ package:
       typing_extensions: ">=4.0.0"
       click: ">=7.1.1"
       httpx: ">=0.20"
-      asgi-csrf: ">=0.9"
       click-default-group: ">=1.2.3"
+      asgi-csrf: ">=0.9"
       itsdangerous: ">=1.1"
       pluggy: ">=1.0"
       hupper: ">=1.9"
@@ -4616,8 +4616,8 @@ package:
       typing_extensions: ">=4.0.0"
       click: ">=7.1.1"
       httpx: ">=0.20"
-      asgi-csrf: ">=0.9"
       click-default-group: ">=1.2.3"
+      asgi-csrf: ">=0.9"
       itsdangerous: ">=1.1"
       pluggy: ">=1.0"
       hupper: ">=1.9"
@@ -4768,42 +4768,42 @@ package:
     category: main
     optional: false
   - name: deprecated
-    version: 1.2.14
+    version: 1.2.15
     manager: conda
     platform: linux-64
     dependencies:
       python: ">=2.7"
       wrapt: <2,>=1.10
-    url: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.14-pyh1a96a4e_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.15-pyhff2d567_0.conda
     hash:
-      md5: 4e4c4236e1ca9bcd8816b921a4805882
-      sha256: 8f61539b00ea315c99f8b6f9e2408caa6894593617676741214cc0280e875ca0
+      md5: ca75e235b44ab995655fae392f99595e
+      sha256: 48182a27a8fd855db3a402ed914823802f94c3344c87b0d074facc51411296ee
     category: main
     optional: false
   - name: deprecated
-    version: 1.2.14
+    version: 1.2.15
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=2.7"
       wrapt: <2,>=1.10
-    url: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.14-pyh1a96a4e_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.15-pyhff2d567_0.conda
     hash:
-      md5: 4e4c4236e1ca9bcd8816b921a4805882
-      sha256: 8f61539b00ea315c99f8b6f9e2408caa6894593617676741214cc0280e875ca0
+      md5: ca75e235b44ab995655fae392f99595e
+      sha256: 48182a27a8fd855db3a402ed914823802f94c3344c87b0d074facc51411296ee
     category: main
     optional: false
   - name: deprecated
-    version: 1.2.14
+    version: 1.2.15
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=2.7"
       wrapt: <2,>=1.10
-    url: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.14-pyh1a96a4e_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.2.15-pyhff2d567_0.conda
     hash:
-      md5: 4e4c4236e1ca9bcd8816b921a4805882
-      sha256: 8f61539b00ea315c99f8b6f9e2408caa6894593617676741214cc0280e875ca0
+      md5: ca75e235b44ab995655fae392f99595e
+      sha256: 48182a27a8fd855db3a402ed914823802f94c3344c87b0d074facc51411296ee
     category: main
     optional: false
   - name: distlib
@@ -7970,8 +7970,8 @@ package:
     platform: osx-64
     dependencies:
       python: ">=3.6.1"
-      hpack: ">=4.0,<5"
       hyperframe: ">=6.0,<7"
+      hpack: ">=4.0,<5"
     url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
     hash:
       md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -7984,8 +7984,8 @@ package:
     platform: osx-arm64
     dependencies:
       python: ">=3.6.1"
-      hpack: ">=4.0,<5"
       hyperframe: ">=6.0,<7"
+      hpack: ">=4.0,<5"
     url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
     hash:
       md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -8467,7 +8467,7 @@ package:
     category: main
     optional: false
   - name: hypothesis
-    version: 6.119.1
+    version: 6.119.3
     manager: conda
     platform: linux-64
     dependencies:
@@ -8478,14 +8478,14 @@ package:
       python: ">=3.8"
       setuptools: ""
       sortedcontainers: ">=2.1.0,<3.0.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.119.1-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.119.3-pyha770c72_0.conda
     hash:
-      md5: 2df500b6bb015e8aa9955fb57e6999bf
-      sha256: 11f35616c90fc68e8aa83dd7dfe4559b5e2812f811b408ef540a41564d0d94c5
+      md5: 7e30097443f140d83aa5ff416eb47fce
+      sha256: 7fc98e6287af7852fcf0d43ccb0053a0871a9c65c0416179c4386d00b37bb3f1
     category: main
     optional: false
   - name: hypothesis
-    version: 6.119.1
+    version: 6.119.3
     manager: conda
     platform: osx-64
     dependencies:
@@ -8496,14 +8496,14 @@ package:
       sortedcontainers: ">=2.1.0,<3.0.0"
       backports.zoneinfo: ">=0.2.1"
       exceptiongroup: ">=1.0.0rc8"
-    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.119.1-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.119.3-pyha770c72_0.conda
     hash:
-      md5: 2df500b6bb015e8aa9955fb57e6999bf
-      sha256: 11f35616c90fc68e8aa83dd7dfe4559b5e2812f811b408ef540a41564d0d94c5
+      md5: 7e30097443f140d83aa5ff416eb47fce
+      sha256: 7fc98e6287af7852fcf0d43ccb0053a0871a9c65c0416179c4386d00b37bb3f1
     category: main
     optional: false
   - name: hypothesis
-    version: 6.119.1
+    version: 6.119.3
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -8514,10 +8514,10 @@ package:
       sortedcontainers: ">=2.1.0,<3.0.0"
       backports.zoneinfo: ">=0.2.1"
       exceptiongroup: ">=1.0.0rc8"
-    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.119.1-pyha770c72_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/hypothesis-6.119.3-pyha770c72_0.conda
     hash:
-      md5: 2df500b6bb015e8aa9955fb57e6999bf
-      sha256: 11f35616c90fc68e8aa83dd7dfe4559b5e2812f811b408ef540a41564d0d94c5
+      md5: 7e30097443f140d83aa5ff416eb47fce
+      sha256: 7fc98e6287af7852fcf0d43ccb0053a0871a9c65c0416179c4386d00b37bb3f1
     category: main
     optional: false
   - name: icu
@@ -10285,14 +10285,13 @@ package:
     category: main
     optional: false
   - name: jupyterlab
-    version: 4.3.0
+    version: 4.3.1
     manager: conda
     platform: linux-64
     dependencies:
       async-lru: ">=1.0.0"
       httpx: ">=0.25.0"
       importlib-metadata: ">=4.8.3"
-      importlib_resources: ">=1.4"
       ipykernel: ">=6.5.0"
       jinja2: ">=3.0.3"
       jupyter-lsp: ">=2.0.0"
@@ -10301,32 +10300,31 @@ package:
       jupyterlab_server: ">=2.27.1,<3"
       notebook-shim: ">=0.2"
       packaging: ""
-      python: ">=3.8"
+      python: ">=3.9"
       setuptools: ">=40.1.0"
       tomli: ">=1.2.2"
       tornado: ">=6.2.0"
       traitlets: ""
-    url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
     hash:
-      md5: 4e51411b565d07405d7d3245b9a3b8c1
-      sha256: a27e5227a11c2ce7b299d02f2f2c99713df4c9bb0e78ddd6cf8ffc6a77593dc2
+      md5: b4f3d579fc21a44518d52c52507461b4
+      sha256: ff1035eb0020dbaf4e332ef4b81a7068b595dfc57dde3313e9c4a37583772644
     category: dev
     optional: true
   - name: jupyterlab
-    version: 4.3.0
+    version: 4.3.1
     manager: conda
     platform: osx-64
     dependencies:
       packaging: ""
       traitlets: ""
       jupyter_core: ""
-      python: ">=3.8"
+      python: ">=3.9"
       tornado: ">=6.2.0"
       tomli: ">=1.2.2"
       jinja2: ">=3.0.3"
       importlib-metadata: ">=4.8.3"
       jupyter_server: ">=2.4.0,<3"
-      importlib_resources: ">=1.4"
       jupyter-lsp: ">=2.0.0"
       async-lru: ">=1.0.0"
       notebook-shim: ">=0.2"
@@ -10334,27 +10332,26 @@ package:
       httpx: ">=0.25.0"
       jupyterlab_server: ">=2.27.1,<3"
       ipykernel: ">=6.5.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
     hash:
-      md5: 4e51411b565d07405d7d3245b9a3b8c1
-      sha256: a27e5227a11c2ce7b299d02f2f2c99713df4c9bb0e78ddd6cf8ffc6a77593dc2
+      md5: b4f3d579fc21a44518d52c52507461b4
+      sha256: ff1035eb0020dbaf4e332ef4b81a7068b595dfc57dde3313e9c4a37583772644
     category: dev
     optional: true
   - name: jupyterlab
-    version: 4.3.0
+    version: 4.3.1
     manager: conda
     platform: osx-arm64
     dependencies:
       packaging: ""
       traitlets: ""
       jupyter_core: ""
-      python: ">=3.8"
+      python: ">=3.9"
       tornado: ">=6.2.0"
       tomli: ">=1.2.2"
       jinja2: ">=3.0.3"
       importlib-metadata: ">=4.8.3"
       jupyter_server: ">=2.4.0,<3"
-      importlib_resources: ">=1.4"
       jupyter-lsp: ">=2.0.0"
       async-lru: ">=1.0.0"
       notebook-shim: ">=0.2"
@@ -10362,10 +10359,10 @@ package:
       httpx: ">=0.25.0"
       jupyterlab_server: ">=2.27.1,<3"
       ipykernel: ">=6.5.0"
-    url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab-4.3.1-pyhff2d567_0.conda
     hash:
-      md5: 4e51411b565d07405d7d3245b9a3b8c1
-      sha256: a27e5227a11c2ce7b299d02f2f2c99713df4c9bb0e78ddd6cf8ffc6a77593dc2
+      md5: b4f3d579fc21a44518d52c52507461b4
+      sha256: ff1035eb0020dbaf4e332ef4b81a7068b595dfc57dde3313e9c4a37583772644
     category: dev
     optional: true
   - name: jupyterlab-lsp
@@ -10480,9 +10477,9 @@ package:
       importlib-metadata: ">=4.8.3"
       requests: ">=2.31"
       jupyter_server: ">=1.21,<3"
+      jsonschema: ">=4.18"
       babel: ">=2.10"
       json5: ">=0.9.0"
-      jsonschema: ">=4.18"
     url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
     hash:
       md5: af8239bf1ba7e8c69b689f780f653488
@@ -10500,9 +10497,9 @@ package:
       importlib-metadata: ">=4.8.3"
       requests: ">=2.31"
       jupyter_server: ">=1.21,<3"
+      jsonschema: ">=4.18"
       babel: ">=2.10"
       json5: ">=0.9.0"
-      jsonschema: ">=4.18"
     url: https://conda.anaconda.org/conda-forge/noarch/jupyterlab_server-2.27.3-pyhd8ed1ab_0.conda
     hash:
       md5: af8239bf1ba7e8c69b689f780f653488
@@ -13810,45 +13807,45 @@ package:
     category: main
     optional: false
   - name: mako
-    version: 1.3.5
+    version: 1.3.6
     manager: conda
     platform: linux-64
     dependencies:
       importlib-metadata: ""
       markupsafe: ">=0.9.2"
-      python: ">=3.6"
-    url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.5-pyhd8ed1ab_0.conda
+      python: ">=3.9"
+    url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.6-pyhff2d567_0.conda
     hash:
-      md5: 29fddbfa0e2361636a98de4f46ead2ac
-      sha256: f0b982e18e31ad373dd8f22ef5ffa0ae112fc13c573a5eb614814b4081c3ddcb
+      md5: bcd0b2d006b1d1b3725a9fa0ad4243f0
+      sha256: 58d87748483313d271835db14e136a1f1138e79a30cd726aaeaf949b51a25a93
     category: main
     optional: false
   - name: mako
-    version: 1.3.5
+    version: 1.3.6
     manager: conda
     platform: osx-64
     dependencies:
       importlib-metadata: ""
-      python: ">=3.6"
+      python: ">=3.9"
       markupsafe: ">=0.9.2"
-    url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.5-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.6-pyhff2d567_0.conda
     hash:
-      md5: 29fddbfa0e2361636a98de4f46ead2ac
-      sha256: f0b982e18e31ad373dd8f22ef5ffa0ae112fc13c573a5eb614814b4081c3ddcb
+      md5: bcd0b2d006b1d1b3725a9fa0ad4243f0
+      sha256: 58d87748483313d271835db14e136a1f1138e79a30cd726aaeaf949b51a25a93
     category: main
     optional: false
   - name: mako
-    version: 1.3.5
+    version: 1.3.6
     manager: conda
     platform: osx-arm64
     dependencies:
       importlib-metadata: ""
-      python: ">=3.6"
+      python: ">=3.9"
       markupsafe: ">=0.9.2"
-    url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.5-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/mako-1.3.6-pyhff2d567_0.conda
     hash:
-      md5: 29fddbfa0e2361636a98de4f46ead2ac
-      sha256: f0b982e18e31ad373dd8f22ef5ffa0ae112fc13c573a5eb614814b4081c3ddcb
+      md5: bcd0b2d006b1d1b3725a9fa0ad4243f0
+      sha256: 58d87748483313d271835db14e136a1f1138e79a30cd726aaeaf949b51a25a93
     category: main
     optional: false
   - name: mapclassify
@@ -16091,10 +16088,10 @@ package:
     platform: linux-64
     dependencies:
       python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
     hash:
-      md5: c16469afe1ec91aaafcf4bea966c0465
-      sha256: 0f8273bf66c2a5c1de72312a509deae07f163bb0ae8de8273c52e6fe945a0850
+      md5: 8508b703977f4c4ada34d657d051972c
+      sha256: 74843f871e5cd8a1baf5ed8c406c571139c287141efe532f8ffbdafa3664d244
     category: main
     optional: false
   - name: packaging
@@ -16103,10 +16100,10 @@ package:
     platform: osx-64
     dependencies:
       python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
     hash:
-      md5: c16469afe1ec91aaafcf4bea966c0465
-      sha256: 0f8273bf66c2a5c1de72312a509deae07f163bb0ae8de8273c52e6fe945a0850
+      md5: 8508b703977f4c4ada34d657d051972c
+      sha256: 74843f871e5cd8a1baf5ed8c406c571139c287141efe532f8ffbdafa3664d244
     category: main
     optional: false
   - name: packaging
@@ -16115,10 +16112,10 @@ package:
     platform: osx-arm64
     dependencies:
       python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/packaging-24.2-pyhff2d567_1.conda
     hash:
-      md5: c16469afe1ec91aaafcf4bea966c0465
-      sha256: 0f8273bf66c2a5c1de72312a509deae07f163bb0ae8de8273c52e6fe945a0850
+      md5: 8508b703977f4c4ada34d657d051972c
+      sha256: 74843f871e5cd8a1baf5ed8c406c571139c287141efe532f8ffbdafa3664d244
     category: main
     optional: false
   - name: pandas
@@ -18261,39 +18258,39 @@ package:
     category: dev
     optional: true
   - name: pyjwt
-    version: 2.9.0
+    version: 2.10.0
     manager: conda
     platform: linux-64
     dependencies:
-      python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.9.0-pyhd8ed1ab_1.conda
+      python: ">=3.9"
+    url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.0-pyhff2d567_0.conda
     hash:
-      md5: 5ba575830ec18d5c51c59f403310e2c7
-      sha256: b6f47cd0737cb1f5aca10be771641466ec1a3be585382d44877140eb2cb2dd46
+      md5: ae45081e9e726f978c514ae1977bd1fb
+      sha256: 49a20637a285f7c9acb2064b91d8c63bce5821f007598cfa64e3913ed4264354
     category: main
     optional: false
   - name: pyjwt
-    version: 2.9.0
+    version: 2.10.0
     manager: conda
     platform: osx-64
     dependencies:
-      python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.9.0-pyhd8ed1ab_1.conda
+      python: ">=3.9"
+    url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.0-pyhff2d567_0.conda
     hash:
-      md5: 5ba575830ec18d5c51c59f403310e2c7
-      sha256: b6f47cd0737cb1f5aca10be771641466ec1a3be585382d44877140eb2cb2dd46
+      md5: ae45081e9e726f978c514ae1977bd1fb
+      sha256: 49a20637a285f7c9acb2064b91d8c63bce5821f007598cfa64e3913ed4264354
     category: main
     optional: false
   - name: pyjwt
-    version: 2.9.0
+    version: 2.10.0
     manager: conda
     platform: osx-arm64
     dependencies:
-      python: ">=3.8"
-    url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.9.0-pyhd8ed1ab_1.conda
+      python: ">=3.9"
+    url: https://conda.anaconda.org/conda-forge/noarch/pyjwt-2.10.0-pyhff2d567_0.conda
     hash:
-      md5: 5ba575830ec18d5c51c59f403310e2c7
-      sha256: b6f47cd0737cb1f5aca10be771641466ec1a3be585382d44877140eb2cb2dd46
+      md5: ae45081e9e726f978c514ae1977bd1fb
+      sha256: 49a20637a285f7c9acb2064b91d8c63bce5821f007598cfa64e3913ed4264354
     category: main
     optional: false
   - name: pylev
@@ -18949,6 +18946,7 @@ package:
       tk: ">=8.6.13,<8.7.0a0"
       tzdata: ""
       xz: ">=5.2.6,<6.0a0"
+      pip: ""
     url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-hc5c86c4_0_cpython.conda
     hash:
       md5: 0515111a9cdf69f83278f7c197db9807
@@ -18972,6 +18970,7 @@ package:
       tk: ">=8.6.13,<8.7.0a0"
       tzdata: ""
       xz: ">=5.2.6,<6.0a0"
+      pip: ""
     url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.7-h8f8b54e_0_cpython.conda
     hash:
       md5: 7f81191b1ca1113e694e90e15c27a12f
@@ -18995,6 +18994,7 @@ package:
       tk: ">=8.6.13,<8.7.0a0"
       tzdata: ""
       xz: ">=5.2.6,<6.0a0"
+      pip: ""
     url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
     hash:
       md5: e0d82e57ebb456077565e6d82cd4a323
@@ -23581,9 +23581,9 @@ package:
       __unix: ""
       pyyaml: ">=5.1"
       websockets: ">=10.4"
+      httptools: ">=0.5.0"
       python-dotenv: ">=0.13"
       watchfiles: ">=0.13"
-      httptools: ">=0.5.0"
       uvloop: ">=0.14.0,!=0.15.0,!=0.15.1"
       uvicorn: 0.32.0
     url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.32.0-h31011fe_1.conda
@@ -23600,9 +23600,9 @@ package:
       __unix: ""
       pyyaml: ">=5.1"
       websockets: ">=10.4"
+      httptools: ">=0.5.0"
       python-dotenv: ">=0.13"
       watchfiles: ">=0.13"
-      httptools: ">=0.5.0"
       uvloop: ">=0.14.0,!=0.15.0,!=0.15.1"
       uvicorn: 0.32.0
     url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.32.0-h31011fe_1.conda

--- a/environments/conda-lock.yml
+++ b/environments/conda-lock.yml
@@ -7970,8 +7970,8 @@ package:
     platform: osx-64
     dependencies:
       python: ">=3.6.1"
-      hyperframe: ">=6.0,<7"
       hpack: ">=4.0,<5"
+      hyperframe: ">=6.0,<7"
     url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
     hash:
       md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -7984,8 +7984,8 @@ package:
     platform: osx-arm64
     dependencies:
       python: ">=3.6.1"
-      hyperframe: ">=6.0,<7"
       hpack: ">=4.0,<5"
+      hyperframe: ">=6.0,<7"
     url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
     hash:
       md5: b748fbf7060927a6e82df7cb5ee8f097
@@ -14800,39 +14800,39 @@ package:
     category: main
     optional: false
   - name: narwhals
-    version: 1.13.5
+    version: 1.14.0
     manager: conda
     platform: linux-64
     dependencies:
       python: ">=3.9"
-    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.13.5-pyhff2d567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.14.0-pyhff2d567_0.conda
     hash:
-      md5: 4a7235fac3384d4aee1c3f75b04271b3
-      sha256: 1c58786f25fd5ed5ca6ffdb20ecb2b9ad97799ba295234a37f4bd8230f025d4b
+      md5: dc78d38bb510dc63524b17cdd1ef3e99
+      sha256: 4f1f539340b51541ff3c1e3018f8a06fac9c8c4f2d077ceb3ede71fe2e3e6ee4
     category: main
     optional: false
   - name: narwhals
-    version: 1.13.5
+    version: 1.14.0
     manager: conda
     platform: osx-64
     dependencies:
       python: ">=3.9"
-    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.13.5-pyhff2d567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.14.0-pyhff2d567_0.conda
     hash:
-      md5: 4a7235fac3384d4aee1c3f75b04271b3
-      sha256: 1c58786f25fd5ed5ca6ffdb20ecb2b9ad97799ba295234a37f4bd8230f025d4b
+      md5: dc78d38bb510dc63524b17cdd1ef3e99
+      sha256: 4f1f539340b51541ff3c1e3018f8a06fac9c8c4f2d077ceb3ede71fe2e3e6ee4
     category: main
     optional: false
   - name: narwhals
-    version: 1.13.5
+    version: 1.14.0
     manager: conda
     platform: osx-arm64
     dependencies:
       python: ">=3.9"
-    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.13.5-pyhff2d567_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/narwhals-1.14.0-pyhff2d567_0.conda
     hash:
-      md5: 4a7235fac3384d4aee1c3f75b04271b3
-      sha256: 1c58786f25fd5ed5ca6ffdb20ecb2b9ad97799ba295234a37f4bd8230f025d4b
+      md5: dc78d38bb510dc63524b17cdd1ef3e99
+      sha256: 4f1f539340b51541ff3c1e3018f8a06fac9c8c4f2d077ceb3ede71fe2e3e6ee4
     category: main
     optional: false
   - name: nbclassic
@@ -15290,7 +15290,7 @@ package:
     category: main
     optional: false
   - name: nodejs
-    version: 22.9.0
+    version: 22.11.0
     manager: conda
     platform: linux-64
     dependencies:
@@ -15298,50 +15298,50 @@ package:
       icu: ">=75.1,<76.0a0"
       libgcc: ">=13"
       libstdcxx: ">=13"
-      libuv: ">=1.48.0,<2.0a0"
+      libuv: ">=1.49.2,<2.0a0"
       libzlib: ">=1.3.1,<2.0a0"
-      openssl: ">=3.3.2,<4.0a0"
+      openssl: ">=3.4.0,<4.0a0"
       zlib: ""
-    url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.9.0-hf235a45_0.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-22.11.0-hf235a45_0.conda
     hash:
-      md5: 40255c9ffb722d614b02ca7aaee6abcb
-      sha256: 1bc6445b7ecb3bff478d5a11eb3504e45eb5a3cdde24c6ec7339f80c193d24c8
+      md5: 64cd0bde7dffac5baa4d9fb0ac3ae713
+      sha256: b90c26267d12d5dd97ef09b4393235be3a3cbe5eef07c5a2ada4230623f0b0b1
     category: main
     optional: false
   - name: nodejs
-    version: 22.9.0
+    version: 22.11.0
     manager: conda
     platform: osx-64
     dependencies:
       __osx: ">=10.15"
       icu: ">=75.1,<76.0a0"
-      libcxx: ">=17"
-      libuv: ">=1.48.0,<2.0a0"
+      libcxx: ">=18"
+      libuv: ">=1.49.2,<2.0a0"
       libzlib: ">=1.3.1,<2.0a0"
-      openssl: ">=3.3.2,<4.0a0"
+      openssl: ">=3.4.0,<4.0a0"
       zlib: ""
-    url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-22.9.0-hd71786a_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-22.11.0-hf4117ec_0.conda
     hash:
-      md5: 0302658eb45c23a7438415bf0ba7541d
-      sha256: 072cc60a3bad30e5dc4a0f9773d655b1ccd73766ca56d7b0eba54f07dc65c096
+      md5: 076c12f64b455b71958dfdfdcd6b6d96
+      sha256: d86709c3c2e2a58331b1642bab314b22d030e3d8738e19429f967d3ab0314604
     category: main
     optional: false
   - name: nodejs
-    version: 22.9.0
+    version: 22.11.0
     manager: conda
     platform: osx-arm64
     dependencies:
       __osx: ">=11.0"
       icu: ">=75.1,<76.0a0"
-      libcxx: ">=17"
-      libuv: ">=1.48.0,<2.0a0"
+      libcxx: ">=18"
+      libuv: ">=1.49.2,<2.0a0"
       libzlib: ">=1.3.1,<2.0a0"
-      openssl: ">=3.3.2,<4.0a0"
+      openssl: ">=3.4.0,<4.0a0"
       zlib: ""
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-22.9.0-h08fde81_0.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-22.11.0-haa7c7e9_0.conda
     hash:
-      md5: 3771a3a6abe5a8db8910d5ebf144811b
-      sha256: 736a4738aba32a03401aa25c8f740e4afe4aea02bc06651b59b06f0fdc024fdf
+      md5: 34da600f0addaef949d28953e23482b4
+      sha256: 304a2bf558f262a8e29f6b6abcc5fabde3b31d903bc699381b1b57f41e7c34d0
     category: main
     optional: false
   - name: nomkl
@@ -18946,7 +18946,6 @@ package:
       tk: ">=8.6.13,<8.7.0a0"
       tzdata: ""
       xz: ">=5.2.6,<6.0a0"
-      pip: ""
     url: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.7-hc5c86c4_0_cpython.conda
     hash:
       md5: 0515111a9cdf69f83278f7c197db9807
@@ -18970,7 +18969,6 @@ package:
       tk: ">=8.6.13,<8.7.0a0"
       tzdata: ""
       xz: ">=5.2.6,<6.0a0"
-      pip: ""
     url: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.7-h8f8b54e_0_cpython.conda
     hash:
       md5: 7f81191b1ca1113e694e90e15c27a12f
@@ -18994,7 +18992,6 @@ package:
       tk: ">=8.6.13,<8.7.0a0"
       tzdata: ""
       xz: ">=5.2.6,<6.0a0"
-      pip: ""
     url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.7-h739c21a_0_cpython.conda
     hash:
       md5: e0d82e57ebb456077565e6d82cd4a323
@@ -19099,42 +19096,42 @@ package:
     category: main
     optional: false
   - name: python-dateutil
-    version: 2.9.0
+    version: 2.9.0.post0
     manager: conda
     platform: linux-64
     dependencies:
-      python: ">=3.7"
+      python: ">=3.9"
       six: ">=1.5"
-    url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
     hash:
-      md5: 2cf4264fffb9e6eff6031c5b6884d61c
-      sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+      md5: b6dfd90a2141e573e4b6a81630b56df5
+      sha256: 3888012c5916efaef45d503e3e544bbcc571b84426c1bb9577799ada9efefb54
     category: main
     optional: false
   - name: python-dateutil
-    version: 2.9.0
+    version: 2.9.0.post0
     manager: conda
     platform: osx-64
     dependencies:
-      python: ">=3.7"
+      python: ">=3.9"
       six: ">=1.5"
-    url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
     hash:
-      md5: 2cf4264fffb9e6eff6031c5b6884d61c
-      sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+      md5: b6dfd90a2141e573e4b6a81630b56df5
+      sha256: 3888012c5916efaef45d503e3e544bbcc571b84426c1bb9577799ada9efefb54
     category: main
     optional: false
   - name: python-dateutil
-    version: 2.9.0
+    version: 2.9.0.post0
     manager: conda
     platform: osx-arm64
     dependencies:
-      python: ">=3.7"
+      python: ">=3.9"
       six: ">=1.5"
-    url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
+    url: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhff2d567_0.conda
     hash:
-      md5: 2cf4264fffb9e6eff6031c5b6884d61c
-      sha256: f3ceef02ac164a8d3a080d0d32f8e2ebe10dd29e3a685d240e38b3599e146320
+      md5: b6dfd90a2141e573e4b6a81630b56df5
+      sha256: 3888012c5916efaef45d503e3e544bbcc571b84426c1bb9577799ada9efefb54
     category: main
     optional: false
   - name: python-dotenv
@@ -23581,9 +23578,9 @@ package:
       __unix: ""
       pyyaml: ">=5.1"
       websockets: ">=10.4"
-      httptools: ">=0.5.0"
       python-dotenv: ">=0.13"
       watchfiles: ">=0.13"
+      httptools: ">=0.5.0"
       uvloop: ">=0.14.0,!=0.15.0,!=0.15.1"
       uvicorn: 0.32.0
     url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.32.0-h31011fe_1.conda
@@ -23600,9 +23597,9 @@ package:
       __unix: ""
       pyyaml: ">=5.1"
       websockets: ">=10.4"
-      httptools: ">=0.5.0"
       python-dotenv: ">=0.13"
       watchfiles: ">=0.13"
+      httptools: ">=0.5.0"
       uvloop: ">=0.14.0,!=0.15.0,!=0.15.1"
       uvicorn: 0.32.0
     url: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.32.0-h31011fe_1.conda
@@ -24510,7 +24507,7 @@ package:
     category: main
     optional: false
   - name: yarl
-    version: 1.17.1
+    version: 1.17.2
     manager: conda
     platform: linux-64
     dependencies:
@@ -24521,14 +24518,14 @@ package:
       propcache: ">=0.2.0"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.17.1-py312h66e93f0_1.conda
+    url: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.17.2-py312h66e93f0_0.conda
     hash:
-      md5: ec87a401644dafa3887b268e100cd8b0
-      sha256: b0addeacbe45e5ed148ec3b61cab0298dab1a6a244daf7bbb6c1fac052f955b2
+      md5: 99518ade67138dcce4f2751b47ab5b00
+      sha256: 4e870938d29f38cd2aa43247efff6f99f6ecd8973735509122cd3167ccc22add
     category: main
     optional: false
   - name: yarl
-    version: 1.17.1
+    version: 1.17.2
     manager: conda
     platform: osx-64
     dependencies:
@@ -24538,14 +24535,14 @@ package:
       propcache: ">=0.2.0"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.17.1-py312h01d7ebd_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-64/yarl-1.17.2-py312h01d7ebd_0.conda
     hash:
-      md5: d07fb6b3b4160580cbc244289a415c36
-      sha256: aa6e140f6d9c0e225d2845fbdc2a49101a24b76c4d4899a95adf7838eb777124
+      md5: 18f8e01081e8f87d09c159912a15bc74
+      sha256: 61b286071ad6485fffc540fe0bee33dff26af7b40d15de94ed098496bc92ae30
     category: main
     optional: false
   - name: yarl
-    version: 1.17.1
+    version: 1.17.2
     manager: conda
     platform: osx-arm64
     dependencies:
@@ -24555,10 +24552,10 @@ package:
       propcache: ">=0.2.0"
       python: ">=3.12,<3.13.0a0"
       python_abi: 3.12.*
-    url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.17.1-py312hea69d52_1.conda
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.17.2-py312hea69d52_0.conda
     hash:
-      md5: 64b70173136092b3b6b07c8d27e3f8fb
-      sha256: 3530756352b69d5fb689080b5902420e6336c42b7df2f56635520d09a8bc6f51
+      md5: e3d4600d565bac01340b12d3c4cba2b2
+      sha256: 43d85ffae29642b81e1ef4191560a7700911f3753078ab23248b8275952abcec
     category: main
     optional: false
   - name: zeromq

--- a/environments/conda-osx-64.lock.yml
+++ b/environments/conda-osx-64.lock.yml
@@ -56,8 +56,8 @@ dependencies:
   - bleach=6.2.0=pyhd8ed1ab_0
   - blinker=1.9.0=pyhff2d567_0
   - blosc=1.21.6=h7d75f6d_0
-  - boto3=1.35.62=pyhd8ed1ab_0
-  - botocore=1.35.62=pyge310_1234567_0
+  - boto3=1.35.63=pyhd8ed1ab_0
+  - botocore=1.35.63=pyge310_1234567_0
   - bottleneck=1.4.2=py312h59f7578_0
   - branca=0.7.2=pyhd8ed1ab_0
   - brotli=1.1.0=h00291cd_2
@@ -109,7 +109,7 @@ dependencies:
   - debugpy=1.8.8=py312haafddd8_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
-  - deprecated=1.2.14=pyh1a96a4e_0
+  - deprecated=1.2.15=pyhff2d567_0
   - distlib=0.3.9=pyhd8ed1ab_0
   - dnspython=2.7.0=pyhff2d567_0
   - doc8=1.1.2=pyhd8ed1ab_1
@@ -192,7 +192,7 @@ dependencies:
   - humanize=4.11.0=pyhd8ed1ab_0
   - hupper=1.12.1=pyhd8ed1ab_0
   - hyperframe=6.0.1=pyhd8ed1ab_0
-  - hypothesis=6.119.1=pyha770c72_0
+  - hypothesis=6.119.3=pyha770c72_0
   - icu=75.1=h120a0e1_0
   - identify=2.6.2=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_0
@@ -232,7 +232,7 @@ dependencies:
   - jupyter_events=0.10.0=pyhd8ed1ab_0
   - jupyter_server=2.14.2=pyhd8ed1ab_0
   - jupyter_server_terminals=0.5.3=pyhd8ed1ab_0
-  - jupyterlab=4.3.0=pyhd8ed1ab_0
+  - jupyterlab=4.3.1=pyhff2d567_0
   - jupyterlab-lsp=5.1.0=pyhd8ed1ab_2
   - jupyterlab_pygments=0.3.0=pyhd8ed1ab_1
   - jupyterlab_server=2.27.3=pyhd8ed1ab_0
@@ -307,7 +307,7 @@ dependencies:
   - lxml=5.3.0=py312h4feaf87_2
   - lz4-c=1.9.4=hf0c8a7f_0
   - lzo=2.10=h10d778d_1001
-  - mako=1.3.5=pyhd8ed1ab_0
+  - mako=1.3.6=pyhff2d567_0
   - mapclassify=2.8.1=pyhd8ed1ab_0
   - markdown=3.6=pyhd8ed1ab_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_0
@@ -355,7 +355,7 @@ dependencies:
   - opentelemetry-semantic-conventions=0.37b0=pyhd8ed1ab_0
   - orc=2.0.2=h22b2039_0
   - overrides=7.7.0=pyhd8ed1ab_0
-  - packaging=24.2=pyhd8ed1ab_0
+  - packaging=24.2=pyhff2d567_1
   - pandas=2.2.3=py312h98e817e_1
   - pandera-core=0.20.4=pyhd8ed1ab_0
   - pandoc=3.5=h694c41f_0
@@ -406,7 +406,7 @@ dependencies:
   - pygls=1.3.1=pyhd8ed1ab_0
   - pygments=2.18.0=pyhd8ed1ab_0
   - pygraphviz=1.14=py312hc79309e_0
-  - pyjwt=2.9.0=pyhd8ed1ab_1
+  - pyjwt=2.10.0=pyhff2d567_0
   - pylev=1.4.0=pyhd8ed1ab_0
   - pynacl=1.5.0=py312hb553811_4
   - pyobjc-core=10.3.1=py312hab44e94_1

--- a/environments/conda-osx-64.lock.yml
+++ b/environments/conda-osx-64.lock.yml
@@ -328,7 +328,7 @@ dependencies:
   - multimethod=1.9.1=pyhd8ed1ab_0
   - munkres=1.1.4=pyh9f0ad1d_0
   - mypy_extensions=1.0.0=pyha770c72_0
-  - narwhals=1.13.5=pyhff2d567_0
+  - narwhals=1.14.0=pyhff2d567_0
   - nbclassic=1.1.0=pyhd8ed1ab_0
   - nbclient=0.10.0=pyhd8ed1ab_0
   - nbconvert=7.16.4=hd8ed1ab_1
@@ -339,7 +339,7 @@ dependencies:
   - nest-asyncio=1.6.0=pyhd8ed1ab_0
   - networkx=3.4.2=pyh267e887_2
   - nodeenv=1.9.1=pyhd8ed1ab_0
-  - nodejs=22.9.0=hd71786a_0
+  - nodejs=22.11.0=hf4117ec_0
   - notebook=6.5.7=pyha770c72_0
   - notebook-shim=0.2.4=pyhd8ed1ab_0
   - numba=0.60.0=py312hc3b515d_0
@@ -425,7 +425,7 @@ dependencies:
   - python=3.12.7=h8f8b54e_0_cpython
   - python-build=1.2.2.post1=pyhff2d567_0
   - python-calamine=0.3.1=py312h0d0de52_0
-  - python-dateutil=2.9.0=pyhd8ed1ab_0
+  - python-dateutil=2.9.0.post0=pyhff2d567_0
   - python-dotenv=1.0.1=pyhd8ed1ab_0
   - python-duckdb=1.1.3=py312haafddd8_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
@@ -555,7 +555,7 @@ dependencies:
   - xyzservices=2024.9.0=pyhd8ed1ab_0
   - xz=5.2.6=h775f41a_0
   - yaml=0.2.5=h0d85af4_2
-  - yarl=1.17.1=py312h01d7ebd_1
+  - yarl=1.17.2=py312h01d7ebd_0
   - zeromq=4.3.5=h7130eaa_7
   - zip=3.0=h0dc2134_3
   - zipp=3.21.0=pyhd8ed1ab_0

--- a/environments/conda-osx-arm64.lock.yml
+++ b/environments/conda-osx-arm64.lock.yml
@@ -328,7 +328,7 @@ dependencies:
   - multimethod=1.9.1=pyhd8ed1ab_0
   - munkres=1.1.4=pyh9f0ad1d_0
   - mypy_extensions=1.0.0=pyha770c72_0
-  - narwhals=1.13.5=pyhff2d567_0
+  - narwhals=1.14.0=pyhff2d567_0
   - nbclassic=1.1.0=pyhd8ed1ab_0
   - nbclient=0.10.0=pyhd8ed1ab_0
   - nbconvert=7.16.4=hd8ed1ab_1
@@ -339,7 +339,7 @@ dependencies:
   - nest-asyncio=1.6.0=pyhd8ed1ab_0
   - networkx=3.4.2=pyh267e887_2
   - nodeenv=1.9.1=pyhd8ed1ab_0
-  - nodejs=22.9.0=h08fde81_0
+  - nodejs=22.11.0=haa7c7e9_0
   - notebook=6.5.7=pyha770c72_0
   - notebook-shim=0.2.4=pyhd8ed1ab_0
   - numba=0.60.0=py312h41cea2d_0
@@ -425,7 +425,7 @@ dependencies:
   - python=3.12.7=h739c21a_0_cpython
   - python-build=1.2.2.post1=pyhff2d567_0
   - python-calamine=0.3.1=py312hcd83bfe_0
-  - python-dateutil=2.9.0=pyhd8ed1ab_0
+  - python-dateutil=2.9.0.post0=pyhff2d567_0
   - python-dotenv=1.0.1=pyhd8ed1ab_0
   - python-duckdb=1.1.3=py312hd8f9ff3_0
   - python-fastjsonschema=2.20.0=pyhd8ed1ab_0
@@ -555,7 +555,7 @@ dependencies:
   - xyzservices=2024.9.0=pyhd8ed1ab_0
   - xz=5.2.6=h57fd34a_0
   - yaml=0.2.5=h3422bc3_2
-  - yarl=1.17.1=py312hea69d52_1
+  - yarl=1.17.2=py312hea69d52_0
   - zeromq=4.3.5=hc1bb282_7
   - zip=3.0=hb547adb_3
   - zipp=3.21.0=pyhd8ed1ab_0

--- a/environments/conda-osx-arm64.lock.yml
+++ b/environments/conda-osx-arm64.lock.yml
@@ -56,8 +56,8 @@ dependencies:
   - bleach=6.2.0=pyhd8ed1ab_0
   - blinker=1.9.0=pyhff2d567_0
   - blosc=1.21.6=h5499902_0
-  - boto3=1.35.62=pyhd8ed1ab_0
-  - botocore=1.35.62=pyge310_1234567_0
+  - boto3=1.35.63=pyhd8ed1ab_0
+  - botocore=1.35.63=pyge310_1234567_0
   - bottleneck=1.4.2=py312h147345f_0
   - branca=0.7.2=pyhd8ed1ab_0
   - brotli=1.1.0=hd74edd7_2
@@ -109,7 +109,7 @@ dependencies:
   - debugpy=1.8.8=py312hd8f9ff3_0
   - decorator=5.1.1=pyhd8ed1ab_0
   - defusedxml=0.7.1=pyhd8ed1ab_0
-  - deprecated=1.2.14=pyh1a96a4e_0
+  - deprecated=1.2.15=pyhff2d567_0
   - distlib=0.3.9=pyhd8ed1ab_0
   - dnspython=2.7.0=pyhff2d567_0
   - doc8=1.1.2=pyhd8ed1ab_1
@@ -192,7 +192,7 @@ dependencies:
   - humanize=4.11.0=pyhd8ed1ab_0
   - hupper=1.12.1=pyhd8ed1ab_0
   - hyperframe=6.0.1=pyhd8ed1ab_0
-  - hypothesis=6.119.1=pyha770c72_0
+  - hypothesis=6.119.3=pyha770c72_0
   - icu=75.1=hfee45f7_0
   - identify=2.6.2=pyhd8ed1ab_0
   - idna=3.10=pyhd8ed1ab_0
@@ -232,7 +232,7 @@ dependencies:
   - jupyter_events=0.10.0=pyhd8ed1ab_0
   - jupyter_server=2.14.2=pyhd8ed1ab_0
   - jupyter_server_terminals=0.5.3=pyhd8ed1ab_0
-  - jupyterlab=4.3.0=pyhd8ed1ab_0
+  - jupyterlab=4.3.1=pyhff2d567_0
   - jupyterlab-lsp=5.1.0=pyhd8ed1ab_2
   - jupyterlab_pygments=0.3.0=pyhd8ed1ab_1
   - jupyterlab_server=2.27.3=pyhd8ed1ab_0
@@ -307,7 +307,7 @@ dependencies:
   - lxml=5.3.0=py312ha59c1f6_2
   - lz4-c=1.9.4=hb7217d7_0
   - lzo=2.10=h93a5062_1001
-  - mako=1.3.5=pyhd8ed1ab_0
+  - mako=1.3.6=pyhff2d567_0
   - mapclassify=2.8.1=pyhd8ed1ab_0
   - markdown=3.6=pyhd8ed1ab_0
   - markdown-it-py=3.0.0=pyhd8ed1ab_0
@@ -355,7 +355,7 @@ dependencies:
   - opentelemetry-semantic-conventions=0.37b0=pyhd8ed1ab_0
   - orc=2.0.2=h75dedd0_0
   - overrides=7.7.0=pyhd8ed1ab_0
-  - packaging=24.2=pyhd8ed1ab_0
+  - packaging=24.2=pyhff2d567_1
   - pandas=2.2.3=py312hcd31e36_1
   - pandera-core=0.20.4=pyhd8ed1ab_0
   - pandoc=3.5=hce30654_0
@@ -406,7 +406,7 @@ dependencies:
   - pygls=1.3.1=pyhd8ed1ab_0
   - pygments=2.18.0=pyhd8ed1ab_0
   - pygraphviz=1.14=py312h1fbede1_0
-  - pyjwt=2.9.0=pyhd8ed1ab_1
+  - pyjwt=2.10.0=pyhff2d567_0
   - pylev=1.4.0=pyhd8ed1ab_0
   - pynacl=1.5.0=py312h024a12e_4
   - pyobjc-core=10.3.1=py312hd24fc31_1


### PR DESCRIPTION
This pull request relocks the dependencies with conda-lock. It is triggered by [update-conda-lockfile](https://github.com/catalyst-cooperative/pudl/blob/main/.github/workflows/update-conda-lockfile.yml).