### PR TITLE
test: make a docs-only change

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,6 +14,7 @@ Expanded Data Coverage
 
 Quality of Life Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Stopped running integration tests in CI for docs-only builds, saving time.
 
 Bug Fixes
 ^^^^^^^^^


### PR DESCRIPTION
Testing GitHub Actions workflow.

Expecting the ci-integration, ci-unit, and ci-coverage checks to all be skipped since this is a docs-only PR.