### PR TITLE
Migrate from deprecated SourceAsset to new AssetSpec

### DIFF
--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -2,8 +2,6 @@
 
 import importlib.resources
 import itertools
-import os
-import warnings
 
 import pandera as pr
 from dagster import (
@@ -11,9 +9,8 @@ from dagster import (
     AssetChecksDefinition,
     AssetKey,
     AssetsDefinition,
-    AssetSelection,
+    AssetSpec,
     Definitions,
-    SourceAsset,
     asset_check,
     define_asset_job,
     load_asset_checks_from_modules,
@@ -119,6 +116,7 @@ default_assets = list(
         load_assets_from_modules(
             modules,
             group_name=group_name,
+            include_specs=True,
         )
         for group_name, modules in all_asset_modules.items()
     )
@@ -170,7 +168,7 @@ def asset_check_from_schema(
 
 
 def _get_keys_from_assets(
-    asset_def: AssetsDefinition | SourceAsset | CacheableAssetsDefinition,
+    asset_def: AssetsDefinition | AssetSpec | CacheableAssetsDefinition,
 ) -> list[AssetKey]:
     """Get a list of asset keys.
 
@@ -180,14 +178,14 @@ def _get_keys_from_assets(
     Multi-assets have multiple keys, which can also be retrieved as a list from
     ``asset.keys``.
 
-    SourceAssets always only have one key, and don't have ``asset.keys``. So we
+    AssetSpecs always only have one key, and don't have ``asset.keys``. So we
     look for ``asset.key`` and wrap it in a list.
 
     We don't handle CacheableAssetsDefinitions yet.
     """
     if isinstance(asset_def, AssetsDefinition):
         return list(asset_def.keys)
-    if isinstance(asset_def, SourceAsset):
+    if isinstance(asset_def, AssetSpec):
         return [asset_def.key]
     return []
 

--- a/src/pudl/extract/ferc1.py
+++ b/src/pudl/extract/ferc1.py
@@ -74,7 +74,7 @@ import pandas as pd
 import sqlalchemy as sa
 from dagster import (
     AssetKey,
-    SourceAsset,
+    AssetSpec,
     asset,
     build_init_resource_context,
     build_input_context,
@@ -342,14 +342,15 @@ class Ferc1DbfExtractor(FercDbfExtractor):
 
 
 # DAGSTER ASSETS
-def create_raw_ferc1_assets() -> list[SourceAsset]:
-    """Create SourceAssets for raw ferc1 tables.
+def create_raw_ferc1_assets() -> list[AssetSpec]:
+    """Create AssetSpecs for raw ferc1 tables.
 
-    SourceAssets allow you to access assets that are generated elsewhere.
-    In our case, the xbrl and dbf database are created in a separate dagster Definition.
+    An :class:`dagster.AssetSpec` allows you to access assets that are generated
+    elsewhere.  In our case, the xbrl and dbf database are created in a separate dagster
+    Definition.
 
     Returns:
-        A list of ferc1 SourceAssets.
+        A list of ferc1 AssetSpecs.
     """
     # Deduplicate the table names because f1_elctrc_erg_acct feeds into multiple pudl tables.
     dbfs = (v["dbf"] for v in TABLE_NAME_MAP_FERC1.values())
@@ -358,9 +359,8 @@ def create_raw_ferc1_assets() -> list[SourceAsset]:
     )
     dbf_table_names = tuple(set(flattened_dbfs))
     raw_ferc1_dbf_assets = [
-        SourceAsset(
-            key=AssetKey(f"raw_ferc1_dbf__{table_name}"),
-            io_manager_key="ferc1_dbf_sqlite_io_manager",
+        AssetSpec(key=AssetKey(f"raw_ferc1_dbf__{table_name}")).with_io_manager_key(
+            "ferc1_dbf_sqlite_io_manager"
         )
         for table_name in dbf_table_names
     ]
@@ -375,9 +375,8 @@ def create_raw_ferc1_assets() -> list[SourceAsset]:
     )
     xbrl_table_names = tuple(set(xbrls_with_periods))
     raw_ferc1_xbrl_assets = [
-        SourceAsset(
-            key=AssetKey(f"raw_ferc1_xbrl__{table_name}"),
-            io_manager_key="ferc1_xbrl_sqlite_io_manager",
+        AssetSpec(key=AssetKey(f"raw_ferc1_xbrl__{table_name}")).with_io_manager_key(
+            "ferc1_xbrl_sqlite_io_manager"
         )
         for table_name in xbrl_table_names
     ]

--- a/src/pudl/extract/ferc714.py
+++ b/src/pudl/extract/ferc714.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import pandas as pd
-from dagster import AssetKey, AssetsDefinition, SourceAsset, asset
+from dagster import AssetKey, AssetsDefinition, AssetSpec, asset
 
 import pudl
 from pudl.workspace.setup import PudlPaths
@@ -170,16 +170,16 @@ def raw_ferc714_xbrl__metadata_json(
     return xbrl_meta_out
 
 
-def create_raw_ferc714_xbrl_assets() -> list[SourceAsset]:
-    """Create SourceAssets for raw FERC 714 XBRL tables.
+def create_raw_ferc714_xbrl_assets() -> list[AssetSpec]:
+    """Create AssetSpecs for raw FERC 714 XBRL tables.
 
-    SourceAssets allow you to access assets that are generated elsewhere.
-    In our case, the XBRL database contains the raw FERC 714 assets from
-    2021 onward. Prior to that, the assets are distributed as CSVs and
-    are extracted with the ``raw_ferc714_csv_asset_factory`` function.
+    AssetSpecs allow you to specify and access assets that are generated elsewhere.  In
+    our case, the XBRL database contains the raw FERC 714 assets from 2021 onward. Prior
+    to that, the assets are distributed as CSVs and are extracted with the
+    ``raw_ferc714_csv_asset_factory`` function.
 
     Returns:
-        A list of FERC 714 SourceAssets.
+        A list of FERC 714 AssetSpecs.
     """
     # Create assets for the duration and instant tables
     xbrls = (v["xbrl"] for v in TABLE_NAME_MAP_FERC714.values())
@@ -191,9 +191,8 @@ def create_raw_ferc714_xbrl_assets() -> list[SourceAsset]:
     )
     xbrl_table_names = tuple(set(xbrls_with_periods))
     raw_ferc714_xbrl_assets = [
-        SourceAsset(
-            key=AssetKey(f"raw_ferc714_xbrl__{table_name}"),
-            io_manager_key="ferc714_xbrl_sqlite_io_manager",
+        AssetSpec(key=AssetKey(f"raw_ferc714_xbrl__{table_name}")).with_io_manager_key(
+            "ferc714_xbrl_sqlite_io_manager"
         )
         for table_name in xbrl_table_names
     ]

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -28,7 +28,7 @@ import pyarrow.parquet as pq
 import requests
 import sqlalchemy as sa
 import yaml
-from dagster import AssetKey, AssetsDefinition, AssetSelection, SourceAsset
+from dagster import AssetKey, AssetsDefinition, AssetSelection, AssetSpec
 from pandas._libs.missing import NAType
 
 import pudl.logging_helpers
@@ -1826,22 +1826,22 @@ def convert_df_to_excel_file(df: pd.DataFrame, **kwargs) -> pd.ExcelFile:
 
 
 def get_asset_keys(
-    assets: list[AssetsDefinition], exclude_source_assets: bool = True
+    assets: list[AssetsDefinition], exclude_asset_specs: bool = True
 ) -> set[AssetKey]:
     """Get a set of asset keys from a list of asset definitions.
 
     Args:
         assets: list of asset definitions.
-        exclude_source_assets: exclude SourceAssets in the returned list.
-            Some selection operations don't allow SourceAsset keys.
+        exclude_asset_specs: exclude AssetSpecs in the returned list.
+            Some selection operations don't allow AssetSpec keys.
 
     Returns:
         A set of asset keys.
     """
     asset_keys = set()
     for asset in assets:
-        if isinstance(asset, SourceAsset):
-            if not exclude_source_assets:
+        if isinstance(asset, AssetSpec):
+            if not exclude_asset_specs:
                 asset_keys = asset_keys.union(asset.key)
         else:
             asset_keys = asset_keys.union(asset.keys)


### PR DESCRIPTION
# Overview

Update our code to use the new `AssetSpec` class, instead of the deprecated `SourceAsset`

Closes #3977 

# Testing

- Rematerialized FERC-714 and FERC Form 1 core assets (which have the source assets affected by this PR upstream) locally without any problems.
- Ran [integration tests in CI on GitHub](https://github.com/catalyst-cooperative/pudl/actions/runs/15510289818/job/43670345264)