### PR TITLE
revert the plant_parts row count update

### DIFF
--- a/dbt/seeds/etl_full_row_counts.csv
+++ b/dbt/seeds/etl_full_row_counts.csv
@@ -2950,7 +2950,7 @@ out_eia__yearly_plant_parts,2007,155277
 out_eia__yearly_plant_parts,2008,161998
 out_eia__yearly_plant_parts,2009,169358
 out_eia__yearly_plant_parts,2010,163994
-out_eia__yearly_plant_parts,2011,170566
+out_eia__yearly_plant_parts,2011,170572
 out_eia__yearly_plant_parts,2012,178269
 out_eia__yearly_plant_parts,2013,190680
 out_eia__yearly_plant_parts,2014,198298


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #XXXX.

## What problem does this address?
... this is a now pretty well established instance of local builds being different than the GHA runs. See [this comment thread](https://github.com/catalyst-cooperative/pudl/pull/4788/files#r2585233689)

## What did you change?

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
