### PR TITLE
fix: keep db migration job working with rename of parquet-fe-prototype

### DIFF
--- a/terraform/pudl-viewer.tf
+++ b/terraform/pudl-viewer.tf
@@ -167,7 +167,7 @@ resource "google_cloud_run_v2_job" "pudl_viewer_db_migration" {
 
       containers {
         image   = "us-east1-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.pudl_viewer.name}/pudl-viewer:latest"
-        command = ["uv", "run", "flask", "--app", "parquet_fe_prototype", "db", "upgrade"]
+        command = ["uv", "run", "flask", "--app", "eel_hole", "db", "upgrade"]
 
         volume_mounts {
           name       = "cloudsql"


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

We renamed `parquet-fe-prototype` to `eel-hole` so we need to update the db migration job.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Ran `terraform plan` to see if the job would try to use `eel_hole` instead of `parquet_fe_prototype`.
Confirmed that that command works in docker compose:

```
$ docker compose exec eel_hole bash
# uv run flask --app eel_hole db upgrade
<snip>
```

## To-do list

- [ ] Review the PR yourself and call out any questions or issues you have.
