### PR TITLE
fix: don't pass a default value for --exclude

### DIFF
--- a/src/pudl/scripts/dbt_helper.py
+++ b/src/pudl/scripts/dbt_helper.py
@@ -506,7 +506,6 @@ def update_tables(
 )
 @click.option(
     "--exclude",
-    default="*",
     help="DBT selector for the asset(s) you want to exclude from validation.",
 )
 @click.option(


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

## What problem does this address?

I added an `--exclude` flag in #4315 which lets you use selection syntax to exclude nodes from validation last night... but it defaulted to "*" which excludes everything :sweat_smile: . So:

* before this gets merged you need to pass something like `--exclude dasdfasldfk` to override the default
* once this is merged then things will work ok

## What did you change?

Stop defaulting to `--exclude "*"`.

# Testing

I ran

```bash
% dbt_helper validate --select "source:pudl_dbt.pudl.out_eia__yearly_generators"
```
And it ran 10 tests.

And then I also ran
```bash
% dbt_helper validate --select "source:pudl_dbt.pudl.out_eia__yearly_generators" --exclude "*check_row_counts*"
```
And it ran 9 tests, successfully filtering out the row counts test.