### PR TITLE
Add boolean column naming standard to naming_conventions doc

### DIFF
--- a/docs/dev/naming_conventions.rst
+++ b/docs/dev/naming_conventions.rst
@@ -186,6 +186,10 @@ quantities are actually different.
 * Regardless of what label utilities are given in the original data source
   (e.g. ``operator`` in EIA or ``respondent`` in FERC) we refer to them as
   ``utilities`` in PUDL.
+* Include verb prefixes (e.g.: ``is_{x}``, ``has_{x}``, or ``served_{x}``)
+  to boolean columns to highlight their binary nature. (Not all columns in
+  the PUDL database follow this standard, but we'd like them to moving
+  forward).
 
 Naming Conventions in Code
 --------------------------


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Just a bb PR to add specifications for boolean column naming conventions to the naming conventions docs page. Now contributors will know to add a verb prefix.

Ran the docs build to make sure it worked.
