### PR TITLE
Tiny tweak to make PUDL work with pandas 2.3

### DIFF
--- a/src/pudl/output/eia930.py
+++ b/src/pudl/output/eia930.py
@@ -64,8 +64,12 @@ def _out_eia930__hourly_subregion_demand(
     )
 
     core_eia930__hourly_subregion_demand["combined_subregion_ba_code_eia"] = (
-        core_eia930__hourly_subregion_demand["balancing_authority_code_eia"]
-        + core_eia930__hourly_subregion_demand["balancing_authority_subregion_code_eia"]
+        core_eia930__hourly_subregion_demand["balancing_authority_code_eia"].astype(
+            "string"
+        )
+        + core_eia930__hourly_subregion_demand[
+            "balancing_authority_subregion_code_eia"
+        ].astype("string")
     )
     return core_eia930__hourly_subregion_demand
 


### PR DESCRIPTION
# Overview

I installed pandas 2.3 and ran the full ETL, and this PR fixes the only thing that broke.

# Testing

- Ran the full ETL locally
- Ran the integration and validation tests locally on the full ETL outputs
- Ran the dbt tests locally



