### PR TITLE
fix: force `run_code_checks` to be a valid boolean value

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -19,7 +19,8 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      run_code_checks: ${{ github.event_name =='workflow_dispatch' || (steps.filter.outputs.code == 'true' && github.event.merge_group) }}
+      # 2025-07-17: because merge_group is an Object and run_code_checks is not a conditional, need to explicitly check for null-ness instead of relying on truthiness.
+      run_code_checks: ${{ github.event_name =='workflow_dispatch' || (steps.filter.outputs.code == 'true' && (github.event.merge_group != null)) }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,6 +38,11 @@ jobs:
               - '!docs/**.html'
               - '!docs/**.rst.jinja'
               - '!README.rst'
+      - name: print out components
+        run: |
+          echo "event name (${{ github.event_name }}) is workflow dispatch: ${{ github.event_name == 'workflow_dispatch' }}"
+          echo "found code changes: ${{ steps.filter.outputs.code }}"
+          echo "merge_group ${{ github.event.merge_group }} is not null: ${{ github.event.merge_group != null }}"
 
   ci-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

In #4429 we found that if `change_filter` itself fails, the downstream `ci-integration` and `ci-coverage` jobs are marked as `skipped`, which [allows the merge to continue](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-status-checks-before-merging).

because we were setting the `run_code_checks` output to a value that included `github.event.merge_group` - which is either `null` (not in merge queue) or an `Object` (while in merge queue). This then got rendered as a mapping within pytest.yaml, instead of a boolean, which caused the [`change_filter` job to fail](https://github.com/catalyst-cooperative/pudl/actions/runs/16331365834).

See #4444 for a PR where I set up:
- a `fake-main` branch that copied the branch protection rules of `main`, minus the "PRs must be approved" condition
- stubbed out CI tests so they would run quickly, and ci-integration would fail

Then, I fixed `change_filter`, which allowed the `ci-integration` test to run in merge queue instead of being skipped. Since [`ci-integration` failed](https://github.com/catalyst-cooperative/pudl/actions/runs/16356364986/job/46215602023), the PR was pulled out of the merge queue.

Afterwards, I added `change_filter` as a required status check on `fake-main`, and undid the change to `change_filter`. Then, after [`change_filter` failed](https://github.com/catalyst-cooperative/pudl/actions/runs/16356695307/job/46216628810), the PR was again pulled out of the merge queue, despite the failure in `change_filter` leading to `skip` results for `ci-integration` and `ci-coverage`.