### PR TITLE
Add to the table description for *_ferc1__yearly_purchased_power_and_exchanges_sched326

### DIFF
--- a/src/pudl/metadata/resources/ferc1.py
+++ b/src/pudl/metadata/resources/ferc1.py
@@ -277,6 +277,7 @@ columns."""
             "and any settlements for imbalanced exchanges."
         ),
         "additional_source_text": "(Schedule 326)",
+        # Remove if bug is squashed: https://github.com/catalyst-cooperative/pudl/issues/4834
         "additional_primary_key_text": """The primary key for this table would be record_id,
   however a small number of these values are duplicated in 2021, 2022, and 2024.""",
         "usage_warnings": ["free_text"],


### PR DESCRIPTION

# Overview

Working on #4797.

## What problem does this address?

## What did you change?

* Added a pk explanation for the shared yearly_purchased_power_and_exchanges_sched326 description.

There are only 5 duplicate record_ids preventing this table from having a primary key. For two of them, the records are identical, and probably shouldn't be duplicated. I have filed #4834 as a low-pri follow-up.

## Documentation

Make sure to update relevant aspects of the documentation:

- [x] Update relevant table or source description metadata (see `src/metadata`).

# Testing

How did you make sure this worked? How can a reviewer verify this?

Previewed in wizard.
