### PR TITLE
Migrate last two ferc1 table descriptions

### DIFF
--- a/src/pudl/metadata/resources/ferc1.py
+++ b/src/pudl/metadata/resources/ferc1.py
@@ -1106,7 +1106,7 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "ferc1",
     },
     "out_ferc1__yearly_cash_flows_sched120": {
-        "description": "Denormalized table that contains FERC cash flow information.",
+        "description": TABLE_DESCRIPTIONS["yearly_cash_flows_sched120"],
         "schema": {
             "fields": [
                 "record_id",
@@ -1876,7 +1876,13 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
         "field_namespace": "ferc1",
     },
     "out_ferc1__yearly_steam_plants_fuel_by_plant_sched402": {
-        "description": "A table summarizing FERC fuel data by plant, using FERC Form 1 data.",
+        "description": {
+            "additional_summary_text": "FERC fuel data by plant.",
+            "additional_source_text": "(Schedule 402)",
+            "usage_warnings": [
+                "aggregation_hazard",
+            ],
+        },
         "schema": {
             "fields": [
                 "report_year",


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Migrates two stragglers I found during some light analysis tasks.

## What problem does this address?

Old descriptions

## What did you change?

New structure

## Documentation

Make sure to update relevant aspects of the documentation:

- [x] Update relevant table or source description metadata (see `src/metadata`).
