### PR TITLE
fix: up fly app timeout

### DIFF
--- a/devtools/datasette/fly/production.toml
+++ b/devtools/datasette/fly/production.toml
@@ -31,4 +31,4 @@ primary_region = "bos"
     timeout = 2000
 
 [deploy]
-wait_timeout = "15m"
+wait_timeout = "25m"

--- a/devtools/datasette/fly/staging.toml
+++ b/devtools/datasette/fly/staging.toml
@@ -24,4 +24,4 @@ primary_region = "bos"
   cpus = 1
 
 [deploy]
-wait_timeout = "15m"
+wait_timeout = "25m"


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

Nightly builds keep failing datasette step with a timeout. The app eventually starts up but only after the timeout is triggered. 

## What did you change?

15 minutes -> 25 minutes.

## Documentation

Don't think there's anything to change here.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Just looked in the documentation for a cap on the wait timeout and couldn't find one.

I could have downloaded the nightly build full outputs from GCS and run the publish command, but that requires a bunch of disk space cleanup and that seemed like a distraction, whereas the risk of 'push-and-wait' seems pretty low.