### PR TITLE
Install ce-certificates package in docker container so git works

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@ SHELL [ "/bin/bash", "-exo", "pipefail", "-c" ]
 # Install some linux packages
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git postgresql && \
+    apt-get install --no-install-recommends -y git postgresql ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
# Overview

Explicitly install the `ca-certificates` package in our nightly build Docker container so that we can use `git` with GitHub (necessary to update `nightly` branch to point at the build tag)

Closes #4890

# Testing

- See notes in #4890 
- Can't fully test without running a nightly build.