### PR TITLE
Dbt add schema diff and update

### DIFF
--- a/src/pudl/scripts/dbt_helper.py
+++ b/src/pudl/scripts/dbt_helper.py
@@ -340,13 +340,14 @@ def update_row_counts(
     partition_column: str = "report_year",
     target: str = "etl-full",
     clobber: bool = False,
+    update: bool = False,
 ) -> UpdateResult:
     """Generate updated row counts per partition and write to csv file within dbt project."""
     existing = _get_existing_row_counts(target)
-    if table_name in existing["table_name"].to_numpy() and not clobber:
+    if table_name in existing["table_name"].to_numpy() and not (clobber or update):
         return UpdateResult(
             success=False,
-            message=f"Row counts for {table_name} already exist (run with clobber to overwrite).",
+            message=f"Row counts for {table_name} already exist (run with clobber or update to overwrite).",
         )
 
     new = _calculate_row_counts(table_name, partition_column)
@@ -713,6 +714,7 @@ def update_tables(
                     data_source,
                     partition_column=partition_column,
                     clobber=args.clobber,
+                    update=args.update,
                 )
             )
         if args.row_counts:
@@ -722,6 +724,7 @@ def update_tables(
                     partition_column=partition_column,
                     target=args.target,
                     clobber=args.clobber,
+                    update=args.update,
                 )
             )
 

--- a/test/unit/dbt_helper_test.py
+++ b/test/unit/dbt_helper_test.py
@@ -32,9 +32,9 @@ def with_name(mock, name):
 
 def test_get_data_source(mocker):
     mock_resource = mocker.Mock()
-    mocker.patch(
-        "pudl.scripts.dbt_helper.PUDL_PACKAGE"
-    ).get_resource.return_value = mock_resource
+    mocker.patch("pudl.scripts.dbt_helper.PUDL_PACKAGE").get_resource.return_value = (
+        mock_resource
+    )
     mock_resource.sources = [""] * 2
     assert get_data_source("multiple sources") == "output"
     mock_resource.sources = [with_name(mocker.Mock(), str(mocker.sentinel.source))]
@@ -61,9 +61,9 @@ def test__get_row_count_csv_path():
 @pytest.mark.parametrize("key", ["report_year", "report_date", "datetime_utc", None])
 def test__infer_partition_column(mocker, key):
     mock_resource = mocker.Mock()
-    mocker.patch(
-        "pudl.scripts.dbt_helper.PUDL_PACKAGE"
-    ).get_resource.return_value = mock_resource
+    mocker.patch("pudl.scripts.dbt_helper.PUDL_PACKAGE").get_resource.return_value = (
+        mock_resource
+    )
     mock_resource.schema.fields = [with_name(mocker.Mock(), key)]
     assert _infer_partition_column("") == key
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #XXXX.

## What problem does this address?
We need an elegant way to handle updates to dbt schemas which allow us to 

## What did you change?
- [x] Add method to DbtSchema class to allow reading existing schemas from yaml
- [x] Add functions to evaluate the difference between old and new schemas and print them in a report
- [x] Add update flag to all update functions to allow dbt schema to be overwritten if no information would be deleted (i.e. there is no information in the existing schema that is not present in the new schema)
- [x] Use this update flag also to allow the row counts to be updated (behavior identical to clobber in the row count case)

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
