### PR TITLE
Disable row counts for etl-fast and remove nightly dbt target

### DIFF
--- a/dbt/README.md
+++ b/dbt/README.md
@@ -2,11 +2,10 @@
 
 This directory contains an initial setup of a `dbt` project meant to write [data
 tests](https://docs.getdbt.com/docs/build/data-tests) for PUDL data. The project is
-setup with profiles that allow you to select running tests on `nightly` builds,
-`etl-full`, or `etl-fast` outputs. The `nightly` profile will operate directly on
-parquet files in our S3 bucket, while both the `etl-full` and `etl-fast` profiles will
-look for parquet files based on your `PUDL_OUTPUT` environment variable. See the `Usage`
-section below for examples using these profiles.
+setup with profiles that allow you to select running tests on `etl-full`, or `etl-fast`
+outputs. Both the `etl-full` and `etl-fast` profiles will look for parquet files based
+on your `PUDL_OUTPUT` environment variable. See the `Usage` section below for examples
+using these profiles. `etl-full` is the default.
 
 # Development
 
@@ -138,8 +137,8 @@ dbt build --select {model_name}
 
 ### Selecting target profile
 
-To select between `nightly`, `etl-full`, and `etl-fast` profiles, append `--target
-{target_name}` to any of the previous commands.
+To select between `etl-full`, and `etl-fast` profiles, append `--target {target_name}`
+to any of the previous commands.
 
 ## Updating a table
 

--- a/dbt/README.md
+++ b/dbt/README.md
@@ -277,7 +277,7 @@ WITH CumulativeWeights AS (
         capacity_mw,
         SUM(capacity_mw) OVER (ORDER BY capacity_factor) AS cumulative_weight,
         SUM(capacity_mw) OVER () AS total_weight
-    FROM 'https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/out_eia__yearly_generators.parquet'
+    FROM '/your/local/pudl_output/parquet/out_eia__yearly_generators.parquet'
     WHERE capacity_factor IS NOT NULL OR capacity_mw IS NOT NULL
 ),
 QuantileData AS (

--- a/dbt/dbt_project.yml
+++ b/dbt/dbt_project.yml
@@ -22,6 +22,4 @@ test-paths: ["tests/data_tests/singular_tests", "tests/unit_tests"]
 sources:
   pudl_dbt:
     +external_location: |
-      {%- if target.name == "nightly" -%} 'https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/{name}.parquet'
-      {%- else -%} '{{ env_var('PUDL_OUTPUT') }}/parquet/{name}.parquet'
-      {%- endif -%}
+      '{{ env_var('PUDL_OUTPUT') }}/parquet/{name}.parquet'

--- a/dbt/profiles.yml
+++ b/dbt/profiles.yml
@@ -1,12 +1,6 @@
 pudl_dbt:
   outputs:
-    # Define targets for nightly build outputs, and local full/fast ETL outputs
-    nightly:
-      threads: 1
-      type: duckdb
-      path: "{{ env_var('PUDL_OUTPUT') }}/pudl_dbt_tests.duckdb"
-      filesystems:
-        - fs: s3
+    # Define targets for local full/fast ETL outputs
     etl-full:
       threads: 1
       type: duckdb

--- a/dbt/tests/data_tests/generic_tests/check_row_counts_per_partition.sql
+++ b/dbt/tests/data_tests/generic_tests/check_row_counts_per_partition.sql
@@ -1,13 +1,12 @@
 {% test check_row_counts_per_partition(model, table_name, partition_column) %}
 
+{% if target.name == "etl-fast" %}
+SELECT NULL WHERE FALSE -- This always returns zero rows, so the test will always pass
+{% else %}
 WITH
     expected AS (
         SELECT table_name, CAST(partition as VARCHAR) as partition, row_count as expected_count
-        {% if target.name == "etl-fast" %}
-        FROM {{ ref("etl_fast_row_counts") }}
-        {% else %}
         FROM {{ ref("etl_full_row_counts") }}
-        {% endif %}
         WHERE table_name = '{{ table_name }}'
     ),
     observed AS (
@@ -28,5 +27,6 @@ SELECT expected.partition, expected.expected_count, observed.observed_count
 FROM expected
 INNER JOIN observed ON expected.partition=observed.partition
 WHERE expected.expected_count != observed.observed_count
+{% endif %}
 
 {% endtest %}


### PR DESCRIPTION
# Overview

- To ensure that we get our `v2025.5.0` data release out on time, this PR short-circuits the row count checks in our Fast ETL outputs, as there's some work required to make sure they behave consistently in local and CI environments, and that's creating friction in the development process right now.
- It also removes the `nightly` target for dbt, since that was primarily useful in the context of our initial migration of the validation tests, which is now complete.

# Testing

I ran the dbt tests locally with both `etl-full` and `etl-fast` targets, with full ETL outputs in my `PUDL_OUTPUT` directory, and the fast tests did not complain about row count violations, while the full tests did (I have some leftover FERC-714 tables that are from another PR).

## To-do list

- [x] Review the PR yourself and call out any questions or issues you have.
