### PR TITLE
feat: Dagster / DBT source tests integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ dbt/dbt_packages/
 dbt/target/
 dbt/logs/
 dbt/.user.yml
+
+# lockfile made by dagster dbt integration
+dbt/package-lock.concurrent-update-lock

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ etl_full_yml := src/pudl/package_data/settings/etl_full.yml
 
 # We use mamba locally, but micromamba in CI, so choose the right binary:
 ifdef GITHUB_ACTIONS
-  mamba := micromamba
+	mamba := micromamba
 else
-  mamba := mamba
+	mamba := ${MAKE_MAMBA_COMMAND:-mamba}
 endif
 
 # Tell make to look in the environments and output directory for targets and sources.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "coloredlogs>=14.0", # Dagster requires 14.0
     "conda-lock>=3",
     "coverage>=7.6",
-    "dagster>=1.10.5",
+    "dagster>=1.10.13",
     "dagster-dbt", # Automatically follows dagster version
     "dagster-postgres", # Automatically follows dagster version
     "dask>=2025",

--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -114,7 +114,13 @@ out_module_groups = {
     "out_state_demand_ferc714": [pudl.analysis.state_demand],
 }
 
-all_asset_modules = raw_module_groups | core_module_groups | out_module_groups
+all_asset_modules = (
+    raw_module_groups
+    | core_module_groups
+    | out_module_groups
+    | {"dbt_assets": [dbt_asset_checks]}
+)
+
 default_assets = list(
     itertools.chain.from_iterable(
         load_assets_from_modules(

--- a/src/pudl/etl/dbt_asset_checks.py
+++ b/src/pudl/etl/dbt_asset_checks.py
@@ -1,0 +1,53 @@
+"""Configure DBT <> Dagster integration."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from dagster import AssetExecutionContext, AssetKey
+from dagster_dbt import (
+    DagsterDbtTranslator,
+    DagsterDbtTranslatorSettings,
+    DbtCliResource,
+    DbtProject,
+    dbt_assets,
+)
+
+from pudl.workspace.setup import PUDL_ROOT_DIR
+
+
+class PudlDagsterDbtTranslator(DagsterDbtTranslator):
+    """Dagster DBT translator that identifies which source checks should point at which assets."""
+
+    def get_asset_key(self, dbt_resource_props: Mapping[str, Any]) -> AssetKey:
+        """Remove auto-generated ``pudl`` prefix if it exists."""
+        stock_asset_key = super().get_asset_key(dbt_resource_props)
+        if stock_asset_key.has_prefix(["pudl"]):
+            return AssetKey(stock_asset_key.path[1:])
+        return stock_asset_key
+
+
+dagster_dbt_translator = PudlDagsterDbtTranslator(
+    settings=DagsterDbtTranslatorSettings(enable_source_tests_as_checks=True)
+)
+
+dbt_project = DbtProject(project_dir=PUDL_ROOT_DIR / "dbt")
+dbt_project.preparer.prepare(dbt_project)
+
+
+@dbt_assets(
+    manifest=dbt_project.manifest_path,
+    dagster_dbt_translator=dagster_dbt_translator,
+)
+def dbt_asset_checks(context: AssetExecutionContext, dbt: DbtCliResource):
+    """Automatically import assets from DBT.
+
+    Questions:
+    * do these assets get picked up at all? should I add them to another module
+      and import them using load_asset_checks_from_modules()?
+    * does it assign source tests to actual Dagster assets?
+      * seems like we might need to override DagsterDbtTranslator methods to get this working right.
+    * does it run checks after asset materialization?
+    * does it handle concurrency well? will it try to re-run dbt seed etc. every check?
+    * does it create assets for the validation views?
+    """
+    yield from dbt.cli(["build"], context=context).stream()

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -10,6 +10,7 @@ with cleaning and restructing dataframes.
 import importlib.resources
 import itertools
 import json
+import multiprocessing
 import pathlib
 import re
 import shutil
@@ -2033,9 +2034,13 @@ def get_dagster_execution_config(
     """Get the dagster execution config for a given number of workers.
 
     If num_workers is 0, then the dagster execution config will not include
-    any limits. With num_workesr set to 1, we will use in-process serial
+    any limits. With num_workers set to 1, we will use in-process serial
     executor, otherwise multi-process executor with maximum of num_workers
     will be used.
+
+    If we use the multi-process executor AND the ``forkserver`` start method is
+    available, we pre-import the ``pudl`` package in the template process. This
+    allows us to reduce the startup latency of each op.
 
     Args:
         num_workers: The number of workers to use for the dagster execution config.
@@ -2045,11 +2050,12 @@ def get_dagster_execution_config(
             particular tags. This is helpful for applying concurrency limits to
             highly concurrent and memory intensive portions of the ETL like CEMS.
 
-            Dagster description: If a value is set, the limit is applied to only
-            that key-value pair. If no value is set, the limit is applied across
-            all values of that key. If the value is set to a dict with
-            `applyLimitPerUniqueValue: true`, the limit will apply to the number
-            of unique values for that key. Note that these limits are per run, not global.
+            Dagster description: If a value is set, the limit is applied to
+            only that key-value pair. If no value is set, the limit is applied
+            across all values of that key. If the value is set to a dict with
+            `applyLimitPerUniqueValue: true`, the limit will apply to the
+            number of unique values for that key. Note that these limits are
+            per run, not global.
 
     Returns:
         A dagster execution config.
@@ -2062,12 +2068,18 @@ def get_dagster_execution_config(
                 },
             },
         }
+
+    start_method_config = {}
+    if "forkserver" in multiprocessing.get_all_start_methods():
+        start_method_config = {"forkserver": {"preload_modules": ["pudl"]}}
+
     return {
         "execution": {
             "config": {
                 "multiprocess": {
                     "max_concurrent": num_workers,
                     "tag_concurrency_limits": tag_concurrency_limits,
+                    "start_method": start_method_config,
                 },
             },
         },

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -14,6 +14,9 @@ logger = pudl.logging_helpers.get_logger(__name__)
 PotentialDirectoryPath = DirectoryPath | NewPath
 
 
+PUDL_ROOT_DIR = Path(__file__).parent.parent.parent.parent
+
+
 class PudlPaths(BaseSettings):
     """These settings provide access to various PUDL directories.
 

--- a/test/unit/dbt_asset_checks_test.py
+++ b/test/unit/dbt_asset_checks_test.py
@@ -1,8 +1,8 @@
-from dagster import load_asset_checks_from_modules
+from dagster import load_assets_from_modules
 
 from pudl.etl import dbt_asset_checks
 
 
 def test_asset_checks_exist():
-    loaded_checks = load_asset_checks_from_modules([dbt_asset_checks])
+    loaded_checks = load_assets_from_modules([dbt_asset_checks])[0].check_specs
     assert loaded_checks != []

--- a/test/unit/dbt_asset_checks_test.py
+++ b/test/unit/dbt_asset_checks_test.py
@@ -1,0 +1,8 @@
+from dagster import load_asset_checks_from_modules
+
+from pudl.etl import dbt_asset_checks
+
+
+def test_asset_checks_exist():
+    loaded_checks = load_asset_checks_from_modules([dbt_asset_checks])
+    assert loaded_checks != []


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #4132.

## What problem does this address?

Use Dagster 1.10.13's new DBT source-test integration to run the source tests as asset checks.

## What did you change?

* update to new Dagster version
* add `dagster_dbt` resource + project + translator classes to read the `manifest.json` and turn it into asset checks
* add those asset checks to the ETL

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

* add unit test asserting that you can load assets from the `dbt_asset_checks` module
* actually run the ETL and see if the dang asset checks are there, fail appropriately, and block the rest of the ETL.

## To-do list

- [ ] ~If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.~
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] ~For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.~
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.~
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
