### PR TITLE
Disable Datasette deployment in nightly builds

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -143,7 +143,6 @@ function notify_slack() {
     message+="SAVE_OUTPUTS_SUCCESS: $SAVE_OUTPUTS_SUCCESS\n"
     message+="UPDATE_NIGHTLY_SUCCESS: $UPDATE_NIGHTLY_SUCCESS\n"
     message+="UPDATE_STABLE_SUCCESS: $UPDATE_STABLE_SUCCESS\n"
-    message+="DATASETTE_SUCCESS: $DATASETTE_SUCCESS\n"
     message+="CLEAN_UP_OUTPUTS_SUCCESS: $CLEAN_UP_OUTPUTS_SUCCESS\n"
     message+="DISTRIBUTION_BUCKET_SUCCESS: $DISTRIBUTION_BUCKET_SUCCESS\n"
     message+="GCS_TEMPORARY_HOLD_SUCCESS: $GCS_TEMPORARY_HOLD_SUCCESS \n"
@@ -210,7 +209,6 @@ ETL_SUCCESS=0
 SAVE_OUTPUTS_SUCCESS=0
 UPDATE_NIGHTLY_SUCCESS=0
 UPDATE_STABLE_SUCCESS=0
-DATASETTE_SUCCESS=0
 WRITE_DATAPACKAGE_SUCCESS=0
 CLEAN_UP_OUTPUTS_SUCCESS=0
 DISTRIBUTION_BUCKET_SUCCESS=0
@@ -268,9 +266,6 @@ fi
 if [[ "$BUILD_TYPE" == "nightly" ]]; then
     merge_tag_into_branch "$NIGHTLY_TAG" nightly 2>&1 | tee -a "$LOGFILE"
     UPDATE_NIGHTLY_SUCCESS=${PIPESTATUS[0]}
-    # Update our datasette deployment
-    python ~/pudl/devtools/datasette/publish.py --production 2>&1 | tee -a "$LOGFILE"
-    DATASETTE_SUCCESS=${PIPESTATUS[0]}
     # Remove files we don't want to distribute and zip SQLite and Parquet outputs
     clean_up_outputs_for_distribution 2>&1 | tee -a "$LOGFILE"
     CLEAN_UP_OUTPUTS_SUCCESS=${PIPESTATUS[0]}
@@ -341,7 +336,6 @@ if [[ $ETL_SUCCESS == 0 && \
       $SAVE_OUTPUTS_SUCCESS == 0 && \
       $UPDATE_NIGHTLY_SUCCESS == 0 && \
       $UPDATE_STABLE_SUCCESS == 0 && \
-      $DATASETTE_SUCCESS == 0 && \
       $CLEAN_UP_OUTPUTS_SUCCESS == 0 && \
       $DISTRIBUTION_BUCKET_SUCCESS == 0 && \
       $GCS_TEMPORARY_HOLD_SUCCESS == 0 && \

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -196,7 +196,8 @@ function clean_up_outputs_for_distribution() {
     popd && \
     # Remove any remaiining files and directories we don't want to distribute
     rm -rf "$PUDL_OUTPUT/parquet" && \
-    rm -f "$PUDL_OUTPUT/metadata.yml"
+    rm -f "$PUDL_OUTPUT/metadata.yml" && \
+    rm -f "$PUDL_OUTPUT/pudl_duckdb_tests.duckdb"
 }
 
 ########################################################################################


### PR DESCRIPTION
We haven't been able to successfully redeploy Datasette to Fly.io since March 28th (6 weeks...) which feels like a functional deprecation, even though we haven't gotten the new user portal to feature parity yet.

The nightly builds currently spend ~45 minutes attempting to redeploy Datasette whenever they run, to no effect.

This PR comments out the Datasette deployment actions in the nightly build script, so that we can stop making those pointless attempts, unless / until we actually go in and fix whatever the problem is. Or, maybe more likely, until we get the PUDL Portal to feature parity and start deploying it to https://data.catalyst.coop, usurping Datasette completely.

## Documentation

Should update our data access documentation and various other links to remove this access mode?  I'm assuming that the site will come back up post-deployment attempt as it has before (presumably reverting to the old machine at Fly.io).  If that's not correct then... maybe Datasette has fully deprecated itself for us and we need to remove it from all of our docs.

## To-do list

- [ ] Verify that https://data.catalyst.coop comes back up (or make it come back up with flyctl...)
- [ ] If it's down for good, update documentation to direct users to the new PUDL Viewer instead
- [ ] If it's down for good, update deployment location of PUDL Viewer to be https://data.catalyst.coop
- [ ] If it's down for good, set up an automatic redirect from https://viewer.catalyst.coop to https://data.catalyst.coop
- [ ] If it's down for good, remove Datasette / Fly.io specific code / scripts from PUDL repo
- [ ] If it's down for good, shut down our Fly.io account.
