### PR TITLE
Setup WIF for pudl-archiver repo

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -233,7 +233,8 @@ resource "google_storage_bucket_iam_member" "pudl_archiver_gcs_iam" {
   for_each = toset([
     "roles/storage.objectCreator",
     "roles/storage.objectViewer",
-    "roles/storage.insightsCollectorService"
+    "roles/storage.legacyBucketReader",
+    "roles/storage.objectViewer",
   ])
 
   bucket = google_storage_bucket.pudl_archive_bucket.name


### PR DESCRIPTION
# Overview

This PR sets up Workload Identity Federation for the `pudl-archiver` repo. This will allow us run archivers which use GCS for backend storage from a github runner.