### PR TITLE
Remove and/or relocate some FERC Form 1 data tests

### DIFF
--- a/dbt/models/ferc1/out_ferc1__yearly_all_plants/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_all_plants/schema.yml
@@ -62,6 +62,8 @@ sources:
           - name: plant_hours_connected_while_generating
           - name: plant_type
           - name: record_id
+            data_tests:
+              - dbt_expectations.expect_column_values_to_be_unique
           - name: water_limited_capacity_mw
           - name: fuel_cost_per_mmbtu
           - name: fuel_type

--- a/dbt/models/ferc1/out_ferc1__yearly_hydroelectric_plants_sched406/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_hydroelectric_plants_sched406/schema.yml
@@ -14,6 +14,8 @@ sources:
           - name: utility_name_ferc1
           - name: plant_name_ferc1
           - name: record_id
+            data_tests:
+              - dbt_expectations.expect_column_values_to_be_unique
           - name: asset_retirement_cost
           - name: avg_num_employees
           - name: capacity_factor

--- a/dbt/models/ferc1/out_ferc1__yearly_pumped_storage_plants_sched408/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_pumped_storage_plants_sched408/schema.yml
@@ -14,6 +14,8 @@ sources:
           - name: utility_name_ferc1
           - name: plant_name_ferc1
           - name: record_id
+            data_tests:
+              - dbt_expectations.expect_column_values_to_be_unique
           - name: asset_retirement_cost
           - name: avg_num_employees
           - name: capacity_factor

--- a/dbt/models/ferc1/out_ferc1__yearly_small_plants_sched410/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_small_plants_sched410/schema.yml
@@ -15,6 +15,8 @@ sources:
           - name: plant_id_pudl
           - name: plant_name_ferc1
           - name: record_id
+            data_tests:
+              - dbt_expectations.expect_column_values_to_be_unique
           - name: capacity_mw
           - name: capex_per_mw
           - name: capex_total

--- a/dbt/models/ferc1/out_ferc1__yearly_steam_plants_fuel_sched402/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_steam_plants_fuel_sched402/schema.yml
@@ -95,3 +95,5 @@ sources:
           - name: fuel_type_code_pudl
           - name: fuel_units
           - name: record_id
+            data_tests:
+              - dbt_expectations.expect_column_values_to_be_unique

--- a/dbt/models/ferc1/out_ferc1__yearly_steam_plants_sched402/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_steam_plants_sched402/schema.yml
@@ -124,6 +124,8 @@ sources:
                   severity: warn
           - name: plant_type
           - name: record_id
+            data_tests:
+              - dbt_expectations.expect_column_values_to_be_unique
           - name: water_limited_capacity_mw
 models:
   - name: validate_ferc1__yearly_steam_plants_sched402

--- a/docs/templates/ferc1_child.rst.jinja
+++ b/docs/templates/ferc1_child.rst.jinja
@@ -50,7 +50,7 @@ data remains in Visual FoxPro databases. The new data remains difficult to acces
 are in the process of understanding the underlying data and integrating this new format
 into PUDL.
 
-Previously the data was strutured as follows:
+Previously the data was structured as follows:
 
 The data is published as a collection of Visual FoxPro databases: one per year
 beginning in 1994. The databases all share a very similar structure and contain a total
@@ -62,12 +62,19 @@ application which allowed this database to be used in Microsoft Access has been
 discontinued. FERC's use of this database format creates a significant
 barrier to data access.
 
-New data is released as a collection of XBRL filings and we are in the process of
-integrating this data into PUDL.
+New data is released as a collection of XBRL filings and the structure of the XBRL
+and DBF data are reconciled so they can be used together seamlessly in PUDL.
 
 The FERC 1 database is poorly normalized and the data itself does not appear to be
 subject to much quality control. For more detailed context and documentation on a
 table-by-table basis, look at :doc:`/data_dictionaries/ferc1_db`.
+
+Many of the FERC Form 1 tables contain a ``record_id`` that indicates what original
+table and record in either the XBRL or DBF derived SQLite databases the data came from
+for forensic / data provenance purposes. The ``record_id`` is NOT in general a unique
+identifier within a given PUDL database table, because in many cases the original
+data has been reshaped and normalized such that several records in the PUDL database
+can be traced back to a single record in the original data.
 {% endblock %}
 
 {% block notable_irregularities %}

--- a/test/integration/ferc_xbrl_extract_test.py
+++ b/test/integration/ferc_xbrl_extract_test.py
@@ -1,0 +1,54 @@
+"""PyTest based testing of the FERC DBF Extraction logic."""
+
+import logging
+from itertools import chain
+
+import pandas as pd
+import pytest
+
+from pudl.etl import defs
+from pudl.extract.ferc1 import TABLE_NAME_MAP_FERC1
+from pudl.transform.ferc import filter_for_freshest_data_xbrl, get_primary_key_raw_xbrl
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.parametrize(
+    "table_name",
+    [  # some sample wide guys
+        "core_ferc1__yearly_sales_by_rate_schedules_sched304",
+        "core_ferc1__yearly_pumped_storage_plants_sched408",
+        "core_ferc1__yearly_steam_plants_sched402",
+        "core_ferc1__yearly_hydroelectric_plants_sched406",
+        "core_ferc1__yearly_transmission_lines_sched422",
+        # some sample guys found to have higher filtering diffs
+        "core_ferc1__yearly_utility_plant_summary_sched200",
+        "core_ferc1__yearly_plant_in_service_sched204",
+        "core_ferc1__yearly_operating_expenses_sched320",
+        "core_ferc1__yearly_income_statements_sched114",
+    ],
+)
+def test_filter_for_freshest_data(
+    ferc1_engine_xbrl, table_name: pd.DataFrame
+) -> pd.DataFrame:
+    """Test if we are unexpectedly replacing records during filter_for_freshest_data."""
+
+    raw_table_names = TABLE_NAME_MAP_FERC1[table_name]["xbrl"]
+    # sometimes there are many raw tables that go into one
+    # core table, but usually its a string.
+    if isinstance(raw_table_names, str):
+        raw_table_names = [raw_table_names]
+    xbrls_with_periods = chain.from_iterable(
+        (f"raw_ferc1_xbrl__{tn}_instant", f"raw_ferc1_xbrl__{tn}_duration")
+        for tn in raw_table_names
+    )
+    for raw_table_name in xbrls_with_periods:
+        logger.info(f"Checking if our filtering methodology works for {raw_table_name}")
+        xbrl_table = defs.load_asset_value(raw_table_name)
+        if not xbrl_table.empty:
+            primary_keys = get_primary_key_raw_xbrl(
+                raw_table_name.removeprefix("raw_ferc1_xbrl__"), "ferc1"
+            )
+            filter_for_freshest_data_xbrl(
+                xbrl_table, primary_keys, compare_methods=True
+            )

--- a/test/validate/ferc1_test.py
+++ b/test/validate/ferc1_test.py
@@ -5,48 +5,12 @@ parameterized fixture that has session scope.
 """
 
 import logging
-from itertools import chain
 
-import pandas as pd
 import pytest
 
 from pudl import validate as pv
-from pudl.etl import defs
-from pudl.extract.ferc1 import TABLE_NAME_MAP_FERC1
-from pudl.metadata.classes import DataSource
-from pudl.transform.ferc import filter_for_freshest_data_xbrl, get_primary_key_raw_xbrl
 
 logger = logging.getLogger(__name__)
-
-# These are tables for which individual records have been sliced up and
-# turned into columns (except for the transmission table) -- so there's no universally
-# unique record ID. But we should parameterize the has_unique_record_ids class
-# attributes in the FERC classes.
-non_unique_record_id_tables = [
-    "core_ferc1__yearly_plant_in_service_sched204",
-    "core_ferc1__yearly_purchased_power_and_exchanges_sched326",
-    "core_ferc1__yearly_energy_sources_sched401",
-    "core_ferc1__yearly_energy_dispositions_sched401",
-    "core_ferc1__yearly_utility_plant_summary_sched200",
-    "core_ferc1__yearly_transmission_lines_sched422",
-    "core_ferc1__yearly_balance_sheet_liabilities_sched110",
-    "core_ferc1__yearly_balance_sheet_assets_sched110",
-    "core_ferc1__yearly_income_statements_sched114",
-    "core_ferc1__yearly_depreciation_summary_sched336",
-    "core_ferc1__yearly_depreciation_changes_sched219",
-    "core_ferc1__yearly_depreciation_by_function_sched219",
-    "core_ferc1__yearly_operating_expenses_sched320",
-    "core_ferc1__yearly_cash_flows_sched120",
-    "core_ferc1__yearly_retained_earnings_sched118",
-    "core_ferc1__yearly_operating_revenues_sched300",
-    "core_ferc1__yearly_other_regulatory_liabilities_sched278",
-    "core_ferc1__yearly_sales_by_rate_schedules_sched304",
-]
-unique_record_tables = [
-    t
-    for t in DataSource.from_id("ferc1").get_resource_ids()
-    if t not in non_unique_record_id_tables
-]
 
 
 @pytest.mark.parametrize(
@@ -71,44 +35,3 @@ def test_no_null_cols_ferc1(live_dbs, asset_value_loader, cols, asset_key):
     pv.no_null_cols(
         asset_value_loader.load_asset_value(asset_key), cols=cols, df_name=asset_key
     )
-
-
-@pytest.mark.parametrize(
-    "table_name",
-    [  # some sample wide guys
-        "core_ferc1__yearly_sales_by_rate_schedules_sched304",
-        "core_ferc1__yearly_pumped_storage_plants_sched408",
-        "core_ferc1__yearly_steam_plants_sched402",
-        "core_ferc1__yearly_hydroelectric_plants_sched406",
-        "core_ferc1__yearly_transmission_lines_sched422",
-        # some sample guys found to have higher filtering diffs
-        "core_ferc1__yearly_utility_plant_summary_sched200",
-        "core_ferc1__yearly_plant_in_service_sched204",
-        "core_ferc1__yearly_operating_expenses_sched320",
-        "core_ferc1__yearly_income_statements_sched114",
-    ],
-)
-def test_filter_for_freshest_data(
-    ferc1_engine_xbrl, table_name: pd.DataFrame
-) -> pd.DataFrame:
-    """Test if we are unexpectedly replacing records during filter_for_freshest_data."""
-
-    raw_table_names = TABLE_NAME_MAP_FERC1[table_name]["xbrl"]
-    # sometimes there are many raw tables that go into one
-    # core table, but usually its a string.
-    if isinstance(raw_table_names, str):
-        raw_table_names = [raw_table_names]
-    xbrls_with_periods = chain.from_iterable(
-        (f"raw_ferc1_xbrl__{tn}_instant", f"raw_ferc1_xbrl__{tn}_duration")
-        for tn in raw_table_names
-    )
-    for raw_table_name in xbrls_with_periods:
-        logger.info(f"Checking if our filtering methodology works for {raw_table_name}")
-        xbrl_table = defs.load_asset_value(raw_table_name)
-        if not xbrl_table.empty:
-            primary_keys = get_primary_key_raw_xbrl(
-                raw_table_name.removeprefix("raw_ferc1_xbrl__"), "ferc1"
-            )
-            filter_for_freshest_data_xbrl(
-                xbrl_table, primary_keys, compare_methods=True
-            )


### PR DESCRIPTION
# Overview

- Removed some leftover infrastructure in the FERC 1 validation tests that was needed to check for unique record_id values in a number of columns -- these tests had already been migrated into dbt.
- Added some missing unique `record_id` checks in FERC 1 output tables.
- Moved the FERC 1 XBRL filter for freshest data test from validtion to integration tests... since it should work on both full and fast FERC XBRL derived SQLite DBs.

Closes #4283
Closes #4282 

## To-do list

- [x] Run `dbt` tests locally to verify that the newly checked `record_id` columns are in fact unique
- [x] [Run integration tests in CI on GitHub](https://github.com/catalyst-cooperative/pudl/actions/runs/15147936870/job/42588049812) to verify that the relocated XBRL data deduplication check still works.
- [x] Review the PR yourself and call out any questions or issues you have.