### PR TITLE
Redeploy the Eel Hole in nightly builds

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,6 +32,7 @@ jobs:
           predicate-quantifier: "every"
           filters: |
             code:
+              - '!docker/*'
               - '!docs/**.rst'
               - '!docs/**.md'
               - '!docs/**.pdf'

--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -140,6 +140,7 @@ function notify_slack() {
     message+="UPDATE_STABLE_SUCCESS: $UPDATE_STABLE_SUCCESS\n"
     message+="CLEAN_UP_OUTPUTS_SUCCESS: $CLEAN_UP_OUTPUTS_SUCCESS\n"
     message+="DISTRIBUTION_BUCKET_SUCCESS: $DISTRIBUTION_BUCKET_SUCCESS\n"
+    message+="DEPLOY_EEL_HOLE_SUCCESS: $DEPLOY_EEL_HOLE_SUCCESS\n"
     message+="GCS_TEMPORARY_HOLD_SUCCESS: $GCS_TEMPORARY_HOLD_SUCCESS \n"
     message+="ZENODO_SUCCESS: $ZENODO_SUCCESS\n\n"
     # we need to trim off the last dash-delimited section off the build ID to get a valid log link
@@ -212,6 +213,7 @@ UPDATE_STABLE_SUCCESS=0
 WRITE_DATAPACKAGE_SUCCESS=0
 CLEAN_UP_OUTPUTS_SUCCESS=0
 DISTRIBUTION_BUCKET_SUCCESS=0
+DEPLOY_EEL_HOLE_SUCCESS=0
 ZENODO_SUCCESS=0
 GCS_TEMPORARY_HOLD_SUCCESS=0
 
@@ -275,6 +277,8 @@ if [[ "$BUILD_TYPE" == "nightly" ]]; then
     # Copy cleaned up outputs to the S3 and GCS distribution buckets
     upload_to_dist_path "nightly" | tee -a "$LOGFILE"
     DISTRIBUTION_BUCKET_SUCCESS=${PIPESTATUS[0]}
+    gcloud run services update pudl-viewer --image us-east1-docker.pkg.dev/catalyst-cooperative-pudl/pudl-viewer/pudl-viewer:latest --region us-east1  | tee -a "$LOGFILE"
+    DEPLOY_EEL_HOLE_SUCCESS=${PIPESTATUS[0]}
     # Remove individual parquet outputs and distribute just the zipped parquet
     # archives on Zenodo, due to their number of files limit
     rm -f "$PUDL_OUTPUT"/*.parquet
@@ -340,6 +344,7 @@ if [[ $ETL_SUCCESS == 0 &&
     $UPDATE_STABLE_SUCCESS == 0 &&
     $CLEAN_UP_OUTPUTS_SUCCESS == 0 &&
     $DISTRIBUTION_BUCKET_SUCCESS == 0 &&
+    $DEPLOY_EEL_HOLE_SUCCESS == 0 &&
     $GCS_TEMPORARY_HOLD_SUCCESS == 0 &&
     $ZENODO_SUCCESS == 0 ]] \
     ; then


### PR DESCRIPTION
# Overview

- Redeploy the Eel Hole / PUDL Viewer service in Cloud Run as soon as the new S3 data has been distributed in a nightly build.
- Update error codes / slack message to include the outcome of the command.
- Exclude anything under `docker/*` from triggering the integration tests in CI, since none of that gets touched in the integration tests -- we have to do a nightly build or (depending) a workflow dispatch / versioned release to see what will happen. So better not to spend the GHA resources and need to wait 1+ hours.

Closes #4457

## Questions

Does this need to be contingent on the S3 data distribution having been successful?  If it fails somehow, restarting the Eel Hole won't be harmful -- it'll still point at the last successful nightly outputs.  And if the nightly outputs are hosed somehow, that will break the Eel Hole even if we don't redeploy.  So it seems like it doesn't need to be contingent.