### PR TITLE
Fix FERC714 fast CI asset check

### DIFF
--- a/src/pudl/transform/ferc714.py
+++ b/src/pudl/transform/ferc714.py
@@ -1279,22 +1279,25 @@ check_specs = [
 def make_check(spec: Ferc714CheckSpec) -> AssetChecksDefinition:
     """Turn the Ferc714CheckSpec into an actual Dagster asset check."""
 
-    @asset_check(asset=spec.asset, blocking=True)
-    def _check(df):
+    @asset_check(
+        asset=spec.asset, required_resource_keys={"dataset_settings"}, blocking=True
+    )
+    def _row_num_check(context, df):
         errors = []
-        for year, expected_rows in spec.num_rows_by_report_year.items():
+        for year in context.resources.dataset_settings.ferc714.years:
+            expected_rows = spec.num_rows_by_report_year[year]
             if (num_rows := len(df.loc[df.report_year == year])) != expected_rows:
                 errors.append(
                     f"Expected {expected_rows} for report year {year}, found {num_rows}"
                 )
-                logger.info(errors)
+                logger.warning(errors)
 
         if errors:
             return AssetCheckResult(passed=False, metadata={"errors": errors})
 
         return AssetCheckResult(passed=True)
 
-    return _check
+    return _row_num_check
 
 
 _checks = [make_check(spec) for spec in check_specs]

--- a/src/pudl/transform/ferc714.py
+++ b/src/pudl/transform/ferc714.py
@@ -1276,7 +1276,7 @@ check_specs = [
 ]
 
 
-def make_check(spec: Ferc714CheckSpec) -> AssetChecksDefinition:
+def make_row_num_check(spec: Ferc714CheckSpec) -> AssetChecksDefinition:
     """Turn the Ferc714CheckSpec into an actual Dagster asset check."""
 
     @asset_check(
@@ -1290,7 +1290,7 @@ def make_check(spec: Ferc714CheckSpec) -> AssetChecksDefinition:
                 errors.append(
                     f"Expected {expected_rows} for report year {year}, found {num_rows}"
                 )
-                logger.warning(errors)
+        logger.warning(errors)
 
         if errors:
             return AssetCheckResult(passed=False, metadata={"errors": errors})
@@ -1300,4 +1300,4 @@ def make_check(spec: Ferc714CheckSpec) -> AssetChecksDefinition:
     return _row_num_check
 
 
-_checks = [make_check(spec) for spec in check_specs]
+_checks = [make_row_num_check(spec) for spec in check_specs]


### PR DESCRIPTION
# Overview

Working on #3928

## What problem does this address?
fixing asset check found in #3990

## What did you change?
only check row nums for years that are in the dataset_settings

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [x] Review the PR yourself and call out any questions or issues you have.
- [x] run the 714 assets w checks in fast and full mode
```
