### PR TITLE
Make it possible to pass another `sources` dict to DataSource

### DIFF
--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1035,20 +1035,22 @@ class DataSource(PudlMeta):
             sys.stdout.write(rendered)
 
     @classmethod
-    def from_field_namespace(cls, x: str) -> list["DataSource"]:
+    def from_field_namespace(
+        cls, x: str, sources: dict[str, Any] = SOURCES
+    ) -> list["DataSource"]:
         """Return list of DataSource objects by field namespace."""
         return [
             cls(**cls.dict_from_id(name))
-            for name, val in SOURCES.items()
+            for name, val in sources.items()
             if val.get("field_namespace") == x
         ]
 
     @staticmethod
-    def dict_from_id(x: str) -> dict:
+    def dict_from_id(x: str, sources: dict[str, Any] = SOURCES) -> dict:
         """Look up the source by source name in the metadata."""
         # If ID ends with _xbrl strip end to find data source
         lookup_id = x.replace("_xbrl", "")
-        return {"name": x, **copy.deepcopy(SOURCES[lookup_id])}
+        return {"name": x, **copy.deepcopy(sources[lookup_id])}
 
     @classmethod
     def from_id(cls, x: str) -> "DataSource":
@@ -1285,6 +1287,7 @@ class Resource(PudlMeta):
             "pudl",
             "nrelatb",
             "vcerare",
+            "phmsagas",
         ]
         | None
     ) = None
@@ -1313,6 +1316,7 @@ class Resource(PudlMeta):
             "service_territories",
             "nrelatb",
             "vcerare",
+            "phmsagas",
         ]
         | None
     ) = None

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1287,7 +1287,6 @@ class Resource(PudlMeta):
             "pudl",
             "nrelatb",
             "vcerare",
-            "phmsagas",
         ]
         | None
     ) = None
@@ -1316,7 +1315,6 @@ class Resource(PudlMeta):
             "service_territories",
             "nrelatb",
             "vcerare",
-            "phmsagas",
         ]
         | None
     ) = None


### PR DESCRIPTION
# Overview

Addresses a lightweight version of https://github.com/catalyst-cooperative/pudl-archiver/issues/499 in concert with https://github.com/catalyst-cooperative/pudl-archiver/pull/506.

## What problem does this address?
In the `pudl-archiver` repository, we want to make it possible to archive datasets that will never end up in the PUDL repository. Eventually, we'll want to fully separate these two repositories, which raises bigger questions about where the metadata should be defined, etc. But for now, we want to make it possible to add a dictionary of `NON_PUDL_SOURCES` to the `pudl-archiver` repository, to be called in a method similar to `from_pudl_metadata` in `frictionless.py`.

## What did you change?
This method imports the `DataSource.from_id()` method from PUDL, which currently hardcodes `SOURCES` into the method. In order to make it possible to provide an alternative dictionary of source metadata into this method, I have added a `sources` parameter to this method which defaults to `SOURCES`, but can take a different SOURCE dictionary.

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
```
