### PR TITLE
debug: see if coercing github.event.merge_group to a boolean works

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -15,25 +15,5 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-
-      - name: Docker Metadata
-        id: docker_metadata
-        uses: docker/metadata-action@v5
-        with:
-          images: catalystcoop/pudl-etl
-          flavor: |
-            latest=auto
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build image but do not push to Docker Hub
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: docker/Dockerfile
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: succeed
+        run: exit 0

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      run_code_checks: ${{ github.event_name =='workflow_dispatch' || (steps.filter.outputs.code == 'true' && (github.event.merge_group != null)) }}
+      run_code_checks: ${{ github.event_name =='workflow_dispatch' || (steps.filter.outputs.code == 'true' && github.event.merge_group) }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      run_code_checks: ${{ github.event_name =='workflow_dispatch' || (steps.filter.outputs.code == 'true' && github.event.merge_group) }}
+      run_code_checks: ${{ github.event_name =='workflow_dispatch' || (steps.filter.outputs.code == 'true' && (github.event.merge_group != null)) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,6 +44,8 @@ jobs:
           echo code: ${{ steps.filter.outputs.code }}
           echo code is true: ${{ steps.filter.outputs.code == 'true' }}
           echo merge_group: ${{ github.event.merge_group }}
+          echo merge_group not null: ${{ github.event.merge_group != null }}
+          echo run_code_checks: ${{ github.event_name =='workflow_dispatch' || (steps.filter.outputs.code == 'true' && (github.event.merge_group != null)) }}
 
   ci-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
After reading the output in [this job](https://github.com/catalyst-cooperative/pudl/actions/runs/16355833697/job/46213849738) it looks like we're assigning some non-boolean value to run_code_checks and that's causing problems.

Strangely the merge queue job *ran* but failed, but the PR job *skipped* and then that was able to pass the branch protection. So that's annoying too.