### PR TITLE
Update row count expectations with clobber after nightly build.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM mambaorg/micromamba:2.1.1-ubuntu24.04
+FROM mambaorg/micromamba:2.3.0-ubuntu24.04
 
 ENV CONTAINER_HOME=/home/$MAMBA_USER
 ENV PGDATA=${CONTAINER_HOME}/pgdata

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -254,6 +254,9 @@ ETL_SUCCESS=${PIPESTATUS[0]}
 write_pudl_datapackage 2>&1 | tee -a "$LOGFILE"
 WRITE_DATAPACKAGE_SUCCESS=${PIPESTATUS[0]}
 
+# Generate new row counts for all tables in the PUDL database
+dbt_helper update-tables --clobber --row-counts all 2>&1 | tee -a "$LOGFILE"
+
 # This needs to happen regardless of the ETL outcome:
 pg_ctlcluster "$PG_VERSION" dagster stop 2>&1 | tee -a "$LOGFILE"
 


### PR DESCRIPTION
# Overview

After the Google Batch ETL is finished, use `dbt_helper` to update row count expectations, so we can save them to builds.catalyst.coop and apply them to the branch, w/o needing to run the ETL locally or worrying about something being stale.

Tried to do this in #4341 but it only looked like it worked because I tested it by removing a line from the row count CSV -- it won't update existing row counts without `--clobber`.

I ran a branch deployment off of the the 88888/99999 PR branch #4291 with this PR #4345 and it updated the row counts for a bunch of different tables/partitions.
