### PR TITLE
Add macro for group_mean_continuity_check

### DIFF
--- a/dbt/macros/group_mean_continuity_check.sql
+++ b/dbt/macros/group_mean_continuity_check.sql
@@ -1,0 +1,23 @@
+{% test group_mean_continuity_check(model, column_name, group_column, max_pct_change) %}
+
+with GroupMean as (
+    select
+    {{ group_column }},
+    avg({{ column_name }}) as mean
+    from {{ model }}
+    group by {{ group_column }}
+),
+Continuity as (
+    select
+    {{ group_column }},
+    mean as newer_value,
+    LAG(mean) OVER (order by {{ group_column }}) as older_value
+    from GroupMean
+)
+select
+{{ group_column }},
+abs(newer_value - older_value)/older_value as pct_change
+from Continuity
+where newer_value is not null and older_value is not null and pct_change >= {{ max_pct_change }}
+
+{% endtest %}

--- a/dbt/models/eia923/_core_eia923__cooling_system_information/schema.yml
+++ b/dbt/models/eia923/_core_eia923__cooling_system_information/schema.yml
@@ -16,25 +16,69 @@ sources:
           - name: monthly_total_cooling_hours_in_service
           - name: flow_rate_method
           - name: temperature_method
+          - name: annual_average_consumption_rate_gallons_per_minute
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 0.1
+          - name: annual_average_discharge_rate_gallons_per_minute
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 0.1
+          - name: annual_average_withdrawal_rate_gallons_per_minute
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 0.1
           - name: annual_maximum_intake_summer_temperature_fahrenheit
           - name: annual_maximum_intake_winter_temperature_fahrenheit
-          - name: monthly_average_intake_temperature_fahrenheit
-          - name: monthly_maximum_intake_temperature_fahrenheit
           - name: annual_maximum_outlet_summer_temperature_fahrenheit
           - name: annual_maximum_outlet_winter_temperature_fahrenheit
-          - name: monthly_average_discharge_temperature_fahrenheit
-          - name: monthly_maximum_discharge_temperature_fahrenheit
-          - name: annual_average_consumption_rate_gallons_per_minute
-          - name: monthly_average_consumption_rate_gallons_per_minute
-          - name: monthly_total_consumption_volume_gallons
-          - name: annual_average_discharge_rate_gallons_per_minute
-          - name: monthly_average_discharge_rate_gallons_per_minute
-          - name: monthly_total_discharge_volume_gallons
-          - name: monthly_average_diversion_rate_gallons_per_minute
-          - name: monthly_total_diversion_volume_gallons
-          - name: annual_average_withdrawal_rate_gallons_per_minute
-          - name: monthly_average_withdrawal_rate_gallons_per_minute
-          - name: monthly_total_withdrawal_volume_gallons
           - name: annual_total_chlorine_lbs
+          - name: monthly_average_consumption_rate_gallons_per_minute
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 0.5
+          - name: monthly_average_discharge_rate_gallons_per_minute
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 0.2
+          - name: monthly_average_discharge_temperature_fahrenheit
+          - name: monthly_average_diversion_rate_gallons_per_minute
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 1.3
+          - name: monthly_average_intake_temperature_fahrenheit
+          - name: monthly_average_withdrawal_rate_gallons_per_minute
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 0.2
+          - name: monthly_maximum_discharge_temperature_fahrenheit
+          - name: monthly_maximum_intake_temperature_fahrenheit
           - name: monthly_total_chlorine_lbs
+          - name: monthly_total_consumption_volume_gallons
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 0.4
+          - name: monthly_total_discharge_volume_gallons
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 0.3
+          - name: monthly_total_diversion_volume_gallons
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 1.3
+          - name: monthly_total_withdrawal_volume_gallons
+            data_tests:
+              - group_mean_continuity_check:
+                  group_column: report_date
+                  max_pct_change: 0.3
           - name: data_maturity


### PR DESCRIPTION
# Overview

Three tables require a `group_mean_continuity_check`, which does the following:

1. Group by a specified column
2. Compute the mean of each group
3. Compute the percent change between successive groups
4. Check against a per-column threshold

This PR contains a draft for a possible implementation.

## What did you change?

- New macro, `group_mean_continuity_check(group_column, max_pct_change)`
- Demo of macro in use for `_core_eia923__cooling_system_information`, using columns and thresholds from [`transform/eia923.py`](https://github.com/catalyst-cooperative/pudl/blob/7ab320421f2e08438469500feec9335f9e5cee86/src/pudl/transform/eia923.py#L1340)

## Debatable design choices

- This is written as a column-level check
  - pros: macro source is simple (no loops); keeps all checks for a column together in the column entry
  - cons: the grouping column is replicated in each data-test entry
  - options: could rewrite as a table-level check with a list of columns and thresholds. We'd replicate column names doing that, but the existing python solution does it that way so maybe past-catalyst already decided that's superior?
 - Currently no support for `n_outliers_allowed`, which is definitely a blocker
   - options: maybe query with an offset?