### PR TITLE
perf: reduce `out_eia923__monthly_generation_by_generator_energy_source_code` memory usage 38GB -> 22 GB

### DIFF
--- a/src/pudl/analysis/allocate_gen_fuel.py
+++ b/src/pudl/analysis/allocate_gen_fuel.py
@@ -1664,7 +1664,9 @@ def adjust_msw_energy_source_codes(
         bf_by_gens.energy_source_code.unique()
     )
     # NOTE 2025-12-11: we sort this reverse-ly to match the indeterminate order that happens to be in nightly builds right now
-    msw_codes_used = sorted({"MSN", "MSB", "MSW"}.intersection(codes_used), reverse=True)
+    msw_codes_used = sorted(
+        {"MSN", "MSB", "MSW"}.intersection(codes_used), reverse=True
+    )
     # join these codes into a string that will be used to replace the MSW code
     replacement_codes = ",".join(msw_codes_used)
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

This asset was blowing up my local ETL runs by using 38GB of memory.

## What did you change?

* set `pd.options.mode.copy_on_write` which drastically reduces the amount of array copies that happen
* fix some parts of our energy source code munging where the energy source code ordering was not stable
* cleaned up a little bit of the "find the right MSN/MSB codes" logic

Looked at changing more, but chose not to:
* moving away from string manipulation as intermediate representation for the MSW -> MSN/MSB expansion - that just seems like a lot of extra logic for... no gain
* moving into duckdb for more out-of-memory processing - 22GB is small enough for this bad boy to run on our dev machines for now and we're out of time for further memory optimizations

## Documentation

I don't think there's anything a user would care about that I changed.

# Testing

Materialized with `memory_profile.py` and compared against nightly to make sure the output data was exactly the same.

## To-do list

- [ ] Review the PR yourself and call out any questions or issues you have.
