### PR TITLE
feat: output a datapackage.json for PUDL parquet files.

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -186,7 +186,7 @@ function clean_up_outputs_for_distribution() {
     # Create a zip file of all the parquet outputs for distribution on Kaggle
     # Don't try to compress the already compressed Parquet files with Zip.
     pushd "$PUDL_OUTPUT/parquet" && \
-    zip -0 "$PUDL_OUTPUT/pudl_parquet.zip" ./*.parquet && \
+    zip -0 "$PUDL_OUTPUT/pudl_parquet.zip" ./*.parquet ./pudl_parquet_datapackage.json && \
     # Move the individual parquet outputs to the output directory for direct access
     mv ./*.parquet "$PUDL_OUTPUT" && \
     # Move the parquet datapackage to the output directory also!

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -115,9 +115,9 @@ function zenodo_data_release() {
     echo "Creating a new PUDL data release on Zenodo."
 
     if [[ "$1" == "production" ]]; then
-        ~/pudl/devtools/zenodo/zenodo_data_release.py --no-publish --env "$1" --source-dir "$PUDL_OUTPUT"
+        ~/pudl/devtools/zenodo/zenodo_data_release.py --no-publish --env "$1" --source-dir "$PUDL_OUTPUT" --ignore $PUDL_OUTPUT/pudl_parquet_datapackage.json
     elif [[ "$1" == "sandbox" ]]; then
-        ~/pudl/devtools/zenodo/zenodo_data_release.py --publish --env "$1" --source-dir "$PUDL_OUTPUT"
+        ~/pudl/devtools/zenodo/zenodo_data_release.py --publish --env "$1" --source-dir "$PUDL_OUTPUT" --ignore $PUDL_OUTPUT/pudl_parquet_datapackage.json
     else
         echo "Invalid Zenodo environment"
         exit 1

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -249,6 +249,10 @@ set -x
 run_pudl_etl 2>&1 | tee "$LOGFILE"
 ETL_SUCCESS=${PIPESTATUS[0]}
 
+# Write out a datapackage.json for external consumption
+write_pudl_datapackage 2>&1 | tee -a "$LOGFILE"
+WRITE_DATAPACKAGE_SUCCESS=${PIPESTATUS[0]}
+
 # This needs to happen regardless of the ETL outcome:
 pg_ctlcluster "$PG_VERSION" dagster stop 2>&1 | tee -a "$LOGFILE"
 
@@ -266,9 +270,6 @@ if [[ "$BUILD_TYPE" == "nightly" ]]; then
     # Update our datasette deployment
     python ~/pudl/devtools/datasette/publish.py --production 2>&1 | tee -a "$LOGFILE"
     DATASETTE_SUCCESS=${PIPESTATUS[0]}
-    # Write out a datapackage.json for external consumption
-    write_pudl_datapackage 2>&1 | tee -a "$LOGFILE"
-    WRITE_DATAPACKAGE_SUCCESS=${PIPESTATUS[0]}
     # Remove files we don't want to distribute and zip SQLite and Parquet outputs
     clean_up_outputs_for_distribution 2>&1 | tee -a "$LOGFILE"
     CLEAN_UP_OUTPUTS_SUCCESS=${PIPESTATUS[0]}
@@ -285,9 +286,6 @@ if [[ "$BUILD_TYPE" == "nightly" ]]; then
 elif [[ "$BUILD_TYPE" == "stable" ]]; then
     merge_tag_into_branch "$BUILD_REF" stable 2>&1 | tee -a "$LOGFILE"
     UPDATE_STABLE_SUCCESS=${PIPESTATUS[0]}
-    # Write out a datapackage.json for external consumption
-    write_pudl_datapackage 2>&1 | tee -a "$LOGFILE"
-    WRITE_DATAPACKAGE_SUCCESS=${PIPESTATUS[0]}
     # Remove files we don't want to distribute and zip SQLite and Parquet outputs
     clean_up_outputs_for_distribution 2>&1 | tee -a "$LOGFILE"
     CLEAN_UP_OUTPUTS_SUCCESS=${PIPESTATUS[0]}
@@ -307,9 +305,6 @@ elif [[ "$BUILD_TYPE" == "stable" ]]; then
     GCS_TEMPORARY_HOLD_SUCCESS=${PIPESTATUS[0]}
 
 elif [[ "$BUILD_TYPE" == "workflow_dispatch" ]]; then
-    # Write out a datapackage.json for external consumption
-    write_pudl_datapackage 2>&1 | tee -a "$LOGFILE"
-    WRITE_DATAPACKAGE_SUCCESS=${PIPESTATUS[0]}
     # Remove files we don't want to distribute and zip SQLite and Parquet outputs
     clean_up_outputs_for_distribution 2>&1 | tee -a "$LOGFILE"
     CLEAN_UP_OUTPUTS_SUCCESS=${PIPESTATUS[0]}

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -62,7 +62,7 @@ function run_pudl_etl() {
 
 function write_pudl_datapackage() {
     echo "Writing PUDL datapackage."
-    python -c "from pudl.metadata.classes import PUDL_PACKAGE; print(PUDL_PACKAGE.to_frictionless().to_json())" > "$PUDL_OUTPUT/pudl_datapackage.json"
+    python -c "from pudl.metadata.classes import PUDL_PACKAGE; print(PUDL_PACKAGE.to_frictionless().to_json())" > "$PUDL_OUTPUT/parquet/pudl_parquet_datapackage.json"
     return $?
 }
 
@@ -189,6 +189,8 @@ function clean_up_outputs_for_distribution() {
     zip -0 "$PUDL_OUTPUT/pudl_parquet.zip" ./*.parquet && \
     # Move the individual parquet outputs to the output directory for direct access
     mv ./*.parquet "$PUDL_OUTPUT" && \
+    # Move the parquet datapackage to the output directory also!
+    mv ./pudl_parquet_datapackage.json "$PUDL_OUTPUT" && \
     popd && \
     # Remove any remaiining files and directories we don't want to distribute
     rm -rf "$PUDL_OUTPUT/parquet" && \

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -23,7 +23,7 @@ Quality of Life Improvements
 
 * We now publish a `Frictionless data package
   <https://datapackage.org/standard/data-package/>`__ describing our Parquet
-  outputs, with the name `pudl_datapackage.json`. See :issue:`4069` and :pr:`4070`.
+  outputs, with the name ``pudl_datapackage.json``. See :issue:`4069` and :pr:`4070`.
 
 .. _release-v2025.2.0:
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -21,6 +21,10 @@ Major Dependency Updates
 Quality of Life Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* We now publish a `Frictionless data package
+  <https://datapackage.org/standard/data-package/>`__ describing our Parquet
+  outputs, with the name `pudl_datapackage.json`. See :issue:`4069` and :pr:`4070`.
+
 .. _release-v2025.2.0:
 
 ---------------------------------------------------------------------------------------

--- a/test/unit/metadata_test.py
+++ b/test/unit/metadata_test.py
@@ -187,3 +187,23 @@ def test_resource_descriptors_can_encode_schemas(dummy_pandera_schema):
 def test_resource_descriptor_schema_failures(error_msg, data, dummy_pandera_schema):
     with pytest.raises(pr.errors.SchemaError, match=error_msg):
         dummy_pandera_schema.validate(data)
+
+
+def test_frictionless_data_package_non_empty():
+    datapackage = PUDL_PACKAGE.to_frictionless()
+    assert len(datapackage.resources) == len(RESOURCE_METADATA)
+
+
+def test_frictionless_data_package_resources_populated():
+    datapackage = PUDL_PACKAGE.to_frictionless()
+    for resource in datapackage.resources:
+        assert resource.name in RESOURCE_METADATA
+        expected_resource = RESOURCE_METADATA[resource.name]
+        assert expected_resource["description"] == resource.description
+        assert expected_resource["schema"]["fields"] == [
+            f.name for f in resource.schema.fields
+        ]
+        assert (
+            expected_resource["schema"].get("primary_key", [])
+            == resource.schema.primary_key
+        )


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #4069 .

## What problem does this address?

I wanted to output a datapackage descriptor for the PUDL viewer to use as the basis for search. Up until now it's been using a vendored version of the Datasette `metadata.yaml` that we generate.

We *could* achieve the effect of "have an up-to-date metadata for PUDL viewer" just by *not* cleaning up the metadata.yaml out of the nightly builds, but distributing some wacky bespoke metadata format seems silly. So I made the necessary changes to output a proper `datapackage.json`.

## What did you change?

* added `to_frictionless` methods to `Package` and `Resource` so we can use their "to a valid datapackage.json" functionality
* added a function to the `gcp_pudl_etl.sh` script to write this datapackage out.

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] ~Update relevant Data Source jinja templates (see `docs/data_sources/templates`).~
- [ ] ~Update relevant table or source description metadata (see `src/metadata`).~
- [ ] ~Review and update any other aspects of the documentation that might be affected by this PR.~
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

Kicking off a manual run of our build.

```[tasklist]
# To-do list
- [ ] ~If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).~
- [x] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [x] Review the PR yourself and call out any questions or issues you have.
- [ ] ~For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.~
- [ ] ~For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.~
- [x] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
```
