### PR TITLE
Fix unintended definition-list in Additional Details for fuel_receipts_costs tables

### DIFF
--- a/docs/dev/metadata.rst
+++ b/docs/dev/metadata.rst
@@ -140,6 +140,8 @@ To make sense of hundreds of resources, structured resource-level metadata is cr
 The following fields should be filled out for each new resource. You may wish to use
 :ref:`one of the preview methods <preview_methods>` to guide your edits.
 
+All the ``_text`` fields below take RST formatting -- use whitespace accordingly.
+
 * ``additional_summary_text``: A ~1 line brief description of the table's contents.
   Based on the table type, this should be a fragment that completes the
   corresponding phrase:
@@ -180,7 +182,11 @@ clarification:
   raw/core/_core/out/_out, etc. This will be appended to the stock text for this layer.
 * ``additional_primary_key_text``: Only set if this table has no natural primary key.
   In that case, this should be used to describe what each row contains and why a
-  primary key doesn't make sense for this table
+  primary key doesn't make sense for this table.
+
+For a full reference on available description fields, including fields that
+override automatic table classifications, see
+:class:`pudl.metadata.classes.PudlResourceDescriptor.PudlDescriptionComponents`.
 
 Because the description is not wholly legible in its structured state,
 we have developed a few tools to help editors see what they are doing.

--- a/src/pudl/metadata/resources/eia923.py
+++ b/src/pudl/metadata/resources/eia923.py
@@ -104,14 +104,14 @@ Additional data which we haven't yet integrated is available in a similar format
         ],
         "additional_details_text": (
             """This table is an aggregation of the more detailed data in the
-            :ref:`core_eia923__fuel_receipts_costs` table. It provides a tidy timeseries
-            of deliveries by fuel type for each plant. However, not all values in the
-            original table can be aggregated meaningfully, so this table contains only a
-            subset of the source table columns -- primarily numerical values and a
-            handful of categorical variables, plus additional attributes that are
-            constant within each plant-fuel-time period grouping and associated with the
-            plant or utility. When aggregating numerical values any sum that contains an
-            NA value is treated as NA."""
+:ref:`core_eia923__fuel_receipts_costs` table. It provides a tidy timeseries
+of deliveries by fuel type for each plant. However, not all values in the
+original table can be aggregated meaningfully, so this table contains only a
+subset of the source table columns -- primarily numerical values and a
+handful of categorical variables, plus additional attributes that are
+constant within each plant-fuel-time period grouping and associated with the
+plant or utility. When aggregating numerical values any sum that contains an
+NA value is treated as NA."""
         ),
     },
     "core_eia923__monthly_generation": {


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

Oops:

> <img width="1373" height="267" alt="image" src="https://github.com/user-attachments/assets/e8cc7d8f-1a4b-4639-aab6-955ff5669fbd" />

## What did you change?

Removed whitespace telling RST that a block is a definition list, when we don't want a definition list.

This feels too minor for a release note but I can add one if desired.

## Documentation

Make sure to update relevant aspects of the documentation:

- [x] Update relevant table or source description metadata (see `src/metadata`).
- [x] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Built and browsed locally.

## To-do list

- [x] Review the PR yourself and call out any questions or issues you have.
