### PR TITLE
test: use a mixed code/docs change to see the right jobs trigger

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -14,6 +14,7 @@ Expanded Data Coverage
 
 Quality of Life Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Stopped running integration tests in CI for docs-only builds, saving time.
 
 Bug Fixes
 ^^^^^^^^^

--- a/src/pudl/__init__.py
+++ b/src/pudl/__init__.py
@@ -1,5 +1,7 @@
 """The Public Utility Data Liberation (PUDL) Project."""
 
+# no-op change to trigger builds - remember to cancel the CI job once it triggers!
+
 import importlib.metadata
 
 from . import (


### PR DESCRIPTION
Testing GHA workflow.

Expect the ci-integration and ci-unit jobs to trigger. Then cancel ci-integration and ci-unit. Hopefully then ci-coverage fails.