### PR TITLE
Pull sphinx-pydata version_match from build environment if available

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -36,14 +36,14 @@ jobs:
       - name: Make input, output and dagster dirs
         run: mkdir -p ${{ env.PUDL_OUTPUT }} ${{ env.PUDL_INPUT}} ${{ env.DAGSTER_HOME }}
 
+      - name: Compute version for switcher and destination directory
+        run: |
+          PUDL_VERSION_MATCH=${{ case(github.ref == 'refs/heads/main', 'latest', github.ref) }}
+          echo PUDL_VERSION_MATCH=${DEST_DIR#refs/heads/} > "$GITHUB_ENV"
+
       - name: Lint and build PUDL documentation with Sphinx
         run: |
           pixi run docs-build
-
-      - name: Compute destination dir
-        run: |
-          DEST_DIR=${{ case(github.ref == 'refs/heads/main', 'latest', github.ref) }}
-          echo DEST_DIR=${DEST_DIR#refs/heads/} > "$GITHUB_ENV"
 
       - name: Deploy to GitHub Pages at the appropriate version path
         uses: peaceiris/actions-gh-pages@v4
@@ -51,6 +51,6 @@ jobs:
           publish_branch: gh-pages
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/_build/html
-          destination_dir: en/${{ env.DEST_DIR }}
+          destination_dir: en/${{ env.PUDL_VERSION_MATCH }}
           user_name: "pudlbot"
           user_email: "pudl@catalyst.coop"

--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -54,3 +54,4 @@ jobs:
           destination_dir: en/${{ env.PUDL_VERSION_MATCH }}
           user_name: "pudlbot"
           user_email: "pudl@catalyst.coop"
+          exclude_assets: ".github,.doctrees,.buildinfo"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,7 @@ if os.environ.get("READTHEDOCS"):
 
 # The full version, including alpha/beta/rc tags
 release = importlib.metadata.version("catalystcoop.pudl")
+version_match = os.environ.get("PUDL_VERSION_MATCH", release)
 
 # -- Project information -----------------------------------------------------
 
@@ -221,7 +222,7 @@ html_theme_options = {
     ],
     "switcher": {
         "json_url": "https://docs.catalyst.coop/pudl/available_versions.json",
-        "version_match": "latest",
+        "version_match": version_match,
     },
     "navbar_start": ["navbar-logo", "version-switcher"],
     "secondary_sidebar_items": {


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Working on #5146.

## What problem does this address?

Currently, if you [browse the nightly version of the docs](https://docs.catalyst.coop/pudl/en/nightly/data.html), it says `latest` in the version picker. This is because `version_match` is hard-coded to "latest" for all builds. Instead, we want the version picker to reflect the version you're actually browsing.

## What did you change?

* grab the value for `version_match` out of an environment variable `PUDL_VERSION_MATCH` if available. If absent (like for typical local builds) it will use the value from `release`, which will not show up in the picker; the picker will appear as "Choose version".
* bonus fix: drop `.doctrees` directories when copying built docs over to github pages. Those files aren't needed for serving the HTML, and removing them reduces the size of each build by ~1/3.

## Documentation

Make sure to update relevant aspects of the documentation:

- [x] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Built locally, then ensured the version_match value was being set to the correct dev release value in the resulting HTML files. Like this:

```
$ pixi run docs-build
[...]
$ pixi run python -c 'import importlib.metadata; print(importlib.metadata.version("catalystcoop.pudl"))'
2026.3.1.dev48
$ find docs/_build/html -name "*.html" -exec grep -F "'2026.3.1.dev48'" {} + | head
docs/_build/html/release_notes.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
docs/_build/html/index.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
docs/_build/html/autoapi/pudl/__main__/index.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
docs/_build/html/autoapi/pudl/settings/index.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
docs/_build/html/autoapi/pudl/glue/index.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
docs/_build/html/autoapi/pudl/glue/ferc714/index.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
docs/_build/html/autoapi/pudl/glue/ferc1_eia/index.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
docs/_build/html/autoapi/pudl/validate/index.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
docs/_build/html/autoapi/pudl/dbt_wrapper/index.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
docs/_build/html/autoapi/pudl/index.html:        DOCUMENTATION_OPTIONS.theme_switcher_version_match = '2026.3.1.dev48';
```


## To-do list

- [x] Review the PR yourself and call out any questions or issues you have.
