### PR TITLE
Add to the table description for core_eia861__yearly_utility_data_misc & friends

### DIFF
--- a/src/pudl/metadata/resources/eia861.py
+++ b/src/pudl/metadata/resources/eia861.py
@@ -817,6 +817,8 @@ Utilities report on Form EIA-861S if they:
     "core_eia861__yearly_utility_data_misc": {
         "description": {
             "additional_summary_text": "utility business activities.",
+            "additional_primary_key_text": """The primary key would have been: utility_id_eia, state, report_date,
+  and nerc_region, but there are nulls in the state column across several years of reporting.""",
             "additional_details_text": """This includes whether they operate alternative fuel vehicles, whether they provide
 transmission, distribution, or generation services (bundled or unbundled), and whether
 they engage in wholesale and/or retail markets.""",
@@ -851,6 +853,8 @@ they engage in wholesale and/or retail markets.""",
     "core_eia861__yearly_utility_data_nerc": {
         "description": {
             "additional_summary_text": "the NERC regions that utilities operate in.",
+            "additional_primary_key_text": """The primary key would have been: utility_id_eia, state, report_date,
+  nerc_region, and nerc_regions_of_operation, but there are nulls in the state column across several years of reporting.""",
         },
         "schema": {
             "fields": [
@@ -869,6 +873,8 @@ they engage in wholesale and/or retail markets.""",
     "core_eia861__yearly_utility_data_rto": {
         "description": {
             "additional_summary_text": "the RTOs that utilities operate in.",
+            "additional_primary_key_text": """The primary key would have been: utility_id_eia, state, report_date,
+  nerc_region, and rtos_of_operation, but there are nulls in the state column across several years of reporting.""",
         },
         "schema": {
             "fields": [


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Working on #4797.

## What problem does this address?

## What did you change?

* Add primary key explanations for core_eia861__yearly_utility_data_{misc,nerc,rto}: there are nulls in the state column, which would ordinarily be part of the pk

## Documentation

Make sure to update relevant aspects of the documentation:

- [x] Update relevant table or source description metadata (see `src/metadata`).

# Testing

How did you make sure this worked? How can a reviewer verify this?

Preview in wizard

