### PR TITLE
Improve performance of `out_eia__yearly_plant_parts`

### DIFF
--- a/src/pudl/analysis/plant_parts_eia.py
+++ b/src/pudl/analysis/plant_parts_eia.py
@@ -367,6 +367,7 @@ plant_parts_assets = [
 @asset(
     io_manager_key="pudl_io_manager",
     compute_kind="Python",
+    op_tags={"memory-use": "high"},
     ins={
         part_name: AssetIn(key=AssetKey(f"_out_eia__plant_part_{part_name}"))
         for part_name in PLANT_PARTS


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #2920 .

## What problem does this address?

`out_eia__yearly_plant_parts` is slow to generate. It's created by making a table for each plant part and then concatenating these part tables together. The creation of these plant parts can be run in parallel with Dagster. This PR creates an asset factory to generate an asset for each of the plant parts (named `out_eia__plant_part_{x}` and then concatenates it together into one.

 I can generate `out_eia__yearly_plant_parts` and its upstream `_out_eia__plant_part_x` assets in 6 minutes and 8 seconds. On `main`, it takes me 7 minutes and 13 seconds to generate `out_eia__yearly_plant_parts`, so overall it's not as big a speed up as I'd expect. However, I wonder if there is a bigger speed up on a slower computer. I have a Mac M3, but the issue says that this asset takes half an hour to generate on a Mac M1. It may be good to have someone with a slower computer run this as well. 

Is it worth taking on other performance improvement ideas for this table if this asset splitting didn't take much time off?

## What did you change?

Created an asset factory to generate an asset for each of the plant parts (named `out_eia__plant_part_{x}`) and then concatenate it together into one `out_eia__yearly_plant_parts`.

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [x] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [x] Update relevant table or source description metadata (see `src/metadata`).
- [x] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

- [x] Check to make sure the `out_eia__yearly_plant_parts` asset is identical when materialized on `main`.
- [x] Check the run time on `main`.

## To-do list

- [x] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [x] Review the PR yourself and call out any questions or issues you have.
- [x] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
