### PR TITLE
feat: capture DBT output and get failure context

### DIFF
--- a/src/pudl/dbt_wrapper.py
+++ b/src/pudl/dbt_wrapper.py
@@ -1,0 +1,74 @@
+"""Wrap DBT invocations so we can get custom behavior."""
+
+from contextlib import chdir
+from typing import NamedTuple, cast
+
+import duckdb
+import pandas as pd
+from dbt.artifacts.schemas.results import TestStatus
+from dbt.artifacts.schemas.run import RunExecutionResult
+from dbt.cli.main import dbtRunner, dbtRunnerResult
+from dbt.contracts.graph.nodes import GenericTestNode
+
+from pudl.workspace.setup import PUDL_ROOT_PATH, PudlPaths
+
+
+def get_failed_nodes(results: RunExecutionResult) -> list[GenericTestNode]:
+    """Get test node output from tests that failed."""
+    return [res.node for res in results if res.status == TestStatus.Fail]
+
+
+class NodeContext(NamedTuple):
+    """Associate a node's *name* with information describing what went wrong."""
+
+    # TODO 2025-06-09: consider adding whether this failed or errored, and a
+    # free-form text description field
+    name: str
+    context: pd.DataFrame
+
+    def pretty_print(self):
+        """Nice output for logging to stdout."""
+        return f"{self.name}:\n\n{self.context}"
+
+
+def get_context_for_nodes(nodes: list[GenericTestNode]) -> list[NodeContext]:
+    """Post-process node output to figure out failure context.
+
+    For most tests, just run the compiled code in the node.
+
+    (TODO 2025-06-09) for weighted quantile tests, run the "debug quantiles" DBT
+    operation.
+    """
+    contexts = []
+    duckdb_path = PudlPaths().output_file("pudl_dbt_tests.duckdb")
+    with duckdb.connect(duckdb_path) as con:
+        for node in nodes:
+            con.execute(node.compiled_code)
+            node_df = con.fetchdf()
+            contexts.append(NodeContext(name=node.name, context=node_df))
+    return contexts
+
+
+def run_build(model_selection):
+    """Run the DBT build and get failure information back.
+
+    * run the DBT build using our selection, returning test failures
+    * get extra context for each test failure
+    * print out test failure context
+    """
+    dbt_target = "etl-full"
+    cli_args = ["--target", dbt_target, "--select", model_selection]
+    dbt = dbtRunner()
+    dbt_dir = PUDL_ROOT_PATH / "dbt"
+
+    # 2025-06-06 TODO: use the --project-dir flag instead of chdiring all the time?
+    with chdir(dbt_dir):
+        _ = dbt.invoke(["deps"])
+        _ = dbt.invoke(["seed"])
+        build_output: dbtRunnerResult = dbt.invoke(["build"] + cli_args)
+        build_results = cast(RunExecutionResult, build_output.result)
+
+    failed_nodes = get_failed_nodes(build_results)
+    failure_contexts = get_context_for_nodes(failed_nodes)
+
+    print("\n\n====\n\n".join(c.pretty_print() for c in failure_contexts))

--- a/src/pudl/workspace/setup.py
+++ b/src/pudl/workspace/setup.py
@@ -13,6 +13,8 @@ logger = pudl.logging_helpers.get_logger(__name__)
 
 PotentialDirectoryPath = DirectoryPath | NewPath
 
+PUDL_ROOT_PATH = Path(__file__).parent.parent.parent.parent
+
 
 class PudlPaths(BaseSettings):
     """These settings provide access to various PUDL directories.


### PR DESCRIPTION
Added a function that runs `dbt build`, captures the output, and uses the output to run the duckdb queries that will give us failure output.

Next steps:

* handle weighted quantile tests differently.
* handle errors as well as failures.
* wrap this function in a CLI command
* use this function in integration tests

<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #XXXX.

## What problem does this address?

## What did you change?

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
