### PR TITLE
chore: remove tasklists since they're being replaced.

### DIFF
--- a/.github/ISSUE_TEMPLATE/nightly_build_failure.md
+++ b/.github/ISSUE_TEMPLATE/nightly_build_failure.md
@@ -20,13 +20,11 @@ What next steps do we need to do to understand or remediate the issue?
 
 Once you've applied any necessary fixes, make sure that the nightly build outputs are all in their right places.
 
-```[tasklist]
 - [ ] [S3 distribution bucket](https://s3.console.aws.amazon.com/s3/buckets/pudl.catalyst.coop?region=us-west-2&bucketType=general&prefix=nightly/&showversions=false) was updated at the expected time
 - [ ] [GCP distribution bucket](https://console.cloud.google.com/storage/browser/pudl.catalyst.coop/nightly;tab=objects?project=catalyst-cooperative-pudl) was updated at the expected time
 - [ ] [GCP internal bucket](https://console.cloud.google.com/storage/browser/builds.catalyst.coop) was updated at the expected time
 - [ ] [Datasette PUDL version](https://data.catalyst.coop/pudl/core_pudl__codes_datasources) points at the same hash as [nightly](https://github.com/catalyst-cooperative/pudl/tree/nightly)
 - [ ] [Zenodo sandbox record](https://sandbox.zenodo.org/doi/10.5072/zenodo.5563) was updated to the record number in the logs (search for `zenodo_data_release.py` and `Draft` in the logs, to see what the new record number should be!)
-```
 
 # Relevant logs
 [link to build logs from internal distribution bucket]( PLEASE FIND THE ACTUAL LINK AND FILL IN HERE )

--- a/.github/ISSUE_TEMPLATE/quarterly_updates.md
+++ b/.github/ISSUE_TEMPLATE/quarterly_updates.md
@@ -12,10 +12,8 @@ Once the new archives have been vetted and published, you can begin the process 
 
 Follow the steps in [Existing Data Updates Docs](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html)
 
-```[tasklist]
 - [ ] EIA 860m {{ date | date('[Q]Q YYYY') }} Update
 - [ ] EIA 923 {{ date | date('[Q]Q YYYY') }} Update
 - [ ] EIA 930 {{ date | date('[Q]Q YYYY') }} Update
 - [ ] CEMS {{ date | date('[Q]Q YYYY') }} Update
 - [ ] EIA Bulk API {{ date | date('[Q]Q YYYY') }} Update
-```

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -18,7 +18,5 @@ How will we know that we're done?
 * [ ] ...
 
 
-```[tasklist]
 ### Next steps
 * [ ] ...
-```

--- a/.github/ISSUE_TEMPLATE/versioned_release.md
+++ b/.github/ISSUE_TEMPLATE/versioned_release.md
@@ -12,7 +12,6 @@ assignees: ""
 
 [Additional release process documentation](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/run_a_release.html).
 
-```[tasklist]
 ## Release Checklist
 - [ ] Set a release date & notify team
 - [ ] Update our CITATION.cff file with the new release date and current Catalyst membership.
@@ -38,9 +37,7 @@ assignees: ""
 - [ ] Update the [release documentation](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/run_a_release.html) to better reflect the actual process for next time
 - [ ] Wait 2-12 hours for a bot to create a PR in the [PUDL conda-forge feedstock](https://github.com/conda-forge/catalystcoop.pudl-feedstock/pulls)
 - [ ] Review the `conda-forge` PR, updating dependencies and CLI entrypoints if necessary. Our direct dependencies (from `pyproject.toml`) should be pinned to the actual version appearing in `environments/conda-linux-64.lock.yml`
-```
 
-```[tasklist]
 ### Zenodo Metadata Tasks
 - [ ] Make sure all Catalyst members are listed in creators (automate!)
 - [ ] Update Zenodo deposition description to reflect current release (automate!)
@@ -48,9 +45,6 @@ assignees: ""
 - [ ] Set keywords for Zenodo data release archive (automate!)
 - [ ] Set language of Zenodo data release archive (automate!)
 - [ ] Zenodo PUDL repo archive: update release notes (cut-and-paste from GitHub)
-```
 
-```[tasklist]
 ### Issues that we ran into
 - [ ] Take notes here during the release if stuff happens.
-```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,27 +12,23 @@ Closes #XXXX.
 
 ## What did you change?
 
-# Documentation
+## Documentation
 
-Make sure to update relevant aspects of the documentation.
+Make sure to update relevant aspects of the documentation:
 
-```[tasklist]
 - [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
 - [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
 - [ ] Update relevant table or source description metadata (see `src/metadata`).
 - [ ] Review and update any other aspects of the documentation that might be affected by this PR.
-```
 
 # Testing
 
-## How did you make sure this worked? How can a reviewer verify this?
+How did you make sure this worked? How can a reviewer verify this?
 
-```[tasklist]
-# To-do list
+## To-do list
 - [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).
 - [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
 - [ ] Review the PR yourself and call out any questions or issues you have.
 - [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
 - [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
 - [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
-```


### PR DESCRIPTION

# Overview

https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#tasklist-blocks-will-be-retired-and-replaced-with-sub-issues

## What did you change?

Converted tasklists to just normal lists.

# Documentation

- [x] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [x] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [x] Update relevant table or source description metadata (see `src/metadata`).
- [x] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

- [x] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).
- [x] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [x] Review the PR yourself and call out any questions or issues you have.
- [x] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [x] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [x] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
