### PR TITLE
Post PUDL v2025.5.0 release cleanup.

### DIFF
--- a/.github/ISSUE_TEMPLATE/versioned_release.md
+++ b/.github/ISSUE_TEMPLATE/versioned_release.md
@@ -13,6 +13,7 @@ assignees: ""
 [Additional release process documentation](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/run_a_release.html).
 
 ## Release Checklist
+
 - [ ] Set a release date & notify team
 - [ ] Update our CITATION.cff file with the new release date and current Catalyst membership.
 - [ ] Update our .zenodo.json file with current Catalyst membership.
@@ -22,7 +23,7 @@ assignees: ""
 - [ ] Verify that the new [GitHub (software) release](https://github.com/catalyst-cooperative/pudl/releases) has been published
 - [ ] Verify [`catalystcoop.pudl` PyPI (software) release](https://pypi.org/project/catalystcoop.pudl/)
 - [ ] Verify that [PUDL repo archive on Zenodo](https://zenodo.org/doi/10.5281/zenodo.3404014) has been updated w/ new version
-- [ ] Wait 6-10 hours for a successful build to complete
+- [ ] Wait 3-5 hours for a successful build to complete
 - [ ] Activate new version on the [RTD admin panel](https://app.readthedocs.org/projects/catalystcoop-pudl/) and verify that it builds successfully.
 - [ ] Verify that `stable` and the version tag point at same git ref
 - [ ] Verify that [`stable` docs on RTD](https://catalystcoop-pudl.readthedocs.io/en/stable/) have been updated
@@ -39,6 +40,7 @@ assignees: ""
 - [ ] Review the `conda-forge` PR, updating dependencies and CLI entrypoints if necessary. Our direct dependencies (from `pyproject.toml`) should be pinned to the actual version appearing in `environments/conda-linux-64.lock.yml`
 
 ### Zenodo Metadata Tasks
+
 - [ ] Make sure all Catalyst members are listed in creators (automate!)
 - [ ] Update Zenodo deposition description to reflect current release (automate!)
 - [ ] Set correct version for Zenodo data release archive (automate!)
@@ -47,4 +49,5 @@ assignees: ""
 - [ ] Zenodo PUDL repo archive: update release notes (cut-and-paste from GitHub)
 
 ### Issues that we ran into
+
 - [ ] Take notes here during the release if stuff happens.

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -197,7 +197,7 @@ function clean_up_outputs_for_distribution() {
     # Remove any remaiining files and directories we don't want to distribute
     rm -rf "$PUDL_OUTPUT/parquet" && \
     rm -f "$PUDL_OUTPUT/metadata.yml" && \
-    rm -f "$PUDL_OUTPUT/pudl_duckdb_tests.duckdb"
+    rm -f "$PUDL_OUTPUT/pudl_dbt_tests.duckdb"
 }
 
 ########################################################################################


### PR DESCRIPTION
# Overview

- Update data release issue template
- Use correct filename when removing `pudl_dbt_tests.duckdb` in nightly build script so we don't distribute it.

Closes #4278