### PR TITLE
Fix default label for existing data updates issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/existing_data_updates.md
+++ b/.github/ISSUE_TEMPLATE/existing_data_updates.md
@@ -2,7 +2,7 @@
 name: Integrate New Year of Data
 about: Check-list for integrating a new year of data
 title: ""
-labels: new-data
+labels: data-update
 assignees: ""
 ---
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

The "Existing data updates" issue template includes a default label for `new-data`, but that's the label designated for adding an entirely new dataset. The correct label for extending the time period available for existing datasets during monthly/quarterly/annual data updates is `data-update`:

<img width="818" height="275" alt="image" src="https://github.com/user-attachments/assets/cd526126-d67e-4d94-bdfd-ca05da4b07c4" />

## Documentation

Make sure to update relevant aspects of the documentation:
- [x] Review and update any other aspects of the documentation that might be affected by this PR.
