### PR TITLE
feat/clean_eia923_schedule8b

### DIFF
--- a/dbt/models/eia923/_core_eia923__byproduct_expenses_and_revenues/schema.yml
+++ b/dbt/models/eia923/_core_eia923__byproduct_expenses_and_revenues/schema.yml
@@ -1,0 +1,37 @@
+version: 2
+sources:
+  - name: pudl
+    tables:
+      - name: _core_eia923__byproduct_expenses_and_revenues
+        columns:
+          - name: plant_id_eia
+          - name: report_year
+          - name: data_maturity
+          - name: capex_air_abatement
+          - name: capex_other_abatement
+          - name: capex_solid_waste
+          - name: capex_water_abatement
+          - name: opex_bottom_ash_collection
+          - name: opex_bottom_ash_disposal
+          - name: opex_bottom_ash_other
+          - name: opex_fgd_byproduct_collection
+          - name: opex_fgd_byproduct_disposal
+          - name: opex_fgd_byproduct_other
+          - name: opex_fly_ash_collection
+          - name: opex_fly_ash_disposal
+          - name: opex_fly_ash_other
+          - name: opex_other_abatement_collection
+          - name: opex_other_abatement_disposal
+          - name: opex_other_abatement_other
+          - name: opex_total_collection_abatement
+          - name: opex_total_disposal_abatement
+          - name: opex_total_other_abatement
+          - name: opex_water_abatement_collection
+          - name: opex_water_abatement_disposal
+          - name: opex_water_abatement_other
+          - name: revenues_bottom_ash
+          - name: revenues_fgd_byproducts
+          - name: revenues_fly_ash
+          - name: revenues_fly_bottom_ash_intermingled
+          - name: revenues_other_byproducts
+          - name: revenues_total_byproduct

--- a/src/pudl/metadata/fields.py
+++ b/src/pudl/metadata/fields.py
@@ -592,6 +592,14 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Total installed (nameplate) capacity, in megawatts.",
         "unit": "MW",
     },
+    "capex_air_abatement": {
+        "type": "number",
+        "description": (
+            "Cost of new structures and/or equipment purchased to reduce, monitor, or "
+            "eliminate airborne pollutants"
+        ),
+        "unit": "USD",
+    },
     "capex_annual_addition": {
         "type": "number",
         "description": "Annual capital addition into `capex_total`.",
@@ -652,6 +660,14 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Cost of plant: land and land rights (USD).",
         "unit": "USD",
     },
+    "capex_other_abatement": {
+        "type": "number",
+        "description": (
+            "Other amortizable expenses and purchases of new structures and or equipment "
+            "when such purchases are not allocated to a particular unit or item."
+        ),
+        "unit": "USD",
+    },
     "capex_other": {
         "type": "number",
         "description": "Other costs associated with the plant (USD).",
@@ -667,6 +683,13 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Cost of plant: roads, railroads, and bridges (USD).",
         "unit": "USD",
     },
+    "capex_solid_waste": {
+        "type": "number",
+        "description": (
+            "Cost of structures or equipment purchased to collect and dispose of objectionable solids or contained liquids."
+        ),
+        "unit": "USD",
+    },
     "capex_structures": {
         "type": "number",
         "description": "Cost of plant: structures and improvements (USD).",
@@ -675,6 +698,15 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     "capex_total": {
         "type": "number",
         "description": "Total cost of plant (USD).",
+        "unit": "USD",
+    },
+    "capex_water_abatement": {
+        "type": "number",
+        "description": (
+            "Cost of new structures and/or equipment purchased to reduce, monitor, "
+            "or eliminate waterborne pollutants, including chlorine, phosphates, acids, bases, hydrocarbons, sewage, "
+            "and other pollutants."
+        ),
         "unit": "USD",
     },
     "capex_wheels_turbines_generators": {
@@ -4093,6 +4125,21 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Maintenance of boiler (or reactor) plant.",
         "unit": "USD",
     },
+    "opex_bottom_ash_collection": {
+        "type": "number",
+        "description": "Costs of materials and labor associated with the collection of bottom ash from all sources.",
+        "unit": "USD",
+    },
+    "opex_bottom_ash_disposal": {
+        "type": "number",
+        "description": "Costs of materials and labor associated with the disposal of bottom ash from all sources.",
+        "unit": "USD",
+    },
+    "opex_bottom_ash_other": {
+        "type": "number",
+        "description": "Other costs associated with the collection and disposal of bottom ash.",
+        "unit": "USD",
+    },
     "opex_coolants": {
         "type": "number",
         "description": "Cost of coolants and water (nuclear plants only)",
@@ -4111,6 +4158,21 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     "opex_engineering": {
         "type": "number",
         "description": "Production expenses: maintenance, supervision, and engineering (USD).",
+        "unit": "USD",
+    },
+    "opex_fgd_byproduct_collection": {
+        "type": "number",
+        "description": "Costs of materials and labor associated with the collection of sulfur by-product (flue gas desulfurization).",
+        "unit": "USD",
+    },
+    "opex_fgd_byproduct_disposal": {
+        "type": "number",
+        "description": "Costs of materials and labor associated with the disposal of sulfur by-product (flue gas desulfurization).",
+        "unit": "USD",
+    },
+    "opex_fgd_byproduct_other": {
+        "type": "number",
+        "description": "Other costs associated with the collection and disposal of sulfur by-product (flue gas desulfurization).",
         "unit": "USD",
     },
     "opex_fgd_feed_materials_chemical": {
@@ -4147,6 +4209,21 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
         "type": "number",
         "description": "Fixed operation and maintenance expenses. Annual expenditures to operate and maintain equipment that are not incurred on a per-unit-energy basis.",
         "unit": "USD_per_kw",
+    },
+    "opex_fly_ash_collection": {
+        "type": "number",
+        "description": "Costs of materials and labor associated with the collection of fly ash from all sources.",
+        "unit": "USD",
+    },
+    "opex_fly_ash_disposal": {
+        "type": "number",
+        "description": "Costs of materials and labor associated with the disposal of fly ash from all sources.",
+        "unit": "USD",
+    },
+    "opex_fly_ash_other": {
+        "type": "number",
+        "description": "Other costs associated with the collection and disposal of fly ash.",
+        "unit": "USD",
     },
     "opex_variable_per_mwh": {
         "type": "number",
@@ -4201,6 +4278,21 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
     "opex_operations": {
         "type": "number",
         "description": "Production expenses: operations, supervision, and engineering (USD).",
+        "unit": "USD",
+    },
+    "opex_other_abatement_collection": {
+        "type": "number",
+        "description": "Abatement costs of by-product collection that are not allocated to a particular expenditure, e.g., costs of operating an environmental protection office.",
+        "unit": "USD",
+    },
+    "opex_other_abatement_disposal": {
+        "type": "number",
+        "description": "Abatement costs of by-product disposal that are not allocated to a particular expenditure.",
+        "unit": "USD",
+    },
+    "opex_other_abatement_other": {
+        "type": "number",
+        "description": "Other abatement costs that are not allocated to a particular expenditure.",
         "unit": "USD",
     },
     "opex_per_mwh": {
@@ -4264,10 +4356,40 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
         "description": "Total production expenses, excluding fuel (USD).",
         "unit": "USD",
     },
+    "opex_total_collection_abatement": {
+        "type": "number",
+        "description": "Sum of abatement costs associated with by-product collection.",
+        "unit": "USD",
+    },
+    "opex_total_disposal_abatement": {
+        "type": "number",
+        "description": "Sum of abatement costs associated with by-product disposal.",
+        "unit": "USD",
+    },
+    "opex_total_other_abatement": {
+        "type": "number",
+        "description": "Sum of other abatement costs associated with the collection and disposal of byproducts.",
+        "unit": "USD",
+    },
     "opex_transfer": {"type": "number", "description": "Steam transferred (Credit)."},
     "opex_water_for_power": {
         "type": "number",
         "description": "Production expenses: water for power (USD).",
+        "unit": "USD",
+    },
+    "opex_water_abatement_collection": {
+        "type": "number",
+        "description": "Costs associated with the collection/abatement of water pollution, e.g., equipment operation and maintenance of pumps, pipes, and settling ponds.",
+        "unit": "USD",
+    },
+    "opex_water_abatement_disposal": {
+        "type": "number",
+        "description": "Costs associated with the disposal of water pollutants.",
+        "unit": "USD",
+    },
+    "opex_water_abatement_other": {
+        "type": "number",
+        "description": "Other abatement costs associated with water pollutants.",
         "unit": "USD",
     },
     "original_planned_generator_operating_date": {
@@ -5086,6 +5208,36 @@ FIELD_METADATA: dict[str, dict[str, Any]] = {
                 "transmission",
             ]
         },
+    },
+    "revenues_bottom_ash": {
+        "type": "number",
+        "description": "Revenue from the sale of bottom ash by-product.",
+        "unit": "USD",
+    },
+    "revenues_fgd_byproducts": {
+        "type": "number",
+        "description": "Revenue from the sale of flue gas desulfurization by-product.",
+        "unit": "USD",
+    },
+    "revenues_fly_ash": {
+        "type": "number",
+        "description": "Revenue from the sale of fly ash by-product.",
+        "unit": "USD",
+    },
+    "revenues_fly_bottom_ash_intermingled": {
+        "type": "number",
+        "description": "Revenue from the sale of intermingled fly and bottom ash by-product.",
+        "unit": "USD",
+    },
+    "revenues_other_byproducts": {
+        "type": "number",
+        "description": "Revenue from the sale of other by-products.",
+        "unit": "USD",
+    },
+    "revenues_total_byproduct": {
+        "type": "number",
+        "description": "Total revenue from the sale of by-products.",
+        "unit": "USD",
     },
     "row_type_xbrl": {
         "type": "string",

--- a/src/pudl/metadata/resources/eia923.py
+++ b/src/pudl/metadata/resources/eia923.py
@@ -901,6 +901,63 @@ and consumption is the net generation."""
         "sources": ["eia923"],
         "etl_group": "eia923",
     },
+    "_core_eia923__byproduct_expenses_and_revenues": {
+        "description": {
+            "additional_summary_text": (
+                "Financial information related to combustion by-products reported by "
+                "thermoelectric power plants with total steam turbine capacity of 100 "
+                "megawatts or greater and that produced combustion by-products during the reporting year."
+            ),
+            "additional_source_text": "(Schedule 8B)",
+            "additional_details_text": (
+                "Cost data must be entered for all entries on Schedule 8A. "
+                "Financial information includes operational and maintenance expenditures (opex), "
+                "capital expenditures (capex), and by-products sales revenue."
+            ),
+        },
+        "schema": {
+            "fields": [
+                "plant_id_eia",
+                "report_year",
+                "data_maturity",
+                "capex_air_abatement",
+                "capex_other_abatement",
+                "capex_solid_waste",
+                "capex_water_abatement",
+                "opex_bottom_ash_collection",
+                "opex_bottom_ash_disposal",
+                "opex_bottom_ash_other",
+                "opex_fgd_byproduct_collection",
+                "opex_fgd_byproduct_disposal",
+                "opex_fgd_byproduct_other",
+                "opex_fly_ash_collection",
+                "opex_fly_ash_disposal",
+                "opex_fly_ash_other",
+                "opex_other_abatement_collection",
+                "opex_other_abatement_disposal",
+                "opex_other_abatement_other",
+                "opex_total_collection_abatement",
+                "opex_total_disposal_abatement",
+                "opex_total_other_abatement",
+                "opex_water_abatement_collection",
+                "opex_water_abatement_disposal",
+                "opex_water_abatement_other",
+                "revenues_bottom_ash",
+                "revenues_fgd_byproducts",
+                "revenues_fly_ash",
+                "revenues_fly_bottom_ash_intermingled",
+                "revenues_other_byproducts",
+                "revenues_total_byproduct",
+            ],
+            "primary_key": [
+                "plant_id_eia",
+                "report_year",
+            ],
+        },
+        "field_namespace": "eia",
+        "sources": ["eia923"],
+        "etl_group": "eia923",
+    },
 }
 """EIA-923 resource attributes organized by PUDL identifier (``resource.name``).
 

--- a/src/pudl/transform/eia923.py
+++ b/src/pudl/transform/eia923.py
@@ -1591,3 +1591,39 @@ def disposition_continuity_check(bpd):
         groupby_col="report_year",
         n_outliers_allowed=5,
     )
+
+
+@asset(io_manager_key="pudl_io_manager")
+def _core_eia923__byproduct_expenses_and_revenues(
+    raw_eia923__byproduct_expenses_and_revenues: pd.DataFrame,
+) -> pd.DataFrame:
+    """Transforms the eia923__byproduct_expenses_and_revenues table.
+
+    Transformations include:
+    * Standardize NA values
+    * Convert 1000 dollars (opex and revenue columns) to dollars
+
+    Args:
+        raw_eia923__byproduct_expenses_and_revenues: The raw ``raw_eia923__byproduct_expenses_and_revenues``
+        dataframe.
+
+    Returns:
+        Cleaned ``_core_eia923__byproduct_expenses_and_revenues`` dataframe ready for harvesting.
+    """
+    df = raw_eia923__byproduct_expenses_and_revenues.copy()
+
+    # This column is dropped from all EIA 923 tables
+    df = df.drop(["early_release"], axis=1)
+
+    df = pudl.helpers.fix_eia_na(df)
+
+    # One dupe for plant_id_eia=6504 and report_year=2010 with no differences in byproduct dollars reported
+    df = pudl.helpers.dedupe_and_drop_nas(
+        df, primary_key_cols=["plant_id_eia", "report_year"]
+    )
+
+    # Convert thousands of dollars to dollars and remove suffix from column name
+    df.loc[:, df.columns.str.endswith("_thousand_dollars")] *= 1000
+    df.columns = df.columns.str.replace("_thousand_dollars", "")
+
+    return df

--- a/src/pudl/transform/eia923.py
+++ b/src/pudl/transform/eia923.py
@@ -1593,7 +1593,7 @@ def disposition_continuity_check(bpd):
     )
 
 
-@asset(io_manager_key="pudl_io_manager")
+@asset
 def _core_eia923__byproduct_expenses_and_revenues(
     raw_eia923__byproduct_expenses_and_revenues: pd.DataFrame,
 ) -> pd.DataFrame:


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview
Closes https://github.com/catalyst-cooperative/pudl/issues/4099

## What problem does this address?
Transforms `raw_eia923__byproduct_expenses_and_revenues` into `_core_eia923__byproduct_expenses_and_revenues`, a new clean table ready to be combined with other EIA 923 and 860 data in PUDL.

# To-do
- [x] Ran unit-tests
- [x] Materialized the new asset in Dagster (with `@asset` decorator)
- [ ] Write the table to the PUDL database and [update alembic schema](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/run_the_etl.html#database-schema-migration). Waiting to do this after initial review (if this is within scope? Not sure if it would be done at the same time as adding dbt tests, which I think may be out of scope?)

I think this is ready for an initial review. Let me know what the next steps are!
