### PR TITLE
Fix nested list formatting in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,6 +45,7 @@ You'll need to fork this repository and get the
 
 * Once you have an idea of how you want to tackle this issue, write out your
   plan so we can guide you around obstacles in your way! Post a comment outlining:
+
   * what steps have you broken this down into?
   * what is the output of each step?
   * how will one know that each step is working?


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

~~Closes #XXXX.~~

## What problem does this address?

A list that was intended to be nested in the first issue section of the contributing guide was not formatted correctly.

## What did you change?

The rst specification says that nested lists need to be separated by a new blank line.  I added that line.

# Documentation

~~Make sure to update relevant aspects of the documentation.~~

# Testing

## How did you make sure this worked? How can a reviewer verify this?

You can see the results [here](https://github.com/crd477/pudl/blob/crd477-patch-1/CONTRIBUTING.rst).
