### PR TITLE
Add FERC Company Identifier metadata

### DIFF
--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -673,7 +673,7 @@ SOURCES: dict[str, Any] = {
             "non-regulated or non-jurisdictional entities to obtain Company Identifier (CID) numbers "
             "in order to make required filings with the Commission including tariff filings and "
             "various required forms. Each regulatory program requires a unique CID number. These "
-            "CID numbers show up in FERC Form 1, 714, and EQR."
+            "CID numbers show up in various FERC filings, such as Forms 1, 2, 6, 60, 714, and EQR."
         ),
         "working_partitions": {},
         "keywords": sorted(


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Metadata PR to close #4832 .

## What problem does this address?

Adds metadata for a new FERC Company Identifier data source. Metadata accompanies FERC CID archives.

## What did you change?

Added FERC CID metadata. I pulled the description from the main page of the FERC page for CID.

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `make pytest-coverage` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
