### PR TITLE
dbt docs: debugging failures

### DIFF
--- a/docs/dev/data_validation_quickstart.rst
+++ b/docs/dev/data_validation_quickstart.rst
@@ -14,7 +14,7 @@ The ``dbt/`` directory contains the PUDL dbt project which manages our `data tes
 The data validation tests run on the Parquet outputs that are in your
 ``$PUDL_OUTPUT/parquet/`` directory. It's important that you ensure the outputs you're
 testing are actually the result of the code on your current branch, otherwise you may
-be surprised when the data test fails in CI or the nightly builds.
+be surprised when the data test passes locally but fails in CI or the nightly builds.
 
 We have a script, :mod:`pudl.scripts.dbt_helper`, to help with some common workflows.
 
@@ -51,6 +51,7 @@ See ``dbt_helper validate --help`` for usage details.
 
    1. Download the Parquet files to ``<any_directory_you_want>/parquet/``.
    2. Set the ``PUDL_OUTPUT`` environment variable to ``<any_directory_you_want>``.
+      (*note* use an absolute path!)
    3. Run any of the ``dbt_helper`` commands you need.
 
    Some examples of useful Parquet outputs and where to find them:

--- a/docs/dev/data_validation_reference.rst
+++ b/docs/dev/data_validation_reference.rst
@@ -63,11 +63,15 @@ aware of:
   DuckDB. This means some of dbt's functionality is not available. For example, we can't
   use `the dbt adapter object
   <https://docs.getdbt.com/reference/dbt-jinja-functions/adapter>`__ in our test
-  definitions because it relies on being able to access the underlying database schema,
-* One exception to this is any intermediate tables that are defined as dbt models (see
-  below). These will be created as materialized views in a DuckDB database at
-  ``$PUDL_OUTPUT/pudl_dbt_tests.duckdb``. Any time you need to refer to those tables
-  while debugging, you'll need to be connected to that database.
+  definitions because it relies on being able to access the underlying database schema.
+* One place we use true dbt models instead of sources is when
+  we define intermediate tables to simplify test definitions.
+  See :ref:`intermediate_tables`.
+  These intermediate tables are created as materialized views in a DuckDB database
+  at ``$PUDL_OUTPUT/pudl_dbt_tests.duckdb``.
+  In this case, the underlying database schema *will* be accessible to dbt.
+  Additionally, any time you need to refer to those tables while debugging,
+  you'll need to be connected to that database.
 
 
 .. _branch_builds:
@@ -820,10 +824,6 @@ default, you add the test to the table level ``data_tests`` with no parameters:
           - name: new_table_name
             data_tests:
               - expect_columns_not_all_null
-              - check_row_counts_per_partition:
-                  arguments:
-                    table_name: new_table_name
-                    partition_expr: "EXTRACT(YEAR FROM report_date)"
 
 --------------------------------------------------------------------------------
 Defining new data validation tests
@@ -1013,6 +1013,8 @@ info for, you can add custom debug handlers for your test type in
 :func:`pudl.dbt_wrapper.build_with_context`, which gives you access to the full
 power of Python.
 
+
+.. _intermediate_tables:
 
 Creating intermediate tables for a test
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/pudl/dbt_wrapper.py
+++ b/src/pudl/dbt_wrapper.py
@@ -94,11 +94,6 @@ def __get_quantile_contexts(
     return contexts
 
 
-def longest_linelength(text):
-    all_lengths = (len(line) for line in text.split("\n"))
-    return max(all_lengths)
-
-
 def __get_compiled_sql_contexts(nodes: list[GenericTestNode]) -> list[NodeContext]:
     """Run the compiled SQL against duckdb to get failure contexts."""
     contexts = []
@@ -108,6 +103,9 @@ def __get_compiled_sql_contexts(nodes: list[GenericTestNode]) -> list[NodeContex
             con.execute(node.compiled_code)
             node_df = con.fetchdf()
             node_str = node_df.head(20).to_markdown(maxcolwidths=40, index=False)
+            if node_str is None:
+                logger.warning(f"Couldn't format data for node {node.name}.")
+                continue
             if node_df.shape[0] > 20:
                 node_str += f"\n(of {node_df.shape[0]})"
             contexts.append(NodeContext(name=node.name, context=node_str))

--- a/src/pudl/dbt_wrapper.py
+++ b/src/pudl/dbt_wrapper.py
@@ -94,6 +94,11 @@ def __get_quantile_contexts(
     return contexts
 
 
+def longest_linelength(text):
+    all_lengths = (len(line) for line in text.split("\n"))
+    return max(all_lengths)
+
+
 def __get_compiled_sql_contexts(nodes: list[GenericTestNode]) -> list[NodeContext]:
     """Run the compiled SQL against duckdb to get failure contexts."""
     contexts = []
@@ -102,7 +107,10 @@ def __get_compiled_sql_contexts(nodes: list[GenericTestNode]) -> list[NodeContex
         for node in nodes:
             con.execute(node.compiled_code)
             node_df = con.fetchdf()
-            contexts.append(NodeContext(name=node.name, context=str(node_df)))
+            node_str = node_df.head(20).to_markdown(maxcolwidths=40, index=False)
+            if node_df.shape[0] > 20:
+                node_str += f"\n(of {node_df.shape[0]})"
+            contexts.append(NodeContext(name=node.name, context=node_str))
     return contexts
 
 

--- a/src/pudl/scripts/dbt_helper.py
+++ b/src/pudl/scripts/dbt_helper.py
@@ -551,19 +551,9 @@ def _extract_row_count_partitions(table: DbtTable) -> list[str | None]:
                 raise ValueError(f"Row counts test expected to be a dictionary: {test}")
             test_def = test.get("check_row_counts_per_partition")
             if isinstance(test_def, dict):
-                partitions.append(test_def.get("partition_expr"))
+                partitions.append(test_def.get("arguments", {}).get("partition_expr"))
 
     return partitions
-
-
-def get_row_count_test_dict(table_name: str, partition_expr: str):
-    """Return a dictionary with a dbt row count data test encoded in a dict."""
-    return {
-        "check_row_counts_per_partition": {
-            "table_name": table_name,
-            "partition_expr": partition_expr,
-        }
-    }
 
 
 @dataclass

--- a/test/unit/dbt_helper_test.py
+++ b/test/unit/dbt_helper_test.py
@@ -21,7 +21,6 @@ from pudl.scripts.dbt_helper import (
     _get_model_path,
     _schema_diff_summary,
     get_data_source,
-    get_row_count_test_dict,
     schema_has_removals_or_modifications,
     update_row_counts,
     update_table_schema,
@@ -52,8 +51,10 @@ def schema_factory():
             data_tests = [
                 {
                     "check_row_counts_per_partition": {
-                        "table_name": table_name,
-                        "partition_expr": partition_expr,
+                        "arguments": {
+                            "table_name": table_name,
+                            "partition_expr": partition_expr,
+                        }
                     }
                 }
             ]
@@ -141,17 +142,6 @@ my_table,2023,100
     assert result["partition"].apply(type).eq(str).all()
 
 
-def test_get_row_count_test_dict():
-    result = get_row_count_test_dict("plants", "report_year")
-    expected = {
-        "check_row_counts_per_partition": {
-            "table_name": "plants",
-            "partition_expr": "report_year",
-        }
-    }
-    assert result == expected
-
-
 @pytest.mark.parametrize(
     "data_tests, expected",
     [
@@ -159,8 +149,10 @@ def test_get_row_count_test_dict():
             [
                 {
                     "check_row_counts_per_partition": {
-                        "table_name": "plants",
-                        "partition_expr": "report_year",
+                        "arguments": {
+                            "table_name": "plants",
+                            "partition_expr": "report_year",
+                        }
                     }
                 }
             ],
@@ -170,8 +162,10 @@ def test_get_row_count_test_dict():
             [
                 {
                     "check_row_counts_per_partition": {
-                        "table_name": "plants",
-                        "partition_expr": None,
+                        "arguments": {
+                            "table_name": "plants",
+                            "partition_expr": None,
+                        }
                     }
                 },
             ],
@@ -628,8 +622,10 @@ def dbt_schema_mocks(request, mocker):
         [
             {
                 "check_row_counts_per_partition": {
-                    "table_name": table_name,
-                    "partition_expr": partition_expr,
+                    "arguments": {
+                        "table_name": table_name,
+                        "partition_expr": partition_expr,
+                    }
                 }
             }
         ]
@@ -662,8 +658,9 @@ def dbt_schema_mocks(request, mocker):
         f"""\
         data_tests:
           - check_row_counts_per_partition:
-              table_name: {table_name}
-              partition_expr: {partition_expr}
+              arguments:
+                table_name: {table_name}
+                partition_expr: {partition_expr}
         """
         if has_row_count_test
         else ""
@@ -963,8 +960,10 @@ MERGE_METADATA_TEST_CASES = [
             "data_tests": [
                 {
                     "check_row_counts_per_partition": {
-                        "table_name": "test_table",
-                        "partition_expr": "year",
+                        "arguments": {
+                            "table_name": "test_table",
+                            "partition_expr": "year",
+                        }
                     }
                 }
             ],
@@ -990,8 +989,10 @@ MERGE_METADATA_TEST_CASES = [
             "data_tests": [
                 {
                     "check_row_counts_per_partition": {
-                        "table_name": "test_table",
-                        "partition_expr": "new_expr",
+                        "arguments": {
+                            "table_name": "test_table",
+                            "partition_expr": "new_expr",
+                        }
                     }
                 }
             ],
@@ -1421,8 +1422,9 @@ sources:
       - name: test_source__table_name
         data_tests:
           - check_row_counts_per_partition:
-              table_name: test_source__table_name
-              {partition_definition}
+              arguments:
+                table_name: test_source__table_name
+                {partition_definition}
         columns:
           - name: year
           - name: state


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #4126 .

## What problem does this address?

## What did you change?

* Initial draft for debugging data validation failures.

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] This was committed `no-verify` so it needs. y'know. verification.
- [ ] dbt wrapper function missing a docstring but I abandoned that so it can probably just go away
- [ ] Line lengths in data_validation.rst are probably horrific
- [ ] Resolve remaining `.. todo::` blocks in debugging section
  - [ ] When to use `--store-failures`
  - [ ] Dedicated guide for rowcounts failures
  - [ ] Refresh dedicated guide for constraints failures
