### PR TITLE
fix: allow usage metrics ETL to access viewer logs

### DIFF
--- a/terraform/pudl-viewer.tf
+++ b/terraform/pudl-viewer.tf
@@ -246,3 +246,11 @@ resource "google_storage_bucket_iam_member" "pudl_viewer_log_writer" {
 
   member = google_logging_project_sink.pudl_viewer_log_sink.writer_identity
 }
+
+resource "google_storage_bucket_iam_member" "usage_metrics_etl_pudl_viewer" {
+  for_each = toset(["roles/storage.legacyBucketReader", "roles/storage.objectViewer"])
+
+  bucket = google_storage_bucket.pudl_viewer_logs.name
+  role   = each.key
+  member = "serviceAccount:pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Fixes the permissions error found in [this attempt at loading the PUDL viewer logs](https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/17542986952/job/49818068262).

## What did you change?

Added the missing permissions block in terraform.

# Testing

Got this from `terraform plan`:

```
  # google_storage_bucket_iam_member.usage_metrics_etl_pudl_viewer["roles/storage.legacyBucketReader"] will be created
  + resource "google_storage_bucket_iam_member" "usage_metrics_etl_pudl_viewer" {
      + bucket = "pudl-viewer-logs.catalyst.coop"
      + etag   = (known after apply)
      + id     = (known after apply)
      + member = "serviceAccount:pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
      + role   = "roles/storage.legacyBucketReader"
    }

  # google_storage_bucket_iam_member.usage_metrics_etl_pudl_viewer["roles/storage.objectViewer"] will be created
  + resource "google_storage_bucket_iam_member" "usage_metrics_etl_pudl_viewer" {
      + bucket = "pudl-viewer-logs.catalyst.coop"
      + etag   = (known after apply)
      + id     = (known after apply)
      + member = "serviceAccount:pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
      + role   = "roles/storage.objectViewer"
    }
```

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
