### PR TITLE
Pass `sources` to `DataSource.from_id()`

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -32,6 +32,15 @@ Bug Fixes
 Major Dependency Updates
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+Quality of Life Improvements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* We added a ``sources`` parameter to ``pudl.metadata.classes.DataSource.from_id()``
+  in order to make it possible to use the `pudl-archiver
+  <https://www.github.com/catalyst-cooperative/pudl-archiver>`__ repository to
+  archive datasets that won't necessarily be ingested into PUDL. See `this PUDL archiver
+  issue <https://github.com/catalyst-cooperative/pudl-archiver/pull/506>`__ and PRs
+  :pr:`4003` and :pr:`4013`.
+
 .. _release-v2024.11.0:
 
 ---------------------------------------------------------------------------------------

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1039,7 +1039,7 @@ class DataSource(PudlMeta):
     ) -> list["DataSource"]:
         """Return list of DataSource objects by field namespace."""
         return [
-            cls(**cls.dict_from_id(name))
+            cls(**cls.dict_from_id(name, sources))
             for name, val in sources.items()
             if val.get("field_namespace") == x
         ]

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1045,16 +1045,16 @@ class DataSource(PudlMeta):
         ]
 
     @staticmethod
-    def dict_from_id(x: str, sources: dict[str, Any] = SOURCES) -> dict:
+    def dict_from_id(x: str, sources: dict[str, Any]) -> dict:
         """Look up the source by source name in the metadata."""
         # If ID ends with _xbrl strip end to find data source
         lookup_id = x.replace("_xbrl", "")
         return {"name": x, **copy.deepcopy(sources[lookup_id])}
 
     @classmethod
-    def from_id(cls, x: str) -> "DataSource":
+    def from_id(cls, x: str, sources: dict[str, Any] = SOURCES) -> "DataSource":
         """Construct Source by source name in the metadata."""
-        return cls(**cls.dict_from_id(x))
+        return cls(**cls.dict_from_id(x, sources=sources))
 
 
 class ResourceHarvest(PudlMeta):


### PR DESCRIPTION
# Overview

Relevant to https://github.com/catalyst-cooperative/pudl-archiver/pull/506.

## What problem does this address?
In #4003 I updated `DataSource.dict_from_id()` to take `sources`. However, `from_id()` is an upstream method called in the `pudl-archiver` repository, and I neglected to add `sources` as a parameter here. This PR fixes this problem.

## What did you change?
* Added `sources` as a parameter to `DataSource.from_id()`
* Made `SOURCES` the default in `from_id()` and not `dict_from_id()`. `from_id()` is more widely called both in PUDL and the `pudl-archiver` repo, and this removes duplicate defaults in the class.

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [x] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
```
