### PR TITLE
Move EQR build VM to same region as EQR data to avoid data transfer

### DIFF
--- a/.github/workflows/build-deploy-ferceqr.yml
+++ b/.github/workflows/build-deploy-ferceqr.yml
@@ -106,4 +106,4 @@ jobs:
 
       # Start the batch job
       - name: Kick off batch job
-        run: gcloud batch jobs submit run-ferceqr-etl-${{ env.BATCH_JOB_ID }} --config ${{ env.BATCH_JOB_JSON }} --location us-west1
+        run: gcloud batch jobs submit run-ferceqr-etl-${{ env.BATCH_JOB_ID }} --config ${{ env.BATCH_JOB_JSON }} --location us-east1


### PR DESCRIPTION
# Overview

- Our big `gs://archives.catalyst.coop` bucket where the FERC EQR (and SEC 10-K) data is stored is a single-region US bucket, in `us-east1`.
- There's a cost for moving data between regions.
- This PR switches the EQR build VM spec from using region `us-west1` to `us-east1` to avoid that cost.

Closes #4816