### PR TITLE
Close out release notes for PUDL v2025.2.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,6 +21,6 @@ authors:
     given-names: Dazhong
 
 title: "The Public Utility Data Liberation (PUDL) Project"
-version: 2024.11.0
+version: 2025.2.0
 doi: 10.5281/zenodo.3404014
-date-released: 2024-11-14
+date-released: 2025-02-13

--- a/docs/data_sources/other_data.rst
+++ b/docs/data_sources/other_data.rst
@@ -27,15 +27,28 @@ converted directly from the original geodatabase distributed by the US Census Bu
 EPA CAMD to EIA Power Sector Data Crosswalk
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This crosswalk is periodically updated through a collaboration between the US EPA and
-the EIA, and connects EPA CAMD emissions units (smokestacks) which appear in
-:doc:`epacems` with corresponding EIA plant components reported in EIA Forms 860
-and 923 (``plant_id_eia``, ``boiler_id``, ``generator_id``).  This one-to-many
-connection is necessary because pollutants from various plant parts are collecitvely
-emitted and measured from one point-source. We augment the crosswalk that they publish
-on GitHub.
+The `original EPA CAMD to EIA crosswalk <https://github.com/USEPA/camd-eia-crosswalk>`__
+was published by the US Environmental Protection Agency on GitHub and connects EPA CAMD
+emissions units (smokestacks) which appear in :doc:`epacems` with corresponding EIA
+plant components reported in EIA Forms 860 and 923 (``plant_id_eia``, ``boiler_id``,
+``generator_id``). This one-to-many connection is necessary because pollutants from
+various plant parts are collecitvely emitted and measured from one point-source.
 
-The crosswalk is distributed by EPA `via GitHub <https://github.com/USEPA/camd-eia-crosswalk>`__.
+The original crosswalk was generated using only 2018 data. However, there is useful
+information in all years of data, and we augment the crosswalk that they publish on
+GitHub by running their code against 2018 and all later years of data.
+
+Re-running the crosswalk pulls the latest data from the
+`CAMD FACT API <https://www.epa.gov/power-sector/field-audit-checklist-tool-fact-api>`__
+which results in some changes to the generator and unit IDs reported on the EPA side of
+the crosswalk.  The changes only result in the addition of new units and generators in
+the EPA data, with no changes to matches at the plant level (other than identification
+of new plant-plant matches). However, the updates to generator and unit IDs have
+resulted in changes to the subplant IDs - some EIA boilers and generators which
+previously had no matches to EPA data have now been matched to EPA unit data, resulting
+in an overall reduction in the number of rows in the
+:ref:`core_epa__assn_eia_epacamd_subplant_ids` table. See :issue:`4039` and :pr:`4056`
+for a discussion of the changes observed when we made these changes.
 
 .. _data-eiaaeo:
 

--- a/docs/data_sources/other_data.rst
+++ b/docs/data_sources/other_data.rst
@@ -31,24 +31,20 @@ The `original EPA CAMD to EIA crosswalk <https://github.com/USEPA/camd-eia-cross
 was published by the US Environmental Protection Agency on GitHub and connects EPA CAMD
 emissions units (smokestacks) which appear in :doc:`epacems` with corresponding EIA
 plant components reported in EIA Forms 860 and 923 (``plant_id_eia``, ``boiler_id``,
-``generator_id``). This one-to-many connection is necessary because pollutants from
+``generator_id``). This many-to-many connection is necessary because pollutants from
 various plant parts are collecitvely emitted and measured from one point-source.
 
 The original crosswalk was generated using only 2018 data. However, there is useful
 information in all years of data, and we augment the crosswalk that they publish on
-GitHub by running their code against 2018 and all later years of data.
+GitHub by running their code against all available later years of data.
 
 Re-running the crosswalk pulls the latest data from the
 `CAMD FACT API <https://www.epa.gov/power-sector/field-audit-checklist-tool-fact-api>`__
 which results in some changes to the generator and unit IDs reported on the EPA side of
-the crosswalk.  The changes only result in the addition of new units and generators in
+the crosswalk. The changes only result in the addition of new units and generators in
 the EPA data, with no changes to matches at the plant level (other than identification
-of new plant-plant matches). However, the updates to generator and unit IDs have
-resulted in changes to the subplant IDs - some EIA boilers and generators which
-previously had no matches to EPA data have now been matched to EPA unit data, resulting
-in an overall reduction in the number of rows in the
-:ref:`core_epa__assn_eia_epacamd_subplant_ids` table. See :issue:`4039` and :pr:`4056`
-for a discussion of the changes observed when we made these changes.
+of new plant-plant matches). Note that the sub-plant IDs are not necessarily stable
+across multiple releases of this data, and should not be hard-coded into analyses.
 
 .. _data-eiaaeo:
 

--- a/docs/data_sources/other_data.rst
+++ b/docs/data_sources/other_data.rst
@@ -43,8 +43,10 @@ Re-running the crosswalk pulls the latest data from the
 which results in some changes to the generator and unit IDs reported on the EPA side of
 the crosswalk. The changes only result in the addition of new units and generators in
 the EPA data, with no changes to matches at the plant level (other than identification
-of new plant-plant matches). Note that the sub-plant IDs are not necessarily stable
-across multiple releases of this data, and should not be hard-coded into analyses.
+of new plant-plant matches). We derive sub-plant IDs (``subplant_id``) from the
+crosswalk in the table :ref:`core_epa__assn_eia_epacamd_subplant_ids`. Note that these
+IDs are not necessarily stable across multiple releases of this data, and should not be
+hard-coded into analyses.
 
 .. _data-eiaaeo:
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -42,8 +42,8 @@ Some potentially breaking changes to be aware of:
   :ref:`data-sources-eia930-changes-in-energy-source-granularity-over-time`.
 * We are now running the EPA's CAMD to EIA unit crosswalk code for each individual year
   starting from 2018, rather than just 2018 and 2021, resulting in more connections
-  between these two datasets, and different sub-plant IDs. See :ref:`data-epacamd_eia`
-  for more details.
+  between these two datasets and changes to some sub-plant IDs. See the note below for
+  more details.
 
 Many thanks to the organizations who make these regular updates possible! Especially
 `GridLab <https://gridlab.org>`__, `RMI <https://rmi.org>`__, and the `ZERO Lab at
@@ -111,9 +111,21 @@ EPA CEMS
 
 EPA CAMD EIA Crosswalk
 ~~~~~~~~~~~~~~~~~~~~~~
-* Updated the crosswalk using 2019, 2020, 2022 and 2023 EIA data, and incorporated the
-  new crosswalk data into the generation of :ref:`core_epa__assn_eia_epacamd` and
-  :ref:`core_epa__assn_eia_epacamd_subplant_ids`. See :issue:`4039` and :pr:`4056`.
+* In the past, the crosswalk in PUDL has used the EPA's published crosswalk (run with
+  2018 data), and an additional crosswalk we ran with 2021 EIA 860 data. To ensure that
+  the crosswalk reflects updates in both EIA and EPA data, we re-ran the EPA R code
+  which generates the EPA CAMD EIA crosswalk with 4 new years of data: 2019, 2020, 2022
+  and 2023. Re-running the crosswalk pulls the latest data from the CAMD FACT API, which
+  results in some changes to the generator and unit IDs reported on the EPA side of the
+  crosswalk, which feeds into the creation of :ref:`core_epa__assn_eia_epacamd`.
+* The changes only result in the addition of new units and generators in the EPA data,
+  with no changes to matches at the plant level. However, the updates to generator and
+  unit IDs have resulted in changes to the subplant IDs - some EIA boilers and
+  generators which previously had no matches to EPA data have now been matched to EPA
+  unit data, resulting in an overall **reduction** in the number of rows in the
+  :ref:`core_epa__assn_eia_epacamd_subplant_ids` table. See issues :issue:`4039`
+  and PR :pr:`4056` for a discussion of the changes observed in the course of this
+  update.
 
 EIA 860M
 ~~~~~~~~

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,27 @@ v2025.XX.x (2025-MM-DD)
 New Data
 ^^^^^^^^
 
+Expanded Data Coverage
+^^^^^^^^^^^^^^^^^^^^^^
+
+Bug Fixes
+^^^^^^^^^
+
+Major Dependency Updates
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Quality of Life Improvements
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. _release-v2025.2.0:
+
+---------------------------------------------------------------------------------------
+v2025.2.0 (2025-02-13)
+---------------------------------------------------------------------------------------
+
+New Data
+^^^^^^^^
+
 SEC Form 10-K Parent-Subsidiary Ownership
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -35,6 +56,19 @@ SEC Form 10-K Parent-Subsidiary Ownership
   * :ref:`core_sec10k__quarterly_exhibit_21_company_ownership`
   * :ref:`core_sec10k__quarterly_company_information`
 
+EIA 176
+~~~~~~~
+* Add a couple of semi-transformed interim EIA-176 (natural gas sources and
+  dispositions) tables. They aren't yet being written to the database, but are one step
+  closer. See :issue:`3555` and PRs :pr:`3590,3978`. Thanks to :user:`davidmudrauskas`
+  for moving this dataset forward.
+* Extracted these interim tables up through the latest 2023 data release. See
+  :issue:`4002` and :pr:`4004`.
+
+EIA 860
+~~~~~~~
+* Added EIA 860 Multifuel table. See :issue:`3438` and :pr:`3946`.
+
 FERC 1
 ~~~~~~
 * Added three new output tables containing granular utility accounting data.
@@ -44,8 +78,8 @@ FERC 1
   * :ref:`out_ferc1__yearly_detailed_balance_sheet_assets`
   * :ref:`out_ferc1__yearly_detailed_balance_sheet_liabilities`
 
-New Data Coverage
-^^^^^^^^^^^^^^^^^
+Expanded Data Coverage
+^^^^^^^^^^^^^^^^^^^^^^
 
 EPA CEMS
 ~~~~~~~~
@@ -56,10 +90,6 @@ EPA CAMD EIA Crosswalk
 * Updated the crosswalk using 2019, 2020, 2022 and 2023 EIA data, and incorporated the
   new crosswalk data into the generation of :ref:`core_epa__assn_eia_epacamd` and
   :ref:`core_epa__assn_eia_epacamd_subplant_ids`. See :issue:`4039` and :pr:`4056`.
-
-EIA 860
-~~~~~~~
-* Added EIA 860 Multifuel data. See :issue:`3438` and :pr:`3946`.
 
 EIA 860M
 ~~~~~~~~
@@ -73,15 +103,6 @@ EIA Bulk Electricity Data
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 * Updated the EIA Bulk Electricity data to include data published up through
   2024-11-01. See :issue:`4042` and PR :pr:`4051`.
-
-EIA 176
-~~~~~~~
-* Add a couple of semi-transformed interim EIA-176 (natural gas sources and
-  dispositions) tables. They aren't yet being written to the database, but are one step
-  closer. See :issue:`3555` and PRs :pr:`3590,3978`. Thanks to :user:`davidmudrauskas`
-  for moving this dataset forward.
-* Extracted these interim tables up through the latest 2023 data release. See
-  :issue:`4002` and :pr:`4004`.
 
 EIA 930
 ~~~~~~~
@@ -104,9 +125,6 @@ Bug Fixes
 * Fix spelling of Lake Huron and Lake Saint Clair in
   :ref:`out_vcerare__hourly_available_capacity_factor` and related tables. See issue
   :issue:`4007` and PR :pr:`4029`.
-
-Major Dependency Updates
-^^^^^^^^^^^^^^^^^^^^^^^^
 
 Quality of Life Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -27,8 +27,54 @@ Quality of Life Improvements
 v2025.2.0 (2025-02-13)
 ---------------------------------------------------------------------------------------
 
+This is our regular quarterly release for 2025Q1. It includes updates to all the
+datasets that are published with quarterly or higher frequency, plus initial verisons
+of a few new data sources that have been in the works for a while.
+
+One major change this quarter is that we are now publishing all processed PUDL data as
+Apache Parquet files, alongside our existing SQLite databases. See :doc:`data_access`
+for more on how to access these outputs.
+
+Some potentially breaking changes to be aware of:
+
+* In the :doc:`data_sources/eia930` a number of new energy sources have been added, and
+  some old energy sources have been split into more granular categories. See
+  :ref:`data-sources-eia930-changes-in-energy-source-granularity-over-time`.
+* We are now running the EPA's CAMD to EIA unit crosswalk code for each individual year
+  starting from 2018, rather than just 2018 and 2021, resulting in more connections
+  between these two datasets, and different sub-plant IDs. See :ref:`data-epacamd_eia`
+  for more details.
+
+Many thanks to the organizations who make these regular updates possible! Especially
+`GridLab <https://gridlab.org>`__, `RMI <https://rmi.org>`__, and the `ZERO Lab at
+Princeton University <https://zero.lab.princeton.edu/>`__. If you rely on PUDL and would
+like to help ensure that the data keeps flowing, please consider joining them as a `PUDL
+Sustainer <https://opencollective.com/pudl>`__, as we are still fundraising for 2025.
+
 New Data
 ^^^^^^^^
+
+EIA 176
+~~~~~~~
+* Add a couple of semi-transformed interim EIA-176 (natural gas sources and
+  dispositions) tables. They aren't yet being written to the database, but are one step
+  closer. See :issue:`3555` and PRs :pr:`3590,3978`. Thanks to :user:`davidmudrauskas`
+  for moving this dataset forward.
+* Extracted these interim tables up through the latest 2023 data release. See
+  :issue:`4002` and :pr:`4004`.
+
+EIA 860
+~~~~~~~
+* Added EIA 860 Multifuel table. See :issue:`3438` and :pr:`3946`.
+
+FERC 1
+~~~~~~
+* Added three new output tables containing granular utility accounting data.
+  See :pr:`4057`, :issue:`3642` and the table descriptions in the data dictionary:
+
+  * :ref:`out_ferc1__yearly_detailed_income_statements`
+  * :ref:`out_ferc1__yearly_detailed_balance_sheet_assets`
+  * :ref:`out_ferc1__yearly_detailed_balance_sheet_liabilities`
 
 SEC Form 10-K Parent-Subsidiary Ownership
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -55,28 +101,6 @@ SEC Form 10-K Parent-Subsidiary Ownership
   * :ref:`core_sec10k__quarterly_filings`
   * :ref:`core_sec10k__quarterly_exhibit_21_company_ownership`
   * :ref:`core_sec10k__quarterly_company_information`
-
-EIA 176
-~~~~~~~
-* Add a couple of semi-transformed interim EIA-176 (natural gas sources and
-  dispositions) tables. They aren't yet being written to the database, but are one step
-  closer. See :issue:`3555` and PRs :pr:`3590,3978`. Thanks to :user:`davidmudrauskas`
-  for moving this dataset forward.
-* Extracted these interim tables up through the latest 2023 data release. See
-  :issue:`4002` and :pr:`4004`.
-
-EIA 860
-~~~~~~~
-* Added EIA 860 Multifuel table. See :issue:`3438` and :pr:`3946`.
-
-FERC 1
-~~~~~~
-* Added three new output tables containing granular utility accounting data.
-  See :pr:`4057`, :issue:`3642` and the table descriptions in the data dictionary:
-
-  * :ref:`out_ferc1__yearly_detailed_income_statements`
-  * :ref:`out_ferc1__yearly_detailed_balance_sheet_assets`
-  * :ref:`out_ferc1__yearly_detailed_balance_sheet_liabilities`
 
 Expanded Data Coverage
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Overview

Close out the release notes for the v2025.2.0 release of PUDL.

- I moved a couple of the the "new data coverage" items up into "new data" because they were entirely new tables or datasets, rather than just extensions in time of existing datasets.
- Added some color to the EPA CAMD -- EIA crosswalk docs since we're doing more work there now.

Part of #4061 

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
```

# Testing

- Ran the docs build locally and it passed.

```[tasklist]
# To-do list
- [x] Make sure the docs build passes in CI.
- [x] Proof read the Release Notes on Read The Docs.
```
