### PR TITLE
Clobber row counts and save new ones in nightly build script

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:2.1.1-ubuntu24.04
+FROM mambaorg/micromamba:2.3.0-ubuntu24.04
 
 ENV CONTAINER_HOME=/home/$MAMBA_USER
 ENV PGDATA=${CONTAINER_HOME}/pgdata

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -254,6 +254,9 @@ ETL_SUCCESS=${PIPESTATUS[0]}
 write_pudl_datapackage 2>&1 | tee -a "$LOGFILE"
 WRITE_DATAPACKAGE_SUCCESS=${PIPESTATUS[0]}
 
+# Generate new row counts for all tables in the PUDL database
+dbt_helper update-tables --clobber --row-counts all 2>&1 | tee -a "$LOGFILE"
+
 # This needs to happen regardless of the ETL outcome:
 pg_ctlcluster "$PG_VERSION" dagster stop 2>&1 | tee -a "$LOGFILE"
 


### PR DESCRIPTION
# Overview

Add a line to the nightly build script that produces new row counts after the build has completed, using `--clobber` to update any existing table row counts.
