### PR TITLE
feat: add stub deploy-pudl workflow

### DIFF
--- a/.github/workflows/deploy-pudl.yml
+++ b/.github/workflows/deploy-pudl.yml
@@ -3,7 +3,6 @@ name: deploy-pudl
 on:
   workflow_dispatch:
 
-
 jobs:
   deploy_pudl:
     name: Deploy PUDL build


### PR DESCRIPTION
# Overview

A small piece of #5003 .

## What problem does this address?

To split out the deployment we need a separate workflow that we can test. GHA needs *some* stub in `main` so that the branch versions will show up in the workflow dispatch UI.

## What did you change?

Add stub workflow.