### PR TITLE
Remove half-baked pudl-dev skill for now.

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -16,10 +16,5 @@
       "sourceType": "github",
       "computedHash": "a7fafd4fc2d88199c107c89104c448b8b2fc5bb307c849f1866f057244873d8b"
     },
-    "pudl-dev": {
-      "source": "catalyst-cooperative/skills",
-      "sourceType": "github",
-      "computedHash": "4b670efbd1ab41cb10b1164429fddb34a8b5bcfab9a5c1f8c10016ce7d45059e"
-    }
   }
 }


### PR DESCRIPTION
# Overview

As we discussed in com-dev: this PR removes the `pudl-dev` from the `skills-lock.json` file in the repo. It's still pretty half-baked and I think is likely just adding noise to agent behavior in the repo. When #5071 merges in we'll have a fully fleshed out `AGENTS.md` which will be a good start to shaping agent behavior. When we finish with the pudl data skill, we can return to `pudl-dev`.