### PR TITLE
Add 2026 ecosystem survey banner to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,6 +153,7 @@ html_theme_options = {
         "color-announcement-background": "yellow",
         "color-announcement-text": "red",
     },
+    "announcement": '<b>Take our ~10 minute <a href="https://forms.gle/E9ou5fgMcR7YVRCRA">2026 Energy Data Ecosystem Survey!</b>',
 }
 
 # Add any paths that contain custom static files (such as style sheets) here,

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -125,12 +125,12 @@ Documentation
   :doc:`data_dictionaries/pudl_db`. See issues :issue:`4869,4951` and PR :pr:`4958`.
   Affected tables include:
 
-    * :ref:`core_epacems__hourly_emissions`
-    * :ref:`core_ferceqr__contracts`
-    * :ref:`core_ferceqr__quarterly_identity`
-    * :ref:`core_ferceqr__quarterly_index_pub`
-    * :ref:`core_ferceqr__transactions`
-    * :ref:`out_vcerare__hourly_available_capacity_factor`
+  * :ref:`core_epacems__hourly_emissions`
+  * :ref:`core_ferceqr__contracts`
+  * :ref:`core_ferceqr__quarterly_identity`
+  * :ref:`core_ferceqr__quarterly_index_pub`
+  * :ref:`core_ferceqr__transactions`
+  * :ref:`out_vcerare__hourly_available_capacity_factor`
 
 Bug Fixes & Data Cleaning
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
# Overview

- Adds a banner pointing users to our [2026 Energy Data Ecosystem Survey](https://forms.gle/E9ou5fgMcR7YVRCRA) from our documentation.
- Also fix some formatting in the release notes (over-indented bullet points).

# Testing

- Ran `pixi run docs-build` and inspected the output locally.