### PR TITLE
Fix GCS read permissions for usage metrics dashboard

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -175,7 +175,7 @@
         "filename": "terraform/pudl-usage-metrics-dashboard.tf",
         "hashed_secret": "10b642e314d4e2aaab3fd757c06a18971d02a746",
         "is_verified": false,
-        "line_number": 72,
+        "line_number": 83,
         "is_secret": false
       },
       {
@@ -183,7 +183,7 @@
         "filename": "terraform/pudl-usage-metrics-dashboard.tf",
         "hashed_secret": "37e891b7e8956f04d734c16d66eeec245078478c",
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 88,
         "is_secret": false
       }
     ],
@@ -216,5 +216,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-01T15:17:31Z"
+  "generated_at": "2026-04-16T17:20:41Z"
 }

--- a/terraform/pudl-usage-metrics-dashboard.tf
+++ b/terraform/pudl-usage-metrics-dashboard.tf
@@ -53,6 +53,17 @@ resource "google_service_account" "pudl_usage_metrics_dashboard_cloud_run" {
   display_name = "PUDL Usage Metrics Dashboard Service Account"
 }
 
+resource "google_storage_bucket_iam_member" "pudl_usage_metrics_dashboard_cloud_run" {
+  for_each = toset([
+    "roles/storage.legacyBucketReader",
+    "roles/storage.objectViewer",
+  ])
+
+  bucket = google_storage_bucket.pudl_usage_metrics_output_bucket.name
+  role   = each.key
+  member = google_service_account.pudl_usage_metrics_dashboard_cloud_run.member
+}
+
 resource "google_secret_manager_secret_iam_member" "pudl_usage_metrics_dashboard_secret_accessor" {
   for_each  = google_secret_manager_secret.pudl_usage_metrics_dashboard_secrets
   secret_id = each.value.secret_id


### PR DESCRIPTION
# Overview

## What problem does this address?

Usage metrics dashboard [couldn't read parquet files out of the nice new output bucket](https://console.cloud.google.com/logs/query;query=timestamp%3D%222026-04-15T13:49:14.762211Z%22%0AinsertId%3D%2269df975a000ba163170dcf0d%22;cursorTimestamp=2026-04-15T13:49:14.762211Z;duration=PT5M?project=catalyst-cooperative-pudl) :(

## What did you change?

* Give read permissions for the output bucket to the metrics dashboard service account
* Update secrets file since terraform line numbers changed

# Testing

How did you make sure this worked? How can a reviewer verify this?

* `terraform fmt -check`
* `terraform validate`
* `terraform plan` - shows a few changes to unrelated resources but I'm pretty sure they're all "running from terraform instead of gha"

## To-do list

- [ ] Review the PR yourself and call out any questions or issues you have.
