### PR TITLE
feat: use forkserver when available for speed

### DIFF
--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -10,6 +10,7 @@ with cleaning and restructing dataframes.
 import importlib.resources
 import itertools
 import json
+import multiprocessing
 import pathlib
 import re
 import shutil
@@ -2033,9 +2034,13 @@ def get_dagster_execution_config(
     """Get the dagster execution config for a given number of workers.
 
     If num_workers is 0, then the dagster execution config will not include
-    any limits. With num_workesr set to 1, we will use in-process serial
+    any limits. With num_workers set to 1, we will use in-process serial
     executor, otherwise multi-process executor with maximum of num_workers
     will be used.
+
+    If we use the multi-process executor AND the ``forkserver`` start method is
+    available, we pre-import the ``pudl`` package in the template process. This
+    allows us to reduce the startup latency of each op.
 
     Args:
         num_workers: The number of workers to use for the dagster execution config.
@@ -2045,11 +2050,12 @@ def get_dagster_execution_config(
             particular tags. This is helpful for applying concurrency limits to
             highly concurrent and memory intensive portions of the ETL like CEMS.
 
-            Dagster description: If a value is set, the limit is applied to only
-            that key-value pair. If no value is set, the limit is applied across
-            all values of that key. If the value is set to a dict with
-            `applyLimitPerUniqueValue: true`, the limit will apply to the number
-            of unique values for that key. Note that these limits are per run, not global.
+            Dagster description: If a value is set, the limit is applied to
+            only that key-value pair. If no value is set, the limit is applied
+            across all values of that key. If the value is set to a dict with
+            `applyLimitPerUniqueValue: true`, the limit will apply to the
+            number of unique values for that key. Note that these limits are
+            per run, not global.
 
     Returns:
         A dagster execution config.
@@ -2062,12 +2068,18 @@ def get_dagster_execution_config(
                 },
             },
         }
+
+    start_method_config = {}
+    if "forkserver" in multiprocessing.get_all_start_methods():
+        start_method_config = {"forkserver": {"preload_modules": ["pudl"]}}
+
     return {
         "execution": {
             "config": {
                 "multiprocess": {
                     "max_concurrent": num_workers,
                     "tag_concurrency_limits": tag_concurrency_limits,
+                    "start_method": start_method_config,
                 },
             },
         },


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Uses a `multiprocessing` option that lets us pre-import a bunch of modules into a 'fork server'. Then all the child processes don't have to re-import e.g. PUDL and sklearn and all that - saves us a few seconds per task, which is nice when so many of our tasks take longer to spin up than to run.

I made this change while trying to work on #4132  - figured I should get this into `main` as a separate small PR instead of tying it to an unrelated, more gnarly piece of work.

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] ~Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.~
- [ ] ~Update relevant Data Source jinja templates (see `docs/data_sources/templates`).~
- [ ] ~Update relevant table or source description metadata (see `src/metadata`).~
- [ ] ~Review and update any other aspects of the documentation that might be affected by this PR.~

# Testing

How did you make sure this worked? How can a reviewer verify this?

* ran the fast ETL locally using dagster UI and nothing blew up

## To-do list

- [ ] ~If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.~
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] `For` minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.~
- [ ] ~For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.~
- [ ] ~Alternatively, run the `build-deploy-pudl` GitHub Action manually.~