### PR TITLE
Update auth methods for conda-lockfile and bot-auto-merge GHA

### DIFF
--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -12,11 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Impersonate auto merge PR bot
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v2
         id: generate-token
         with:
-          app_id: ${{ secrets.BOT_AUTO_MERGE_PRS_APP_ID }}
-          private_key: ${{ secrets.BOT_AUTO_MERGE_PRS_APP_KEY }}
+          app-id: ${{ secrets.BOT_AUTO_MERGE_PRS_APP_ID }}
+          private-key: ${{ secrets.BOT_AUTO_MERGE_PRS_APP_KEY }}
       - name: Auto-merge passing dependabot PRs
         if: ${{ github.event.workflow_run.conclusion == 'success' }}
         uses: ridedott/merge-me-action@v2

--- a/.github/workflows/update-conda-lockfile.yml
+++ b/.github/workflows/update-conda-lockfile.yml
@@ -21,9 +21,15 @@ jobs:
       - name: Get today's date
         run: |
           echo "TODAY=$(date +%Y-%m-%d)" >> $GITHUB_ENV
+      - name: Generate GH token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.WORKFLOW_TRIGGERER_APP_ID }}
+          private-key: ${{ secrets.WORKFLOW_TRIGGERER_PRIVATE_KEY }}
       - uses: actions/checkout@v5
         with:
-          token: ${{ secrets.PUDL_BOT_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
       - name: Install Micromamba
         uses: mamba-org/setup-micromamba@v2
         with:
@@ -45,7 +51,7 @@ jobs:
         if: ${{ (github.event_name == 'schedule' && github.repository == 'catalyst-cooperative/pudl') || (github.event_name == 'workflow_dispatch') }}
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.PUDL_BOT_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           commit-message: "Update conda-lock.yml and re-render conda environment files. Autoupdate pre-commit hooks."
           title: Update conda lockfile for week of ${{ env.TODAY }}
           body: >


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?
Following the resolution of https://github.com/catalyst-cooperative/pudl-archiver/pull/787, we noticed two things:
1) The `update-conda-lockfile.yml` action is authenticating using a PAT
2) The `bot-auto-merge.yml` action is using a deprecated marketplace action to authenticate to the app.

## What did you change?
To ensure consistency and reduce the number of tokens we're managing, this PR:
1) Auths the `conda-lock.yml` action using the new Github app set up to manage creating PRs with access to GH workflows.
2) Updates the action used in the `bot-auto-merge.yml` method to the newest version which is actively maintained.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run `conda-lock.yml`: https://github.com/catalyst-cooperative/pudl/actions/runs/17243756074 :heavy_check_mark: 
Run `bot-auto-merge.yml`: Can't manually kick this off, so we'll just have to check that this doesn't break once it merges.

## To-do list

- [x] Review the PR yourself and call out any questions or issues you have.
