### PR TITLE
Make asset checks run in integration test

### DIFF
--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -34,8 +34,6 @@ from pudl.resources import dataset_settings, datastore, ferc_to_sqlite_settings
 from pudl.settings import EtlSettings
 
 from . import (
-    check_foreign_keys,
-    cli,
     eia_bulk_elec_assets,
     epacems_assets,
     glue_assets,

--- a/src/pudl/etl/cli.py
+++ b/src/pudl/etl/cli.py
@@ -36,10 +36,11 @@ def pudl_etl_job_factory(
         The job definition to be executed.
     """
 
-    def get_pudl_etl_job():
+    def get_pudl_etl_job(job_name: str | None = None):
         """Create an pudl_etl_job wrapped by to be wrapped by reconstructable."""
         pudl.logging_helpers.configure_root_logger(logfile=logfile, loglevel=loglevel)
-        job_name = "etl_full_no_cems" if not process_epacems else "etl_full"
+        if job_name is None:
+            job_name = "etl_full_no_cems" if not process_epacems else "etl_full"
         return defs.get_job_def(job_name)
 
     return get_pudl_etl_job

--- a/src/pudl/etl/cli.py
+++ b/src/pudl/etl/cli.py
@@ -8,14 +8,13 @@ import click
 import fsspec
 from dagster import (
     DagsterInstance,
-    Definitions,
     JobDefinition,
     build_reconstructable_job,
-    define_asset_job,
     execute_job,
 )
 
 import pudl
+from pudl.etl import defs
 from pudl.helpers import get_dagster_execution_config
 from pudl.settings import EpaCemsSettings, EtlSettings
 from pudl.workspace.setup import PudlPaths
@@ -40,21 +39,8 @@ def pudl_etl_job_factory(
     def get_pudl_etl_job():
         """Create an pudl_etl_job wrapped by to be wrapped by reconstructable."""
         pudl.logging_helpers.configure_root_logger(logfile=logfile, loglevel=loglevel)
-        jobs = [define_asset_job("etl_job")]
-        if not process_epacems:
-            jobs = [
-                define_asset_job(
-                    "etl_job",
-                    selection=pudl.etl.create_non_cems_selection(
-                        pudl.etl.default_assets
-                    ),
-                )
-            ]
-        return Definitions(
-            assets=pudl.etl.default_assets,
-            resources=pudl.etl.default_resources,
-            jobs=jobs,
-        ).get_job_def("etl_job")
+        job_name = "etl_full_no_cems" if not process_epacems else "etl_full"
+        return defs.get_job_def(job_name)
 
     return get_pudl_etl_job
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -363,7 +363,7 @@ def pudl_io_manager(
         md = PUDL_PACKAGE.to_sql()
         md.create_all(engine)
         # Run the ETL and generate a new PUDL SQLite DB for testing:
-        execute_result = pudl_etl_job_factory()().execute_in_process(
+        execute_result = pudl_etl_job_factory()("etl_fast").execute_in_process(
             run_config={
                 "resources": {
                     "dataset_settings": {


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #3928 .

## What problem does this address?

#3711 inadvertently disabled the asset checks again, in service of fixing `pudl_etl` 😞 

Getting rid of `pudl_etl` (#3161) seemed out of scope here, but I made the tests use the same `Definitions` as the nightly builds again.

# Testing

## How did you make sure this worked? How can a reviewer verify this?

Made the pandera checks all fail, ran `make integration-test`, and checked to make sure that the integration tests bailed out once we ran into a failure.

Then got other people to fix the failing asset checks and re-ran integration tests. They passed.


```[tasklist]
# To-do list
- [x] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [x] Un-break the pandera checks
- [x] Fix the various asset checks that have failed over time through the CI not running them
```
