### PR TITLE
Tiny fixes post-release v2025.10.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/versioned_release.md
+++ b/.github/ISSUE_TEMPLATE/versioned_release.md
@@ -20,7 +20,7 @@ assignees: ""
 - [ ] Close out the [PUDL Release Notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html) with an overview of the changes in this release
 - [ ] Merge those changes into `main`
 - [ ] Verify that all `stable` commits are on `main` with `git log main..stable`
-- [ ] Tag the release `git tag -as -m "PUDL vYYYY.M.x"`
+- [ ] Tag the release `git tag -as -m "PUDL vYYYY.M.x" vYYYY.M.x`
 - [ ] Push the release tag to `main`: `git push origin vYYYY.M.x`
 - [ ] Verify that the new [GitHub (software) release](https://github.com/catalyst-cooperative/pudl/releases) has been published
 - [ ] Verify [`catalystcoop.pudl` PyPI (software) release](https://pypi.org/project/catalystcoop.pudl/)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -28,6 +28,15 @@ EIA-860M
 * Updated EIA-860M monthly generator report with newly published data for August
   of 2025. See issue :issue:`4639` and PR :pr:`4638`.
 
+
+Re-introduce 88888 and 99999 utility_id_eia
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These values, representing redacted values and state aggregates, were
+intentionally dropped from eia923 and eia861 due to primary key and
+data inconsistency issues. We're adding them back in! See :issue:`808`
+and PR :pr:`4291`.
+
 New Data
 ^^^^^^^^
 
@@ -142,13 +151,6 @@ tables with a valid ``geometry`` column are:
 
 Expanded Data Coverage
 ^^^^^^^^^^^^^^^^^^^^^^
-
-Re-introduce 88888 and 99999 utility_id_eia
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-These values, representing redacted values and state aggregates, were
-intentionally dropped from eia923 and eia861 due to primary key and
-data inconsistency issues. We're adding them back in! See :issue:`808`
-and PR :pr:`4291`.
 
 EIA-860M
 ~~~~~~~~


### PR DESCRIPTION
# Overview

- Fix a minor issue in the git tag command suggested in the data release template so it is cut-and-paste ready.
- Move the 88888/99999 improvement into the v2025.10.0 release notes section, since that's where it actually landed (I didn't notice it was in the wrong place until it was too late)

Closes #4652 

# Testing

- I built the docs locally to make sure I didn't break anything when editing the release notes.

## To-do list

- [x] Review the PR yourself and call out any questions or issues you have.