### PR TITLE
Add data set partition to `ferccid` metadata

### DIFF
--- a/src/pudl/metadata/sources.py
+++ b/src/pudl/metadata/sources.py
@@ -695,7 +695,8 @@ SOURCES: dict[str, Any] = {
             "various required forms. Each regulatory program requires a unique CID number. These "
             "CID numbers show up in various FERC filings, such as Forms 1, 2, 6, 60, 714, and EQR."
         ),
-        "working_partitions": {},
+        # we only want the data table, not the data dictionary table
+        "working_partitions": {"data_set": "data_table"},
         "keywords": sorted(
             set(
                 ["ferc", "cid", "company identifier"]


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

This adds a `data_set` partition to the `ferccid` metadata. As explained in [this archiver PR](https://github.com/catalyst-cooperative/pudl-archiver/pull/1007), this is necessary for differentiating between the data table and data dictionary CSVs when downloading via the data store.

## What problem does this address?

During the extraction process of the FERC CID table, I got to the point where the data store needed partitions in order to know which of the files (data table vs data dictionary) to download.

## What did you change?

This PR adds partitions to the metadata which help in differentiating between the data table and data dictionary CSVs. I was following the partition naming convention used in the EIA API metadata and archive.

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run pre-commit-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
