### PR TITLE
Add PUDL viewer log sink

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -26,6 +26,7 @@ provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "6.16.0"
   constraints = ">= 3.64.0, < 7.0.0"
   hashes = [
+    "h1:VQ/1D9HwjXBaMWC+qcakOeF1alAOiFQs7yuvaoltxT8=",
     "h1:Z+sQyUt2iYkELNpRTEv6pZoBr9EP1PxYZzhRthiK9DU=",
     "zh:0ef35e34ffa21e11c85593b48d1c879fe9b74c961b4dd8dada6017776112feac",
     "zh:234517614495c99c756cc8ffe9d79f2a07e161b711e4a496f2b72fdf846509e4",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -109,11 +109,11 @@ resource "google_storage_bucket_iam_binding" "binding" {
 
 # Generate a random password for the mlflow db user
 resource "random_password" "mlflow_postgresql_password" {
-  length  = 16  # Adjust the password length as needed
-  special = true  # Include special characters
-  upper   = true  # Include uppercase letters
-  lower   = true  # Include lowercase letters
-  numeric  = true  # Include numbers
+  length  = 16   # Adjust the password length as needed
+  special = true # Include special characters
+  upper   = true # Include uppercase letters
+  lower   = true # Include lowercase letters
+  numeric = true # Include numbers
 }
 
 # Create secret to store mlflow db password
@@ -603,7 +603,7 @@ resource "google_sql_database_instance" "pudl_viewer_database" {
 }
 
 resource "google_sql_database" "pudl_viewer_database" {
-  name = "pudl_viewer"
+  name     = "pudl_viewer"
   instance = google_sql_database_instance.pudl_viewer_database.name
 }
 
@@ -631,9 +631,9 @@ resource "google_cloud_run_v2_service" "pudl_viewer" {
 
   template {
     annotations = {
-      "client.knative.dev/user-image"         = "us-east1-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.pudl_viewer.name}/pudl-viewer:latest"
-      "run.googleapis.com/client-name"        = "terraform"
-      "run.googleapis.com/client-version"     = timestamp()
+      "client.knative.dev/user-image"     = "us-east1-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.pudl_viewer.name}/pudl-viewer:latest"
+      "run.googleapis.com/client-name"    = "terraform"
+      "run.googleapis.com/client-version" = timestamp()
     }
 
     service_account = google_service_account.pudl_viewer_sa.email
@@ -648,17 +648,17 @@ resource "google_cloud_run_v2_service" "pudl_viewer" {
       image = "us-east1-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.pudl_viewer.name}/pudl-viewer:latest"
 
       volume_mounts {
-        name = "cloudsql"
+        name       = "cloudsql"
         mount_path = "/cloudsql"
       }
 
       env {
-        name = "IS_CLOUD_RUN"
+        name  = "IS_CLOUD_RUN"
         value = "True"
       }
 
       env {
-        name = "CLOUD_SQL_CONNECTION_NAME"
+        name  = "CLOUD_SQL_CONNECTION_NAME"
         value = google_sql_database_instance.pudl_viewer_database.connection_name
       }
 
@@ -696,21 +696,21 @@ resource "google_cloud_run_v2_job" "pudl_viewer_db_migration" {
       }
 
       containers {
-        image = "us-east1-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.pudl_viewer.name}/pudl-viewer:latest"
+        image   = "us-east1-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.pudl_viewer.name}/pudl-viewer:latest"
         command = ["uv", "run", "flask", "--app", "parquet_fe_prototype", "db", "upgrade"]
 
         volume_mounts {
-          name = "cloudsql"
+          name       = "cloudsql"
           mount_path = "/cloudsql"
         }
 
         env {
-          name = "IS_CLOUD_RUN"
+          name  = "IS_CLOUD_RUN"
           value = "True"
         }
 
         env {
-          name = "CLOUD_SQL_CONNECTION_NAME"
+          name  = "CLOUD_SQL_CONNECTION_NAME"
           value = google_sql_database_instance.pudl_viewer_database.connection_name
         }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -784,6 +784,7 @@ resource "google_logging_project_sink" "pudl_viewer_log_sink" {
   filter      = <<EOT
     resource.type = "cloud_run_revision"
     AND resource.labels.service_name="${google_cloud_run_v2_service.pudl_viewer.name}"
+    AND (severity >= DEFAULT)
   EOT
 
   unique_writer_identity = true

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -636,6 +636,11 @@ resource "google_cloud_run_v2_service" "pudl_viewer" {
       "run.googleapis.com/client-version" = timestamp()
     }
 
+    scaling {
+      min_instance_count = 1
+      max_instance_count = 1
+    }
+
     service_account = google_service_account.pudl_viewer_sa.email
     volumes {
       name = "cloudsql"
@@ -646,6 +651,14 @@ resource "google_cloud_run_v2_service" "pudl_viewer" {
 
     containers {
       image = "us-east1-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.pudl_viewer.name}/pudl-viewer:latest"
+
+      resources {
+        limits = {
+          cpu    = "1000m"
+          memory = "768Mi"
+        }
+        cpu_idle = true
+      }
 
       volume_mounts {
         name       = "cloudsql"


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Part of catalyst-cooperative/parquet-fe-prototype#21.

## What problem does this address?

Adds a log sink for PUDL viewer logs to be persisted.

## What did you change?

* ran `terraform fmt` to make sure our file stays clean - only look at [*this commit*](https://github.com/catalyst-cooperative/pudl/pull/4071/commits/a076df9443de9023454b3230121da27a38a1f1a8) and later ones if you want to skip those changes
* added a bucket, a log sink, and some permissions to allow the log sink to write to the bucket

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [ ] ~Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.~
- [ ] ~Update relevant Data Source jinja templates (see `docs/data_sources/templates`).~
- [ ] ~Update relevant table or source description metadata (see `src/metadata`).~
- [ ] ~Review and update any other aspects of the documentation that might be affected by this PR.~
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

Looked in the console after terraform apply and there does appear to be a log sink and corresponding bucket. Hopefully I'll check in the morning and see some logs in that bucket.

```[tasklist]
# To-do list
- [ ] ~If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).~
- [ ] ~Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.~
- [ ] ~Review the PR yourself and call out any questions or issues you have.~
- [ ] ~For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.~
- [ ] ~For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.~
- [ ] ~Alternatively, run the `build-deploy-pudl` GitHub Action manually.~
```
