### PR TITLE
test: make unit tests not environment-aware

### DIFF
--- a/src/pudl/scripts/dbt_helper.py
+++ b/src/pudl/scripts/dbt_helper.py
@@ -336,8 +336,9 @@ def get_data_source(table_name: str) -> str:
 UpdateResult = namedtuple("UpdateResult", ["success", "message"])
 
 
-def _get_local_table_path(table_name):
-    return str(PudlPaths().parquet_path(table_name))
+def _get_local_table_path(table_name: str) -> Path:
+    """Return the local parquet file path for a PUDL table."""
+    return PudlPaths().parquet_path(table_name)
 
 
 def _get_model_path(table_name: str, data_source: str) -> Path:
@@ -357,10 +358,9 @@ def _get_existing_row_counts() -> pd.DataFrame:
 
 def _calculate_row_counts(
     table_name: str,
+    table_path: Path,
     partition_expr: str | None = None,
 ) -> pd.DataFrame:
-    table_path = _get_local_table_path(table_name)
-
     if partition_expr is None:
         partition_expr_sql = "''"
         group_by_clause = ""
@@ -403,8 +403,19 @@ def update_row_counts(
     table_name: str,
     data_source: str,
     clobber: bool = False,
+    local_table_path: Path | None = None,
 ) -> UpdateResult:
-    """Generate updated row counts per partition and write to csv file within dbt project."""
+    """Update dbt row counts for a table using data from a local parquet file.
+
+    Args:
+        table_name: Name of the PUDL table whose row counts should be refreshed.
+        data_source: dbt source directory containing the table's schema.
+        clobber: Whether existing row counts may be overwritten or removed.
+        local_table_path: Explicit parquet path for the table. Callers normally
+            omit this and let the helper resolve the standard PUDL output path.
+            Tests may supply it directly to avoid depending on ambient path
+            configuration.
+    """
     model_path = _get_model_path(table_name, data_source)
     schema_path = model_path / "schema.yml"
     schema = DbtSchema.from_yaml(schema_path)
@@ -457,7 +468,8 @@ def update_row_counts(
         )
 
     partition_expr = partition_expressions[0]  # TODO: support multiple partitions
-    new = _calculate_row_counts(table_name, partition_expr)
+    table_path = local_table_path or _get_local_table_path(table_name)
+    new = _calculate_row_counts(table_name, table_path, partition_expr)
 
     # Make old and new row counts comparable so we can detect changes
     row_count_idx = ["table_name", "partition"]

--- a/test/integration/io_managers_test.py
+++ b/test/integration/io_managers_test.py
@@ -1,0 +1,28 @@
+"""Integration tests for IO manager behaviors that depend on migrations."""
+
+from pathlib import Path
+
+import alembic.config
+
+from pudl.io_managers import PudlSQLiteIOManager
+from pudl.metadata.classes import PUDL_PACKAGE
+
+
+def test_migrations_match_metadata(tmp_path, monkeypatch) -> None:
+    """If you create a `PudlSQLiteIOManager` that points at a non-existing
+    `pudl.sqlite` - it will initialize the DB based on the `package`.
+
+    If you create a `PudlSQLiteIOManager` that points at an existing
+    `pudl.sqlite`, like one initialized via `alembic upgrade head`, it
+    will compare the existing db schema with the db schema in `package`.
+
+    We want to make sure that the schema defined in `package` is the same as
+    the one we arrive at by applying all the migrations.
+    """
+    monkeypatch.chdir(Path(__file__).parent.parent.parent)
+    monkeypatch.setenv("PUDL_OUTPUT", str(tmp_path))
+    alembic.config.main(["upgrade", "head"])
+
+    PudlSQLiteIOManager(base_dir=tmp_path, db_name="pudl", package=PUDL_PACKAGE)
+
+    assert True

--- a/test/integration/settings_test.py
+++ b/test/integration/settings_test.py
@@ -1,0 +1,23 @@
+"""Integration tests for settings that require real datastore configuration."""
+
+from pudl.workspace.datastore import Datastore
+from pudl.workspace.setup import PudlPaths
+
+
+def test_partitions_for_datasource_table(pudl_etl_settings) -> None:
+    """Test that a Datastore with *real local cache dir* generates a non-empty
+    datasources table.
+
+    NOTE (2026-04-03): Probably worth beefing up the assertions to confirm more
+    of the metadata fallback behavior (i.e., look in local cache, *and* Zenodo,
+    etc.). And probably worth testing out with populated & unpopulated local
+    cache.
+    """
+    ds = Datastore(local_cache_path=PudlPaths().data_dir)
+    datasource = pudl_etl_settings.make_datasources_table(ds)
+    datasets = pudl_etl_settings.get_datasets().keys()
+    if datasource.empty and datasets:
+        raise AssertionError(
+            "Datasource table is empty with the following datasets in the settings: "
+            f"{datasets}"
+        )

--- a/test/unit/conftest.py
+++ b/test/unit/conftest.py
@@ -1,53 +1,47 @@
-import logging
-from pathlib import Path
-
-import pydantic
 import pytest
 
 from pudl.workspace.setup import PudlPaths
 
-logger = logging.getLogger(__name__)
-
 
 @pytest.fixture(scope="session", autouse=True)
-def configure_paths_for_tests(tmp_path_factory, request):
-    """Configures PudlPaths for tests.
+def configure_paths_for_tests():
+    """Disable the root session path bootstrap for the unit-test subtree.
 
-    Default behavior:
+    ``test/conftest.py`` installs a session-scoped autouse fixture with this
+    name that configures ``PudlPaths`` for the full test suite.
 
-    PUDL_INPUT is read from the environment.
-    PUDL_OUTPUT is set to a tmp path, to avoid clobbering existing databases.
+    This means that if you make a session-scoped fixture, it *could* depend on
+    the env setup from the root ``configure_paths_for_tests``.
 
-    Set ``--tmp-data`` to force PUDL_INPUT to a temporary directory, causing
-    re-downloads of all raw inputs.
+    Shadowing that fixture here lets us catch that while running unit tests, so
+    we don't accidentally introduce environment-aware tests to our unit test suite.
 
-    Ignores the ``--live-dbs`` flag; always forces PUDL_OUTPUT to a temp dir so
-    unit test can never mess with the outputs.
-
-    See pudl/test/conftest.py for the non-unit test counterpart.
+    NOTE (2026-04-03): In *mixed* runs, i.e. integration + unit in one process,
+    the root fixture will still run and its side effects will still occur. This
+    means that the env *will* be tweaked! But in theory the unit-only runs that
+    happen every time you commit will catch any tests that are sneakily relying on
+    the environment.
     """
-    pudl_tmpdir = tmp_path_factory.mktemp("pudl")
+    yield
 
-    # We only use a temporary input directory when explicitly requested.
-    # This will force a re-download of raw inputs from Zenodo or the S3 cache.
-    if request.config.getoption("--tmp-data"):
-        in_tmp = pudl_tmpdir / "input"
-        in_tmp.mkdir()
-        PudlPaths.set_path_overrides(
-            input_dir=str(Path(in_tmp).resolve()),
-        )
-        logger.info(f"Using temporary PUDL_INPUT: {in_tmp}")
 
-    out_tmp = pudl_tmpdir / "output"
-    out_tmp.mkdir()
-    PudlPaths.set_path_overrides(
-        output_dir=str(Path(out_tmp).resolve()),
-    )
-    logger.info(f"Using temporary PUDL_OUTPUT: {out_tmp}")
+@pytest.fixture(autouse=True)
+def disable_ambient_pudlpaths_config(monkeypatch):
+    """Make unit tests fail if they rely on ambient PUDL path configuration.
 
-    try:
-        return PudlPaths()
-    except pydantic.ValidationError as err:
-        pytest.exit(
-            f"Set PUDL_INPUT, PUDL_OUTPUT env variables, or use --tmp-path, --live-dbs flags. Error: {err}."
-        )
+    Unit tests should not pick up `PUDL_INPUT` / `PUDL_OUTPUT` from process
+    environment variables or a local `.env` file. Tests that need explicit path
+    configuration should inject it directly or set environment variables locally
+    within the test.
+    """
+    monkeypatch.delenv("PUDL_INPUT", raising=False)
+    monkeypatch.delenv("PUDL_OUTPUT", raising=False)
+
+    original_init = PudlPaths.__init__
+
+    def patched_init(self, *args, **kwargs):
+        """Disable `.env` loading unless a test opts back into it explicitly."""
+        kwargs.setdefault("_env_file", None)
+        original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(PudlPaths, "__init__", patched_init)

--- a/test/unit/dbt_helper_test.py
+++ b/test/unit/dbt_helper_test.py
@@ -2,6 +2,7 @@ import unittest
 from collections import namedtuple
 from dataclasses import dataclass
 from io import StringIO
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -26,7 +27,6 @@ from pudl.scripts.dbt_helper import (
     update_table_schema,
     update_tables,
 )
-from pudl.workspace.setup import PudlPaths
 
 GivenExpect = namedtuple("GivenExpect", ["given", "expect"])
 
@@ -310,6 +310,7 @@ def test_update_row_counts(case, schema_factory, mocker):
         table_name=given["table_name"],
         data_source="pudl",
         clobber=given["clobber"],
+        local_table_path=Path("unused.parquet"),
     )
 
     # Assert the expected result object
@@ -1414,7 +1415,7 @@ def test_update_table_row_counts_clobber(
     tmp_path,
     mocker,
 ):
-    # make test data
+    # Build a minimal schema.yml with a row-count test for the table under test.
     test_schema = f"""
 sources:
   - name: pudl_test
@@ -1430,29 +1431,33 @@ sources:
           - name: state
           - name: fake_data
 """
-    # set up test paths (patch dbt_dir to a tmp path, add schema and rowcounts directories)
-    # don't need to make temporary PUDL_OUT because we do that already in conftest.py
+    # Create a temporary dbt project and a parquet file for the CLI to read.
     dbt_dir = tmp_path / "dbt"
     schema_path = (
         dbt_dir / "models" / "source" / "test_source__table_name" / "schema.yml"
     )
     row_count_csv_path = dbt_dir / "seeds" / "etl_full_row_counts.csv"
-    parquet_path = PudlPaths().parquet_path("test_source__table_name")
+    parquet_path = (
+        tmp_path / "pudl-output" / "parquet" / "test_source__table_name.parquet"
+    )
 
     schema_path.parent.mkdir(parents=True, exist_ok=True)
     row_count_csv_path.parent.mkdir(parents=True, exist_ok=True)
     parquet_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # write out test data to disk
+    # Seed the temporary dbt project with the schema, row counts, and parquet data.
     test_data.to_parquet(parquet_path)
     old_row_counts.to_csv(row_count_csv_path, index=False)
     with schema_path.open("w") as f:
         f.write(test_schema)
 
-    # patch out DBT_DIR so we use our lovely test schema + rowcounts
+    # Point the CLI at the temporary dbt project and allow the test table through
+    # input validation.
     mocker.patch("pudl.scripts.dbt_helper.DBT_DIR", new=dbt_dir)
-    # patch out ALL_TABLES so that we're allowed to run tests
     mocker.patch("pudl.scripts.dbt_helper.ALL_TABLES", new=["test_source__table_name"])
+    mock_paths = mocker.Mock()
+    mock_paths.parquet_path.return_value = parquet_path
+    mocker.patch("pudl.scripts.dbt_helper.PudlPaths", return_value=mock_paths)
     runner = CliRunner()
 
     logger_mock = mocker.patch("pudl.scripts.dbt_helper.logger.info")

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -17,7 +17,6 @@ from pudl.settings import (
     FercToSqliteSettings,
     XbrlFormNumber,
 )
-from pudl.workspace.setup import PudlPaths
 
 
 def test_ferc_xbrl_datastore_get_taxonomy(mocker):
@@ -88,12 +87,25 @@ def test_ferc_xbrl_datastore_get_filings(mocker):
     ],
 )
 def test_xbrl2sqlite(settings, forms, mocker, tmp_path):
+    """Mock out the actual work of convert_form, then run the XBRL ops and see
+    if convert_form was called in the right way.
+
+    We *DO* have to mock out PudlPaths, since underlying code accesses
+    PudlPaths. But we *DON'T* have to set env vars - this all executes in the
+    same process, so the mock persists through task execution boundary.
+    """
     convert_form_mock = mocker.MagicMock()
     mocker.patch("pudl.extract.xbrl.convert_form", new=convert_form_mock)
 
     # Mock datastore object to allow comparison
     mock_datastore = mocker.MagicMock()
     mocker.patch("pudl.extract.xbrl.FercXbrlDatastore", return_value=mock_datastore)
+
+    mock_paths = mocker.Mock()
+    mock_paths.output_dir = tmp_path
+    mock_paths.sqlite_db_path.side_effect = lambda name: tmp_path / f"{name}.sqlite"
+    mock_paths.duckdb_db_path.side_effect = lambda name: tmp_path / f"{name}.duckdb"
+    mocker.patch("pudl.extract.xbrl.PudlPaths", return_value=mock_paths)
 
     # Only select operations that are tagged with data_format=xbrl.
     op_selection = [
@@ -121,15 +133,15 @@ def test_xbrl2sqlite(settings, forms, mocker, tmp_path):
             settings.get_xbrl_dataset_settings(form),
             form,
             mock_datastore,
-            output_path=PudlPaths().output_dir,
-            sqlite_path=PudlPaths().output_dir / f"ferc{form.value}_xbrl.sqlite",
-            duckdb_path=PudlPaths().output_dir / f"ferc{form.value}_xbrl.duckdb",
+            output_path=tmp_path,
+            sqlite_path=tmp_path / f"ferc{form.value}_xbrl.sqlite",
+            duckdb_path=tmp_path / f"ferc{form.value}_xbrl.duckdb",
             batch_size=20,
             workers=10,
         )
 
 
-def test_convert_form(mocker):
+def test_convert_form(mocker, tmp_path):
     """Test convert_form method is properly calling extractor."""
     extractor_mock = mocker.MagicMock()
     mocker.patch("pudl.extract.xbrl.run_main", new=extractor_mock)
@@ -146,7 +158,7 @@ def test_convert_form(mocker):
         years=[2020, 2021],
     )
 
-    output_path = PudlPaths().pudl_output
+    output_path = tmp_path
 
     # Test convert_form for every form number
     for form in XbrlFormNumber:

--- a/test/unit/helpers_test.py
+++ b/test/unit/helpers_test.py
@@ -239,8 +239,15 @@ def test_monthly_attribute_merge():
         ({"year": 2022, "state": "ca"}, "2022_ca.parquet"),
     ],
 )
-def test_parquet_data_paths(partitions: dict[str, object], expected_filename: str):
+def test_parquet_data_paths(
+    partitions: dict[str, object], expected_filename: str, tmp_path, mocker
+):
     """ParquetData builds expected paths and ensures target directory exists."""
+    parquet_data_root = tmp_path / "parquet"
+    mock_paths = mocker.Mock()
+    mock_paths.parquet_path.return_value = parquet_data_root
+    mocker.patch("pudl.helpers.PudlPaths", return_value=mock_paths)
+
     parquet_data = ParquetData(table_name="core_eia__plants", partitions=partitions)
 
     # Accessing parquet_directory should create the table-specific directory.

--- a/test/unit/io_managers_test.py
+++ b/test/unit/io_managers_test.py
@@ -1,8 +1,5 @@
 """Test Dagster IO Managers."""
 
-from pathlib import Path
-
-import alembic.config
 import pandas as pd
 import pytest
 import sqlalchemy as sa
@@ -19,7 +16,6 @@ from pudl.io_managers import (
     PudlSQLiteIOManager,
     SQLiteIOManager,
 )
-from pudl.metadata import PUDL_PACKAGE
 from pudl.metadata.classes import Package, Resource
 
 
@@ -259,31 +255,6 @@ def test_pudl_sqlite_io_manager_delete_stmt(fake_pudl_sqlite_io_manager_fixture)
     input_context = build_input_context(asset_key=AssetKey(asset_key))
     returned_df = manager.load_input(input_context)
     assert len(returned_df) == 1
-
-
-@pytest.mark.slow
-def test_migrations_match_metadata(tmp_path, monkeypatch):
-    """If you create a `PudlSQLiteIOManager` that points at a non-existing
-    `pudl.sqlite` - it will initialize the DB based on the `package`.
-
-    If you create a `PudlSQLiteIOManager` that points at an existing
-    `pudl.sqlite`, like one initialized via `alembic upgrade head`, it
-    will compare the existing db schema with the db schema in `package`.
-
-    We want to make sure that the schema defined in `package` is the same as
-    the one we arrive at by applying all the migrations.
-    """
-    # alembic wants current directory to be the one with `alembic.ini` in it
-    monkeypatch.chdir(Path(__file__).parent.parent.parent)
-    # alembic knows to use PudlPaths().pudl_db - so we need to set PUDL_OUTPUT env var
-    monkeypatch.setenv("PUDL_OUTPUT", str(tmp_path))
-    # run all the migrations on a fresh DB at tmp_path/pudl.sqlite
-    alembic.config.main(["upgrade", "head"])
-
-    PudlSQLiteIOManager(base_dir=tmp_path, db_name="pudl", package=PUDL_PACKAGE)
-
-    # all we care about is that it didn't raise an error
-    assert True
 
 
 def test_error_when_handling_view_without_metadata(fake_pudl_sqlite_io_manager_fixture):

--- a/test/unit/settings_test.py
+++ b/test/unit/settings_test.py
@@ -29,8 +29,6 @@ from pudl.settings import (
     _convert_settings_to_dagster_config,
     create_dagster_config,
 )
-from pudl.workspace.datastore import Datastore
-from pudl.workspace.setup import PudlPaths
 
 
 class TestGenericDatasetSettings:
@@ -457,17 +455,4 @@ def test_partitions_with_json_normalize(pudl_etl_settings):
     if list(cems_parts.columns) != ["year_quarter"]:
         raise AssertionError(
             f"CEMS paritions should have year_quarter columns only, found:{cems_parts}"
-        )
-
-
-@pytest.mark.slow
-def test_partitions_for_datasource_table(pudl_etl_settings):
-    """Test whether or not we can make the datasource table."""
-    ds = Datastore(local_cache_path=PudlPaths().data_dir)
-    datasource = pudl_etl_settings.make_datasources_table(ds)
-    datasets = pudl_etl_settings.get_datasets().keys()
-    if datasource.empty and datasets != 0:
-        raise AssertionError(
-            "Datasource table is empty with the following datasets in the settings: "
-            f"{datasets}"
         )

--- a/test/unit/workspace/setup_test.py
+++ b/test/unit/workspace/setup_test.py
@@ -1,0 +1,14 @@
+"""Unit tests for workspace setup configuration."""
+
+import pytest
+from pydantic import ValidationError
+
+from pudl.workspace.setup import PudlPaths
+
+
+def test_pudlpaths_requires_env_vars_without_env_file() -> None:
+    """Make sure bare PudlPaths() fails by default in unit tests.
+
+    You can still opt in by passing in params."""
+    with pytest.raises(ValidationError):
+        PudlPaths()


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

Unit tests should not *know about* nor *care* what `PUDL_INPUT` and `PUDL_OUTPUT` happen to be set to.

The proximate cause of this is that there's a bunch of logic in #5071 to stop unit tests and integration tests from interfering with each other's environments. Instead the unit test should just not touch the environment ever.

## What did you change?

So I made [ an LLM ] blank that environment setup in `test/unit/conftest.py`.

Then fixed the tests that broke:
* some tests are actually integration tests - they *are* testing behavior with real config. So... we put them into integration tests.
  * `test_migrations_match_metadata`
  * `test_partitions_for_datasource_table`
* otherwise, dependency inject or mock.
  * dependency injection: `test_update_row_counts`
  * mocking: `test_update_table_row_counts_clobber`, `test_parquet_data_paths`

Added one test that makes sure PudlPaths is properly broken in unit test.

## Documentation

# Testing

Still need to run integration tests *and* unit tests in the same process, with `--live-dbs`, across nightly build output, to verify that things aren't broken.

## To-do list

- [ ] Review the PR yourself and call out any questions or issues you have.

