### PR TITLE
Test saving observed dbt row counts in nightly builds

### DIFF
--- a/dbt/seeds/etl_full_row_counts.csv
+++ b/dbt/seeds/etl_full_row_counts.csv
@@ -299,6 +299,7 @@ _out_eia__yearly_heat_rate_by_unit,2020,2010
 _out_eia__yearly_heat_rate_by_unit,2021,1954
 _out_eia__yearly_heat_rate_by_unit,2022,1886
 _out_eia__yearly_heat_rate_by_unit,2023,1865
+_out_ferc1__yearly_plants_utilities,,8101
 core_eia860__assn_boiler_cooling,2009,2586
 core_eia860__assn_boiler_cooling,2010,2834
 core_eia860__assn_boiler_cooling,2011,2963

--- a/dbt/seeds/etl_full_row_counts.csv
+++ b/dbt/seeds/etl_full_row_counts.csv
@@ -299,7 +299,6 @@ _out_eia__yearly_heat_rate_by_unit,2020,2010
 _out_eia__yearly_heat_rate_by_unit,2021,1954
 _out_eia__yearly_heat_rate_by_unit,2022,1886
 _out_eia__yearly_heat_rate_by_unit,2023,1865
-_out_ferc1__yearly_plants_utilities,,8101
 core_eia860__assn_boiler_cooling,2009,2586
 core_eia860__assn_boiler_cooling,2010,2834
 core_eia860__assn_boiler_cooling,2011,2963

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -69,6 +69,7 @@ function write_pudl_datapackage() {
 function save_outputs_to_gcs() {
     echo "Copying outputs to GCP bucket $PUDL_GCS_OUTPUT" && \
     gcloud storage --quiet cp -r "$PUDL_OUTPUT" "$PUDL_GCS_OUTPUT" && \
+    gcloud storage --quiet cp -r "$PUDL_REPO"/dbt/seeds/etl_full_row_counts.csv "$PUDL_GCS_OUTPUT" && \
     rm -f "$PUDL_OUTPUT/success"
 }
 

--- a/docs/dev/testing.rst
+++ b/docs/dev/testing.rst
@@ -146,8 +146,17 @@ database:
 The data validation cases that pertain to the contents of the data tables are
 currently stored as part of the :mod:`pudl.validate` module.
 
-The expected number of records in each output table is stored in the validation
-test modules under ``test/validate`` as pytest parameterizations.
+To catch unexpected changes to the data, we keep track of the expected number of rows in
+each data table we distribute. These expectations are stored in
+``dbt/seeds/etl_full_row_counts.csv`` and they can be updated using the ``dbt_helper``
+script. If you can't run the full ETL locally, the nightly builds / branch deployments
+also generate updated row count expectations. So you can kick off the
+``build-deploy-pudl`` GitHub Action using the ``workflow_dispatch`` trigger on your
+branch on GitHub, and then download the updated ``etl_full_row_counts.csv`` file from
+the build outputs that are uploaded to
+``gs://builds.catalyst.coop/<build-id>/etl_full_row_counts.csv`` once the build has
+completed. See the :doc:`nightly_data_builds` documentation for more details on the
+nightly builds.
 
 Data Validation Notebooks
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Overview

Copy the observed full ETL row counts to the nightly build outputs so they can be generated and used without needing to to run the Full ETL locally.

## To-do list

- [x] Run a branch deployment. Check that observed row counts are available on on `gs://builds.catalyst.coop`.
- [x] Undo the test change I made to the row counts file.
- [x] Update developer docs to offer this option for grabbing authoritative nightly build row count expectations.