### PR TITLE
Resolve GeoPandas library warnings

### DIFF
--- a/src/pudl/analysis/spatial.py
+++ b/src/pudl/analysis/spatial.py
@@ -103,7 +103,7 @@ def explode(gdf: gpd.GeoDataFrame, ratios: Iterable[str] = None) -> gpd.GeoDataF
     gdf = gdf.reset_index(drop=True)
     is_mpoly = gdf.geometry.geom_type == "MultiPolygon"
     if ratios and is_mpoly.any():
-        union_area = gdf.geometry[is_mpoly].apply(shapely.ops.union_all()).area
+        union_area = gdf.geometry[is_mpoly].apply(shapely.ops.unary_union).area
         if (union_area != gdf.geometry[is_mpoly].area).any():
             raise ValueError("Geometry contains self-intersecting MultiPolygon")
     result = gdf.explode(index_parts=False)


### PR DESCRIPTION
# Overview
This small PR resolves the GeoPandas deprecation warnings:
```python
/home/runner/work/pudl/pudl/src/pudl/analysis/spatial.py:147: DeprecationWarning: The 'unary_union' attribute is deprecated, use the 'union_all()' method instead.
````
Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing
Run tests

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
