### PR TITLE
Add to the table description for `out_eia__{freq}_generators`

### DIFF
--- a/src/pudl/metadata/resources/eia.py
+++ b/src/pudl/metadata/resources/eia.py
@@ -1218,13 +1218,15 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
     f"out_eia__{freq}_generators": {
         "description": {
             "additional_summary_text": "all generator attributes including calculated capacity factor, heat rate, fuel cost per MMBTU and fuel cost per MWh.",
-            "additional_details_text": f"""This table includes all generators reported to EIA
-with all of the attributes associated with generator records including directly reported,
-imputed and many calculated columns. We suggest using this table if you want to explore
-{freq} attributes about generators and would rather use a more complete and denormalized table.
-Many tables were used to compile this table - if you are more interested in the originally
-reported values, we recommend searching for ``core_eia`` with the column you are most
-interested in.
+            "additional_details_text": f"""This table includes all {freq} attributes
+for all generators reported to EIA-860 and EIA-923.
+
+To provide a complete picture of generator data, this table compiles data from many
+different EIA tables, including directly reported, imputed and calculated columns.
+We suggest using this table if you want to explore {freq} attributes about generators
+and would rather use a more complete and denormalized table. If you are more interested
+in the originally reported values, we recommend searching for core_eia with the column
+you are most interested in.
 
 The calculations of capacity factor, heat rate, fuel cost per MMBTU and fuel cost per MWh
 are based on the allocation of net generation reported on the basis of plant, prime mover


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Working on  #4797.

## What problem does this address?

## What did you change?

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
