### PR TITLE
Fix clobber bug in build-deploy-docs

### DIFF
--- a/.github/workflows/build-deploy-docs.yml
+++ b/.github/workflows/build-deploy-docs.yml
@@ -39,13 +39,14 @@ jobs:
       - name: Compute version for switcher and destination directory
         run: |
           PUDL_VERSION_MATCH=${{ case(github.ref == 'refs/heads/main', 'latest', github.ref) }}
-          echo PUDL_VERSION_MATCH=${DEST_DIR#refs/heads/} > "$GITHUB_ENV"
+          echo PUDL_VERSION_MATCH=${PUDL_VERSION_MATCH##*/} > "$GITHUB_ENV"
 
       - name: Lint and build PUDL documentation with Sphinx
         run: |
           pixi run docs-build
 
       - name: Deploy to GitHub Pages at the appropriate version path
+        if: ${{ env.PUDL_VERSION_MATCH != '' }}
         uses: peaceiris/actions-gh-pages@v4
         with:
           publish_branch: gh-pages


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

Whoops, #5178 had an error in it that clobbered the `en/` tree on the `gh-pages` branch. We have the git history, so nothing was truly lost, but we should try to not do that again!

## What did you change?

* Fix bad old variable expression that generated an empty string for version_match
* Add guard to gh-pages publish step, so that if we somehow do get an empty string for version_match through some other pathway, we won't make any changes to the `gh-pages` branch. it might generate a mystery ("why didn't the docs update?") but at least it'll be nondestructive.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```
Esker:pudl 16:26:38$ foo="refs/heads/nightly"; echo ${foo##*/}
nightly
Esker:pudl 16:28:12$ foo="refs/tags/v2026.7.3"; echo ${foo##*/}
v2026.7.3
Esker:pudl 16:36:02$ foo="latest"; echo ${foo##*/}
latest
```

## To-do list

- [ ] Review the PR yourself and call out any questions or issues you have.
