### PR TITLE
fix: retry on OS errors

### DIFF
--- a/devtools/zenodo/zenodo_data_release.py
+++ b/devtools/zenodo/zenodo_data_release.py
@@ -98,7 +98,7 @@ class ZenodoClient:
                 return requests.request(
                     method=method, url=url, timeout=timeout**try_num, **kwargs
                 )
-            except requests.RequestException as e:
+            except (requests.RequestException, OSError) as e:
                 logger.warning(
                     f"Attempt #{try_num} Got {e}, retrying in {timeout**try_num} s"
                 )
@@ -195,6 +195,7 @@ class ZenodoClient:
             url=url,
             headers=self.auth_headers,
             data=file_content,
+            stream=True,
         )
         return response
 


### PR DESCRIPTION


<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #4184 .

## What problem does this address?

It *looks* like we can catch this exception by catching OSError, too. But reproducing this EINT locally is tricky so this is a bit of a guess.


## What did you change?

* add catch on OSError in addition to RequestException
* use `stream=True` to use multipart uploading built in to requests - hopefully that behaves a little more stably.
* didn't add multipart resume - it seemed complicated / not worth it

# Testing

How did you make sure this worked? How can a reviewer verify this?
* downloaded the .zip files from the aws nightly builds to `$PUDL_NIGHTLY`
* ```
  ./zenodo_data_release.py --publish --env "sandbox" --source-dir "$PUDL_NIGHTLY" --ignore $PUDL_NIGHTLY/pudl_parquet_datapackage.json --ignore $PUDL_NIGHTLY/parquet/
  ```

The EINT also seems to have stopped happening in the most recent nightly builds so I'm not sure if it will get exercised in any given run. So I think probably we just have to merge & hope :(
