### PR TITLE
Update ferc-eia id mapping docs

### DIFF
--- a/docs/dev/pudl_id_mapping.rst
+++ b/docs/dev/pudl_id_mapping.rst
@@ -168,16 +168,16 @@ to have the same PUDL ID.
     plants csv for the first plant under 5 MW and everything below that can remain
     unlinked.
 
-For each new record, search the entire plants_combined tab for a piece of the
+For each new record, search the ``pudl_id_mapping`` spreadsheet for a piece of the
 plant name string (e.g. for ``chenango solar``, you could search for ``chen``,
-or ``chenan``). Searching the entire plant tab helps find other records within
-both FERC and EIA that may be the same or part of the same facility. Searching
+or ``chenan``). If the new records you're mapping come from FERC, look for matches
+in the ``plant_name_eia`` column (and vice versa for EIA). Searching
 for a piece can help catch misspellings in the plant name, which are more common
-in the FERC records. Use the ``devtools/pudl_id_mapping_help.ipynb`` notebook to speed
-up this process.
+in the FERC records. You can also use the ``devtools/pudl_id_mapping_help.ipynb``
+notebook to speed up this process.
 
-* **If co-located EIA plants have distinct plant IDs and no FERC 1 plant:**
-  they should not be lumped under a single PUDL Plant ID, as that artificially reduces
+* **If co-located EIA plants have distinct EIA plant IDs and no FERC 1 plant:**
+  they should *not* be lumped under a single PUDL Plant ID, as that artificially reduces
   the granularity of data without providing any additional linkage to other datasets.
 * **If a record has the same plant and utility name as another record:**
   assign it the same PUDL ID as the other record **by reference** to the cell in which


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #4537 

## What problem does this address?

Some of the docs for linking EIA and FERC IDs were antiquated and referred to things that no longer exist! This makes sure no one is confused when they try and follow these instructions again.

## What did you change?

- Remove reference to the `plants_combined` tab.
- Add a few more clarifying sentences.