### PR TITLE
Remove PUDL user survey banner from documentation.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,7 +132,6 @@ html_icon = "_static/favicon.ico"
 # documentation.
 html_theme_options = {
     "navigation_with_keys": True,
-    "announcement": "<b>Take the <a href='https://forms.gle/cT1ZY4yunhza3YLK9'>2025 PUDL Community Survey</a> (~10 min)</b>",
     "light_css_variables": {
         "color-announcement-background": "yellow",
         "color-announcement-text": "red",


### PR DESCRIPTION
# Overview

Removes the banner announcing our 2025 annual user survey from the top of our docs.

## To-do list

- [x] Inspect documentation after it's built on RTD to make sure everything looks right.