### PR TITLE
add model level macro to test no null cols

### DIFF
--- a/dbt/README.md
+++ b/dbt/README.md
@@ -329,7 +329,7 @@ models:
       - ...
 ```
 
-By default the `no_null_cols` test applies to all columns in the table. To handle deprecated columns (where it is expected that after a certain date the column will only product null values), you can add conditions to select columns for when the test should apply:
+By default the `no_null_cols` test applies to all columns in the table. To handle deprecated columns (where it is expected that after a certain date the column will only produce null values), you can add conditions to select the rows when the test should apply:
 ```
 models:
   - name: some_model
@@ -357,7 +357,7 @@ columns:
   - name: deprecated_column
     data_tests:
       - not_all_null:
-          filter: "WHERE report_date < '2025-01-01'"
+          filter: "report_date < '2025-01-01'"
 
 ```
 

--- a/dbt/macros/no_null_cols.sql
+++ b/dbt/macros/no_null_cols.sql
@@ -1,0 +1,23 @@
+{% macro no_null_cols(model) %}
+    {% set columns = dbt_utils.get_columns_in_relation(model) %}
+    {% set null_columns = [] %}
+
+    {% for column in columns %}
+        {% set column_name = column.name %}
+
+        -- Use the existing not_all_null test for each column
+        {% if execute_test('not_all_null', model=model, column_name=column_name) %}
+            -- If the test fails (all values are null), add the column to the null_columns list
+            {% do null_columns.append(column_name) %}
+        {% endif %}
+    {% endfor %}
+
+    {% if null_columns | length > 0 %}
+        -- Return the list of columns with all null values (test fails)
+        SELECT 
+            '{{ null_columns | join(", ") }}' AS column_with_all_nulls
+    {% else %}
+        -- If no columns with all nulls, return no rows, meaning the test passes
+        {% do return() %}
+    {% endif %}
+{% endmacro %}

--- a/dbt/macros/no_null_cols.sql
+++ b/dbt/macros/no_null_cols.sql
@@ -1,23 +1,29 @@
-{% macro no_null_cols(model) %}
-    {% set columns = dbt_utils.get_columns_in_relation(model) %}
-    {% set null_columns = [] %}
+{% test no_null_cols(model, filter_condition=None, filtered_columns=[]) %}
 
+WITH column_checks AS (
+    {% set columns = dbt_utils.get_columns_in_relation(model) %}
+    
     {% for column in columns %}
         {% set column_name = column.name %}
-
-        -- Use the existing not_all_null test for each column
-        {% if execute_test('not_all_null', model=model, column_name=column_name) %}
-            -- If the test fails (all values are null), add the column to the null_columns list
-            {% do null_columns.append(column_name) %}
-        {% endif %}
+        
+        SELECT 
+            '{{ column_name }}' AS column_name,
+            COUNT(*) AS relevant_rows,  -- Count rows in scope (filtered or full)
+            {% if column_name in filtered_columns and filter_condition %}
+                COUNT(CASE WHEN {{ filter_condition }} THEN {{ column_name }} END) AS non_null_rows
+            {% else %}
+                COUNT({{ column_name }}) AS non_null_rows
+            {% endif %}
+        FROM {{ model }}
+        
+        {% if not loop.last %} UNION ALL {% endif %}
+        
     {% endfor %}
+)
 
-    {% if null_columns | length > 0 %}
-        -- Return the list of columns with all null values (test fails)
-        SELECT
-            '{{ null_columns | join(", ") }}' AS column_with_all_nulls
-    {% else %}
-        -- If no columns with all nulls, return no rows, meaning the test passes
-        {% do return() %}
-    {% endif %}
-{% endmacro %}
+SELECT STRING_AGG(column_name, ', ') AS null_columns
+FROM column_checks
+WHERE relevant_rows > 0  -- Ignore columns where all rows were filtered out
+  AND non_null_rows = 0   -- Fail only if the column is entirely NULL in relevant rows
+
+{% endtest %}

--- a/dbt/macros/no_null_cols.sql
+++ b/dbt/macros/no_null_cols.sql
@@ -2,11 +2,11 @@
 
 WITH column_checks AS (
     {% set columns = dbt_utils.get_columns_in_relation(model) %}
-    
+
     {% for column in columns %}
         {% set column_name = column.name %}
-        
-        SELECT 
+
+        SELECT
             '{{ column_name }}' AS column_name,
             COUNT(*) AS relevant_rows,  -- Count rows in scope (filtered or full)
             {% if column_name in filtered_columns and filter_condition %}
@@ -15,9 +15,9 @@ WITH column_checks AS (
                 COUNT({{ column_name }}) AS non_null_rows
             {% endif %}
         FROM {{ model }}
-        
+
         {% if not loop.last %} UNION ALL {% endif %}
-        
+
     {% endfor %}
 )
 

--- a/dbt/macros/no_null_cols.sql
+++ b/dbt/macros/no_null_cols.sql
@@ -13,8 +13,8 @@ WITH column_checks AS (
                 {% set condition_sql = partial_col.get('expect_at_least_one_value_when') %}
             {% endif %}
         {% endfor %}
-        
-        SELECT 
+
+        SELECT
             '{{ column_name }}' AS column_name,
             COUNT(CASE WHEN {{ condition_sql }} THEN 1 END) AS relevant_rows,  -- Count rows in scope (filtered or full)
             COUNT(CASE WHEN {{ condition_sql }} THEN {{ column_name }} END) AS non_null_rows

--- a/dbt/macros/no_null_cols.sql
+++ b/dbt/macros/no_null_cols.sql
@@ -14,7 +14,7 @@
 
     {% if null_columns | length > 0 %}
         -- Return the list of columns with all null values (test fails)
-        SELECT 
+        SELECT
             '{{ null_columns | join(", ") }}' AS column_with_all_nulls
     {% else %}
         -- If no columns with all nulls, return no rows, meaning the test passes

--- a/dbt/macros/not_all_null.sql
+++ b/dbt/macros/not_all_null.sql
@@ -1,9 +1,12 @@
-{% test not_all_null(model, column_name) %}
+{% test not_all_null(model, column_name, filter=None) %}
 
 WITH not_null_count AS (
     SELECT COUNT(*) as not_null_count
     FROM {{ model }}
     WHERE {{ column_name }} IS NOT NULL
+    {% if filter %}
+      AND {{ filter }}
+    {% endif %}
 )
 
 SELECT not_null_count FROM not_null_count WHERE not_null_count = 0


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Part of https://github.com/catalyst-cooperative/pudl/issues/4075
Namely, the issue of templating no_null_rows/cols tests.

## What problem does this address?
There is a model-level test macro for no_null_rows, but the equivalent test for no_null_cols was not implemented; the available macro just tests a single column for not being all null.
Since these tests are not informative (i.e. they are a basic hygiene test for any model), it is preferable to only use the model-level tests, in order to reduce the bloat of uninformative tests in the model schemas.

## What did you change?
Add macro to loop over all of a model's columns and do the `not_all_null` column level test, returning an error if any of the columns fail this test.

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
```
