### PR TITLE
Identify FERC 1 Missing Respondent 516 as Mid-Atlantic Interstate Transmission, LLC

### DIFF
--- a/src/pudl/analysis/timeseries_cleaning.py
+++ b/src/pudl/analysis/timeseries_cleaning.py
@@ -1565,7 +1565,7 @@ def impute_flagged_values(
     .. note::
        The imputation is parallelized internally, and by default will use all available
        CPU cores. If you want to limit the number of cores used, you can set the
-       ``OPM_NUM_THREADS`` environment variable to the desired number of threads.
+       ``OMP_NUM_THREADS`` environment variable to the desired number of threads.
 
     Args:
         df: Timeseries matrix as described in :func:`_prepare_timeseries_matrix`

--- a/src/pudl/package_data/glue/utility_id_pudl.csv
+++ b/src/pudl/package_data/glue/utility_id_pudl.csv
@@ -6750,7 +6750,7 @@ utility_id_pudl,utility_id_ferc1,utility_name_ferc1,utility_id_eia,utility_name_
 6764,80,missing respondent 253,,
 5514,372,aep texas (pudl determined),,
 6766,439,missing respondent 515,,
-6767,370,missing respondent 516,,
+6767,370,"Mid-Atlantic Interstate Transmission, LLC",,
 6768,375,missing respondent 517,,
 6769,371,missing respondent 518,,
 6771,440,missing respondent 520,,


### PR DESCRIPTION
# Overview

* Identifies one of our mystery FERC Form 1 Respondents: ID 516
* Adds an explicit mapping for Mid-Atlantic Interstate Transmission, LLC

Closes #4670

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
