### PR TITLE
chore: bump eel hole memory

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -221,6 +221,10 @@ resource "google_storage_bucket" "pudl_archive_bucket" {
   labels = {
     component = "archives"
   }
+  autoclass {
+    enabled                = true
+    terminal_storage_class = "ARCHIVE"
+  }
 }
 
 resource "google_service_account" "nrel_finito_inputs_gha" {

--- a/terraform/pudl-viewer.tf
+++ b/terraform/pudl-viewer.tf
@@ -139,7 +139,7 @@ resource "google_cloud_run_v2_service" "pudl_viewer" {
       resources {
         limits = {
           cpu    = "1000m"
-          memory = "768Mi"
+          memory = "1Gi"
         }
         cpu_idle = true
       }


### PR DESCRIPTION
Also keep the autoclass setup for pudl_archive that presumably was manually twiddled as part of #4816 .
# Overview

Closes #XXXX.

## What problem does this address?

PUDL viewer memory usage is [kind of high](https://console.cloud.google.com/monitoring/metrics-explorer;duration=P1D?pageState=%7B%22xyChart%22:%7B%22constantLines%22:%5B%5D,%22dataSets%22:%5B%7B%22legendTemplate%22:%2299%25%22,%22plotType%22:%22LINE%22,%22pointConnectionMethod%22:%22GAP_DETECTION%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22alignmentPeriod%22:%2260s%22,%22crossSeriesReducer%22:%22REDUCE_PERCENTILE_99%22,%22groupByFields%22:%5B%22resource.label.%5C%22service_name%5C%22%22%5D,%22perSeriesAligner%22:%22ALIGN_SUM%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_PERCENTILE_99%22,%22filter%22:%22metric.type%3D%5C%22run.googleapis.com%2Fcontainer%2Fmemory%2Futilizations%5C%22%20resource.type%3D%5C%22cloud_run_revision%5C%22%20resource.label.%5C%22location%5C%22%3D%5C%22us-east1%5C%22%20resource.label.%5C%22project_id%5C%22%3D%5C%22catalyst-cooperative-pudl%5C%22%20resource.label.%5C%22service_name%5C%22%3D%5C%22pudl-viewer%5C%22%22,%22groupByFields%22:%5B%22resource.label.%5C%22service_name%5C%22%22%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_SUM%22%7D%7D,%7B%22legendTemplate%22:%2295%25%22,%22plotType%22:%22LINE%22,%22pointConnectionMethod%22:%22GAP_DETECTION%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22alignmentPeriod%22:%2260s%22,%22crossSeriesReducer%22:%22REDUCE_PERCENTILE_95%22,%22groupByFields%22:%5B%22resource.label.%5C%22service_name%5C%22%22%5D,%22perSeriesAligner%22:%22ALIGN_SUM%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_PERCENTILE_95%22,%22filter%22:%22metric.type%3D%5C%22run.googleapis.com%2Fcontainer%2Fmemory%2Futilizations%5C%22%20resource.type%3D%5C%22cloud_run_revision%5C%22%20resource.label.%5C%22location%5C%22%3D%5C%22us-east1%5C%22%20resource.label.%5C%22project_id%5C%22%3D%5C%22catalyst-cooperative-pudl%5C%22%20resource.label.%5C%22service_name%5C%22%3D%5C%22pudl-viewer%5C%22%22,%22groupByFields%22:%5B%22resource.label.%5C%22service_name%5C%22%22%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_SUM%22%7D%7D,%7B%22legendTemplate%22:%2250%25%22,%22plotType%22:%22LINE%22,%22pointConnectionMethod%22:%22GAP_DETECTION%22,%22targetAxis%22:%22Y1%22,%22timeSeriesFilter%22:%7B%22aggregations%22:%5B%7B%22alignmentPeriod%22:%2260s%22,%22crossSeriesReducer%22:%22REDUCE_PERCENTILE_50%22,%22groupByFields%22:%5B%22resource.label.%5C%22service_name%5C%22%22%5D,%22perSeriesAligner%22:%22ALIGN_SUM%22%7D%5D,%22apiSource%22:%22DEFAULT_CLOUD%22,%22crossSeriesReducer%22:%22REDUCE_PERCENTILE_50%22,%22filter%22:%22metric.type%3D%5C%22run.googleapis.com%2Fcontainer%2Fmemory%2Futilizations%5C%22%20resource.type%3D%5C%22cloud_run_revision%5C%22%20resource.label.%5C%22location%5C%22%3D%5C%22us-east1%5C%22%20resource.label.%5C%22project_id%5C%22%3D%5C%22catalyst-cooperative-pudl%5C%22%20resource.label.%5C%22service_name%5C%22%3D%5C%22pudl-viewer%5C%22%22,%22groupByFields%22:%5B%22resource.label.%5C%22service_name%5C%22%22%5D,%22minAlignmentPeriod%22:%2260s%22,%22perSeriesAligner%22:%22ALIGN_SUM%22%7D%7D%5D,%22options%22:%7B%22mode%22:%22COLOR%22%7D,%22y1Axis%22:%7B%22label%22:%22%22,%22scale%22:%22LINEAR%22%7D%7D%7D&project=catalyst-cooperative-pudl) and I saw an OOM restart recently.

<img width="1675" height="516" alt="image" src="https://github.com/user-attachments/assets/05e0d85d-53ff-48fd-91f8-35ba9a88bae5" />

So let's bump it fro 768Mi to 1Gi.

Tried to apply in terraform, but since we goofed up the parquet filepaths (fix in #4992 ) the service won't start. If both PRs get merged before nightly builds, we'll have a bit more RAM once the nightly build re-deploys a fresh revision of the service.