### PR TITLE
Updates to splink FERC to EIA record linkage notebook

### DIFF
--- a/devtools/splink-ferc1-eia-match.ipynb
+++ b/devtools/splink-ferc1-eia-match.ipynb
@@ -83,7 +83,7 @@
    "outputs": [],
    "source": [
     "# Get a table summarizing fuel data by plant, using FERC Form 1 data\n",
-    "out_ferc1__yearly_steam_plants_fuel_by_plant_sched402 = pd.read_parquet(\"s3://pudl.catalyst.coop/stable/out_ferc1__yearly_steam_plants_fuel_by_plant_sched402.parquet\")"
+    "out_ferc1__yearly_steam_plants_fuel_by_plant_sched402 = pd.read_parquet(\"s3://pudl.catalyst.coop/stable/out_ferc1__yearly_steam_plants_fuel_by_plant_sched402.parquet\",)"
    ]
   },
   {
@@ -95,6 +95,16 @@
    "source": [
     "# Get a table with the aggregation of all EIA \"plant parts\"\n",
     "out_eia__yearly_plant_parts = pd.read_parquet(\"s3://pudl.catalyst.coop/stable/out_eia__yearly_plant_parts.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b52f0a91-3ab6-44ea-ae96-050ea3155978",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "out_eia__yearly_plant_parts[\"report_date\"] = pd.to_datetime(out_eia__yearly_plant_parts[\"report_date\"])"
    ]
   },
   {

--- a/devtools/splink-ferc1-eia-match.ipynb
+++ b/devtools/splink-ferc1-eia-match.ipynb
@@ -7,9 +7,9 @@
    "source": [
     "# Use Splink to match FERC1 plants to EIA plant parts\n",
     "\n",
-    "This notebook walks through how to use splink to match FERC1 plants to EIA plant parts, as is done in `pudl.analysis.record_linkage.eia_ferc1_record_linkage_model.py`. Splink has several visualizations during the model training process that are helpful for understanding model weights and the input datasets. Thos visualizations are not captured in the PUDL module that implements this model, so this companion notebook provides insight into how to use splink for model development.\n",
+    "This notebook walks through using splink to match FERC1 plants to EIA plant parts, as is done in `pudl.analysis.record_linkage.eia_ferc1_record_linkage_model.py`. Splink provides several visualizations during the model training process that are helpful for understanding model weights and the input datasets. For now, those visualizations are not captured in the PUDL module that implements this model, so this companion notebook provides additional insight into model development.\n",
     "\n",
-    "The [Splink docs](https://moj-analytical-services.github.io/splink/index.html) include helpful tutorials and the Github issues and discussions are also helpful places to look."
+    "The [Splink docs](https://moj-analytical-services.github.io/splink/index.html) include tutorials and the Github issues and discussions are also helpful places to look."
    ]
   },
   {
@@ -32,26 +32,16 @@
    "source": [
     "import jellyfish\n",
     "import sqlalchemy as sa\n",
-    "from splink.duckdb.linker import DuckDBLinker\n",
-    "from splink.duckdb.blocking_rule_library import block_on\n",
+    "from splink import block_on, DuckDBAPI, Linker, SettingsCreator\n",
+    "from splink.blocking_analysis import count_comparisons_from_blocking_rule, cumulative_comparisons_to_be_scored_from_blocking_rules_chart, n_largest_blocks\n",
+    "from splink.exploratory import completeness_chart, profile_columns\n",
     "import pandas as pd\n",
     "\n",
     "import pudl\n",
     "from pudl.analysis.record_linkage import eia_ferc1_record_linkage as eia_ferc1_model\n",
     "from pudl.analysis.record_linkage.name_cleaner import CompanyNameCleaner\n",
     "from pudl.analysis.record_linkage.embed_dataframe import _fill_fuel_type_from_name\n",
-    "from pudl.analysis.record_linkage import eia_ferc1_model_config\n",
-    "from pudl.etl import defs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fc3fc801-aa7e-4bf2-9748-200461f1c1ff",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl_engine = sa.create_engine(pudl.workspace.setup.PudlPaths().pudl_db)"
+    "from pudl.analysis.record_linkage import eia_ferc1_model_config"
    ]
   },
   {
@@ -63,15 +53,48 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "88efc43b-4571-47a7-8e35-06cb58d8215f",
+   "metadata": {},
+   "source": [
+    "Practically speaking, a plant is a collection of generator(s). There are many attributes of generators (i.e. prime mover, primary fuel source, technology type). We can use these generator attributes to group generator records into larger aggregate records which we call \"plant parts\". A plant part is a record which corresponds to a particular collection of generators that all share an identical attribute and utility owner, e.g. all of the generators with unit_id=2, or all of the generators with coal as their primary fuel source.\n",
+    "\n",
+    "The EIA data about power plants (from EIA 923 and 860) is reported in tables with records that correspond to mostly generators and plants. FERC 1 is less well organized and include plants, generators and other plant parts all in the same table without any clear labels. This EIA plant part table is an attempt to create records corresponding to many different plant parts in order to connect specific slices of EIA plants to FERC.\n",
+    "\n",
+    "Because generators are often owned by multiple utilities, another dimension of this plant part table involves generating two records for each owner: one for the portion of the plant part they own and one for the plant part as a whole. The portion records are labeled in the ``ownership_record_type`` column as ``owned`` and the total records are labeled as ``total``. This table includes A LOT of duplicative information about EIA plants. It is meant for use as an input into the record linkage between FERC1 plants and EIA."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b81d9beb-2385-450a-af45-e4e0541a8df4",
+   "id": "064af8a0-c5a2-49d3-b403-6e9bf31ac080",
    "metadata": {},
    "outputs": [],
    "source": [
-    "out_ferc1__yearly_all_plants = defs.load_asset_value(\"out_ferc1__yearly_all_plants\")\n",
-    "out_ferc1__yearly_steam_plants_fuel_by_plant_sched402 = defs.load_asset_value(\"out_ferc1__yearly_steam_plants_fuel_by_plant_sched402\")\n",
-    "out_eia__yearly_plant_parts = defs.load_asset_value(\"out_eia__yearly_plant_parts\")"
+    "# Get a denormalized FERC Form 1 table containing the steam, small generators, hydro, and pumped storage tables\n",
+    "out_ferc1__yearly_all_plants = pd.read_parquet(\"s3://pudl.catalyst.coop/stable/out_ferc1__yearly_all_plants.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5aa3a188-b39c-45ab-88c7-800aefde4a52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a table summarizing fuel data by plant, using FERC Form 1 data\n",
+    "out_ferc1__yearly_steam_plants_fuel_by_plant_sched402 = pd.read_parquet(\"s3://pudl.catalyst.coop/stable/out_ferc1__yearly_steam_plants_fuel_by_plant_sched402.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "651cb03f-85b0-4390-8a3c-8249ca9d06e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a table with the aggregation of all EIA \"plant parts\"\n",
+    "out_eia__yearly_plant_parts = pd.read_parquet(\"s3://pudl.catalyst.coop/stable/out_eia__yearly_plant_parts.parquet\")"
    ]
   },
   {
@@ -87,6 +110,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "e3ce845f-aa7c-4515-b06d-20a87c049eb8",
+   "metadata": {},
+   "source": [
+    "Do a little preprocessing so the datasets have the same columns. Also, load in a dataset of manually matched training data, found [here](https://github.com/catalyst-cooperative/pudl/blob/main/src/pudl/package_data/glue/eia_ferc1_train.csv) . We'll use this to train and validate the model."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "bdc336ed-8dd2-407e-a23b-75a64888abaf",
@@ -94,7 +125,18 @@
    "outputs": [],
    "source": [
     "eia_df, ferc_df = eia_ferc1_model.get_input_dfs(inputs)\n",
+    "# we have a dataset of manually matched training data\n",
     "train_df = eia_ferc1_model.get_training_data_df(inputs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b89a255-af77-4531-9688-223f6f9de14a",
+   "metadata": {},
+   "source": [
+    "Normalize plant and utility name strings. Do things like expand legal terms (e.g. llc -> limited liability company), remove punctuation, remove numbers, etc.\n",
+    "\n",
+    "This name cleaner is being refactored and will soon be 3x faster."
    ]
   },
   {
@@ -146,6 +188,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c0a7541a-ef2c-41b5-9e22-e264e30e0757",
+   "metadata": {},
+   "source": [
+    "We can use metaphones of the plant and utility names as columns for blocking. With splink, metaphones can work better/faster than string similarity."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "b80e123a-062f-47e2-906a-d1b6afa4c3e7",
@@ -194,46 +244,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddaed355-501a-4a38-b7fa-7d1b5f355306",
-   "metadata": {},
-   "source": [
-    "# Set settings dictionary and create linker"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fdc68f8a-e4a0-4b3a-bde3-bea1e0ac1338",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "settings_dict = {\"link_type\": \"link_only\",\n",
-    "                 \"unique_id_column_name\": \"record_id\",\n",
-    "                 \"additional_columns_to_retain\": [\"plant_id_pudl\", \"utility_id_pudl\", \"utility_name_mphone\", \"plant_name_mphone\"]}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "730c9bfe-dade-494e-aaec-ae1827f2c9de",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "linker = DuckDBLinker([eia_df, ferc_df], input_table_aliases = [\"eia_df\", \"ferc_df\"], settings_dict=settings_dict)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5f4b43ad-61a0-4c7f-957e-3094576db86d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "train_table = linker.register_table(train_df, \"training_labels\", overwrite=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "e2777501-8cc5-4a05-95ae-0616a8e9a794",
    "metadata": {},
    "source": [
@@ -243,11 +253,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "14dc9e4c-551c-4a7f-ad84-72ed72138fe0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "db_api = DuckDBAPI()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "bf24b3ef-2cc0-455b-9f7e-89fd1fca8a1d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "linker.completeness_chart(cols=eia_ferc1_model.MATCHING_COLS)"
+    "completeness_chart(eia_df, db_api=db_api, cols=eia_ferc1_model.MATCHING_COLS)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf465746-3a39-408f-98ef-14ad9b22c111",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "completeness_chart(ferc_df, db_api=db_api, cols=eia_ferc1_model.MATCHING_COLS)"
    ]
   },
   {
@@ -261,11 +291,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5d728332-839c-42ac-bd72-de534a410962",
+   "id": "830d8136-8d21-4958-9c6c-aca6bfeb04b0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "linker.profile_columns(eia_ferc1_model.MATCHING_COLS, top_n=10, bottom_n=5)"
+    "profile_columns(eia_df[eia_ferc1_model.MATCHING_COLS], db_api=DuckDBAPI(), top_n=10, bottom_n=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7820f60-1454-43a0-b8b0-275d8e31e812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "profile_columns(ferc_df[eia_ferc1_model.MATCHING_COLS], db_api=DuckDBAPI(), top_n=10, bottom_n=5)"
    ]
   },
   {
@@ -285,11 +325,63 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68d5a3cf-2e0b-426d-aab5-86babd6d2751",
+   "id": "b39f7633-c97e-4c31-a553-6cfd3ccc0a4a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "linker.cumulative_num_comparisons_from_blocking_rules_chart(eia_ferc1_model_config.BLOCKING_RULES)"
+    "br0 = eia_ferc1_model_config.BLOCKING_RULES[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b52e9c62-6502-4ae5-91fb-ffedeca383ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "count_comparisons_from_blocking_rule(\n",
+    "    table_or_tables=[eia_df, ferc_df],\n",
+    "    blocking_rule=br0,\n",
+    "    link_type=\"link_only\",\n",
+    "    unique_id_column_name='record_id',\n",
+    "    db_api=db_api,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "891915e3-564f-43dc-af86-be0ea21f49d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = n_largest_blocks(\n",
+    "    table_or_tables=[eia_df, ferc_df],\n",
+    "    blocking_rule=br0,\n",
+    "    link_type=\"link_only\",\n",
+    "    db_api=db_api,\n",
+    "    n_largest=3\n",
+    ")\n",
+    "\n",
+    "result.as_pandas_dataframe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a20be45-152e-4e82-9cc0-4e57c0f1dca7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blocking_rules_for_analysis = eia_ferc1_model_config.BLOCKING_RULES\n",
+    "\n",
+    "cumulative_comparisons_to_be_scored_from_blocking_rules_chart(\n",
+    "    table_or_tables=[eia_df, ferc_df],\n",
+    "    blocking_rules=blocking_rules_for_analysis,\n",
+    "    db_api=db_api,\n",
+    "    unique_id_column_name='record_id',\n",
+    "    link_type=\"link_only\",\n",
+    ")"
    ]
   },
   {
@@ -297,7 +389,15 @@
    "id": "573573a2-056b-41a0-86a3-6477877acf6c",
    "metadata": {},
    "source": [
-    "# Define Comparison Levels"
+    "# Define Model Settings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7301917f-e753-4f3e-a2dd-fb996ab6633c",
+   "metadata": {},
+   "source": [
+    "See the [splink settings guide](https://moj-analytical-services.github.io/splink/api_docs/settings_dict_guide.html) for more on model parameters."
    ]
   },
   {
@@ -307,24 +407,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(eia_ferc1_model_config.plant_name_comparison.human_readable_description)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b979157e-f46d-4bfb-b9b5-0900e2545753",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "settings_dict.update({\n",
-    "    \"comparisons\": eia_ferc1_model_config.COMPARISONS,\n",
-    "    \"blocking_rules_to_generate_predictions\": eia_ferc1_model_config.BLOCKING_RULES,\n",
-    "    \"retain_matching_columns\": True,\n",
-    "    \"retain_intermediate_calculation_columns\": True,\n",
-    "    \"probability_two_random_records_match\": 1/len(eia_df) # this parameter can also be estimated if it's unknown\n",
-    "    }\n",
-    ")"
+    "print(eia_ferc1_model_config.plant_name_comparison.get_comparison(\"duckdb\").human_readable_description)"
    ]
   },
   {
@@ -345,11 +428,30 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e205d00-da15-4c20-8d7b-a7d08e0ff815",
+   "id": "d6f30b15-3480-4253-8763-8bcaf3345ebc",
    "metadata": {},
    "outputs": [],
    "source": [
-    "linker.load_settings(settings_dict)"
+    "settings = SettingsCreator(\n",
+    "    link_type=\"link_only\",\n",
+    "    unique_id_column_name=\"record_id\",\n",
+    "    comparisons=eia_ferc1_model_config.COMPARISONS,\n",
+    "    blocking_rules_to_generate_predictions=eia_ferc1_model_config.BLOCKING_RULES,\n",
+    "    retain_intermediate_calculation_columns=True,\n",
+    "    probability_two_random_records_match=1/len(eia_df) # this parameter can also be estimated if it's unknown\n",
+    ")\n",
+    "\n",
+    "linker = Linker([eia_df, ferc_df], settings, db_api=DuckDBAPI())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "180d48cc-bacf-4115-9a89-4450f04097d6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_table = linker.table_management.register_table(train_df, \"training_labels\", overwrite=True)"
    ]
   },
   {
@@ -369,7 +471,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linker.estimate_u_using_random_sampling(max_pairs=1e7)"
+    "linker.training.estimate_u_using_random_sampling(max_pairs=1e7)"
    ]
   },
   {
@@ -387,7 +489,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linker.estimate_m_from_pairwise_labels(\"training_labels\")"
+    "linker.training.estimate_m_from_pairwise_labels(\"training_labels\")"
    ]
   },
   {
@@ -397,7 +499,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# if we do it unsupervised, we need to define training blocking rules\n",
+    "# if we want this to be unsupervised, we need to define training blocking rules\n",
     "# training_blocking_rule_1 = \"l.plant_name = r.plant_name\"\n",
     "# training_session_1 = linker.estimate_parameters_using_expectation_maximisation(training_blocking_rule_1)\n",
     "# training_session_2 = linker.estimate_parameters_using_expectation_maximisation(block_on([\"utility_name\", \"net_generation_mwh\"]))\n",
@@ -411,7 +513,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linker.match_weights_chart()"
+    "linker.visualisations.match_weights_chart()"
    ]
   },
   {
@@ -421,7 +523,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linker.m_u_parameters_chart()"
+    "linker.visualisations.m_u_parameters_chart()"
    ]
   },
   {
@@ -442,7 +544,7 @@
    "outputs": [],
    "source": [
     "# save model settings to a chosen directory\n",
-    "settings = linker.save_model_to_json(f\"./model_settings_{model_name}.json\", overwrite=True)"
+    "settings = linker.misc.save_model_to_json(f\"./model_settings_{model_name}.json\", overwrite=True)"
    ]
   },
   {
@@ -461,7 +563,7 @@
    "outputs": [],
    "source": [
     "# predict matches above a certain threshold match probability or match weight\n",
-    "df_preds = linker.predict(threshold_match_probability=.25)"
+    "df_preds = linker.inference.predict(threshold_match_probability=.25)"
    ]
   },
   {
@@ -710,7 +812,7 @@
    "outputs": [],
    "source": [
     "rec_true = rec_true.to_dict(orient=\"records\")\n",
-    "linker.waterfall_chart(rec_true, filter_nulls=False)"
+    "linker.visualisations.waterfall_chart(rec_true, filter_nulls=False)"
    ]
   },
   {
@@ -721,7 +823,7 @@
    "outputs": [],
    "source": [
     "rec_pred = rec_pred.to_dict(orient=\"records\")\n",
-    "linker.waterfall_chart(rec_pred, filter_nulls=False)"
+    "linker.visualisations.waterfall_chart(rec_pred, filter_nulls=False)"
    ]
   },
   {
@@ -749,7 +851,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.8"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -57,6 +57,12 @@ EPA CEMS
 ~~~~~~~~
 * Added 2024 Q3 of CEMS data. See :issue:`3943` and :pr:`3948`.
 
+FERC to EIA Record Linkage
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Updated the ``splink`` FERC to EIA development notebook to be compatible with
+  the latest version of ``splink``. This notebook is not run in production but
+  is helpful for visualizing model weights and what is happening under the hood.
+
 .. _release-v2024.10.0:
 
 ---------------------------------------------------------------------------------------

--- a/src/pudl/analysis/plant_parts_eia.py
+++ b/src/pudl/analysis/plant_parts_eia.py
@@ -1483,10 +1483,14 @@ def match_to_single_plant_part(
     """
     # select only the plant-part records that we are trying to scale to
     ppe_part_df = ppe[ppe.plant_part == part_name]
+    if not pd.api.types.is_datetime64_any_dtype(ppe_part_df["report_date"]):
+        ppe_part_df["report_date"] = pd.to_datetime(ppe_part_df["report_date"])
+    if not pd.api.types.is_datetime64_any_dtype(multi_gran_df["report_date"]):
+        multi_gran_df["report_date"] = pd.to_datetime(multi_gran_df["report_date"])
     # convert the date to year start - this is necessary because the
     # depreciation data is often reported as EOY and the ppe is always SOY
     multi_gran_df.loc[:, "report_date"] = pd.to_datetime(
-        multi_gran_df.report_date.dt.year, format="%Y"
+        multi_gran_df["report_date"].dt.year, format="%Y"
     )
     out_dfs = []
     for merge_part in PLANT_PARTS:

--- a/src/pudl/analysis/plant_parts_eia.py
+++ b/src/pudl/analysis/plant_parts_eia.py
@@ -1483,10 +1483,6 @@ def match_to_single_plant_part(
     """
     # select only the plant-part records that we are trying to scale to
     ppe_part_df = ppe[ppe.plant_part == part_name]
-    if not pd.api.types.is_datetime64_any_dtype(ppe_part_df["report_date"]):
-        ppe_part_df["report_date"] = pd.to_datetime(ppe_part_df["report_date"])
-    if not pd.api.types.is_datetime64_any_dtype(multi_gran_df["report_date"]):
-        multi_gran_df["report_date"] = pd.to_datetime(multi_gran_df["report_date"])
     # convert the date to year start - this is necessary because the
     # depreciation data is often reported as EOY and the ppe is always SOY
     multi_gran_df.loc[:, "report_date"] = pd.to_datetime(


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

This PR updates the `devtools` notebook for FERC to EIA record linkage with `splink`. This notebook isn't actually run in production, but it's helpful for visualizing the model weights and the decisions that go into making the match. 

## What problem does this address?

The notebook now runs with the latest version of `splink` and reads in parquet inputs from S3 instead of from dagster storage.

## What did you change?

Updated the notebook to have more documentation cells and run with the latest version of splink. Also, fixed an error that was cropping up in the plant parts list creation with datetime types. I think this came up because I'm now reading in parquet inputs from S3 instead of dagster storage, and the `report_date` column was an object instead of a datetime.

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [x] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [x] Update relevant table or source description metadata (see `src/metadata`).
- [x] Review and update any other aspects of the documentation that might be affected by this PR.
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

Run the FERC to EIA match notebook from top to bottom.

```[tasklist]
# To-do list
- [x] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).
- [x] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [x] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
```
