### PR TITLE
Apply polars dtypes to vcerare output table

### DIFF
--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -313,11 +313,11 @@ class PudlParquetIOManager(IOManager):
     ) -> None:
         """Writes pudl dataframe to parquet file."""
         table_name = get_table_name_from_context(context)
+        res = Resource.from_id(table_name)
         parquet_path = PudlPaths().parquet_path(table_name)
         parquet_path.parent.mkdir(parents=True, exist_ok=True)
 
         if isinstance(obj, pd.DataFrame):
-            res = Resource.from_id(table_name)
             df = res.enforce_schema(obj)
             pa_schema = res.to_pyarrow()
             df.to_parquet(
@@ -327,7 +327,7 @@ class PudlParquetIOManager(IOManager):
             )
         elif isinstance(obj, pl.LazyFrame):
             logger.warning("PudlParquetIOManager does not do any schema enforcement.")
-            obj.sink_parquet(
+            obj.cast(res.to_polars_dtypes()).sink_parquet(
                 parquet_path,
                 engine="streaming",
                 row_group_size=100_000,

--- a/src/pudl/transform/vcerare.py
+++ b/src/pudl/transform/vcerare.py
@@ -20,7 +20,6 @@ from pudl.helpers import (
     simplify_columns,
     zero_pad_numeric_string,
 )
-from pudl.metadata.classes import Resource
 from pudl.metadata.dfs import POLITICAL_SUBDIVISIONS
 from pudl.workspace.setup import PudlPaths
 
@@ -517,8 +516,4 @@ def out_vcerare__hourly_available_capacity_factor(
 
     return lf_from_parquet(
         ParquetData(table_name=partitioned_output_table), use_all_partitions=True
-    ).cast(
-        Resource.from_id(
-            "out_vcerare__hourly_available_capacity_factor"
-        ).to_polars_dtypes()
     )


### PR DESCRIPTION
# Overview

This PR fixes an issue with a recent update to `vcerare` processing meant to improve memory performance. In that PR, we switched to using Polars/duckdb for processing, but this resulted in minor changes to dtypes. This PR makes sure that we apply the appropriate dtypes when writing to parquet.