### PR TITLE
Close out release notes for PUDL v2025.9.0

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -27,16 +27,14 @@
       "name": "Xia, Dazhong"
     },
     {
+      "orcid": "0000-0001-9784-8531",
       "affiliation": "Catalyst Cooperative",
       "name": "Belfer, Ella"
     },
     {
+      "orcid": "0009-0009-9063-080X",
       "affiliation": "Catalyst Cooperative",
       "name": "Mazaitis, Kathryn"
-    },
-    {
-      "affiliation": "Catalyst Cooperative",
-      "name": "Hoogeveen, Marianne"
     }
   ],
   "language": "eng",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,14 +15,14 @@ authors:
     given-names: Katherine
   - family-names: Belfer
     given-names: Ella
+    orcid: https://orcid.org/0000-0001-9784-8531
   - family-names: Xia
     given-names: Dazhong
-  - family-names: Hoogeveen
-    given-names: Marianne
   - family-names: Mazaitis
     given-names: Kathryn
+    orcid: https://orcid.org/0009-0009-9063-080X
 
 title: "The Public Utility Data Liberation (PUDL) Project"
-version: 2025.8.0
+version: 2025.9.0
 doi: 10.5281/zenodo.3404014
-date-released: 2025-08-14
+date-released: 2025-09-05

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,9 +2,25 @@
 PUDL Release Notes
 =======================================================================================
 
+.. _release-v2025.9.0:
+
 ---------------------------------------------------------------------------------------
-v202X.XX.x (YYYY-MM-DD)
+v2025.9.0 (2025-09-05)
 ---------------------------------------------------------------------------------------
+
+This is a monthly release primarily focused on updating the EIA-860M, with other
+incremental changes coming along for the ride. A couple of things to be aware of:
+
+* :user:`mfripp` identified a bug in how we were constructing detailed utility
+  asset/liability and income/expense tables from FERC Form 1. This has been partially
+  addressed, but the fix needs to be applied to a couple of additional tables. See
+  :issue:`4593` to track our progress.
+* We are now producing GeoParquet outputs for tables that contain spatial data. This
+  is a great new feature! But also potentially a breaking change, depending on what
+  tools you've been using to read our Parquet outputs. `GeoPandas
+  <https://geopandas.org/>`__ and `DuckDB's spatial extension
+  <https://duckdb.org/docs/stable/core_extensions/spatial/overview.html>`__ both work
+  well.
 
 Enhancements
 ^^^^^^^^^^^^
@@ -34,9 +50,6 @@ tables with a valid ``geometry`` column are:
 * :ref:`out_censusdp1tract__counties`
 * :ref:`out_censusdp1tract__tracts`
 * :ref:`out_ferc714__georeferenced_respondents`
-
-New Data
-^^^^^^^^
 
 Expanded Data Coverage
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -85,12 +98,6 @@ Documentation
 * Added data source pages for:
 
   * :doc:`data_sources/eiaapi`; see issue :issue:`4372` and PR :pr:`4567`.
-
-Deprecations
-^^^^^^^^^^^^
-
-New Tests and Data Validations
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. _release-v2025.8.0:
 


### PR DESCRIPTION
# Overview

* Closes out release notes for PUDL v2025.9.0
* Update citation & zenodo metadata.

Part of #4596 