### PR TITLE
Sec distribution fix

### DIFF
--- a/src/pudl/analysis/pudl_models.py
+++ b/src/pudl/analysis/pudl_models.py
@@ -31,7 +31,8 @@ def pudl_models_asset_factory(table_name: str) -> AssetsDefinition:
 
     @asset(
         name=table_name,
-        io_manager_key="pudl_io_manager",
+        io_manager_key="parquet_io_manager",
+        group_name="pudl_models",
     )
     def _asset() -> pd.DataFrame:
         return DeltaTable(_get_table_uri(table_name)).to_pandas()

--- a/src/pudl/analysis/pudl_models.py
+++ b/src/pudl/analysis/pudl_models.py
@@ -16,7 +16,7 @@ def get_model_tables() -> list[str]:
             "core_sec10k__company_information",
             "core_sec10k__exhibit_21_company_ownership",
             "core_sec10k__filings",
-            "out_sec_10k__parents_and_subsidiaries",
+            "out_sec10k__parents_and_subsidiaries",
         ]
 
     return pudl_models_tables

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -1486,6 +1486,7 @@ class Resource(PudlMeta):
             name=name,
             description=description,
             schema=Schema.from_pyarrow_schema(schema),
+            create_database_schema=False,
         )
 
     def get_field(self, name: str) -> Field:


### PR DESCRIPTION
# Overview

This PR fixes the nightly build failure caused by adding `sec10k` tables. This error occurred because I forgot to commit the database migrations with the new tables. However, after further consideration, I realized that including these `sec10k` tables in the SQLITE db there will be schema inconsistencies for outside contributors who can't pull the metadata from GCS. Because of this, this PR also updates the PUDL models assets to use only the parquet IO-manager.