### PR TITLE
fix: lower concurrency so we don't run into skyrocketing memory issue

### DIFF
--- a/devtools/datasette/fly/production.toml
+++ b/devtools/datasette/fly/production.toml
@@ -14,7 +14,7 @@ primary_region = "bos"
   protocol = "tcp"
 
   [services.concurrency]
-    hard_limit = 80
+    hard_limit = 40
     soft_limit = 20
 
   [[services.ports]]


### PR DESCRIPTION
# Overview

## What problem does this address?

We're hitting OOMs because with 80 concurrent requests we end up having pile-ups of slow requests.

## What did you change?

Bring concurrency from 80 -> 40.

We originally had 25 concurrency, which was causing lots of 502s when Fly hit the limit. But with 80 max connections we ran into resource constraints. Let's try something in the middle.

# Documentation

Make sure to update relevant aspects of the documentation.

```[tasklist]
- [ ] ~Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.~
- [ ] ~Update relevant Data Source jinja templates (see `docs/data_sources/templates`).~
- [ ] ~Update relevant table or source description metadata (see `src/metadata`).~
- [ ] ~Review and update any other aspects of the documentation that might be affected by this PR.~
```

# Testing

## How did you make sure this worked? How can a reviewer verify this?

```[tasklist]
# To-do list
- [ ] ~If updating analyses or data processing functions: make sure to update or write data validation tests (e.g. `test_minmax_rows()`).~
- [ ] ~Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.~
- [ ] ~Review the PR yourself and call out any questions or issues you have.~
- [ ] ~For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.~
- [ ] ~For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.~
- [ ] ~Alternatively, run the `build-deploy-pudl` GitHub Action manually.~
```
