### PR TITLE
chore: add PUDL viewer to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -179,6 +179,9 @@ For details on how to access PUDL data, see the `data access documentation
 <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_access.html>`__. A quick
 summary:
 
+* `PUDL Viewer <https://viewer.catalyst.coop>`__ provides search, live preview,
+  and CSV export for our processed data. Currently it doesn't provide access to
+  the *raw* FERC data - you'll still have to go to Datasette for that.
 * `Datasette <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_access.html#-access-datasette>`__
   provides browsable and queryable data from our nightly builds on the web:
   https://data.catalyst.coop

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -13,10 +13,6 @@ We recommend working with tables with the ``out_`` prefix, as these tables conta
 most complete and easiest to work with data. For more information about the different
 types of tables, read through :ref:`PUDL's naming conventions <asset-naming>`.
 
-The :doc:`PUDL data dictionary </data_dictionaries/pudl_db>` provides direct links to
-:ref:`access-datasette` for each table if it is included in our SQLite outputs, and to
-the Parquet outputs if the table is available in that format.
-
 ---------------------------------------------------------------------------------------
 Quick Reference
 ---------------------------------------------------------------------------------------
@@ -144,12 +140,13 @@ PUDL Viewer
 
 We recently released the `PUDL Viewer <https://viewer.catalyst.coop/>`__ in beta.
 
-It provides flexible search of table metadata, live data preview, and CSV
-export of up to 5 million rows. It also provides access to tables that were too
-large for Datasette, such as the EPA CEMS emissions data and the VCE RARE
-hourly renewable capacity factors data.
+It provides flexible search of table metadata, live data preview with filtering
+and sorting, and CSV export of up to 5 million rows. It also provides access to
+tables that were too large for Datasette, such as the EPA CEMS emissions data
+and the VCE RARE hourly renewable capacity factors data.
 
-Finally, it also has links to the Parquet downloads for each table, which you can view directly with tools like `Tad <https://www.tadviewer.com/>`__.
+Finally, it also has links to the Parquet downloads for each table, which you
+can view directly with tools like `Tad <https://www.tadviewer.com/>`__.
 
 Note that the raw :ref:`FERC SQLite databases <access-raw-ferc>` derived from
 the old Visual FoxPro and new XBRL data formats are not available here yet - if

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -13,6 +13,12 @@ We recommend working with tables with the ``out_`` prefix, as these tables conta
 most complete and easiest to work with data. For more information about the different
 types of tables, read through :ref:`PUDL's naming conventions <asset-naming>`.
 
+.. note::
+
+  We recently released a beta `PUDL Database Viewer <https://viewer.catalyst.coop/>`__.
+  It provides fuzzy table search, live preview, and CSV export of up to 5 million rows.
+  It also provides links to the Parquet downloads for each table.
+
 The :doc:`PUDL data dictionary </data_dictionaries/pudl_db>` provides direct links to
 :ref:`access-datasette` for each table if it is included in our SQLite outputs, and to
 the Parquet outputs if the table is available in that format.

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -13,12 +13,6 @@ We recommend working with tables with the ``out_`` prefix, as these tables conta
 most complete and easiest to work with data. For more information about the different
 types of tables, read through :ref:`PUDL's naming conventions <asset-naming>`.
 
-.. note::
-
-  We recently released a beta `PUDL Database Viewer <https://viewer.catalyst.coop/>`__.
-  It provides flexible search of table descriptions, live data preview, and CSV export of up to 5 million rows. It also provides access to tables that were too large for Datasette, such as the EPA CEMS emissions data and the VCE RARE hourly renewable capacity factors data.
-  Finally, it also has links to the Parquet downloads for each table, which you can view directly with tools like `Tad <https://www.tadviewer.com/>`__.
-
 The :doc:`PUDL data dictionary </data_dictionaries/pudl_db>` provides direct links to
 :ref:`access-datasette` for each table if it is included in our SQLite outputs, and to
 the Parquet outputs if the table is available in that format.
@@ -36,11 +30,18 @@ Quick Reference
      - :ref:`Version <access-version>`
      - User Types
      - Use Cases
+
+   * - :ref:`access-viewer`
+     - Parquet, CSV
+     - ``nightly``
+     - Data Explorer, Spreadsheet Analyst
+     - Explore PUDL data interactively in a web browser, including hourly timeseries data.
+       Select data to download as CSVs for local analysis in spreadsheets.
    * - :ref:`access-datasette`
      - SQLite, CSV
      - ``nightly``
-     - Data Explorer, Spreadsheet Analyst
-     - Explore PUDL SQLite databases interactively in a web browser.
+     - Data Explorer, Spreadsheet Analyst, SQL User
+     - Run SQL queries on our SQLite database within your browser.
        Select data to download as CSVs for local analysis in spreadsheets.
        Create sharable links to a particular selection of data.
    * - :ref:`access-kaggle`
@@ -87,7 +88,8 @@ Data Platform
 ^^^^^^^^^^^^^
 
 PUDL data is distributed on a number of different platforms to acommodate a variety of
-different use cases. These include :ref:`access-datasette`, :ref:`access-kaggle`,
+different use cases. These include :ref:`access-viewer`,
+:ref:`access-datasette`, :ref:`access-kaggle`,
 :ref:`access-cloud`, and :ref:`access-zenodo`.
 
 .. _access-format:
@@ -103,13 +105,18 @@ PUDL data is distributed in two main file formats
   columnar storage format in which each file stores a single table. Parquet supports
   rich data types and metadata, and is highly performant.
 
-Any data that is published using SQLite is available through :ref:`access-datasette`,
-and can be downloaded as a CSV through that platform. See below.
+All data is distributed with both formats, except:
 
 - **Parquet Only**: The hourly data tables are distributed only as Parquet files.
   These tables have ``hourly`` in their names.
 - **SQLite Only**: The :ref:`minimally processed FERC data <access-raw-ferc>` which we
   have converted from XBRL and DBF into SQLite are only available in SQLite.
+
+All Parquet data is available through :ref:`access-viewer`, and can be
+downloaded as a CSV through that platform.
+
+All SQLite data is available through :ref:`access-datasette`,
+and can be downloaded as a CSV through that platform.
 
 .. _access-version:
 
@@ -126,11 +133,35 @@ We also provide access to a ``nightly`` development build of the data, which is 
 most weekday mornings. These builds are useful for beta testing new outputs, but are
 ephemeral and may not be as well validated as the ``stable`` releases.
 
+.. _access-viewer:
+
+---------------------------------------------------------------------------------------
+PUDL Viewer
+---------------------------------------------------------------------------------------
+
+We recently released the `PUDL Viewer <https://viewer.catalyst.coop/>`__ in beta.
+
+It provides flexible search of table descriptions, live data preview, and CSV
+export of up to 5 million rows. It also provides access to tables that were too
+large for Datasette, such as the EPA CEMS emissions data and the VCE RARE
+hourly renewable capacity factors data.
+
+Finally, it also has links to the Parquet downloads for each table, which you can view directly with tools like `Tad <https://www.tadviewer.com/>`__.
+
+Note that the raw :ref:`FERC SQLite databases <access-raw-ferc>` derived from
+the old Visual FoxPro and new XBRL data formats are not available here yet - if
+you need that, see :ref:`access-datasette`.
+
 .. _access-datasette:
 
 ---------------------------------------------------------------------------------------
 Datasette
 ---------------------------------------------------------------------------------------
+
+.. warning::
+
+  Our Datasette instance is deprecated. For performance reasons, we will be
+  moving all data access to our new :ref:`access-viewer` in early-mid 2025.
 
 We provide web-based access to the PUDL data via a
 `Datasette <https://datasette.io>`__ deployment at:
@@ -157,7 +188,8 @@ selected.
 
    Only PUDL database tables that are available in SQLite are accessible via Datasette.
    Due to their size, we currently do not load any of the hourly tables into SQLite, and
-   distribute them only as Parquet files.
+   distribute them only as Parquet files. For access to the hourly tables, see
+   the :ref:`access-viewer`.
 
 .. _access-kaggle:
 

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -34,16 +34,19 @@ Quick Reference
    * - :ref:`access-viewer`
      - Parquet, CSV
      - ``nightly``
-     - Data Explorer, Spreadsheet Analyst
-     - Explore PUDL data interactively in a web browser, including hourly timeseries data.
-       Select data to download as CSVs for local analysis in spreadsheets.
+     - Data Explorer, Spreadsheet Analyst, Jupyter Notebook User
+     - Explore PUDL data interactively in a web browser, including hourly
+       timeseries data. Select data to download as CSVs for local analysis in
+       spreadsheets. Download full tables as Parquet files to play with
+       programmatically.
    * - :ref:`access-datasette`
      - SQLite, CSV
      - ``nightly``
      - Data Explorer, Spreadsheet Analyst, SQL User
-     - Run SQL queries on our SQLite database within your browser.
-       Select data to download as CSVs for local analysis in spreadsheets.
-       Create sharable links to a particular selection of data.
+     - **DEPRECATED - in early-to-mid-2025 we will switch to**
+       :ref:`access-viewer`. Run SQL queries on our SQLite database within your
+       browser. Select data to download as CSVs for local analysis in
+       spreadsheets. Create sharable links to a particular selection of data.
    * - :ref:`access-kaggle`
      - SQLite, Parquet
      - ``nightly``
@@ -141,7 +144,7 @@ PUDL Viewer
 
 We recently released the `PUDL Viewer <https://viewer.catalyst.coop/>`__ in beta.
 
-It provides flexible search of table descriptions, live data preview, and CSV
+It provides flexible search of table metadata, live data preview, and CSV
 export of up to 5 million rows. It also provides access to tables that were too
 large for Datasette, such as the EPA CEMS emissions data and the VCE RARE
 hourly renewable capacity factors data.

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -16,8 +16,8 @@ types of tables, read through :ref:`PUDL's naming conventions <asset-naming>`.
 .. note::
 
   We recently released a beta `PUDL Database Viewer <https://viewer.catalyst.coop/>`__.
-  It provides fuzzy table search, live preview, and CSV export of up to 5 million rows.
-  It also provides links to the Parquet downloads for each table.
+  It provides flexible search of table descriptions, live data preview, and CSV export of up to 5 million rows. It also provides access to tables that were too large for Datasette, such as the EPA CEMS emissions data and the VCE RARE hourly renewable capacity factors data.
+  Finally, it also has links to the Parquet downloads for each table, which you can view directly with tools like `Tad <https://www.tadviewer.com/>`__.
 
 The :doc:`PUDL data dictionary </data_dictionaries/pudl_db>` provides direct links to
 :ref:`access-datasette` for each table if it is included in our SQLite outputs, and to

--- a/docs/data_dictionaries/index.rst
+++ b/docs/data_dictionaries/index.rst
@@ -9,6 +9,8 @@ The PUDL data dictionary provides detailed metadata for the tables
 in the PUDL database. This includes table descriptions,
 field names, field descriptions, and field datatypes.
 
+You can find this data at the `beta PUDL Viewer <https://viewer.catalyst.coop>`__ if you want interactive search, filtering, and CSV export.
+
 .. toctree::
    :maxdepth: 1
    :titlesonly:

--- a/docs/data_dictionaries/index.rst
+++ b/docs/data_dictionaries/index.rst
@@ -9,7 +9,9 @@ The PUDL data dictionary provides detailed metadata for the tables
 in the PUDL database. This includes table descriptions,
 field names, field descriptions, and field datatypes.
 
-You can find this data at the `beta PUDL Viewer <https://viewer.catalyst.coop>`__ if you want interactive search, filtering, and CSV export.
+**You can find this data at the** `beta PUDL Viewer
+<https://viewer.catalyst.coop>`__ **if you want interactive search, filtering,
+and CSV export.**
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -298,6 +298,7 @@ Enable Open Source Ecosystems (POSE) program
 
   About PUDL <self>
   data_access
+  PUDL Database Viewer <https://viewer.catalyst.coop>
   data_sources/index
   data_dictionaries/index
   Contributing <CONTRIBUTING>


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

As part of launching the PUDL viewer we should actually include it in our docs.

## What did you change?

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [ ] ~Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.~
- [ ] ~Update relevant Data Source jinja templates (see `docs/data_sources/templates`).~
- [ ] ~Update relevant table or source description metadata (see `src/metadata`).~
- [x] Review and update any other aspects of the documentation that might be affected by this PR.
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

Built docs locally and looked at them.

```[tasklist]
# To-do list
- [ ] ~If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).~
- [ ] ~Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.~
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] ~For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.~
- [ ] ~For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.~
- [ ] ~Alternatively, run the `build-deploy-pudl` GitHub Action manually.~
```
