### PR TITLE
Fix validation logic for year rollover

### DIFF
--- a/src/pudl/validate.py
+++ b/src/pudl/validate.py
@@ -1,7 +1,7 @@
-import pandas as pd
-import numpy as np
 import matplotlib.pyplot as plt
-from dagster import asset_check, AssetCheckResult, AssetCheckSeverity
+import numpy as np
+import pandas as pd
+from dagster import AssetCheckResult, AssetCheckSeverity, asset_check
 
 
 class ExcessiveNullRowsError(ValueError):
@@ -22,7 +22,6 @@ def no_null_rows(
     """Check for rows with excessive missing values, usually due to a merge gone wrong."""
     if cols == "all":
         cols = df.columns
-        
 
     null_rows = df[cols].isna().sum(axis="columns") / len(cols) > max_null_fraction
     if null_rows.any():
@@ -104,7 +103,7 @@ def weighted_quantile(data: pd.Series, weights: pd.Series, quantile: float) -> f
         raise ValueError("quantile must have a value between 0 and 1.")
     if len(data) != len(weights):
         raise ValueError("data and weights must have the same length")
-    
+
     df = (
         pd.DataFrame({"data": data, "weights": weights})
         .replace([np.inf, -np.inf], np.nan)
@@ -176,7 +175,9 @@ def bounds_histogram(
     )
 
     if low_bound:
-        plt.axvline(low_bound, lw=3, ls="--", color="red", label=f"lower bound for {low_q:.0%}")
+        plt.axvline(
+            low_bound, lw=3, ls="--", color="red", label=f"lower bound for {low_q:.0%}"
+        )
         plt.axvline(
             weighted_quantile(df[data_col], df[weight_col], low_q),
             lw=3,
@@ -185,7 +186,9 @@ def bounds_histogram(
         )
 
     if hi_bound:
-        plt.axvline(hi_bound, lw=3, ls="--", color="blue", label=f"upper bound for {hi_q:.0%}")
+        plt.axvline(
+            hi_bound, lw=3, ls="--", color="blue", label=f"upper bound for {hi_q:.0%}"
+        )
         plt.axvline(
             weighted_quantile(df[data_col], df[weight_col], hi_q),
             lw=3,


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #XXXX.

## What problem does this address?

## What did you change?

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
