### PR TITLE
Update row counts that changed due to calamine upgrade

### DIFF
--- a/dbt/seeds/etl_full_row_counts.csv
+++ b/dbt/seeds/etl_full_row_counts.csv
@@ -1179,7 +1179,7 @@ core_eia861__yearly_utility_data_rto,2021,1564
 core_eia861__yearly_utility_data_rto,2022,1592
 core_eia861__yearly_utility_data_rto,2023,1621
 core_eia861__yearly_utility_data_rto,2024,1635
-core_eia923__entity_coalmine,,4501
+core_eia923__entity_coalmine,,4650
 core_eia923__monthly_boiler_fuel,2008,77537
 core_eia923__monthly_boiler_fuel,2009,79002
 core_eia923__monthly_boiler_fuel,2010,81197
@@ -2275,7 +2275,7 @@ core_phmsagas__yearly_distribution_operators,2024,1428
 core_pudl__assn_eia_pudl_plants,,18650
 core_pudl__assn_eia_pudl_utilities,,16760
 core_pudl__assn_ferc1_dbf_pudl_utilities,,411
-core_pudl__assn_ferc1_pudl_plants,,8101
+core_pudl__assn_ferc1_pudl_plants,,8100
 core_pudl__assn_ferc1_pudl_utilities,,432
 core_pudl__assn_ferc1_xbrl_pudl_utilities,,282
 core_pudl__assn_ferc714_csv_pudl_respondents,,213


### PR DESCRIPTION
# Overview

The update to `python-calamine` v0.6.0 resulted in some material changes to the contents of the data we're extracting from Excel spreadsheets, including these row counts. But I wonder what other changes there might be.

| table_name                   | expected_partition   | observed_partition   |   expected_count |   observed_count |   diff_relative_to_expected |
|:-----------------------------|:---------------------|:---------------------|-----------------:|-----------------:|----------------------------:|
| core_eia923__entity_coalmine |                      |                      |             4501 |             4650 |                   0.0331038 |

| table_name                        | expected_partition   | observed_partition   |   expected_count |   observed_count |   diff_relative_to_expected |
|:----------------------------------|:---------------------|:---------------------|-----------------:|-----------------:|----------------------------:|
| core_pudl__assn_ferc1_pudl_plants |                      |                      |             8101 |             8100 |                -0.000123442 |

# Testing

- I switched back to `python-calamine==0.5.3` and rematerialized the above assets and everything upstream of them, and re-checked the row counts, and they were back to the expected values.

## To-do list

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
