### PR TITLE
Fix PR creation to not overwrite branch

### DIFF
--- a/.github/workflows/update-dois.yml
+++ b/.github/workflows/update-dois.yml
@@ -45,24 +45,6 @@ jobs:
             echo "Changes detected!"
           fi
 
-      - name: Create branch and commit
-        if: steps.update.outputs.changes == 'true'
-        run: |
-          git config user.name "zenodo-bot"
-          git config user.email "bot@github.com"
-          git checkout -b update-zenodo-dois-${{ github.run_number }}-${{ github.run_id }}
-          git add src/pudl/package_data/settings/zenodo_dois.yml
-          git commit -m "chore(zenodo): update DOIs to latest record versions
-
-          Automated update via GitHub Actions.
-
-          Run by: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-      - name: Push changes
-        if: steps.update.outputs.changes == 'true'
-        run: |
-          git push --set-upstream origin update-zenodo-dois-${{ github.run_number }}-${{ github.run_id }}
-
       - name: Format datasets as labels
         id: format-datasets
         run: |
@@ -75,8 +57,9 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore(zenodo): update DOIs to latest versions"
-          title: "chore(zenodo): update DOIs to latest record versions"
+          commit-message: "[chore] update Zenodo DOIs to latest versions"
+          title: "[chore] update Zenodo DOIs to latest record versions"
+          add-paths: src/pudl/package_data/settings/zenodo_dois.yml
           body: |
             Automated update of Zenodo DOIs to latest record versions.
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Fixes problem introduced in #5051 

## What problem does this address?
The script in #5051 updated the files correctly, created a branch, committed changes, overwrote that branch and then pushed the non-changes. Effectively, it did nothing!

## What did you change?
Switch to just using the `create-pull-request` action, with the `add-path` parameter to make sure we're only adding the one file we expect to change.

# Testing

How did you make sure this worked? How can a reviewer verify this?
See https://github.com/catalyst-cooperative/pudl/actions/runs/23259681945 and https://github.com/catalyst-cooperative/pudl/pull/5109.

Also see https://github.com/catalyst-cooperative/pudl/actions/runs/23259922556 and https://github.com/catalyst-cooperative/pudl/pull/5111
## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run pre-commit-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [x] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
