### PR TITLE
feat: add secrets for Auth0 user management API to pudl_viewer

### DIFF
--- a/terraform/pudl-viewer.tf
+++ b/terraform/pudl-viewer.tf
@@ -1,13 +1,15 @@
 // secrets
 locals {
   pudl_viewer_secret_versions = {
-    pudl_viewer_secret_key          = 1
-    pudl_viewer_db_username         = 1
-    pudl_viewer_db_password         = 1
-    pudl_viewer_db_name             = 1
-    pudl_viewer_auth0_domain        = 1
-    pudl_viewer_auth0_client_id     = 1
-    pudl_viewer_auth0_client_secret = 1
+    pudl_viewer_secret_key                   = 1
+    pudl_viewer_db_username                  = 1
+    pudl_viewer_db_password                  = 1
+    pudl_viewer_db_name                      = 1
+    pudl_viewer_auth0_domain                 = 1
+    pudl_viewer_auth0_client_id              = 1
+    pudl_viewer_auth0_client_secret          = 1
+    pudl_viewer_auth0_user_api_client_id     = 1
+    pudl_viewer_auth0_user_api_client_secret = 1
   }
 }
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Affects catalyst-cooperative/eel-hole#130.

We need these secrets to be wired into the `pudl-viewer` service before we merge https://github.com/catalyst-cooperative/eel-hole/pull/137.

I've already hit `terraform apply` since this was a small change, but we should merge this in for consistency.

Notes on how this works:

The terraform definition tries to use every secret in the map as an env var, so all we have to do is add new secret version references to the map.

Applying changes will create the secrets, but not any secret *versions* (because those have to be entered manually) - so then updating the service fails. But then we can add the versions manually and re-run `terraform apply`, and the services will update properly. No interruption in service because GCP only cuts traffic over to the new revision of the service if it passes healthchecks.

## Documentation


# Testing

How did you make sure this worked? How can a reviewer verify this?

You can look for the secrets in [Secret Manager](https://console.cloud.google.com/security/secret-manager?referrer=search&project=catalyst-cooperative-pudl) and you can see they're wired in via [Cloud Run service details page](https://console.cloud.google.com/run/detail/us-east1/pudl-viewer/revisions?project=catalyst-cooperative-pudl).

## To-do list

- [ ] Review the PR yourself and call out any questions or issues you have.