### PR TITLE
Fix row count asset check for vcerare

### DIFF
--- a/src/pudl/transform/vcerare.py
+++ b/src/pudl/transform/vcerare.py
@@ -373,7 +373,7 @@ def check_rows(context: AssetCheckExecutionContext) -> AssetCheckResult:
     vce = _load_duckdb_table()  # noqa: F841
     (length,) = duckdb.query("SELECT COUNT(*) FROM vce").fetchone()
     if (
-        expecteded_length := row_counts[context.op_execution_context.job_name]
+        expected_length := row_counts[context.op_execution_context.job_name]
     ) != length:
         return AssetCheckResult(
             passed=False,

--- a/src/pudl/transform/vcerare.py
+++ b/src/pudl/transform/vcerare.py
@@ -378,7 +378,7 @@ def check_rows(context: AssetCheckExecutionContext) -> AssetCheckResult:
         return AssetCheckResult(
             passed=False,
             description="Table unexpected length",
-            metadata={"table_length": length, "expected_length": expecteded_length},
+            metadata={"table_length": length, "expected_length": expected_length},
         )
     return AssetCheckResult(passed=True)
 

--- a/src/pudl/transform/vcerare.py
+++ b/src/pudl/transform/vcerare.py
@@ -372,9 +372,7 @@ def check_rows(context: AssetCheckExecutionContext) -> AssetCheckResult:
 
     vce = _load_duckdb_table()  # noqa: F841
     (length,) = duckdb.query("SELECT COUNT(*) FROM vce").fetchone()
-    if (
-        expected_length := row_counts[context.op_execution_context.job_name]
-    ) != length:
+    if (expected_length := row_counts[context.op_execution_context.job_name]) != length:
         return AssetCheckResult(
             passed=False,
             description="Table unexpected length",


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

This PR fixes the VCERARE row count `asset_check`. This check was using the expected row count for the full ETL, and would fail for the fast ETL. Now it handles both correctly. 