### PR TITLE
Test calculate rowcounts

### DIFF
--- a/test/unit/dbt_helper_test.py
+++ b/test/unit/dbt_helper_test.py
@@ -121,10 +121,15 @@ my_table,2023,100
 
     # Expected output
     expected = pd.DataFrame(
-        {
+        data={
             "table_name": ["my_table"],
             "partition": ["2023"],
             "row_count": [100],
+        },
+    ).astype(
+        {
+            "table_name": "string",
+            "partition": "string",
         }
     )
 
@@ -427,9 +432,14 @@ CALCULATE_ROW_COUNTS_CASES = [
         expect={
             "expected_df": pd.DataFrame(
                 {
+                    "table_name": ["foo", "foo"],
                     "partition": ["2020", "2021"],
                     "row_count": [10, 15],
-                    "table_name": ["foo", "foo"],
+                }
+            ).astype(
+                {
+                    "table_name": "string",
+                    "partition": "string",
                 }
             ),
         },


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #XXXX.

## What problem does this address?

It was hard to test the whole flow of row count updates - "I have this asset table, this old rowcounts csv, this schema, and I expect *this* new rowcounts CSV".

## What did you change?
Added a test that does that + allows for more parametrization.


# Testing

How did you make sure this worked? How can a reviewer verify this?

ran the dang tests

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
