### PR TITLE
Remove premature polars dtype change

### DIFF
--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -652,8 +652,6 @@ class Field(PudlMeta):
 
     def to_polars_dtype(self) -> pl.DataType:
         """Return polars data type."""
-        if self.constraints.enum:
-            return pl.Enum(self.constraints.enum)
         return FIELD_DTYPES_POLARS[self.type]
 
     def to_pandas_dtype(self, compact: bool = False) -> str | pd.CategoricalDtype:


### PR DESCRIPTION
# Overview

This PR fixes the build failure from [2026-03-02-0619-6a5902855-main](https://console.cloud.google.com/batch/jobsDetail/regions/us-west1/jobs/run-etl-2026-03-02-0619-6a5902855/logs?project=catalyst-cooperative-pudl). This was caused by PR #5027, which included a change to how `polars` dtypes are handled. This change was meant for a followup PR to make our `pandera` schema checks use a `polars` backend, and it breaks without other changes in conjunction.

## What did you change?
Revert change to how `polars` dtypes are handled.