### PR TITLE
Add direct table preview links to PUDL data dictionary

### DIFF
--- a/docs/templates/access_examples/core_epacems__hourly_emissions.rst.jinja
+++ b/docs/templates/access_examples/core_epacems__hourly_emissions.rst.jinja
@@ -1,4 +1,4 @@
-* `Browse and query this table online <https://data.catalyst.coop/search?&q=name:{{ resource.name }}>`__
+* `Browse and query this table online <https://data.catalyst.coop/preview/pudl/{{ resource.name }}>`__
 * `Download this table as a Parquet file <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/{{ resource.name }}.parquet>`__
 
 

--- a/docs/templates/access_examples/core_ferceqr__contracts.rst.jinja
+++ b/docs/templates/access_examples/core_ferceqr__contracts.rst.jinja
@@ -1,3 +1,4 @@
+* `Browse and query this table online <https://data.catalyst.coop/preview/pudl/{{ resource.name }}>`__
 
 .. note::
 

--- a/docs/templates/access_examples/core_ferceqr__quarterly_identity.rst.jinja
+++ b/docs/templates/access_examples/core_ferceqr__quarterly_identity.rst.jinja
@@ -1,3 +1,4 @@
+* `Browse and query this table online <https://data.catalyst.coop/preview/pudl/{{ resource.name }}>`__
 
 .. note::
 

--- a/docs/templates/access_examples/core_ferceqr__quarterly_index_pub.rst.jinja
+++ b/docs/templates/access_examples/core_ferceqr__quarterly_index_pub.rst.jinja
@@ -1,3 +1,4 @@
+* `Browse and query this table online <https://data.catalyst.coop/preview/pudl/{{ resource.name }}>`__
 
 .. note::
 

--- a/docs/templates/access_examples/core_ferceqr__transactions.rst.jinja
+++ b/docs/templates/access_examples/core_ferceqr__transactions.rst.jinja
@@ -1,3 +1,4 @@
+* `Browse and query this table online <https://data.catalyst.coop/preview/pudl/{{ resource.name }}>`__
 
 .. note::
 

--- a/docs/templates/access_examples/default.rst.jinja
+++ b/docs/templates/access_examples/default.rst.jinja
@@ -1,4 +1,4 @@
-* `Browse and query this table online <https://data.catalyst.coop/search?&q=name:{{ resource.name }}>`__
+* `Browse and query this table online <https://data.catalyst.coop/preview/pudl/{{ resource.name }}>`__
 * `Download this table as a Parquet file <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/{{ resource.name }}.parquet>`__
 
 .. tabs::

--- a/docs/templates/access_examples/out_vcerare__hourly_available_capacity_factor.rst.jinja
+++ b/docs/templates/access_examples/out_vcerare__hourly_available_capacity_factor.rst.jinja
@@ -1,4 +1,4 @@
-* `Browse and query this table online <https://data.catalyst.coop/search?&q=name:{{ resource.name }}>`__
+* `Browse and query this table online <https://data.catalyst.coop/preview/pudl/{{ resource.name }}>`__
 * `Download this table as a Parquet file <https://s3.us-west-2.amazonaws.com/pudl.catalyst.coop/nightly/{{ resource.name }}.parquet>`__
 
 .. warning::

--- a/docs/templates/data_source_parent.rst.jinja
+++ b/docs/templates/data_source_parent.rst.jinja
@@ -42,7 +42,7 @@ the names and descriptions of each of its fields.
    {%- for resource in source_resources %}
    * - :ref:`{{ resource.sphinx_ref_name }}`
    {%- block browse_online scoped %}
-     - https://data.catalyst.coop/search?q=name:{{ resource.name }}
+     - https://data.catalyst.coop/preview/pudl/{{ resource.name }}
    {% endblock %}
    {%- endfor %}
 
@@ -63,7 +63,7 @@ existing tables.
    {%- for resource in extra_resources %}
    * - :ref:`{{ resource.sphinx_ref_name }}`
    {%- block browse_extra_online scoped %}
-     - https://data.catalyst.coop/search?q=name:{{ resource.name }}
+     - https://data.catalyst.coop/preview/pudl/{{ resource.name }}
    {% endblock %}
    {%- endfor %}
 {%- endif %}


### PR DESCRIPTION
# Overview

- Adds direct links to the `/preview/pudl/table_name` endpoint on the PUDL Data Viewer from PUDL Data Dictionary and data source documentation pages.
- Add links to the PUDL Data Viewer for the FERC EQR tables (table level, not partitions).

# Testing

- Rebuilt the documentation locally and tested links in the data dictionary and data source pages.

## To-do list

- [x] Review the PR yourself and call out any questions or issues you have.
