### PR TITLE
Add model/table-level macro for group_mean_continuity_check

### DIFF
--- a/dbt/macros/group_mean_continuity_check.sql
+++ b/dbt/macros/group_mean_continuity_check.sql
@@ -1,0 +1,39 @@
+{% test group_mean_continuity_check(model, ordered_group_column, thresholds, n_outliers_allowed=0) %}
+
+with GroupMean as (
+    select
+    {{ ordered_group_column }},
+    {% for threshold in thresholds %}
+    avg({{ threshold.column }}) as mean_{{ loop.index }} {%- if not loop.last -%},{%- endif -%}
+    {% endfor %}
+    from {{ model }}
+    group by {{ ordered_group_column }}
+),
+Continuity as (
+    select
+    {{ ordered_group_column }},
+    {% for threshold in thresholds %}
+    mean_{{ loop.index }} as newer_value_{{ loop.index }},
+    LAG(mean_{{ loop.index }}) OVER w as older_value_{{ loop.index }} {%- if not loop.last -%},{%- endif -%}
+    {% endfor %}
+    from GroupMean
+    window w as (order by {{ ordered_group_column }})
+),
+{% for threshold in thresholds %}
+Violations_{{ loop.index }} as (
+    select
+    {{ ordered_group_column }},
+    '{{ threshold.column }}' as 'column_name',
+    abs(newer_value_{{ loop.index }} - older_value_{{ loop.index }})/older_value_{{ loop.index }} as fr_change
+    from Continuity
+    where newer_value_{{ loop.index }} is not null and older_value_{{ loop.index }} is not null and fr_change >= {{ threshold.max_fr_change }}
+    limit 1e6 offset {{ n_outliers_allowed }}
+){%- if not loop.last -%},{%- endif -%}
+{% endfor %}
+{% for threshold in thresholds %}
+select * from
+Violations_{{ loop.index }}
+{% if not loop.last %} union all {% endif %}
+{% endfor %}
+
+{% endtest %}

--- a/dbt/macros/schema.yml
+++ b/dbt/macros/schema.yml
@@ -1,0 +1,28 @@
+version: 2
+
+macros:
+  - name: test_group_mean_continuity_check
+    description: >
+      Check that certain variables don't vary by too much. Groups the data by
+      ``ordered_group_column``, takes the mean of each group, then compares neighboring
+      means in ``ordered_group_column`` order. Useful for saying something like "the
+      average water usage of cooling systems didn't jump by 10x from 2012-2013."
+    arguments:
+      - name: ordered_group_column
+        type: string
+        description: The name of the column to group and order by (usually ``report_date`` or similar).
+      - name: thresholds
+        type: list
+        description: >
+          List of thresholds to check. Each element in the list should specify two keys.
+          The `column` key should indicate the name of the column. The `max_fr_change` key
+          should indicate the ratio by which the means of this column are permitted to
+          fluctuate from one group to the next. For an example, see
+          _core_eia923__cooling_system_information.
+      - name: n_outliers_allowed
+        type: int
+        description: >
+          How many data points are allowed to be above the threshold; default 0. This is
+          computed per column, so if you specify n_outliers_allowed = 1, then each
+          threshold column can have 1 instance where the change between groups exceeds its
+          threshold.

--- a/dbt/models/eia923/_core_eia923__cooling_system_information/schema.yml
+++ b/dbt/models/eia923/_core_eia923__cooling_system_information/schema.yml
@@ -7,6 +7,32 @@ sources:
           - check_row_counts_per_partition:
               table_name: _core_eia923__cooling_system_information
               partition_column: report_date
+          - group_mean_continuity_check:
+              ordered_group_column: report_date
+              n_outliers_allowed: 2
+              thresholds:
+                - column: annual_average_consumption_rate_gallons_per_minute
+                  max_fr_change: 0.1
+                - column: annual_average_discharge_rate_gallons_per_minute
+                  max_fr_change: 0.1
+                - column: annual_average_withdrawal_rate_gallons_per_minute
+                  max_fr_change: 0.1
+                - column: monthly_average_consumption_rate_gallons_per_minute
+                  max_fr_change: 0.5
+                - column: monthly_average_discharge_rate_gallons_per_minute
+                  max_fr_change: 0.2
+                - column: monthly_average_diversion_rate_gallons_per_minute
+                  max_fr_change: 1.3
+                - column: monthly_average_withdrawal_rate_gallons_per_minute
+                  max_fr_change: 0.2
+                - column: monthly_total_consumption_volume_gallons
+                  max_fr_change: 0.4
+                - column: monthly_total_discharge_volume_gallons
+                  max_fr_change: 0.3
+                - column: monthly_total_diversion_volume_gallons
+                  max_fr_change: 1.3
+                - column: monthly_total_withdrawal_volume_gallons
+                  max_fr_change: 0.3
         columns:
           - name: report_date
           - name: plant_id_eia


### PR DESCRIPTION
Alternate implementation of #4092. Would contribute to completion of #4095.

Where #4092 implements this check at the column level, this PR implements it at the model/table level, which significantly reduces the amount of duplicated information in the `schema.yml` files that use it... at the possible expense of having to build a pretty complicated query.

# Overview

Three tables require a [`group_mean_continuity_check`, which does the following](https://github.com/catalyst-cooperative/pudl/blob/e4bd17d8478ad44de0c7ce8175b3ae84a12b409d/src/pudl/validate.py#L163):

1. Group by a specified column
2. Compute the mean of each group
3. Compute the percent change between successive groups
4. Check against a per-column threshold

This PR contains a draft for a possible implementation.

## What did you change?

- New macro, `group_mean_continuity_check(ordered_group_column, thresholds, n_outliers_allowed)`
- Demo of macro in use for `_core_eia923__cooling_system_information`, using columns and thresholds from [`transform/eia923.py`](https://github.com/catalyst-cooperative/pudl/blob/7ab320421f2e08438469500feec9335f9e5cee86/src/pudl/transform/eia923.py#L1340)
