### PR TITLE
Add extra flag to timeseries imputation for bad years of data

### DIFF
--- a/src/pudl/metadata/dfs.py
+++ b/src/pudl/metadata/dfs.py
@@ -24,6 +24,7 @@ class ImputationReasonCodes(Enum):
     SINGLE_DELTA = (
         "Indicates value is significantly different from nearest unflagged value."
     )
+    BAD_YEAR = "Indicates the entire year of data for a respondent was dropped due to too much missing data."
     SIMULATED = "Used for scoring imputation using simulated data. SHOULD NOT APPEAR IN PRODUCTION DATA."
 
 


### PR DESCRIPTION
# Overview

This PR adds a new imputation flag, `BAD_YEAR`. This flag indicates that an entire year of data was dropped for a specific respondent because there was too much missing data. This should ensure that anytime the `imputed` column isn't equal to the `reported` column, there will be a corresponding `flag` for the value.
