### PR TITLE
Increase file size limit to 800k to accommodate pixi lock file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files # Don't accidentally commit giant files.
+        args: ["--maxkb=800"]
       - id: check-merge-conflict # Watch for lingering merge markers.
       - id: check-yaml # Validate all YAML files.
       - id: check-toml


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

Our pixi lock file is ~650 kilobytes, which exceeds the default 500kb limit of `check-added-large-files`. This prevents updated pixi lock files from being committed to the repo.

## What did you change?

Added an argument to our use of `check-added-large-files` to permit files up to 800 kilobytes.

## To-do list

- [x] Run `pixi run pre-commit-run` to run linters and static code analysis checks.