### PR TITLE
Add data validation tests for imputed demand tables.

### DIFF
--- a/dbt/models/eia930/out_eia930__hourly_operations/schema.yml
+++ b/dbt/models/eia930/out_eia930__hourly_operations/schema.yml
@@ -7,21 +7,49 @@ sources:
           - check_row_counts_per_partition:
               table_name: out_eia930__hourly_operations
               partition_column: datetime_utc
+          - expect_unimputed_values_are_unchanged:
+              original: demand_reported_mwh
+              imputed: demand_imputed_pudl_mwh
+              imputation_code: demand_imputed_pudl_mwh_imputation_code
+              severity: warn
         columns:
           - name: datetime_utc
           - name: balancing_authority_code_eia
           - name: net_generation_reported_mwh
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.0
+                  upper_bound: 0.02
           - name: net_generation_adjusted_mwh
           - name: net_generation_imputed_eia_mwh
           - name: interchange_reported_mwh
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.0
+                  upper_bound: 0.02
           - name: interchange_adjusted_mwh
           - name: interchange_imputed_eia_mwh
           - name: demand_reported_mwh
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.1
+                  upper_bound: 0.2
           - name: demand_adjusted_mwh
           - name: demand_imputed_pudl_mwh
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.1
+                  upper_bound: 0.2
           - name: demand_imputed_pudl_mwh_imputation_code
             tests:
               - dbt_expectations.expect_column_values_to_not_be_in_set:
                   value_set: ["simulated"]
+              - expect_missingness_between:
+                  lower_bound: 0.98
+                  upper_bound: 1.0
           - name: demand_imputed_eia_mwh
           - name: demand_forecast_mwh
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.1
+                  upper_bound: 0.2

--- a/dbt/models/eia930/out_eia930__hourly_subregion_demand/schema.yml
+++ b/dbt/models/eia930/out_eia930__hourly_subregion_demand/schema.yml
@@ -7,13 +7,29 @@ sources:
           - check_row_counts_per_partition:
               table_name: out_eia930__hourly_subregion_demand
               partition_column: datetime_utc
+          - expect_unimputed_values_are_unchanged:
+              original: demand_reported_mwh
+              imputed: demand_imputed_pudl_mwh
+              imputation_code: demand_imputed_pudl_mwh_imputation_code
+              severity: warn
         columns:
           - name: datetime_utc
           - name: balancing_authority_code_eia
           - name: balancing_authority_subregion_code_eia
           - name: demand_reported_mwh
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.0
+                  upper_bound: 0.03
           - name: demand_imputed_pudl_mwh
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.06
+                  upper_bound: 0.12
           - name: demand_imputed_pudl_mwh_imputation_code
             tests:
               - dbt_expectations.expect_column_values_to_not_be_in_set:
                   value_set: ["simulated"]
+              - expect_missingness_between:
+                  lower_bound: 0.94
+                  upper_bound: 0.98

--- a/dbt/models/ferc714/out_ferc714__hourly_planning_area_demand/schema.yml
+++ b/dbt/models/ferc714/out_ferc714__hourly_planning_area_demand/schema.yml
@@ -7,13 +7,42 @@ sources:
           - check_row_counts_per_partition:
               table_name: out_ferc714__hourly_planning_area_demand
               partition_column: report_date
+          - expect_unimputed_values_are_unchanged:
+              original: demand_reported_mwh
+              imputed: demand_imputed_pudl_mwh
+              imputation_code: demand_imputed_pudl_mwh_imputation_code
+              severity: warn
         columns:
           - name: respondent_id_ferc714
           - name: respondent_id_ferc714_csv
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.0
+                  upper_bound: 0.01
           - name: respondent_id_ferc714_xbrl
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.0
+                  upper_bound: 0.2
           - name: report_date
           - name: datetime_utc
           - name: timezone
+            tests:
+              - dbt_expectations.expect_column_values_to_not_be_null
           - name: demand_reported_mwh
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.0
+                  upper_bound: 0.0
           - name: demand_imputed_pudl_mwh
+            tests:
+              - expect_missingness_between:
+                  lower_bound: 0.0
+                  upper_bound: 0.05
           - name: demand_imputed_pudl_mwh_imputation_code
+            tests:
+              - dbt_expectations.expect_column_values_to_not_be_in_set:
+                  value_set: ["simulated"]
+              - expect_missingness_between:
+                  lower_bound: 0.96
+                  upper_bound: 0.99

--- a/dbt/package-lock.yml
+++ b/dbt/package-lock.yml
@@ -4,5 +4,5 @@ packages:
   - package: dbt-labs/dbt_utils
     version: 1.3.0
   - package: godatadriven/dbt_date
-    version: 0.13.0
+    version: 0.14.1
 sha1_hash: 984baac0716f78c8f3a7d03a7ff41ba9f609ae21

--- a/dbt/tests/data_tests/generic_tests/expect_missingness_between.sql
+++ b/dbt/tests/data_tests/generic_tests/expect_missingness_between.sql
@@ -1,0 +1,16 @@
+{% test expect_missingness_between(
+    model,
+    column_name,
+    lower_bound=0,
+    upper_bound=1
+) %}
+
+SELECT
+    COUNT(*) AS total_records,
+    COUNT(*) - COUNT({{ column_name }}) AS null_records,
+    (COUNT(*) - COUNT({{ column_name }})::FLOAT) / NULLIF(COUNT(*), 0) AS null_proportion
+FROM {{ model }}
+HAVING null_proportion < {{ lower_bound }}
+    OR null_proportion > {{ upper_bound }}
+
+{% endtest %}

--- a/dbt/tests/data_tests/generic_tests/expect_unimputed_values_are_unchanged.sql
+++ b/dbt/tests/data_tests/generic_tests/expect_unimputed_values_are_unchanged.sql
@@ -1,0 +1,18 @@
+{% test expect_unimputed_values_are_unchanged(
+    model,
+    original,
+    imputed,
+    imputation_code,
+    atol=1,
+    rtol=0.001
+) %}
+SELECT * FROM {{ model }}
+WHERE {{ imputation_code }} IS NULL
+AND (
+    (abs({{ original }} - {{ imputed }}) > {{ atol }})
+    OR (abs({{ original }} - {{ imputed }}) / greatest(abs({{ original }}), abs({{ imputed }})) > {{ rtol }})
+    OR ({{ original }} IS NULL AND {{ imputed }} IS NOT NULL)
+    OR ({{ original }} IS NOT NULL AND {{ imputed }} IS NULL)
+)
+
+{% endtest %}


### PR DESCRIPTION
# Overview

- Adds a new generic `dbt` data test `expect_missingness_between`
- Adds checks related to the missingness of some values in our imputed demand output tables
- Adds a new generic `dbt` data test `expect_unimputed_values_are_unchanged`
- Adds a check that reported values that weren't flagged for imputation do not change (currently WARNing)

Closes #4157

## Notes

- We could replace `not_all_null` tests with more flexible `expect_missingness_between`
- Maybe the imputation check could be made more general by using a `row_condition`s and a more generic `expect_column_is_approx_equal` test that checks two float columns are close?

## Testing

- I materialized the FERC-714 and EIA-930 tables and ran their `dbt` tests locally

## Before Merging

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Run `make pytest-coverage` locally to ensure new `dbt` tests pass on fast ETL outputs too.
- [ ] Review the PR yourself and call out any questions or issues you have.
