### PR TITLE
Bloat the Google Batch VM

### DIFF
--- a/dbt/package-lock.yml
+++ b/dbt/package-lock.yml
@@ -4,5 +4,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.3.0
   - package: godatadriven/dbt_date
-    version: 0.11.0
+    version: 0.13.0
 sha1_hash: 984baac0716f78c8f3a7d03a7ff41ba9f609ae21

--- a/dbt/seeds/etl_full_row_counts.csv
+++ b/dbt/seeds/etl_full_row_counts.csv
@@ -1009,7 +1009,7 @@ core_eia861__yearly_utility_data_rto,2020,1551
 core_eia861__yearly_utility_data_rto,2021,1562
 core_eia861__yearly_utility_data_rto,2022,1590
 core_eia861__yearly_utility_data_rto,2023,1619
-core_eia923__entity_coalmine,,4623
+core_eia923__entity_coalmine,,4458
 core_eia923__monthly_boiler_fuel,2008,77537
 core_eia923__monthly_boiler_fuel,2009,79002
 core_eia923__monthly_boiler_fuel,2010,81197
@@ -2008,7 +2008,7 @@ core_nrelatb__yearly_technology_status,2021,131
 core_nrelatb__yearly_technology_status,2022,195
 core_nrelatb__yearly_technology_status,2023,189
 core_nrelatb__yearly_technology_status,2024,197
-core_pudl__assn_eia_pudl_plants,,17939
+core_pudl__assn_eia_pudl_plants,,18280
 core_pudl__assn_eia_pudl_utilities,,16488
 core_pudl__assn_ferc1_dbf_pudl_utilities,,411
 core_pudl__assn_ferc1_pudl_plants,,8101

--- a/devtools/generate_batch_config.py
+++ b/devtools/generate_batch_config.py
@@ -56,8 +56,8 @@ def to_config(
                         }
                     ],
                     "computeResource": {
-                        "cpuMilli": 8000,
-                        "memoryMib": int(63 * MIB_PER_GB),
+                        "cpuMilli": 16000,
+                        "memoryMib": int(127 * MIB_PER_GB),
                         "bootDiskMib": 100 * 1024,
                     },
                     "maxRunDuration": f"{60 * 60 * 12}s",


### PR DESCRIPTION
# Overview

Nightly builds are currently failing due to concurrency issues resulting from all the new time series imputations and larger data with the quarterly update. This PR temporarily increases the resources available to the nightly builds so we can get the quarterly release out on time, while we figure out a better concurrency management setup.

- Also add a couple of missing row-count expectations from the EIA-860/923 updates.
- Update package versions in dbt environment.