### PR TITLE
fix: remaining pandera import that was throwing a warning

### DIFF
--- a/src/pudl/extract/eiaaeo.py
+++ b/src/pudl/extract/eiaaeo.py
@@ -17,7 +17,7 @@ from dagster import (
     asset_check,
     multi_asset,
 )
-from pandera import DataFrameModel, Field
+from pandera.pandas import DataFrameModel, Field
 from pydantic import BaseModel
 
 import pudl.logging_helpers


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

This was so annoying.

# Testing

How did you make sure this worked? How can a reviewer verify this?

`python -c "import pudl"` and see that blissfully there is only the one warning:

```
/home/daz/work/pudl/src/pudl/metadata/classes.py:1301: UserWarning: Field name "schema" in "Resource" shadows an attribute in parent "PudlMeta"
  class Resource(PudlMeta):
```
