### PR TITLE
fix: trigger eel-hole deploy via GH workflow

### DIFF
--- a/docker/gcp_pudl_etl.sh
+++ b/docker/gcp_pudl_etl.sh
@@ -139,13 +139,7 @@ function deploy_data_viewer() {
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${PUDL_BOT_PAT}" \
             https://api.github.com/repos/catalyst-cooperative/eel-hole/actions/workflows/build-deploy.yml/dispatches \
-            -d @<(
-                cat <<JSON
-{
-  "ref": "main"
-}
-JSON
-            ) &&
+            -g -d '{"ref":"main"}' &&
         set -x
 }
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Eel-hole was deploying a stale image because we don't build the image in the deploy.

This was fine until we changed it so that eel-hole builds the index at *build* time not at *run* time. Then we started getting stale index which means we don't get to see all the cool new data!

## What did you change?

* add a `deploy_data_viewer` function that's like the Zenodo deploy function - kicks off the eel-hole `build-deploy` workflow
  * this makes it so that `DEPLOY_EEL_HOLE_SUCCESS`  doesn't actually reflect... whether... the deploy succeeded... so see catalyst-cooperative/eel-hole#131 for getting notified about actual deploy success
* remove the old data viewer service restart command
* add `--fail-with-body` to our curl calls - LLM told me about this flag. It fails the command if we get a 4xx or 5xx back, which would be kind of nice to know about.

## Documentation

Make sure to update relevant aspects of the documentation:

- [x] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked?

We gotta wait for nightly build - even if we trigger a branch build it won't try to deploy eel-hole. Would be nice if we had the distribution logic separated out already (#5016) but we still would have to merge to `main` to test this out in that case. Fortunately the failure case isn't that bad.

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run pre-commit-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
