### PR TITLE
feat: translate dagster asset selections to dbt node selections

### DIFF
--- a/dbt/README.md
+++ b/dbt/README.md
@@ -64,17 +64,22 @@ dbt_helper update-tables --help
 
 #### `validate`
 
-If you want to check if a materialized asset passes the validation tests defined in DBT, you can use `dbt_helper validate`. You can pass in the `--select` parameter to filter to a specific set of validation tests, and `--target` to set the DBT target.
+If you want to check if a materialized asset passes the validation tests defined in DBT, you can use `dbt_helper validate`.
 
-This will run the associated tests, then print out the test query output so you can see what went wrong.
+This understands how to translate dagster asset selections into DBT node selections, and does some extra legwork to make the test outputs more informative.
+
+See `dbt_helper validate --help` for usage details.
 
 Example usage:
 
 ```bash
-dbt_helper validate --select "source:pudl_dbt.pudl.out_eia__yearly_generators"
+dbt_helper validate --asset-select "key:out_eia__yearly_generators" # for just this asset
+dbt_helper validate --asset-select "+key:out_eia__yearly_generators" # for this asset as well as all upstream assets
+dbt_helper validate --asset-select "+key:out_eia__yearly_generators" --exclude "*check_row_counts*"  # skip rowcounts
+dbt_helper validate --select "source:pudl_dbt.pudl.out_eia__yearly_generators" # if you want to select a DBT node in particular
 ```
 
-See [official selection syntax documentation](https://docs.getdbt.com/reference/node-selection/syntax) for details.
+See [dbt selection syntax documentation](https://docs.getdbt.com/reference/node-selection/syntax) and [Dagster selection syntax documentation](https://docs.dagster.io/guides/build/assets/asset-selection-syntax/reference) to see all the possibilities.
 
 ## Adding tests
 

--- a/src/pudl/dbt_wrapper.py
+++ b/src/pudl/dbt_wrapper.py
@@ -6,6 +6,7 @@ from contextlib import chdir, redirect_stdout
 from pathlib import Path
 from typing import NamedTuple, cast
 
+import dagster as dg
 import duckdb
 from dbt.artifacts.schemas.results import TestStatus
 from dbt.artifacts.schemas.run import RunExecutionResult
@@ -146,3 +147,41 @@ def build_with_context(
         success=build_output.success,
         failure_contexts=compiled_sql_contexts + weighted_quantile_contexts,
     )
+    return BuildResult(success=build_output.success, failure_contexts=failure_contexts)
+
+
+def dagster_to_dbt_selection(
+    selection: str, defs: dg.Definitions | None = None, manifest=None
+) -> str:
+    """Translate dagster asset selection to db node selection.
+
+    * turn asset selection into asset keys
+    * turn asset keys into node names
+    * turn node names into selection string
+    """
+    if defs is None:
+        import pudl.etl
+
+        defs = pudl.etl.defs
+
+    asset_keys = dg.AssetSelection.from_string(selection).resolve(
+        defs.resolve_asset_graph()
+    )
+    asset_names = {asset_key.to_user_string() for asset_key in asset_keys}
+
+    if manifest is None:
+        manifest_path = PUDL_ROOT_PATH / "dbt" / "target" / "manifest.json"
+        with chdir(PUDL_ROOT_PATH / "dbt"):
+            dbt = dbtRunner()
+            dbt.invoke(["parse"])
+
+        with manifest_path.open("r") as f:
+            manifest = json.load(f)
+
+    # all dagster assets are treated as sources so we only have to look here.
+    dbt_node_selectors = [
+        f"source:{s['package_name']}.{s['source_name']}.{s['name']}"
+        for s in manifest["sources"].values()
+        if s["name"] in asset_names
+    ]
+    return " ".join(dbt_node_selectors)

--- a/src/pudl/scripts/dbt_helper.py
+++ b/src/pudl/scripts/dbt_helper.py
@@ -1,5 +1,6 @@
 """A basic CLI to autogenerate dbt data test configurations."""
 
+import json
 from collections import namedtuple
 from dataclasses import dataclass
 from pathlib import Path
@@ -12,7 +13,7 @@ import yaml
 from deepdiff import DeepDiff
 from pydantic import BaseModel
 
-from pudl.dbt_wrapper import build_with_context
+from pudl.dbt_wrapper import build_with_context, dagster_to_dbt_selection
 from pudl.logging_helpers import configure_root_logger, get_logger
 from pudl.metadata.classes import PUDL_PACKAGE
 from pudl.workspace.setup import PudlPaths
@@ -502,11 +503,25 @@ def update_tables(
 
 @click.command()
 @click.option(
-    "--select", default="*", help="DBT selector for the asset(s) you want to validate."
+    "--select",
+    help="DBT selector for the asset(s) you want to validate. Syntax "
+    "documentation at https://docs.getdbt.com/reference/node-selection/syntax",
+)
+@click.option(
+    "--asset-select",
+    "-a",
+    help=(
+        "*DAGSTER* selector for the asset(s) you want to validate."
+        "This gets translated into a DBT selection. For example, you can"
+        "use '+key:\"out_eia__yearly_generators\"' to validate"
+        "out_eia_yearly_generators and its upstream assets. Syntax "
+        "documentation at https://docs.dagster.io/guides/build/assets/asset-selection-syntax/reference"
+    ),
 )
 @click.option(
     "--exclude",
-    help="DBT selector for the asset(s) you want to exclude from validation.",
+    help="DBT selector for the asset(s) you want to exclude from validation. Syntax"
+    "documentation at https://docs.getdbt.com/reference/node-selection/syntax",
 )
 @click.option(
     "--target",
@@ -514,20 +529,71 @@ def update_tables(
     type=click.Choice(["etl-full", "etl-fast"]),
     help="DBT target - etl-full (default) or etl-fast.",
 )
+@click.option("--dry-run/--wet-run", default=False)
 def validate(
-    select: str = "*", exclude: str | None = None, target: str = "etl-full"
+    select: str | None = None,
+    asset_select: str | None = None,
+    exclude: str | None = None,
+    target: str = "etl-full",
+    dry_run: bool = False,
 ) -> None:
     """Validate a selection of DBT nodes.
 
     Wraps the ``dbt build`` command line so we can annotate the result with the
     actual data that was returned from the test query.
-    """
-    test_result = build_with_context(
-        node_selection=select,
-        dbt_target=target,
-        node_exclusion=exclude,
-    )
 
+    Understands how to translate Dagster asset selection syntax into dbt node
+    selections via the --asset-select flag.
+
+    Default behavior if you do not pass `--asset-select` or `--select` is to
+    validate everything.
+
+    Usage examples:
+
+    Run all the checks for one asset:
+
+        $ dbt_helper validate --asset-select "key:out_eia__yearly_generators"
+
+    Run the checks for one specific dbt node:
+
+        $ dbt_helper validate --select "source:pudl_dbt.pudl.out_eia__yearly_generators"
+
+    Run checks for an asset and all its upstream dependencies:
+
+        $ dbt_helper validate --asset-select "+key:out_eia__yearly_generators"
+
+    Exclude the row count tests:
+
+        $ dbt_helper validate --asset-select "+key:out_eia__yearly_generators" --exclude "*check_row_counts*"
+
+
+
+    """
+    if select is not None:
+        if asset_select is not None:
+            raise click.UsageError(
+                "You can't pass --select and --asset-select at the same time."
+            )
+        node_selection = select
+    else:
+        if asset_select is not None:
+            node_selection = dagster_to_dbt_selection(asset_select)
+        else:
+            node_selection = "*"
+
+    build_params = {
+        "node_selection": node_selection,
+        "dbt_target": target,
+        "node_exclusion": exclude,
+    }
+
+    if dry_run:
+        logger.info(
+            f"Dry run - would build with these params: {json.dumps(build_params)}"
+        )
+        return
+
+    test_result = build_with_context(**build_params)
     if not test_result.success:
         raise AssertionError(
             f"failure contexts:\n{test_result.format_failure_contexts()}"

--- a/src/pudl/scripts/dbt_helper.py
+++ b/src/pudl/scripts/dbt_helper.py
@@ -511,16 +511,16 @@ def update_tables(
     "--asset-select",
     "-a",
     help=(
-        "*DAGSTER* selector for the asset(s) you want to validate."
-        "This gets translated into a DBT selection. For example, you can"
-        "use '+key:\"out_eia__yearly_generators\"' to validate"
+        "*DAGSTER* selector for the asset(s) you want to validate. "
+        "This gets translated into a DBT selection. For example, you can "
+        "use '+key:\"out_eia__yearly_generators\"' to validate "
         "out_eia_yearly_generators and its upstream assets. Syntax "
-        "documentation at https://docs.dagster.io/guides/build/assets/asset-selection-syntax/reference"
+        "documentation at https://docs.dagster.io/guides/build/assets/asset-selection-syntax/reference "
     ),
 )
 @click.option(
     "--exclude",
-    help="DBT selector for the asset(s) you want to exclude from validation. Syntax"
+    help="DBT selector for the asset(s) you want to exclude from validation. Syntax "
     "documentation at https://docs.getdbt.com/reference/node-selection/syntax",
 )
 @click.option(
@@ -529,7 +529,12 @@ def update_tables(
     type=click.Choice(["etl-full", "etl-fast"]),
     help="DBT target - etl-full (default) or etl-fast.",
 )
-@click.option("--dry-run/--wet-run", default=False)
+@click.option(
+    "--dry-run/--no-dry-run",
+    default=False,
+    help="If dry, will print out the parameters we would pass to dbt, but not "
+    "actually run the validation tests. Defaults to not-dry.",
+)
 def validate(
     select: str | None = None,
     asset_select: str | None = None,

--- a/test/unit/dbt_wrapper_test.py
+++ b/test/unit/dbt_wrapper_test.py
@@ -61,22 +61,10 @@ def dummy_dbt_manifest(tmp_path):
 @pytest.mark.parametrize(
     "dagster_selection,dbt_selection",
     [
-        (
-            "key:core",
-            "source:test_project.test.core",
-        ),
-        (
-            "+key:core",
-            "source:test_project.test.core",
-        ),
-        (
-            "+key:core+",
-            "source:test_project.test.core source:test_project.test.out",
-        ),
-        (
-            "key:*cor*",
-            "source:test_project.test.core",
-        ),
+        ("key:core", "source:test.core"),
+        ("+key:core", "source:test.core"),
+        ("+key:core+", "source:test.core source:test.out"),
+        ("key:*cor*", "source:test.core"),
     ],
 )
 def test_dagster_to_dbt_selection(

--- a/test/unit/dbt_wrapper_test.py
+++ b/test/unit/dbt_wrapper_test.py
@@ -1,0 +1,89 @@
+import dagster as dg
+import pytest
+
+from pudl.dbt_wrapper import dagster_to_dbt_selection
+
+
+@pytest.fixture(scope="session")
+def dummy_dagster():
+    """Minimal dagster defs with some dependencies for us to test against."""
+
+    @dg.asset
+    def raw():
+        return "raw"
+
+    @dg.asset
+    def core(raw):
+        return "core"
+
+    @dg.asset
+    def out(core):
+        return "out"
+
+    defs = dg.Definitions(assets=[raw, core, out])
+    return defs
+
+
+@pytest.fixture
+def dummy_dbt_manifest(tmp_path):
+    """Minimal manifest required for getting the source selector.
+
+    Only core and out are defined as sources - we're assuming that raw is not
+    persisted & thus shouldn't be tracked in dbt.
+    """
+    manifest = {
+        "metadata": {
+            "project_name": "test_project",
+        },
+        "sources": {
+            "source.test_project.test.core": {
+                "name": "core",
+                "source_name": "test",
+                "package_name": "test_project",
+                "schema": "main",
+                "unique_id": "source.test_project.test.core",
+            },
+            "source.test_project.test.out": {
+                "name": "out",
+                "source_name": "test",
+                "package_name": "test_project",
+                "schema": "main",
+                "unique_id": "source.test_project.test.out",
+            },
+        },
+        "nodes": {},
+        "parent_map": {},
+        "child_map": {},
+    }
+    return manifest
+
+
+@pytest.mark.parametrize(
+    "dagster_selection,dbt_selection",
+    [
+        (
+            "key:core",
+            "source:test_project.test.core",
+        ),
+        (
+            "+key:core",
+            "source:test_project.test.core",
+        ),
+        (
+            "+key:core+",
+            "source:test_project.test.core source:test_project.test.out",
+        ),
+        (
+            "key:*cor*",
+            "source:test_project.test.core",
+        ),
+    ],
+)
+def test_dagster_to_dbt_selection(
+    dagster_selection, dbt_selection, dummy_dagster, dummy_dbt_manifest
+):
+    observed = dagster_to_dbt_selection(
+        dagster_selection, defs=dummy_dagster, manifest=dummy_dbt_manifest
+    )
+    expected = dbt_selection
+    assert sorted(observed.split(" ")) == sorted(expected.split(" "))


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #4132 . For real this time.

## What problem does this address?

We work on dagster assets but have to run validation tests with dbt nodes. dbt has no idea what the dependencies in dagster are so it's hard to select "all downstream assets" or somesuch. Plus the dbt names are much longer.

## What did you change?

* add a flag to dbt_helper validate to pass in dagster selections instead
* add stub translation logic to `dbt_wrapper.py`
* add stub unit tests

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [x] make a fake manifest for testing - maybe make the yamls, and then write them / run dbt parse in a temp dir so we can make sure it's a real manifest.
  file structure:

  ```
  your_dbt_project/
  ├── dbt_project.yml            # Required: Project configuration
  ├── models/                    # Required: Directory for models (can be empty)
  └── models/sources.yml         # Defines your sources
  ```

  source should only include cell and animal. dna is like a 'raw' asset that doesn't get persisted. maybe i should just rename those to raw/core/out haha.
- [x] grab the source selector out of the `manifest.json`'s `sources` map using `f"source:{package_name}.{schema}.{name}"`. make a map from the dbt source's name to the selector. then for each asset, try to grab a selector.
- [x] some dagster assets won't have a corresponding dbt source, log out the tables you'll be checking and which you'll be skipping.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
