### PR TITLE
Add parquet download link to data dictionary

### DIFF
--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -9,7 +9,8 @@ PUDL data, so if you have a suggestion, please `open a GitHub issue
 can `create a GitHub discussion <https://github.com/orgs/catalyst-cooperative/discussions/new?category=help-me>`__.
 
 PUDL's primary data output is the ``pudl.sqlite`` database. All the tables are also
-distributed as individual Parquet files which are more space efficient, have richer
+distributed as individual `Apache Parquet <https://parquet.apache.org/docs/>`__ files
+which are more space efficient, have richer
 data types and are better suited for distributed and large-scale data analysis.
 We recommend working with tables with the ``out_`` prefix, as these tables contain
 the most complete and easiest to work with data. For more information about the
@@ -108,7 +109,9 @@ resulting outputs pass all of the data validation tests we've defined, the outpu
 automatically uploaded to the `AWS Open Data Registry
 <https://registry.opendata.aws/catalyst-cooperative-pudl/>`__, and used to deploy a new
 version of Datasette (see above). These nightly build outputs can be accessed using the
-AWS CLI, or programmatically via the S3 API. If you don't want to mess with the API
+AWS CLI, or programmatically via the S3 API.
+
+If you don't want to mess with the API
 or CLI, you can also download the data directly over HTTPS. The download links for
 each table's Parquet file can be found in
 the :doc:`PUDL data dictionary page </data_dictionaries/pudl_db>`.
@@ -120,6 +123,22 @@ Fully Processed SQLite Databases
 
 * `Main PUDL Database <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/pudl.sqlite.zip>`__
 * `US Census DP1 Database (2010) <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/censusdp1tract.sqlite.zip>`__
+
+Hourly Tables as Parquet
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Hourly time series take up a lot of space in SQLite and can be slow to query in bulk,
+so all our hourly tables are only distributed as Parquet files:
+
+* `EIA-930 BA Hourly Interchange <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia930__hourly_interchange.parquet>`__
+* `EIA-930 BA Hourly Net Generation by Energy Source <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia930__hourly_net_generation_by_energy_source.parquet>`__
+* `EIA-930 BA Hourly Operations <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia930__hourly_operations.parquet>`__
+* `EIA-930 BA Hourly Subregion Demand <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia930__hourly_subregion_demand.parquet>`__
+* `EPA CEMS Hourly Emissions <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_epacems__hourly_emissions.parquet>`__
+* `FERC-714 Hourly Estimated State Demand <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/out_ferc714__hourly_estimated_state_demand.parquet>`__
+* `FERC-714 Hourly Planning Area Demand <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/out_ferc714__hourly_planning_area_demand.parquet>`__
+* `GridPath RA Toolkit Hourly Available Capacity Factors <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/out_gridpathratoolkit__hourly_available_capacity_factor.parquet>`__
+* `VCE Resource Adequacy Renewable Energy (RARE) Dataset <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/out_vcerare__hourly_available_capacity_factor.parquet>`__
 
 Raw FERC DBF & XBRL data converted to SQLite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -8,10 +8,12 @@ PUDL data, so if you have a suggestion, please `open a GitHub issue
 <https://github.com/catalyst-cooperative/pudl/issues>`__. If you have a question, you
 can `create a GitHub discussion <https://github.com/orgs/catalyst-cooperative/discussions/new?category=help-me>`__.
 
-PUDL's primary data output is the ``pudl.sqlite`` database. We recommend working with
-tables with the ``out_`` prefix, as these tables contain the most complete and easiest
-to work with data. For more information about the different types
-of tables, read through :ref:`PUDL's naming conventions <asset-naming>`.
+PUDL's primary data output is the ``pudl.sqlite`` database. All the tables are also
+distributed as individual Parquet files which are more space efficient, have richer
+data types and are better suited for distributed and large-scale data analysis.
+We recommend working with tables with the ``out_`` prefix, as these tables contain
+the most complete and easiest to work with data. For more information about the
+different types of tables, read through :ref:`PUDL's naming conventions <asset-naming>`.
 
 .. _access-modes:
 
@@ -106,31 +108,18 @@ resulting outputs pass all of the data validation tests we've defined, the outpu
 automatically uploaded to the `AWS Open Data Registry
 <https://registry.opendata.aws/catalyst-cooperative-pudl/>`__, and used to deploy a new
 version of Datasette (see above). These nightly build outputs can be accessed using the
-AWS CLI, or programmatically via the S3 API. They can also be downloaded directly over
-HTTPS using the following links:
+AWS CLI, or programmatically via the S3 API. If you don't want to mess with the API
+or CLI, you can also download the data directly over HTTPS. The download links for
+each table's Parquet file can be found in
+the :doc:`PUDL data dictionary page </data_dictionaries/pudl_db>`.
+
+These are the download links for the PUDL and raw FERC SQLite databases:
 
 Fully Processed SQLite Databases
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * `Main PUDL Database <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/pudl.sqlite.zip>`__
 * `US Census DP1 Database (2010) <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/censusdp1tract.sqlite.zip>`__
-
-Hourly Tables as Parquet
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-Hourly time series take up a lot of space in SQLite and can be slow to query in bulk,
-so we have moved to publishing all our hourly tables using the compressed, columnar
-`Apache Parquet <https://parquet.apache.org/docs/>`__ file format.
-
-* `EIA-930 BA Hourly Interchange <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia930__hourly_interchange.parquet>`__
-* `EIA-930 BA Hourly Net Generation by Energy Source <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia930__hourly_net_generation_by_energy_source.parquet>`__
-* `EIA-930 BA Hourly Operations <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia930__hourly_operations.parquet>`__
-* `EIA-930 BA Hourly Subregion Demand <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_eia930__hourly_subregion_demand.parquet>`__
-* `EPA CEMS Hourly Emissions <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/core_epacems__hourly_emissions.parquet>`__
-* `FERC-714 Hourly Estimated State Demand <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/out_ferc714__hourly_estimated_state_demand.parquet>`__
-* `FERC-714 Hourly Planning Area Demand <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/out_ferc714__hourly_planning_area_demand.parquet>`__
-* `GridPath RA Toolkit Hourly Available Capacity Factors <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/out_gridpathratoolkit__hourly_available_capacity_factor.parquet>`__
-* `VCE Resource Adequacy Renewable Energy (RARE) Dataset <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/out_vcerare__hourly_available_capacity_factor.parquet>`__
 
 Raw FERC DBF & XBRL data converted to SQLite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/templates/resource.rst.jinja
+++ b/docs/templates/resource.rst.jinja
@@ -20,7 +20,7 @@
 {% else -%}
 * This table is not published to Datasette.
 {%- endif %}
-* `Download this table as a Parquet file. <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/stable/{{ resource.name }}.parquet>`__
+* `Download this table as a Parquet file. <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/{{ resource.name }}.parquet>`__
 
 .. list-table::
   :widths: auto

--- a/docs/templates/resource.rst.jinja
+++ b/docs/templates/resource.rst.jinja
@@ -13,11 +13,14 @@
 **This table has no primary key.**
 {%- endif %}
 
+**Access methods:**
+
 {% if resource.create_database_schema -%}
-`Browse or query this table in Datasette. <https://data.catalyst.coop/pudl/{{ resource.name }}>`__
+* `Browse or query this table in Datasette. <https://data.catalyst.coop/pudl/{{ resource.name }}>`__
 {% else -%}
-This table is not published to Datasette.
+* This table is not published to Datasette.
 {%- endif %}
+* `Download this table as a Parquet file. <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/stable/{{ resource.name }}.parquet>`__
 
 .. list-table::
   :widths: auto


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

I added a parquet file download link to the data dictionary so it's easier for people to access the s3 files.

```[tasklist]
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Add brief description of the different data access methods on data dictionary
- [ ] Add parquet description to data access page somewhere
```

# Testing

I built the docs locally and was able to download a parquet file.

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
```
