### PR TITLE
Clobber updated nightly row-counts before updating nightly tag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: end-of-file-fixer
 
   ####################################################################################
-  # Formatters: hooks that re-write Python & documentation files
+  # Formatters: hooks that re-write code & documentation files
   ####################################################################################
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.12.1
@@ -40,6 +40,11 @@ repos:
     hooks:
       - id: prettier
         types_or: [yaml]
+
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
 
   ####################################################################################
   # Linters: hooks that check but don't alter files

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -23,54 +23,54 @@ function initialize_postgres() {
     # 3. tell it to actually fail when we mess up, instead of continuing blithely
     # 4. create a *dagster* user, whose creds correspond with those in docker/dagster.yaml
     # 5. make a database for dagster, which is owned by the dagster user
-    pg_ctlcluster "$PG_VERSION" dagster start && \
-    createdb -h127.0.0.1 -p5433 && \
-    psql -v "ON_ERROR_STOP=1" -h127.0.0.1 -p5433 && \
-    psql -c "CREATE USER dagster WITH SUPERUSER PASSWORD 'dagster_password'" -h127.0.0.1 -p5433 && \
-    psql -c "CREATE DATABASE dagster OWNER dagster" -h127.0.0.1 -p5433
+    pg_ctlcluster "$PG_VERSION" dagster start &&
+        createdb -h127.0.0.1 -p5433 &&
+        psql -v "ON_ERROR_STOP=1" -h127.0.0.1 -p5433 &&
+        psql -c "CREATE USER dagster WITH SUPERUSER PASSWORD 'dagster_password'" -h127.0.0.1 -p5433 &&
+        psql -c "CREATE DATABASE dagster OWNER dagster" -h127.0.0.1 -p5433
 }
 
 function run_pudl_etl() {
     echo "Running PUDL ETL"
     send_slack_msg ":large_yellow_circle: Deployment started for $BUILD_ID :floppy_disk:"
-    initialize_postgres && \
-    authenticate_gcp && \
-    alembic upgrade head && \
-    ferc_to_sqlite \
-        --loglevel DEBUG \
-        --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
-        --workers 8 \
-        "$PUDL_SETTINGS_YML" \
-    && pudl_etl \
-        --loglevel DEBUG \
-        --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
-        "$PUDL_SETTINGS_YML" \
-    && pytest \
-        -n auto \
-        --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
-        --etl-settings "$PUDL_SETTINGS_YML" \
-        --live-dbs test/integration test/unit \
-        --no-cov \
-    && pytest \
-        -n auto \
-        --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
-        --etl-settings "$PUDL_SETTINGS_YML" \
-        --live-dbs test/validate \
-        --no-cov \
-    && touch "$PUDL_OUTPUT/success"
+    initialize_postgres &&
+        authenticate_gcp &&
+        alembic upgrade head &&
+        ferc_to_sqlite \
+            --loglevel DEBUG \
+            --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
+            --workers 8 \
+            "$PUDL_SETTINGS_YML" &&
+        pudl_etl \
+            --loglevel DEBUG \
+            --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
+            "$PUDL_SETTINGS_YML" &&
+        pytest \
+            -n auto \
+            --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
+            --etl-settings "$PUDL_SETTINGS_YML" \
+            --live-dbs test/integration test/unit \
+            --no-cov &&
+        pytest \
+            -n auto \
+            --gcs-cache-path gs://internal-zenodo-cache.catalyst.coop \
+            --etl-settings "$PUDL_SETTINGS_YML" \
+            --live-dbs test/validate \
+            --no-cov &&
+        touch "$PUDL_OUTPUT/success"
 }
 
 function write_pudl_datapackage() {
     echo "Writing PUDL datapackage."
-    python -c "from pudl.metadata.classes import PUDL_PACKAGE; print(PUDL_PACKAGE.to_frictionless().to_json())" > "$PUDL_OUTPUT/parquet/pudl_parquet_datapackage.json"
+    python -c "from pudl.metadata.classes import PUDL_PACKAGE; print(PUDL_PACKAGE.to_frictionless().to_json())" >"$PUDL_OUTPUT/parquet/pudl_parquet_datapackage.json"
     return $?
 }
 
 function save_outputs_to_gcs() {
-    echo "Copying outputs to GCP bucket $PUDL_GCS_OUTPUT" && \
-    gcloud storage --quiet cp -r "$PUDL_OUTPUT" "$PUDL_GCS_OUTPUT" && \
-    gcloud storage --quiet cp -r "$PUDL_REPO"/dbt/seeds/etl_full_row_counts.csv "$PUDL_GCS_OUTPUT" && \
-    rm -f "$PUDL_OUTPUT/success"
+    echo "Copying outputs to GCP bucket $PUDL_GCS_OUTPUT" &&
+        gcloud storage --quiet cp -r "$PUDL_OUTPUT" "$PUDL_GCS_OUTPUT" &&
+        gcloud storage --quiet cp -r "$PUDL_REPO"/dbt/seeds/etl_full_row_counts.csv "$PUDL_GCS_OUTPUT" &&
+        rm -f "$PUDL_OUTPUT/success"
 }
 
 function remove_dist_path() {
@@ -102,10 +102,10 @@ function upload_to_dist_path() {
         # Do not && this command with the others, as it will exit with status 1 if the
         # old outputs don't exist.
         remove_dist_path "$DIST_PATH"
-        echo "Copying outputs to $GCS_PATH:" && \
-        gcloud storage cp --quiet --recursive --billing-project="$GCP_BILLING_PROJECT" "$PUDL_OUTPUT/*" "$GCS_PATH" && \
-        echo "Copying outputs to $AWS_PATH" && \
-        gcloud storage cp --quiet --recursive "$PUDL_OUTPUT/*" "$AWS_PATH"
+        echo "Copying outputs to $GCS_PATH:" &&
+            gcloud storage cp --quiet --recursive --billing-project="$GCP_BILLING_PROJECT" "$PUDL_OUTPUT/*" "$GCS_PATH" &&
+            echo "Copying outputs to $AWS_PATH" &&
+            gcloud storage cp --quiet --recursive "$PUDL_OUTPUT/*" "$AWS_PATH"
     else
         echo "No distribution path provided. Not updating outputs."
         exit 1
@@ -116,9 +116,9 @@ function zenodo_data_release() {
     echo "Creating a new PUDL data release on Zenodo."
 
     if [[ "$1" == "production" ]]; then
-        ~/pudl/devtools/zenodo/zenodo_data_release.py --no-publish --env "$1" --source-dir "$PUDL_OUTPUT" --ignore $PUDL_OUTPUT/pudl_parquet_datapackage.json
+        ~/pudl/devtools/zenodo/zenodo_data_release.py --no-publish --env "$1" --source-dir "$PUDL_OUTPUT" --ignore "$PUDL_OUTPUT"/pudl_parquet_datapackage.json
     elif [[ "$1" == "sandbox" ]]; then
-        ~/pudl/devtools/zenodo/zenodo_data_release.py --publish --env "$1" --source-dir "$PUDL_OUTPUT" --ignore $PUDL_OUTPUT/pudl_parquet_datapackage.json
+        ~/pudl/devtools/zenodo/zenodo_data_release.py --publish --env "$1" --source-dir "$PUDL_OUTPUT" --ignore "$PUDL_OUTPUT"/pudl_parquet_datapackage.json
     else
         echo "Invalid Zenodo environment"
         exit 1
@@ -161,44 +161,48 @@ function merge_tag_into_branch() {
     BRANCH=$2
     # When building the image, GHA adds an HTTP basic auth header in git
     # config, which overrides the auth we set below. So we unset it.
-    git config --unset http.https://github.com/.extraheader && \
-    git config user.email "pudl@catalyst.coop" && \
-    git config user.name "pudlbot" && \
-    set +x && \
-    echo "Setting authenticated git remote URL using PAT" && \
-    git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git" && \
-    set -x && \
-    echo "Updating $BRANCH branch to point at $TAG." && \
-    git fetch --force --tags origin "$TAG" && \
-    git fetch origin "$BRANCH":"$BRANCH" && \
-    git checkout "$BRANCH" && \
-    git show-ref -d "$BRANCH" "$TAG" && \
-    git merge --ff-only "$TAG" && \
-    git push -u origin "$BRANCH"
+    git config --unset http.https://github.com/.extraheader &&
+        git config user.email "pudl@catalyst.coop" &&
+        git config user.name "pudlbot" &&
+        set +x &&
+        echo "Setting authenticated git remote URL using PAT" &&
+        git remote set-url origin "https://pudlbot:$PUDL_BOT_PAT@github.com/catalyst-cooperative/pudl.git" &&
+        set -x &&
+        echo "Updating $BRANCH branch to point at $TAG." &&
+        # Check out the original row counts so the working tree is clean.
+        # This is a temporary hack around the unstable row-counts in some tables.
+        # TODO: fix this for real in issue #4364 / PR #4367
+        git checkout -- dbt/seeds/ &&
+        git fetch --force --tags origin "$TAG" &&
+        git fetch origin "$BRANCH":"$BRANCH" &&
+        git checkout "$BRANCH" &&
+        git show-ref -d "$BRANCH" "$TAG" &&
+        git merge --ff-only "$TAG" &&
+        git push -u origin "$BRANCH"
 }
 
 function clean_up_outputs_for_distribution() {
     # Compress the SQLite DBs for easier distribution
-    pushd "$PUDL_OUTPUT" && \
-    for file in *.sqlite; do
-        echo "Compressing $file" && \
-        zip "$file.zip" "$file" && \
-        rm "$file"
-    done
-    popd && \
-    # Create a zip file of all the parquet outputs for distribution on Kaggle
-    # Don't try to compress the already compressed Parquet files with Zip.
-    pushd "$PUDL_OUTPUT/parquet" && \
-    zip -0 "$PUDL_OUTPUT/pudl_parquet.zip" ./*.parquet ./pudl_parquet_datapackage.json && \
-    # Move the individual parquet outputs to the output directory for direct access
-    mv ./*.parquet "$PUDL_OUTPUT" && \
-    # Move the parquet datapackage to the output directory also!
-    mv ./pudl_parquet_datapackage.json "$PUDL_OUTPUT" && \
-    popd && \
-    # Remove any remaiining files and directories we don't want to distribute
-    rm -rf "$PUDL_OUTPUT/parquet" && \
-    rm -f "$PUDL_OUTPUT/metadata.yml" && \
-    rm -f "$PUDL_OUTPUT/pudl_dbt_tests.duckdb"
+    pushd "$PUDL_OUTPUT" &&
+        for file in *.sqlite; do
+            echo "Compressing $file" &&
+                zip "$file.zip" "$file" &&
+                rm "$file"
+        done
+    popd &&
+        # Create a zip file of all the parquet outputs for distribution on Kaggle
+        # Don't try to compress the already compressed Parquet files with Zip.
+        pushd "$PUDL_OUTPUT/parquet" &&
+        zip -0 "$PUDL_OUTPUT/pudl_parquet.zip" ./*.parquet ./pudl_parquet_datapackage.json &&
+        # Move the individual parquet outputs to the output directory for direct access
+        mv ./*.parquet "$PUDL_OUTPUT" &&
+        # Move the parquet datapackage to the output directory also!
+        mv ./pudl_parquet_datapackage.json "$PUDL_OUTPUT" &&
+        popd &&
+        # Remove any remaiining files and directories we don't want to distribute
+        rm -rf "$PUDL_OUTPUT/parquet" &&
+        rm -f "$PUDL_OUTPUT/metadata.yml" &&
+        rm -f "$PUDL_OUTPUT/pudl_dbt_tests.duckdb"
 }
 
 ########################################################################################
@@ -239,10 +243,10 @@ fi
 # set +x / set -x is used to avoid printing the AWS credentials in the logs
 echo "Setting AWS credentials"
 mkdir -p ~/.aws
-echo "[default]" > ~/.aws/credentials
+echo "[default]" >~/.aws/credentials
 set +x
-echo "aws_access_key_id = ${AWS_ACCESS_KEY_ID}" >> ~/.aws/credentials
-echo "aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}" >> ~/.aws/credentials
+echo "aws_access_key_id = ${AWS_ACCESS_KEY_ID}" >>~/.aws/credentials
+echo "aws_secret_access_key = ${AWS_SECRET_ACCESS_KEY}" >>~/.aws/credentials
 set -x
 
 # Run ETL. Copy outputs to GCS and shutdown VM if ETL succeeds or fails
@@ -291,8 +295,8 @@ elif [[ "$BUILD_TYPE" == "stable" ]]; then
     clean_up_outputs_for_distribution 2>&1 | tee -a "$LOGFILE"
     CLEAN_UP_OUTPUTS_SUCCESS=${PIPESTATUS[0]}
     # Copy cleaned up outputs to the S3 and GCS distribution buckets
-    upload_to_dist_path "$BUILD_REF" | tee -a "$LOGFILE" && \
-    upload_to_dist_path "stable" | tee -a "$LOGFILE"
+    upload_to_dist_path "$BUILD_REF" | tee -a "$LOGFILE" &&
+        upload_to_dist_path "stable" | tee -a "$LOGFILE"
     DISTRIBUTION_BUCKET_SUCCESS=${PIPESTATUS[0]}
     # Remove individual parquet outputs and distribute just the zipped parquet
     # archives on Zenodo, due to their number of files limit
@@ -336,15 +340,15 @@ gcloud storage --quiet cp "$LOGFILE" "$PUDL_GCS_OUTPUT"
 rm -f ~/.aws/credentials
 
 # Notify slack about entire pipeline's success or failure;
-if [[ $ETL_SUCCESS == 0 && \
-      $SAVE_OUTPUTS_SUCCESS == 0 && \
-      $UPDATE_NIGHTLY_SUCCESS == 0 && \
-      $UPDATE_STABLE_SUCCESS == 0 && \
-      $CLEAN_UP_OUTPUTS_SUCCESS == 0 && \
-      $DISTRIBUTION_BUCKET_SUCCESS == 0 && \
-      $GCS_TEMPORARY_HOLD_SUCCESS == 0 && \
-      $ZENODO_SUCCESS == 0
-]]; then
+if [[ $ETL_SUCCESS == 0 &&
+    $SAVE_OUTPUTS_SUCCESS == 0 &&
+    $UPDATE_NIGHTLY_SUCCESS == 0 &&
+    $UPDATE_STABLE_SUCCESS == 0 &&
+    $CLEAN_UP_OUTPUTS_SUCCESS == 0 &&
+    $DISTRIBUTION_BUCKET_SUCCESS == 0 &&
+    $GCS_TEMPORARY_HOLD_SUCCESS == 0 &&
+    $ZENODO_SUCCESS == 0 ]] \
+    ; then
     notify_slack "success"
 else
     notify_slack "failure"


### PR DESCRIPTION
# Overview

The real change in here is just a couple of lines (which I will highlight) that check-out the original row counts before attempting to update the nightly or stable tag.  This is a short-term fix to get around the fact that a few tables have unstable row counts, and we have no way of excluding them from the row counts that are automatically generated at the moment.  See #4364 and #4367

However... in the process of making this update my VS Code ShellCheck plugin reformatted the whole script. And also somehow this is now being applied by NeoVim.  I've found the ShellCheck linting to be really helpful in the past for avoiding common shell programming errors / pitfalls & enforcing best practices so I went ahead and added it as a pre-commit hook so we can all have the same formatting & catch the same common issues.

# Testing

- Ran shell-check locally on the nightly build script and dealt with errors / warnings.
- Ran it again and got it to pass.
- Can only check the nightly build tag updating process by running a nightly build on main, so this hasn't been tested yet.
