### PR TITLE
chore: fix 'legacy alias' for ruff pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,8 +31,8 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.13
     hooks:
-      - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-check
+        args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/rbubley/mirrors-prettier


### PR DESCRIPTION
## Overview

We're supposed to use `ruff-check` instead of `ruff` now, I guess. Also, dropping the `--exit-non-zero-on-fix` didn't seem to change the behavior when there was a linting error that got auto-fixed. So we might as well remove it.

# Testing

I added an extra newline to the import block of `transform/eia930.py` then tried to commit it. `ruff` complained and the commit didn't go through. I had to manually add the fix from `ruff` before re-committing.