### PR TITLE
Remove 'make ci' target since pre-commit --all-files is too invasive

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,6 +28,6 @@ How did you make sure this worked? How can a reviewer verify this?
 ## To-do list
 
 - [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
-- [ ] Run `make ci` locally to ensure that the merge queue will accept your PR.
+- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
 - [ ] Review the PR yourself and call out any questions or issues you have.
 - [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.

--- a/Makefile
+++ b/Makefile
@@ -162,15 +162,3 @@ unmapped-ids:
 		--ignore-foreign-key-constraints \
 		--etl-settings ${etl_full_yml} \
 		test/integration/glue_test.py
-
-########################################################################################
-# Continuous Integration Tests
-########################################################################################
-.PHONY: pre-commit
-pre-commit:
-	pre-commit run --all-files
-
-# This target will run all the tests that typically take place in our continuous
-# integration tests on GitHub (with the exception building our docker container).
-.PHONY: ci
-ci: pre-commit pytest-coverage

--- a/docs/dev/testing.rst
+++ b/docs/dev/testing.rst
@@ -10,15 +10,15 @@ We use `pytest <https://pytest.org>`__ to specify software unit
 stored as targets in the PUDL ``Makefile`` for convenience and to ensure that
 we're all running the tests in similar ways by default.
 
-To run the checks that will be run on a PR by our continuous integration (CI) on GitHub
+To run the tests that will be run on a PR by our continuous integration (CI) on GitHub
 before it's merged into the ``main`` branch you can use the following command:
 
 .. code-block:: console
 
-    $ make ci
+    $ make pytest-coverage
 
-This includes running the pre-commit hooks, building the documentation, unit tests,
-integration tests, and checking to make sure we've got sufficient test coverage.
+This includes building the documentation, running unit & integration tests, and checking
+to make sure we've got sufficient test coverage.
 
 .. note::
 
@@ -83,8 +83,6 @@ There are several non-test ``make`` targets. To see them all open the ``Makefile
 * ``docs-build``: Remove existing PUDL documentation outputs and rebuild from scratch.
 * ``jlab``: start up a JupyerLab notebook server (will remain running in your terminal
   until you kill it with ``Control-C``).
-* ``ci``: Run all the checks that would be run in CI on GitHub, including the pre-commit
-  hooks, docs build, and software unit and integration tests.
 
 -------------------------------------------------------------------------------
 Selecting Input Data for Integration Tests


### PR DESCRIPTION
# Overview

* Our PR template has been instructing folks to run `make ci` which also calls `pre-commit --all-files`
* This is actually more invasive than what `pre-commit.ci` runs in our CI, since some of the local pre-commit hooks are disabled in the `pre-commit.ci` configuration.
* This was resulting in undesirable behavior like unnecessarily regenerating the conda lockfiles, even when no dependencies had been updated.
* Reverting to telling contributors to run `make pytest-coverage` will avoid those unnecessary actions.
* However, we **do** want everybody to be running the local pre-commit hooks during development, since they don't get run by `pre-commit.ci` and without this step, that won't happen if the contributor does not install the pre-commit hooks in their development environment.
* This means we need to keep an eye out for things like unsorted row-counts, or conda lockfiles that haven't been updated when a new dependency has been added.
* If we see `pre-commit.ci` consistently modifying the PR when new pushes are made we should ask whether the pre-commit hooks are installed.

## Documentation

- Updated the dev docs page.
- Updated the PR template.

## To-do list

- [ ] Review the PR yourself and call out any questions or issues you have.
