### PR TITLE
Migrate eia930 metadata

### DIFF
--- a/src/pudl/metadata/resources/eia930.py
+++ b/src/pudl/metadata/resources/eia930.py
@@ -137,7 +137,7 @@ This table is based on ``core_eia930__hourly_operations``, but adds imputed dema
 
 This table is available in the nightly builds during development, but has not been fully
 vetted yet.""",
-            "usage_warnings": ["imputed_values"],
+            "usage_warnings": ["imputed_values", "experimental_wip"],
         },
         "schema": {
             "fields": [
@@ -172,7 +172,7 @@ vetted yet.""",
             "additional_details_text": """(EXPERIMENTAL / WORK-IN-PROGRESS, 2025-04-04)
 
 The spatial granularity of each record is indicated by `aggregation_level`.""",
-            "usage_warnings": ["aggregation_hazard"],
+            "usage_warnings": ["aggregation_hazard", "experimental_wip"],
         },
         "schema": {
             "fields": [
@@ -198,7 +198,7 @@ The spatial granularity of each record is indicated by `aggregation_level`.""",
             "additional_details_text": """(EXPERIMENTAL / WORK-IN-PROGRESS, 2025-03-31)
 
 This table is based on ``core_eia930__hourly_subregion_demand``, but adds imputed demand where the original data was missing or anomalous. Codes explaining why values have been imputed can be found in the ``core_pudl__codes_imputation_reasons`` table.""",
-            "usage_warnings": ["imputed_values"],
+            "usage_warnings": ["imputed_values", "experimental_wip"],
         },
         "schema": {
             "fields": [

--- a/src/pudl/metadata/warnings.py
+++ b/src/pudl/metadata/warnings.py
@@ -20,4 +20,5 @@ USAGE_WARNINGS = {
     "outliers": "Outliers present.",
     "missing_years": "Some years are missing from the data record.",
     "ferc_is_hard": "FERC data is notoriously difficult to extract cleanly; see TODO for details.",
+    "experimental_wip": "This table is experimental and/or a work in progress and may change in the future.",
 }


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

* Closes #4453 

## What problem does this address?

Migrates the metadata for EIA930 tables into the new metadata format

## What did you change?

table description metadata in `pudl/metadata/resources/eia930.py`

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For minor ETL changes or data additions, once `make pytest-coverage` passes, make sure you have a fresh full PUDL DB downloaded locally, materialize new/changed assets and all their downstream assets and [run relevant data validation tests](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `pytest` and `--live-dbs`.
- [ ] For bigger ETL or data changes run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/testing.html#data-validation) using `make pytest-validate`.
- [ ] Alternatively, run the `build-deploy-pudl` GitHub Action manually.
