### PR TITLE
Update documentation on CEMS accessibility

### DIFF
--- a/docs/templates/epacems_child.rst.jinja
+++ b/docs/templates/epacems_child.rst.jinja
@@ -3,7 +3,7 @@
 Clicking on the links will show you a description of the table as well as the names and
 descriptions of each of its fields. Due to the size of the CEMS data we do not publish
 it as part of our SQLite database, but it is available through all of our other
-`access methods <https://catalystcoop-pudl.readthedocs.io/en/latest/data_access.html#>`.
+`access methods <https://catalystcoop-pudl.readthedocs.io/en/latest/data_access.html#>`__.
 {% endblock %}
 
 {% block background %}


### PR DESCRIPTION
# Overview

Closes #4738 

## What problem does this address?
- Ran into some outdated documentation on the CEMS data source page.

## What did you change?
- Simplify and update access warnings for CEMS, now that we have the PUDL viewer and not Datasette
- Remove language about only updating CEMS for one client, now that updates are supported through PUDL Sus

## Documentation

Make sure to update relevant aspects of the documentation:

- [x] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).

# Testing

How did you make sure this worked? How can a reviewer verify this?
`make docs-build` and inspect results.

## To-do list

- [x] Review the PR yourself and call out any questions or issues you have.
