### PR TITLE
[DRAFT] dbt `not_all_null` migrations

### DIFF
--- a/dbt/README.md
+++ b/dbt/README.md
@@ -328,7 +328,7 @@ validate that there are no completely null columns. We've added a custom test to
       - not_all_null
 ```
 
-See `dbt/models/_out_eia__monthly_heat_rate_by_unit/schema.yml` for specific examples.
+See `dbt/models/output/_out_eia__monthly_heat_rate_by_unit/schema.yml` for specific examples.
 
 Note: there is also a builtin test in `dbt` called `not_null` that will make sure
 there are no null values at all in a column.

--- a/dbt/models/output/_out_eia__monthly_capacity_factor_by_generator/schema.yml
+++ b/dbt/models/output/_out_eia__monthly_capacity_factor_by_generator/schema.yml
@@ -9,8 +9,20 @@ sources:
               partition_column: report_date
         columns:
           - name: report_date
+            data_tests:
+              - not_all_null
           - name: plant_id_eia
+            data_tests:
+              - not_all_null
           - name: generator_id
+            data_tests:
+              - not_all_null
           - name: net_generation_mwh
+            data_tests:
+              - not_all_null
           - name: capacity_mw
+            data_tests:
+              - not_all_null
           - name: capacity_factor
+            data_tests:
+              - not_all_null

--- a/dbt/models/output/_out_eia__monthly_derived_generator_attributes/schema.yml
+++ b/dbt/models/output/_out_eia__monthly_derived_generator_attributes/schema.yml
@@ -10,14 +10,38 @@ sources:
               partition_column: report_date
         columns:
           - name: plant_id_eia
+            data_tests:
+              - not_all_null
           - name: generator_id
+            data_tests:
+              - not_all_null
           - name: unit_id_pudl
+            data_tests:
+              - not_all_null
           - name: report_date
+            data_tests:
+              - not_all_null
           - name: capacity_factor
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mmbtu_source
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mmbtu
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mwh
+            data_tests:
+              - not_all_null
           - name: unit_heat_rate_mmbtu_per_mwh
+            data_tests:
+              - not_all_null
           - name: net_generation_mwh
+            data_tests:
+              - not_all_null
           - name: total_fuel_cost
+            data_tests:
+              - not_all_null
           - name: total_mmbtu
+            data_tests:
+              - not_all_null

--- a/dbt/models/output/_out_eia__monthly_fuel_cost_by_generator/schema.yml
+++ b/dbt/models/output/_out_eia__monthly_fuel_cost_by_generator/schema.yml
@@ -9,17 +9,47 @@ sources:
               partition_column: report_date
         columns:
           - name: report_date
+            data_tests:
+              - not_all_null
           - name: plant_id_eia
+            data_tests:
+              - not_all_null
           - name: generator_id
+            data_tests:
+              - not_all_null
           - name: unit_id_pudl
+            data_tests:
+              - not_all_null
           - name: plant_name_eia
+            data_tests:
+              - not_all_null
           - name: plant_id_pudl
+            data_tests:
+              - not_all_null
           - name: utility_id_eia
+            data_tests:
+              - not_all_null
           - name: utility_name_eia
+            data_tests:
+              - not_all_null
           - name: utility_id_pudl
+            data_tests:
+              - not_all_null
           - name: fuel_type_count
+            data_tests:
+              - not_all_null
           - name: fuel_type_code_pudl
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mmbtu_source
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mmbtu
+            data_tests:
+              - not_all_null
           - name: unit_heat_rate_mmbtu_per_mwh
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mwh
+            data_tests:
+              - not_all_null

--- a/dbt/models/output/_out_eia__monthly_heat_rate_by_generator/schema.yml
+++ b/dbt/models/output/_out_eia__monthly_heat_rate_by_generator/schema.yml
@@ -9,10 +9,26 @@ sources:
               partition_column: report_date
         columns:
           - name: report_date
+            data_tests:
+              - not_all_null
           - name: plant_id_eia
+            data_tests:
+              - not_all_null
           - name: unit_id_pudl
+            data_tests:
+              - not_all_null
           - name: generator_id
+            data_tests:
+              - not_all_null
           - name: unit_heat_rate_mmbtu_per_mwh
+            data_tests:
+              - not_all_null
           - name: fuel_type_code_pudl
+            data_tests:
+              - not_all_null
           - name: fuel_type_count
+            data_tests:
+              - not_all_null
           - name: prime_mover_code
+            data_tests:
+              - not_all_null

--- a/dbt/models/output/_out_eia__yearly_capacity_factor_by_generator/schema.yml
+++ b/dbt/models/output/_out_eia__yearly_capacity_factor_by_generator/schema.yml
@@ -9,8 +9,20 @@ sources:
               partition_column: report_date
         columns:
           - name: report_date
+            data_tests:
+              - not_all_null
           - name: plant_id_eia
+            data_tests:
+              - not_all_null
           - name: generator_id
+            data_tests:
+              - not_all_null
           - name: net_generation_mwh
+            data_tests:
+              - not_all_null
           - name: capacity_mw
+            data_tests:
+              - not_all_null
           - name: capacity_factor
+            data_tests:
+              - not_all_null

--- a/dbt/models/output/_out_eia__yearly_derived_generator_attributes/schema.yml
+++ b/dbt/models/output/_out_eia__yearly_derived_generator_attributes/schema.yml
@@ -9,14 +9,38 @@ sources:
               partition_column: report_date
         columns:
           - name: plant_id_eia
+            data_tests:
+              - not_all_null
           - name: generator_id
+            data_tests:
+              - not_all_null
           - name: unit_id_pudl
+            data_tests:
+              - not_all_null
           - name: report_date
+            data_tests:
+              - not_all_null
           - name: capacity_factor
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mmbtu_source
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mmbtu
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mwh
+            data_tests:
+              - not_all_null
           - name: unit_heat_rate_mmbtu_per_mwh
+            data_tests:
+              - not_all_null
           - name: net_generation_mwh
+            data_tests:
+              - not_all_null
           - name: total_fuel_cost
+            data_tests:
+              - not_all_null
           - name: total_mmbtu
+            data_tests:
+              - not_all_null

--- a/dbt/models/output/_out_eia__yearly_fuel_cost_by_generator/schema.yml
+++ b/dbt/models/output/_out_eia__yearly_fuel_cost_by_generator/schema.yml
@@ -9,17 +9,47 @@ sources:
               partition_column: report_date
         columns:
           - name: report_date
+            data_tests:
+              - not_all_null
           - name: plant_id_eia
+            data_tests:
+              - not_all_null
           - name: generator_id
+            data_tests:
+              - not_all_null
           - name: unit_id_pudl
+            data_tests:
+              - not_all_null
           - name: plant_name_eia
+            data_tests:
+              - not_all_null
           - name: plant_id_pudl
+            data_tests:
+              - not_all_null
           - name: utility_id_eia
+            data_tests:
+              - not_all_null
           - name: utility_name_eia
+            data_tests:
+              - not_all_null
           - name: utility_id_pudl
+            data_tests:
+              - not_all_null
           - name: fuel_type_count
+            data_tests:
+              - not_all_null
           - name: fuel_type_code_pudl
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mmbtu_source
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mmbtu
+            data_tests:
+              - not_all_null
           - name: unit_heat_rate_mmbtu_per_mwh
+            data_tests:
+              - not_all_null
           - name: fuel_cost_per_mwh
+            data_tests:
+              - not_all_null

--- a/dbt/models/output/_out_eia__yearly_heat_rate_by_generator/schema.yml
+++ b/dbt/models/output/_out_eia__yearly_heat_rate_by_generator/schema.yml
@@ -9,10 +9,26 @@ sources:
               partition_column: report_date
         columns:
           - name: report_date
+            data_tests:
+              - not_all_null
           - name: plant_id_eia
+            data_tests:
+              - not_all_null
           - name: unit_id_pudl
+            data_tests:
+              - not_all_null
           - name: generator_id
+            data_tests:
+              - not_all_null
           - name: unit_heat_rate_mmbtu_per_mwh
+            data_tests:
+              - not_all_null
           - name: fuel_type_code_pudl
+            data_tests:
+              - not_all_null
           - name: fuel_type_count
+            data_tests:
+              - not_all_null
           - name: prime_mover_code
+            data_tests:
+              - not_all_null

--- a/dbt/models/output/_out_eia__yearly_heat_rate_by_unit/schema.yml
+++ b/dbt/models/output/_out_eia__yearly_heat_rate_by_unit/schema.yml
@@ -9,8 +9,20 @@ sources:
               partition_column: report_date
         columns:
           - name: report_date
+            data_tests:
+              - not_all_null
           - name: plant_id_eia
+            data_tests:
+              - not_all_null
           - name: unit_id_pudl
+            data_tests:
+              - not_all_null
           - name: net_generation_mwh
+            data_tests:
+              - not_all_null
           - name: fuel_consumed_for_electricity_mmbtu
+            data_tests:
+              - not_all_null
           - name: unit_heat_rate_mmbtu_per_mwh
+            data_tests:
+              - not_all_null


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

Migrates `not_all_null` tests to dbt.

Draft: mostly this was getting comfortable with the helper script and `dbt build`, but if we get bonus migrated tests out of it, great!

## What did you change?

# Documentation

Make sure to update relevant aspects of the documentation.

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.


# Testing

## How did you make sure this worked? How can a reviewer verify this?

```
$ dbt build --target etl-fast
```

(no failures in any of the tables touched by this PR. though I do have one in ferc that looks suspicious, and it complains about not being able to find sec10k tables even though i don't think they're even in etl-fast?)

# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.

