### PR TITLE
Remove obsolete vs_self, vs_historical, & check_unique_rows tests

### DIFF
--- a/dbt/models/ferc1/core_ferc1__yearly_hydroelectric_plants_sched406/schema.yml
+++ b/dbt/models/ferc1/core_ferc1__yearly_hydroelectric_plants_sched406/schema.yml
@@ -7,6 +7,12 @@ sources:
           - check_row_counts_per_partition:
               table_name: core_ferc1__yearly_hydroelectric_plants_sched406
               partition_column: report_year
+          - dbt_utils.unique_combination_of_columns:
+              combination_of_columns:
+                - report_year
+                - utility_id_ferc1
+                - plant_name_ferc1
+                - capacity_mw
         columns:
           - name: record_id
             data_tests:

--- a/dbt/models/ferc1/core_ferc1__yearly_pumped_storage_plants_sched408/schema.yml
+++ b/dbt/models/ferc1/core_ferc1__yearly_pumped_storage_plants_sched408/schema.yml
@@ -7,6 +7,12 @@ sources:
           - check_row_counts_per_partition:
               table_name: core_ferc1__yearly_pumped_storage_plants_sched408
               partition_column: report_year
+          - dbt_utils.unique_combination_of_columns:
+              combination_of_columns:
+                - report_year
+                - utility_id_ferc1
+                - plant_name_ferc1
+                - capacity_mw
         columns:
           - name: record_id
             data_tests:

--- a/src/pudl/validate.py
+++ b/src/pudl/validate.py
@@ -365,91 +365,6 @@ def vs_bounds(
             )
 
 
-def vs_self(
-    df, data_col, weight_col, query="", title="", low_q=0.05, mid_q=0.5, hi_q=0.95
-):
-    """Test a distribution against its own historical range.
-
-    This is a special case of the :func:`pudl.validate.vs_historical` function, in which
-    both the ``orig_df`` and ``test_df`` are the same. Mostly it helps ensure that the
-    test itself is valid for the given distribution.
-    """
-    if weight_col is None or weight_col == "":
-        df["ones"] = 1.0
-        weight_col = "ones"
-    vs_historical(
-        df,
-        df,
-        data_col,
-        weight_col,
-        query=query,
-        low_q=low_q,
-        mid_q=mid_q,
-        hi_q=hi_q,
-        title=title,
-    )
-
-
-def vs_historical(  # noqa: C901
-    orig_df,
-    test_df,
-    data_col,
-    weight_col,
-    query="",
-    low_q=0.05,
-    mid_q=0.5,
-    hi_q=0.95,
-    title="",
-):
-    """Validate aggregated distributions against original data."""
-    if query != "":
-        orig_df = orig_df.copy().query(query)
-        test_df = test_df.copy().query(query)
-    if title != "":
-        logger.info(title)
-    if weight_col is None or weight_col == "":
-        orig_df["ones"] = 1.0
-        test_df["ones"] = 1.0
-        weight_col = "ones"
-    if low_q:
-        low_range = historical_distribution(orig_df, data_col, weight_col, low_q)
-        low_test = weighted_quantile(test_df[data_col], test_df[weight_col], low_q)
-        logger.info(f"{data_col} ({low_q:.0%}): {low_test:.6} >= {min(low_range):.6}")
-        if low_test < min(low_range):
-            raise ValueError(
-                f"Lower value {low_test} below lower limit {min(low_range)} "
-                f"in validation of {data_col}"
-            )
-
-    if mid_q:
-        mid_range = historical_distribution(orig_df, data_col, weight_col, mid_q)
-        mid_test = weighted_quantile(test_df[data_col], test_df[weight_col], mid_q)
-        logger.info(
-            f"{data_col} ({mid_q:.0%}): {min(mid_range):.6} <= {mid_test:.6} "
-            f"<= {max(mid_range):.6}"
-        )
-        if mid_test < min(mid_range):
-            raise ValueError(
-                f"Middle value {mid_test} below lower limit {min(mid_range)} "
-                f"in validation of {data_col}"
-            )
-        if mid_test > max(mid_range):
-            raise ValueError(
-                f"Middle value {mid_test} above upper limit {max(mid_range)} "
-                f"in validation of {data_col}"
-            )
-
-    if hi_q:
-        hi_range = historical_distribution(orig_df, data_col, weight_col, hi_q)
-        hi_test = weighted_quantile(test_df[data_col], test_df[weight_col], hi_q)
-        logger.info(f"{data_col} ({hi_q:.0%}): {hi_test:.6} <= {max(hi_range):.6}.")
-        if hi_test > max(hi_range):
-            raise ValueError(
-                f"Upper value {hi_test} above upper limit {max(hi_range)} "
-                f"in validation of {data_col}"
-            )
-
-
 def bounds_histogram(
     df, data_col, weight_col, query, low_q, hi_q, low_bound, hi_bound, title=""
 ):
@@ -622,30 +537,6 @@ def plot_vs_bounds(df, validation_cases):
             warnings.warn("ERROR: Validation Failed", stacklevel=1)
 
         bounds_histogram(df, **args)
-
-
-def plot_vs_self(df, validation_cases):
-    """Validate a bunch of distributions against themselves."""
-    for args in validation_cases:
-        try:
-            vs_self(df, **args)
-        except ValueError as e:
-            logger.error(str(e))
-            warnings.warn("ERROR: Validation Failed", stacklevel=1)
-
-        historical_histogram(df, test_df=None, **args)
-
-
-def plot_vs_agg(orig_df, agg_df, validation_cases):
-    """Validate a bunch of distributions against aggregated versions."""
-    for args in validation_cases:
-        try:
-            vs_historical(orig_df, agg_df, **args)
-        except ValueError as e:
-            logger.error(str(e))
-            warnings.warn("ERROR: Validation Failed", stacklevel=1)
-
-        historical_histogram(orig_df, agg_df, **args)
 
 
 ###############################################################################

--- a/src/pudl/validate.py
+++ b/src/pudl/validate.py
@@ -203,30 +203,6 @@ def group_mean_continuity_check(
     return AssetCheckResult(passed=True, metadata=metadata)
 
 
-def check_unique_rows(
-    df: pd.DataFrame, subset: list[str] | None = None, df_name: str = ""
-) -> pd.DataFrame:
-    """Test whether dataframe has unique records within a subset of columns.
-
-    Args:
-        df: DataFrame to check for duplicate records.
-        subset: Columns to consider in checking for dupes.
-        df_name: Name of the dataframe, to aid in debugging/logging.
-
-    Returns:
-        The same DataFrame as was passed in, for use in DataFrame.pipe().
-
-    Raises:
-        ValueError:  If there are duplicate records in the subset of selected
-            columns.
-    """
-    n_dupes = len(df[df.duplicated(subset=subset)])
-    if n_dupes != 0:
-        raise ValueError(f"Found {n_dupes} dupes of {subset} in dataframe {df_name}")
-
-    return df
-
-
 def weighted_quantile(data: pd.Series, weights: pd.Series, quantile: float) -> float:
     """Calculate the weighted quantile of a Series or DataFrame column.
 

--- a/test/validate/bf_eia923_test.py
+++ b/test/validate/bf_eia923_test.py
@@ -38,32 +38,3 @@ def test_vs_bounds(pudl_out_eia, live_dbs, cases):
 
     for args in cases:
         pudl.validate.vs_bounds(pudl_out_eia.bf_eia923(), **args)
-
-
-###############################################################################
-# Tests validating distributions against historical subsamples of themselves
-###############################################################################
-
-
-def test_self_vs_historical(pudl_out_eia, live_dbs):
-    """Validate the whole dataset against historical annual subsamples."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    if pudl_out_eia.freq is not None:
-        pytest.skip("Test only runs on un-aggregated data.")
-
-    for args in pudl.validate.bf_eia923_self:
-        pudl.validate.vs_self(pudl_out_eia.bf_eia923(), **args)
-
-
-def test_agg_vs_historical(pudl_out_orig, pudl_out_eia, live_dbs):
-    """Validate whole dataset against aggregated historical values."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    if pudl_out_eia.freq is None:
-        pytest.skip("Only run if pudl_out_eia != pudl_out_orig.")
-
-    for args in pudl.validate.bf_eia923_agg:
-        pudl.validate.vs_historical(
-            pudl_out_orig.bf_eia923(), pudl_out_eia.bf_eia923(), **args
-        )

--- a/test/validate/eia_test.py
+++ b/test/validate/eia_test.py
@@ -5,7 +5,6 @@ import logging
 import pytest
 
 from pudl import validate as pv
-from pudl.metadata.classes import Resource
 from test.conftest import skip_table_if_null_freq_table
 
 logger = logging.getLogger(__name__)
@@ -39,95 +38,4 @@ def test_no_null_cols_eia(pudl_out_eia, live_dbs, cols, df_name):
     skip_table_if_null_freq_table(table_name=df_name, freq=pudl_out_eia.freq)
     pv.no_null_cols(
         pudl_out_eia.__getattribute__(df_name)(), cols=cols, df_name=df_name
-    )
-
-
-@pytest.mark.parametrize(
-    "df_name,unique_subset",
-    [
-        (
-            "bf_eia923",
-            Resource.from_id("core_eia923__monthly_boiler_fuel").schema.primary_key,
-        ),
-        (
-            "bga_eia860",
-            Resource.from_id("core_eia860__assn_boiler_generator").schema.primary_key,
-        ),
-        (
-            "boil_eia860",
-            Resource.from_id("core_eia860__scd_boilers").schema.primary_key,
-        ),
-        (
-            "gen_eia923",
-            Resource.from_id("core_eia923__monthly_generation").schema.primary_key,
-        ),
-        (
-            "gens_eia860",
-            Resource.from_id("core_eia860__scd_generators").schema.primary_key,
-        ),
-        (
-            "gf_eia923",
-            Resource.from_id("out_eia923__generation_fuel_combined").schema.primary_key,
-        ),
-        (
-            "own_eia860",
-            Resource.from_id("core_eia860__scd_ownership").schema.primary_key,
-        ),
-        (
-            "plants_eia860",
-            Resource.from_id("core_eia860__scd_plants").schema.primary_key,
-        ),
-        (
-            "pu_eia860",
-            Resource.from_id("_out_eia__plants_utilities").schema.primary_key,
-        ),
-        (
-            "utils_eia860",
-            Resource.from_id("core_eia860__scd_utilities").schema.primary_key,
-        ),
-        (
-            "denorm_emissions_control_equipment_eia860",
-            (
-                Resource.from_id(
-                    "out_eia860__yearly_emissions_control_equipment"
-                ).schema.primary_key
-            ),
-        ),
-        (
-            "emissions_control_equipment_eia860",
-            (
-                Resource.from_id(
-                    "core_eia860__scd_emissions_control_equipment"
-                ).schema.primary_key
-            ),
-        ),
-        (
-            "boiler_emissions_control_equipment_assn_eia860",
-            (
-                Resource.from_id(
-                    "core_eia860__assn_yearly_boiler_emissions_control_equipment"
-                ).schema.primary_key
-            ),
-        ),
-        (
-            "boiler_cooling_assn_eia860",
-            (Resource.from_id("core_eia860__assn_boiler_cooling").schema.primary_key),
-        ),
-        (
-            "boiler_stack_flue_assn_eia860",
-            (
-                Resource.from_id(
-                    "core_eia860__assn_boiler_stack_flue"
-                ).schema.primary_key
-            ),
-        ),
-    ],
-)
-def test_unique_rows_eia(pudl_out_eia, live_dbs, unique_subset, df_name):
-    """Test whether dataframe has unique records within a subset of columns."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    skip_table_if_null_freq_table(table_name=df_name, freq=pudl_out_eia.freq)
-    pv.check_unique_rows(
-        pudl_out_eia.__getattribute__(df_name)(), subset=unique_subset, df_name=df_name
     )

--- a/test/validate/fbp_ferc1_test.py
+++ b/test/validate/fbp_ferc1_test.py
@@ -34,20 +34,3 @@ def test_vs_bounds(pudl_out_ferc1, live_dbs, cases):
 
     for case in cases:
         pv.vs_bounds(fbp_ferc1, **case)
-
-
-def test_self_vs_historical(pudl_out_ferc1, live_dbs):
-    """Validate fuel by plants vs.
-
-    historical data.
-    """
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    else:
-        fbp_ferc1 = pudl_out_ferc1.fbp_ferc1()
-        for f in ["gas", "oil", "coal", "waste", "nuclear"]:
-            fbp_ferc1[f"{f}_cost_per_mmbtu"] = (
-                fbp_ferc1[f"{f}_fraction_cost"] * fbp_ferc1["fuel_cost"]
-            ) / (fbp_ferc1[f"{f}_fraction_mmbtu"] * fbp_ferc1["fuel_mmbtu"])
-        for args in pv.fbp_ferc1_self:
-            pv.vs_self(fbp_ferc1, **args)

--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -74,52 +74,6 @@ def test_no_null_cols_ferc1(live_dbs, asset_value_loader, cols, asset_key):
 
 
 @pytest.mark.parametrize(
-    "asset_key,unique_subset",
-    [
-        (
-            "_out_ferc1__yearly_plants_utilities",
-            ["utility_id_ferc1", "plant_name_ferc1"],
-        ),
-        (
-            "out_ferc1__yearly_steam_plants_fuel_by_plant_sched402",
-            ["report_year", "utility_id_ferc1", "plant_name_ferc1"],
-        ),
-        (
-            "out_ferc1__yearly_hydroelectric_plants_sched406",
-            [
-                "report_year",
-                "utility_id_ferc1",
-                "plant_name_ferc1",
-                "capacity_mw",  # Why does having capacity here make sense???
-            ],
-        ),
-        (
-            "out_ferc1__yearly_pumped_storage_plants_sched408",
-            [
-                "report_year",
-                "utility_id_ferc1",
-                "plant_name_ferc1",
-                "capacity_mw",  # Why does having capacity here make sense???
-            ],
-        ),
-        (
-            "out_ferc1__yearly_plant_in_service_sched204",
-            ["report_year", "utility_id_ferc1", "ferc_account_label"],
-        ),
-    ],
-)
-def test_unique_rows_ferc1(live_dbs, asset_value_loader, asset_key, unique_subset):
-    """Test whether dataframe has unique records within a subset of columns."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    pv.check_unique_rows(
-        asset_value_loader.load_asset_value(asset_key),
-        subset=unique_subset,
-        df_name=asset_key,
-    )
-
-
-@pytest.mark.parametrize(
     "table_name",
     [  # some sample wide guys
         "core_ferc1__yearly_sales_by_rate_schedules_sched304",

--- a/test/validate/frc_eia923_test.py
+++ b/test/validate/frc_eia923_test.py
@@ -80,27 +80,3 @@ def test_vs_bounds(pudl_out_eia, live_dbs, cases):
 
     for case in cases:
         pudl.validate.vs_bounds(pudl_out_eia.frc_eia923(), **case)
-
-
-def test_self_vs_historical(pudl_out_eia, live_dbs):
-    """Validate the whole dataset against historical annual subsamples."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    if pudl_out_eia.freq is not None:
-        pytest.skip("Test only runs on un-aggregated data.")
-
-    for args in pudl.validate.frc_eia923_self:
-        pudl.validate.vs_self(pudl_out_eia.frc_eia923(), **args)
-
-
-def test_agg_vs_historical(pudl_out_orig, pudl_out_eia, live_dbs):
-    """Validate whole dataset against aggregated historical values."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    if pudl_out_eia.freq is None:
-        pytest.skip("Only run if pudl_out_eia != pudl_out_orig.")
-
-    for args in pudl.validate.frc_eia923_agg:
-        pudl.validate.vs_historical(
-            pudl_out_orig.frc_eia923(), pudl_out_eia.frc_eia923(), **args
-        )

--- a/test/validate/fuel_ferc1_test.py
+++ b/test/validate/fuel_ferc1_test.py
@@ -64,17 +64,3 @@ def test_vs_bounds(pudl_out_ferc1, live_dbs, cases):
             ),
             **case,
         )
-
-
-def test_self_vs_historical(pudl_out_ferc1, live_dbs):
-    """Validate..."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    for args in pv.fuel_ferc1_self:
-        pv.vs_self(
-            pd.read_sql(
-                "out_ferc1__yearly_steam_plants_fuel_sched402",
-                pudl_out_ferc1.pudl_engine,
-            ),
-            **args,
-        )

--- a/test/validate/gens_eia860_test.py
+++ b/test/validate/gens_eia860_test.py
@@ -23,14 +23,3 @@ def test_capacity_bounds(pudl_out_eia, live_dbs):
 
     for args in pudl.validate.gens_eia860_vs_bound:
         pudl.validate.vs_bounds(pudl_out_eia.gens_eia860(), **args)
-
-
-def test_capacity_self(pudl_out_eia, live_dbs):
-    """Check that the distribution of coal heat content per unit is valid."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    if pudl_out_eia.freq is not None:
-        pytest.skip("Test should only run on un-aggregated data.")
-
-    for args in pudl.validate.gens_eia860_self:
-        pudl.validate.vs_self(pudl_out_eia.gens_eia860(), **args)

--- a/test/validate/gf_eia923_test.py
+++ b/test/validate/gf_eia923_test.py
@@ -27,25 +27,3 @@ def test_vs_bounds(pudl_out_eia, live_dbs, cases):
 
     for args in cases:
         pudl.validate.vs_bounds(pudl_out_eia.gf_eia923(), **args)
-
-
-#######################################################################################
-# Tests validating distributions against historical subsamples of themselves Note that
-# all of the fields we're testing in this table are the fuel_type_code_pudl fields which
-# are simplified lumpings of the other fuel types, and aren't as useful to test against
-# their historical selves. So we're only testing the aggregation (i.e. there's no
-# test_self_vs_historical() here)
-#######################################################################################
-
-
-def test_agg_vs_historical(pudl_out_orig, pudl_out_eia, live_dbs):
-    """Validate whole dataset against aggregated historical values."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    if pudl_out_eia.freq is None:
-        pytest.skip("Only run if pudl_out_eia != pudl_out_orig.")
-
-    for args in pudl.validate.gf_eia923_agg:
-        pudl.validate.vs_historical(
-            pudl_out_orig.gf_eia923(), pudl_out_eia.gf_eia923(), **args
-        )

--- a/test/validate/mcoe_test.py
+++ b/test/validate/mcoe_test.py
@@ -183,8 +183,6 @@ def test_fuel_cost_per_mwh(pudl_out_mcoe, live_dbs):
     # The annual numbers for MCOE costs have too many NA values:
     if pudl_out_mcoe.freq != "MS":
         pytest.skip()
-    for args in pv.mcoe_self_fuel_cost_per_mwh:
-        pv.vs_self(pudl_out_mcoe.mcoe_generators(), **args)
 
     for args in pv.mcoe_fuel_cost_per_mwh:
         pv.vs_bounds(pudl_out_mcoe.mcoe_generators(), **args)
@@ -197,18 +195,6 @@ def test_fuel_cost_per_mmbtu(pudl_out_mcoe, live_dbs):
     # The annual numbers for MCOE costs have too many NA values:
     if pudl_out_mcoe.freq != "MS":
         pytest.skip()
-    for args in pv.mcoe_self_fuel_cost_per_mmbtu:
-        pv.vs_self(pudl_out_mcoe.mcoe_generators(), **args)
 
     for args in pv.mcoe_fuel_cost_per_mmbtu:
         pv.vs_bounds(pudl_out_mcoe.mcoe_generators(), **args)
-
-
-def test_mcoe_self(pudl_out_mcoe, live_dbs):
-    """Test MCOE outputs against their historical selves..."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    if pudl_out_mcoe.freq is None:
-        pytest.skip()
-    for args in pv.mcoe_self:
-        pv.vs_self(pudl_out_mcoe.mcoe_generators(), **args)

--- a/test/validate/mcoe_test.py
+++ b/test/validate/mcoe_test.py
@@ -91,27 +91,6 @@ def test_no_null_rows_mcoe(pudl_out_mcoe, live_dbs, df_name, thresh):
     )
 
 
-@pytest.mark.parametrize(
-    "df_name,unique_subset",
-    [
-        ("hr_by_unit", ["report_date", "plant_id_eia", "unit_id_pudl"]),
-        ("hr_by_gen", ["report_date", "plant_id_eia", "generator_id"]),
-        ("fuel_cost", ["report_date", "plant_id_eia", "generator_id"]),
-        ("capacity_factor", ["report_date", "plant_id_eia", "generator_id"]),
-        ("mcoe", ["report_date", "plant_id_eia", "generator_id"]),
-    ],
-)
-def test_unique_rows_mcoe(pudl_out_mcoe, live_dbs, unique_subset, df_name):
-    """Test whether dataframe has unique records within a subset of columns."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    if pudl_out_mcoe.freq is None:
-        pytest.skip()
-    pv.check_unique_rows(
-        pudl_out_mcoe.__getattribute__(df_name)(), subset=unique_subset, df_name=df_name
-    )
-
-
 ###############################################################################
 # Tests that look at distributions of MCOE calculation outputs.
 ###############################################################################

--- a/test/validate/notebooks/validate_bf_eia923.ipynb
+++ b/test/validate/notebooks/validate_bf_eia923.ipynb
@@ -214,85 +214,11 @@
    "source": [
     "pudl.validate.plot_vs_bounds(bf_eia923_orig, pudl.validate.bf_eia923_coal_sulfur_content)"
    ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validating Historical Distributions\n",
-    "As a sanity check of the testing process itself, we can check to see whether the entire historical distribution has attributes that place it within the extremes of a historical subsampling of the distribution. In this case, we sample each historical year, and look at the range of values taken on by some quantile, and see whether the same quantile for the whole of the dataset fits within that range"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_self(bf_eia923_orig, pudl.validate.bf_eia923_self)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validate Monthly Aggregation\n",
-    "It's possible that the distribution will change as a function of aggregation, or we might make an error in the aggregation process. These tests check that a collection of quantiles for the original and the data aggregated by month have internally consistent values."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl_out_month = pudl.output.pudltabl.PudlTabl(pudl_engine, freq=\"MS\")\n",
-    "bf_eia923_month = pudl_out_month.bf_eia923()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_agg(bf_eia923_orig, bf_eia923_month, pudl.validate.bf_eia923_agg)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validate Annual Aggregation\n",
-    "It's possible that the distribution will change as a function of aggregation, or we might make an error in the aggregation process. These tests check that a collection of quantiles for the original and the data aggregated by year have internally consistent values."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl_out_year = pudl.output.pudltabl.PudlTabl(pudl_engine, freq=\"AS\")\n",
-    "bf_eia923_year = pudl_out_year.bf_eia923()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_agg(bf_eia923_orig, bf_eia923_year, pudl.validate.bf_eia923_agg)"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pudl-dev",
    "language": "python",
    "name": "python3"
   },
@@ -306,7 +232,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/test/validate/notebooks/validate_fbp_ferc1.ipynb
+++ b/test/validate/notebooks/validate_fbp_ferc1.ipynb
@@ -132,10 +132,14 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "toc-hr-collapsed": false
+   },
    "source": [
-    "# Validating Historical Distributions\n",
-    "As a sanity check of the testing process itself, we can check to see whether the entire historical distribution has attributes that place it within the extremes of a historical subsampling of the distribution. In this case, we sample each historical year, and look at the range of values taken on by some quantile, and see whether the same quantile for the whole of the dataset fits within that range"
+    "# Validation Against Fixed Bounds \n",
+    "Some of the variables reported in this table have a fixed range of reasonable values, like the heat content per unit of a given fuel type.  These varaibles can be tested for validity against external standards directly.  In general we have two kinds of tests in this section:\n",
+    "* **Tails:** are the exteme values too extreme? Typically, this is at the 5% and 95% level, but depending on the distribution, sometimes other thresholds are used.\n",
+    "* **Middle:** Is the central value of the distribution where it should be?"
    ]
   },
   {
@@ -147,28 +151,6 @@
     "# This is required to get the fuel costs per unit back into the dataframe.... just for sanity checking:\n",
     "for fuel in [\"gas\", \"oil\", \"coal\", \"waste\", \"nuclear\"]:\n",
     "    fbp_ferc1[f\"{fuel}_cost_per_mmbtu\"] = (fbp_ferc1[f\"{fuel}_fraction_cost\"] * fbp_ferc1[\"fuel_cost\"]) /  (fbp_ferc1[f\"{fuel}_fraction_mmbtu\"] * fbp_ferc1[\"fuel_mmbtu\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pv.plot_vs_self(fbp_ferc1, pv.fbp_ferc1_self)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {
-    "toc-hr-collapsed": false
-   },
-   "source": [
-    "# Validation Against Fixed Bounds \n",
-    "Some of the variables reported in this table have a fixed range of reasonable values, like the heat content per unit of a given fuel type.  These varaibles can be tested for validity against external standards directly.  In general we have two kinds of tests in this section:\n",
-    "* **Tails:** are the exteme values too extreme? Typically, this is at the 5% and 95% level, but depending on the distribution, sometimes other thresholds are used.\n",
-    "* **Middle:** Is the central value of the distribution where it should be?"
    ]
   },
   {
@@ -200,7 +182,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pudl-dev",
    "language": "python",
    "name": "python3"
   },
@@ -214,7 +196,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/test/validate/notebooks/validate_frc_eia923.ipynb
+++ b/test/validate/notebooks/validate_frc_eia923.ipynb
@@ -236,85 +236,11 @@
    "source": [
     "pudl.validate.plot_vs_bounds(frc_eia923_orig, pudl.validate.frc_eia923_coal_moisture_content)"
    ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validating Historical Distributions\n",
-    "As a sanity check of the testing process itself, we can check to see whether the entire historical distribution has attributes that place it within the extremes of a historical subsampling of the distribution. In this case, we sample each historical year, and look at the range of values taken on by some quantile, and see whether the same quantile for the whole of the dataset fits within that range"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_self(frc_eia923_orig, pudl.validate.frc_eia923_self)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validate Monthly Aggregation\n",
-    "It's possible that the distribution will change as a function of aggregation, or we might make an error in the aggregation process. These tests check that a collection of quantiles for the original and the data aggregated by month have internally consistent values."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl_out_month = pudl.output.pudltabl.PudlTabl(pudl_engine, freq=\"MS\")\n",
-    "frc_eia923_month = pudl_out_month.frc_eia923()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_agg(frc_eia923_orig, frc_eia923_month, pudl.validate.frc_eia923_agg)"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validate Annual Aggregation\n",
-    "It's possible that the distribution will change as a function of aggregation, or we might make an error in the aggregation process. These tests check that a collection of quantiles for the original and the data aggregated by year have internally consistent values."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl_out_year = pudl.output.pudltabl.PudlTabl(pudl_engine, freq=\"AS\")\n",
-    "frc_eia923_year = pudl_out_year.frc_eia923()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_agg(frc_eia923_orig, frc_eia923_year, pudl.validate.frc_eia923_agg)"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pudl-dev",
    "language": "python",
    "name": "python3"
   },
@@ -328,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/test/validate/notebooks/validate_fuel_ferc1.ipynb
+++ b/test/validate/notebooks/validate_fuel_ferc1.ipynb
@@ -79,9 +79,8 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
-    "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
-    "pudl_settings"
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri('ferc1'))\n",
+    "pudl_engine = sa.create_engine(PudlPaths().pudl_db)"
    ]
   },
   {
@@ -106,14 +105,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Validating Historical Distributions\n",
-    "As a sanity check of the testing process itself, we can check to see whether the entire historical distribution has attributes that place it within the extremes of a historical subsampling of the distribution. In this case, we sample each historical year, and look at the range of values taken on by some quantile, and see whether the same quantile for the whole of the dataset fits within that range"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Columns to Validate\n",
     "* `fuel_cost_per_mmbtu` (by fuel, coal, oil, or gas)\n",
     "* `fuel_cost_per_unit` (by fuel, coal, oil, or gas)\n",
@@ -122,15 +113,6 @@
     "## Other Quantities to validate..\n",
     "* Does cost per unit burned X units burned == total cost?\n",
     "* MMBTU per unit X units burned == total MMBTU?"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_self(fuel_ferc1, pv.fuel_ferc1_self)"
    ]
   },
   {
@@ -202,7 +184,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pudl-dev",
    "language": "python",
    "name": "python3"
   },
@@ -216,7 +198,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/test/validate/notebooks/validate_gens_eia860.ipynb
+++ b/test/validate/notebooks/validate_gens_eia860.ipynb
@@ -78,7 +78,7 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri('ferc1'))\n",
     "pudl_engine = sa.create_engine(PudlPaths().pudl_db)"
    ]
   },
@@ -150,35 +150,11 @@
    "source": [
     "pudl.validate.plot_vs_bounds(gens_eia860_orig, pudl.validate.gens_eia860_vs_bound)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validating Historical Distributions\n",
-    "As a sanity check of the testing process itself, we can check to see whether the entire historical distribution has attributes that place it within the extremes of a historical subsampling of the distribution. In this case, we sample each historical year, and look at the range of values taken on by some quantile, and see whether the same quantile for the whole of the dataset fits within that range"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_self(gens_eia860_orig, pudl.validate.gens_eia860_self)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pudl-dev",
    "language": "python",
    "name": "python3"
   },
@@ -192,7 +168,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/test/validate/notebooks/validate_gf_eia923.ipynb
+++ b/test/validate/notebooks/validate_gf_eia923.ipynb
@@ -78,9 +78,8 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
-    "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
-    "pudl_settings"
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri('ferc1'))\n",
+    "pudl_engine = sa.create_engine(PudlPaths().pudl_db)"
    ]
   },
   {
@@ -173,65 +172,11 @@
    "source": [
     "pudl.validate.plot_vs_bounds(gf_eia923_orig, pudl.validate.gf_eia923_gas_heat_content)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validate Monthly Aggregation\n",
-    "It's possible that the distribution will change as a function of aggregation, or we might make an error in the aggregation process. These tests check that a collection of quantiles for the original and the data aggregated by month have internally consistent values."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl_out_month = pudl.output.pudltabl.PudlTabl(pudl_engine, freq=\"MS\")\n",
-    "gf_eia923_month = pudl_out_month.gf_eia923()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_agg(gf_eia923_orig, gf_eia923_month, pudl.validate.gf_eia923_agg)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validate Annual Aggregation\n",
-    "It's possible that the distribution will change as a function of aggregation, or we might make an error in the aggregation process. These tests check that a collection of quantiles for the original and the data aggregated by year have internally consistent values."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl_out_year = pudl.output.pudltabl.PudlTabl(pudl_engine, freq=\"AS\")\n",
-    "gf_eia923_year = pudl_out_year.gf_eia923()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_agg(gf_eia923_orig, gf_eia923_year, pudl.validate.gf_eia923_agg)"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pudl-dev",
    "language": "python",
    "name": "python3"
   },
@@ -245,7 +190,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/test/validate/notebooks/validate_mcoe.ipynb
+++ b/test/validate/notebooks/validate_mcoe.ipynb
@@ -79,9 +79,8 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
-    "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
-    "pudl_settings"
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri('ferc1'))\n",
+    "pudl_engine = sa.create_engine(PudlPaths().pudl_db)"
    ]
   },
   {
@@ -98,7 +97,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pudl_out_year = pudl.output.pudltabl.PudlTabl(pudl_engine, freq=\"AS\")\n",
+    "pudl_out_year = pudl.output.pudltabl.PudlTabl(pudl_engine, freq=\"YS\")\n",
     "pudl_out_month = pudl.output.pudltabl.PudlTabl(pudl_engine, freq=\"MS\")"
    ]
   },
@@ -132,13 +131,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "mcoe_month = pudl_out_month.mcoe(\n",
-    "    update=True,\n",
-    "    min_heat_rate=None,\n",
-    "    min_fuel_cost_per_mwh=None,\n",
-    "    min_cap_fact=None,\n",
-    "    max_cap_fact=None\n",
-    ")"
+    "mcoe_month = pudl_out_month.mcoe()"
    ]
   },
   {
@@ -167,40 +160,6 @@
    "source": [
     "# mcoe = mcoe_year\n",
     "mcoe = mcoe_month"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## MCOE vs Self"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_self(mcoe, pudl.validate.mcoe_self)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_self(mcoe, pudl.validate.mcoe_self_fuel_cost_per_mmbtu)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_self(mcoe, pudl.validate.mcoe_self_fuel_cost_per_mwh)"
    ]
   },
   {
@@ -320,7 +279,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pudl-dev",
    "language": "python",
    "name": "python3"
   },
@@ -334,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/test/validate/notebooks/validate_plants_steam_ferc1.ipynb
+++ b/test/validate/notebooks/validate_plants_steam_ferc1.ipynb
@@ -79,9 +79,8 @@
    "outputs": [],
    "source": [
     "from pudl.workspace.setup import PudlPaths\n",
-    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri("ferc1"))\n",
-    "pudl_engine = sa.create_engine(PudlPaths().pudl_db)\n",
-    "pudl_settings"
+    "ferc1_engine = sa.create_engine(PudlPaths().sqlite_db_uri('ferc1'))\n",
+    "pudl_engine = sa.create_engine(PudlPaths().pudl_db)"
    ]
   },
   {
@@ -108,23 +107,6 @@
     "        capability_ratio=lambda x: x.plant_capability_mw / x.capacity_mw,\n",
     "    )\n",
     ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validating Historical Distributions\n",
-    "As a sanity check of the testing process itself, we can check to see whether the entire historical distribution has attributes that place it within the extremes of a historical subsampling of the distribution. In this case, we sample each historical year, and look at the range of values taken on by some quantile, and see whether the same quantile for the whole of the dataset fits within that range"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pudl.validate.plot_vs_self(plants_steam_ferc1, pudl.validate.plants_steam_ferc1_self)"
    ]
   },
   {
@@ -203,30 +185,11 @@
    "source": [
     "pudl.validate.plot_vs_bounds(plants_steam_ferc1, pudl.validate.plants_steam_ferc1_connected_hours)"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Validate an Individual Column\n",
-    "If there's a particular column that is failing the validation, you can check several different validation cases with something like this cell:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "testcol =  \"plant_hours_connected_while_generating\"\n",
-    "self_tests = [x for x in pudl.validate.plants_steam_ferc1_self if x[\"data_col\"] == testcol]\n",
-    "pudl.validate.plot_vs_self(plants_steam_ferc1, self_tests)"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "pudl-dev",
    "language": "python",
    "name": "python3"
   },
@@ -240,7 +203,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/test/validate/plants_steam_ferc1_test.py
+++ b/test/validate/plants_steam_ferc1_test.py
@@ -50,20 +50,3 @@ def test_vs_bounds(pudl_out_ferc1, live_dbs, cases):
     )
     for case in cases:
         pudl.validate.vs_bounds(validate_df, **case)
-
-
-def test_self_vs_historical(pudl_out_ferc1, live_dbs):
-    """Validate..."""
-    if not live_dbs:
-        pytest.skip("Data validation only works with a live PUDL DB.")
-    validate_df = pd.read_sql(
-        "out_ferc1__yearly_steam_plants_sched402", pudl_out_ferc1.pudl_engine
-    ).assign(
-        water_limited_ratio=lambda x: x.water_limited_capacity_mw / x.capacity_mw,
-        not_water_limited_ratio=lambda x: x.not_water_limited_capacity_mw
-        / x.capacity_mw,
-        peak_demand_ratio=lambda x: x.peak_demand_mw / x.capacity_mw,
-        capability_ratio=lambda x: x.plant_capability_mw / x.capacity_mw,
-    )
-    for args in pv.core_ferc1__yearly_steam_plants_sched402_self:
-        pudl.validate.vs_self(validate_df, **args)


### PR DESCRIPTION
# Overview

This PR removes a number of data validations that we're deprecating or that are duplicative, including:

- `check_unique_rows`
- `vs_self` (a statistical distribution check)
- `vs_historical` (another statistical distribution check)

Closes #4182

## What did you change?

* I removed the functions implementing these checks from `pudl/validate.py`
* Removed all tests from under `test/validate` that relied on these functions.
* Updated all of the weighted quantile notebooks not to use `vs_self` or `vs_historical` (deleted related cells)
* For `check_unique_rows` I verified that every test was checking the set of columns that already defined the primary key for the table it was running on.  In 2 instances, this wasn't the case, but the columns being checked were an ad-hoc combination including plant `capacity_mw` in the FERC small plants tables, which are a trash fire and now use a psuedo-key.

## Testing

- I ran all cells in all of the `test/validate/notebooks/*.ipynb` notebooks and removed offending cells. All but 2 now run successfully, and the remaining 2 failures are due to the reorganization of a columns in a table, not the removal of these tests.
- I ran `dbt build` against the two models that I updated with `unique_combination_of_columns` tests.
- Currently running the data validations locally...

# To-do list

- [x] Add 2 non-PK unique combination of columns tests to dbt
- [x] Run dbt tests against those two tables and make sure they pass
- [x] Review the PR yourself and call out any questions or issues you have.
- [x] Run the data validations locally to make sure nothing blows up.