### PR TITLE
Dagster housekeeping housekeeping

### DIFF
--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -346,7 +346,7 @@ def build_defs(
                     FercDbfSQLiteConfigurableIOManager(
                         etl_settings=etl_settings_override,
                         zenodo_dois=zenodo_dois_override,
-                        db_name=ferc1_dbf_sqlite_io_manager.db_name,
+                        dataset=ferc1_dbf_sqlite_io_manager.dataset,
                     )
                 )
 
@@ -355,7 +355,7 @@ def build_defs(
                     FercXbrlSQLiteConfigurableIOManager(
                         etl_settings=etl_settings_override,
                         zenodo_dois=zenodo_dois_override,
-                        db_name=ferc1_xbrl_sqlite_io_manager.db_name,
+                        dataset=ferc1_xbrl_sqlite_io_manager.dataset,
                     )
                 )
 
@@ -364,7 +364,7 @@ def build_defs(
                     FercXbrlSQLiteConfigurableIOManager(
                         etl_settings=etl_settings_override,
                         zenodo_dois=zenodo_dois_override,
-                        db_name=ferc714_xbrl_sqlite_io_manager.db_name,
+                        dataset=ferc714_xbrl_sqlite_io_manager.dataset,
                     )
                 )
 

--- a/src/pudl/etl/__init__.py
+++ b/src/pudl/etl/__init__.py
@@ -29,7 +29,6 @@ from pudl.resources import (
     etl_settings,
     zenodo_dois,
 )
-from pudl.settings import load_packaged_etl_settings
 
 from . import (
     eia_bulk_elec_assets,
@@ -252,18 +251,14 @@ def load_etl_run_config_from_file(setting_filename: str) -> dict:
     The settings file path is resolved via ``importlib.resources`` so the config
     works correctly regardless of the current working directory.
     """
-    etl_settings = load_packaged_etl_settings(setting_filename)
-    if etl_settings.ferc_to_sqlite_settings is None:
-        raise ValueError("Missing ferc_to_sqlite_settings in ETL settings file.")
-
-    etl_settings_path = str(
+    etl_settings_path = (
         importlib.resources.files("pudl.package_data.settings")
         / f"{setting_filename}.yml"
     )
 
     return {
         "resources": {
-            "etl_settings": {"config": {"etl_settings_path": etl_settings_path}},
+            "etl_settings": {"config": {"etl_settings_path": str(etl_settings_path)}},
             "runtime_settings": {
                 "config": {},
             },

--- a/src/pudl/etl/ferc_to_sqlite_assets.py
+++ b/src/pudl/etl/ferc_to_sqlite_assets.py
@@ -53,11 +53,11 @@ def dbf_to_sqlite_asset_factory(
                         data_format="dbf",
                         status="complete",
                         zenodo_doi=context.resources.zenodo_dois.get_doi(dataset),
-                        years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                        years=context.resources.etl_settings.ferc_to_sqlite.get_dataset_years(
                             dataset=dataset, data_format="dbf"
                         ),
                         settings=json.loads(
-                            context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
+                            context.resources.etl_settings.ferc_to_sqlite.model_dump_json()
                         ),
                         sqlite_path=PudlPaths().sqlite_db_path(f"{dataset}_dbf"),
                     ).model_dump(mode="json")
@@ -86,10 +86,8 @@ def xbrl_to_sqlite_asset_factory(
     )
     def _asset(context) -> dg.MaterializeResult[str]:
         runtime_settings = context.resources.runtime_settings
-        settings = (
-            context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_settings(
-                dataset=f"ferc{form.value}", data_format="xbrl"
-            )
+        settings = context.resources.etl_settings.ferc_to_sqlite.get_dataset_settings(
+            dataset=f"ferc{form.value}", data_format="xbrl"
         )
         if settings is None or not settings.years:
             logger.info(
@@ -139,11 +137,11 @@ def xbrl_to_sqlite_asset_factory(
                         zenodo_doi=context.resources.zenodo_dois.get_doi(
                             f"ferc{form.value}"
                         ),
-                        years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                        years=context.resources.etl_settings.ferc_to_sqlite.get_dataset_years(
                             dataset=f"ferc{form.value}", data_format="xbrl"
                         ),
                         settings=json.loads(
-                            context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
+                            context.resources.etl_settings.ferc_to_sqlite.model_dump_json()
                         ),
                         sqlite_path=PudlPaths().sqlite_db_path(
                             f"ferc{form.value}_xbrl"

--- a/src/pudl/etl/ferc_to_sqlite_assets.py
+++ b/src/pudl/etl/ferc_to_sqlite_assets.py
@@ -54,9 +54,7 @@ def dbf_to_sqlite_asset_factory(
                         years=context.resources.etl_settings.ferc_to_sqlite.get_dataset_years(
                             dataset=dataset, data_format="dbf"
                         ),
-                        settings=context.resources.etl_settings.ferc_to_sqlite.model_dump(
-                            mode="json"
-                        ),
+                        settings=context.resources.etl_settings.ferc_to_sqlite,
                         sqlite_path=PudlPaths().sqlite_db_path(f"{dataset}_dbf"),
                     ).model_dump(mode="json")
                 )
@@ -138,9 +136,7 @@ def xbrl_to_sqlite_asset_factory(
                         years=context.resources.etl_settings.ferc_to_sqlite.get_dataset_years(
                             dataset=f"ferc{form.value}", data_format="xbrl"
                         ),
-                        settings=context.resources.etl_settings.ferc_to_sqlite.model_dump(
-                            mode="json"
-                        ),
+                        settings=context.resources.etl_settings.ferc_to_sqlite,
                         sqlite_path=PudlPaths().sqlite_db_path(
                             f"ferc{form.value}_xbrl"
                         ),

--- a/src/pudl/etl/ferc_to_sqlite_assets.py
+++ b/src/pudl/etl/ferc_to_sqlite_assets.py
@@ -56,7 +56,7 @@ def dbf_to_sqlite_asset_factory(
                         years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
                             dataset=dataset, data_format="dbf"
                         ),
-                        settings_json=json.loads(
+                        settings=json.loads(
                             context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
                         ),
                         sqlite_path=PudlPaths().sqlite_db_path(f"{dataset}_dbf"),
@@ -142,7 +142,7 @@ def xbrl_to_sqlite_asset_factory(
                         years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
                             dataset=f"ferc{form.value}", data_format="xbrl"
                         ),
-                        settings_json=json.loads(
+                        settings=json.loads(
                             context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
                         ),
                         sqlite_path=PudlPaths().sqlite_db_path(

--- a/src/pudl/etl/ferc_to_sqlite_assets.py
+++ b/src/pudl/etl/ferc_to_sqlite_assets.py
@@ -13,6 +13,7 @@ from pudl.extract.ferc import (
 )
 from pudl.extract.xbrl import FercXbrlDatastore, convert_form
 from pudl.ferc_sqlite_provenance import (
+    FERC_TO_SQLITE_METADATA_KEY,
     FercSQLiteProvenanceRecord,
 )
 from pudl.settings import XbrlFormNumber
@@ -45,19 +46,23 @@ def dbf_to_sqlite_asset_factory(
         ).execute()
         return dg.MaterializeResult(
             value="complete",
-            metadata=FercSQLiteProvenanceRecord(
-                dataset=dataset,
-                data_format="dbf",
-                status="complete",
-                zenodo_doi=context.resources.zenodo_dois.get_doi(dataset),
-                years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
-                    dataset=dataset, data_format="dbf"
-                ),
-                settings_json=json.loads(
-                    context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
-                ),
-                sqlite_path=PudlPaths().sqlite_db_path(f"{dataset}_dbf"),
-            ).to_dagster_metadata(),
+            metadata={
+                FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
+                    FercSQLiteProvenanceRecord(
+                        dataset=dataset,
+                        data_format="dbf",
+                        status="complete",
+                        zenodo_doi=context.resources.zenodo_dois.get_doi(dataset),
+                        years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                            dataset=dataset, data_format="dbf"
+                        ),
+                        settings_json=json.loads(
+                            context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
+                        ),
+                        sqlite_path=PudlPaths().sqlite_db_path(f"{dataset}_dbf"),
+                    ).model_dump(mode="json")
+                )
+            },
         )
 
     return _asset
@@ -92,11 +97,15 @@ def xbrl_to_sqlite_asset_factory(
             )
             return dg.MaterializeResult(
                 value="not_configured",
-                metadata=FercSQLiteProvenanceRecord(
-                    dataset=f"ferc{form.value}",
-                    data_format="xbrl",
-                    status="not_configured",
-                ).to_dagster_metadata(),
+                metadata={
+                    FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
+                        FercSQLiteProvenanceRecord(
+                            dataset=f"ferc{form.value}",
+                            data_format="xbrl",
+                            status="not_configured",
+                        ).model_dump(mode="json")
+                    )
+                },
             )
 
         output_path = PudlPaths().output_dir
@@ -121,19 +130,27 @@ def xbrl_to_sqlite_asset_factory(
 
         return dg.MaterializeResult(
             value="complete",
-            metadata=FercSQLiteProvenanceRecord(
-                dataset=f"ferc{form.value}",
-                data_format="xbrl",
-                status="complete",
-                zenodo_doi=context.resources.zenodo_dois.get_doi(f"ferc{form.value}"),
-                years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
-                    dataset=f"ferc{form.value}", data_format="xbrl"
-                ),
-                settings_json=json.loads(
-                    context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
-                ),
-                sqlite_path=PudlPaths().sqlite_db_path(f"ferc{form.value}_xbrl"),
-            ).to_dagster_metadata(),
+            metadata={
+                FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
+                    FercSQLiteProvenanceRecord(
+                        dataset=f"ferc{form.value}",
+                        data_format="xbrl",
+                        status="complete",
+                        zenodo_doi=context.resources.zenodo_dois.get_doi(
+                            f"ferc{form.value}"
+                        ),
+                        years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                            dataset=f"ferc{form.value}", data_format="xbrl"
+                        ),
+                        settings_json=json.loads(
+                            context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
+                        ),
+                        sqlite_path=PudlPaths().sqlite_db_path(
+                            f"ferc{form.value}_xbrl"
+                        ),
+                    ).model_dump(mode="json")
+                )
+            },
         )
 
     return _asset

--- a/src/pudl/etl/ferc_to_sqlite_assets.py
+++ b/src/pudl/etl/ferc_to_sqlite_assets.py
@@ -1,5 +1,7 @@
 """Dagster asset definitions for granular FERC-to-SQLite extraction."""
 
+import json
+
 import dagster as dg
 
 import pudl
@@ -12,7 +14,6 @@ from pudl.extract.ferc import (
 from pudl.extract.xbrl import FercXbrlDatastore, convert_form
 from pudl.ferc_sqlite_provenance import (
     FercSQLiteProvenanceRecord,
-    build_ferc_sqlite_provenance_metadata,
 )
 from pudl.settings import XbrlFormNumber
 from pudl.workspace.setup import PudlPaths
@@ -44,13 +45,18 @@ def dbf_to_sqlite_asset_factory(
         ).execute()
         return dg.MaterializeResult(
             value="complete",
-            metadata=build_ferc_sqlite_provenance_metadata(
+            metadata=FercSQLiteProvenanceRecord(
                 dataset=dataset,
                 data_format="dbf",
-                etl_settings=context.resources.etl_settings,
-                zenodo_dois=context.resources.zenodo_dois,
-                sqlite_path=PudlPaths().sqlite_db_path(f"{dataset}_dbf"),
                 status="complete",
+                zenodo_doi=context.resources.zenodo_dois.get_doi(dataset),
+                years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                    dataset=dataset, data_format="dbf"
+                ),
+                settings_json=json.loads(
+                    context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
+                ),
+                sqlite_path=PudlPaths().sqlite_db_path(f"{dataset}_dbf"),
             ).to_dagster_metadata(),
         )
 
@@ -75,7 +81,11 @@ def xbrl_to_sqlite_asset_factory(
     )
     def _asset(context) -> dg.MaterializeResult[str]:
         runtime_settings = context.resources.runtime_settings
-        settings = context.resources.etl_settings.get_xbrl_dataset_settings(form)
+        settings = (
+            context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_settings(
+                dataset=f"ferc{form.value}", data_format="xbrl"
+            )
+        )
         if settings is None or not settings.years:
             logger.info(
                 f"No years configured for ferc{form.value}_xbrl: skipping extraction."
@@ -84,6 +94,7 @@ def xbrl_to_sqlite_asset_factory(
                 value="not_configured",
                 metadata=FercSQLiteProvenanceRecord(
                     dataset=f"ferc{form.value}",
+                    data_format="xbrl",
                     status="not_configured",
                 ).to_dagster_metadata(),
             )
@@ -107,15 +118,21 @@ def xbrl_to_sqlite_asset_factory(
             workers=runtime_settings.xbrl_num_workers,
             loglevel=runtime_settings.xbrl_loglevel,
         )
+
         return dg.MaterializeResult(
             value="complete",
-            metadata=build_ferc_sqlite_provenance_metadata(
+            metadata=FercSQLiteProvenanceRecord(
                 dataset=f"ferc{form.value}",
                 data_format="xbrl",
-                etl_settings=context.resources.etl_settings,
-                zenodo_dois=context.resources.zenodo_dois,
-                sqlite_path=sqlite_path,
                 status="complete",
+                zenodo_doi=context.resources.zenodo_dois.get_doi(f"ferc{form.value}"),
+                years=context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                    dataset=f"ferc{form.value}", data_format="xbrl"
+                ),
+                settings_json=json.loads(
+                    context.resources.etl_settings.ferc_to_sqlite_settings.model_dump_json()
+                ),
+                sqlite_path=PudlPaths().sqlite_db_path(f"ferc{form.value}_xbrl"),
             ).to_dagster_metadata(),
         )
 

--- a/src/pudl/etl/ferc_to_sqlite_assets.py
+++ b/src/pudl/etl/ferc_to_sqlite_assets.py
@@ -1,7 +1,5 @@
 """Dagster asset definitions for granular FERC-to-SQLite extraction."""
 
-import json
-
 import dagster as dg
 
 import pudl
@@ -56,8 +54,8 @@ def dbf_to_sqlite_asset_factory(
                         years=context.resources.etl_settings.ferc_to_sqlite.get_dataset_years(
                             dataset=dataset, data_format="dbf"
                         ),
-                        settings=json.loads(
-                            context.resources.etl_settings.ferc_to_sqlite.model_dump_json()
+                        settings=context.resources.etl_settings.ferc_to_sqlite.model_dump(
+                            mode="json"
                         ),
                         sqlite_path=PudlPaths().sqlite_db_path(f"{dataset}_dbf"),
                     ).model_dump(mode="json")
@@ -140,8 +138,8 @@ def xbrl_to_sqlite_asset_factory(
                         years=context.resources.etl_settings.ferc_to_sqlite.get_dataset_years(
                             dataset=f"ferc{form.value}", data_format="xbrl"
                         ),
-                        settings=json.loads(
-                            context.resources.etl_settings.ferc_to_sqlite.model_dump_json()
+                        settings=context.resources.etl_settings.ferc_to_sqlite.model_dump(
+                            mode="json"
                         ),
                         sqlite_path=PudlPaths().sqlite_db_path(
                             f"ferc{form.value}_xbrl"

--- a/src/pudl/extract/ferc1.py
+++ b/src/pudl/extract/ferc1.py
@@ -87,8 +87,8 @@ from pudl.extract.dbf import (
     deduplicate_by_year,
 )
 from pudl.io_managers import (
-    FercDbfSQLiteIOManager,
-    FercXbrlSQLiteIOManager,
+    FercDbfSQLiteConfigurableIOManager,
+    FercXbrlSQLiteConfigurableIOManager,
     ferc1_dbf_sqlite_io_manager,
     ferc1_xbrl_sqlite_io_manager,
 )
@@ -98,6 +98,7 @@ from pudl.settings import (
     FercDbfToSqliteSettings,
     FercToSqliteSettings,
 )
+from pudl.workspace.datastore import ZenodoDoiSettings
 from pudl.workspace.setup import PudlPaths
 
 logger = pudl.logging_helpers.get_logger(__name__)
@@ -485,7 +486,7 @@ def raw_ferc1_xbrl__metadata_json(
 # Ferc extraction functions for devtool notebook testing
 def extract_dbf_generic(
     table_names: list[str],
-    io_manager: FercDbfSQLiteIOManager,
+    io_manager: FercDbfSQLiteConfigurableIOManager,
     dataset_settings: DatasetsSettings,
 ) -> pd.DataFrame:
     """Combine multiple raw dbf tables into one.
@@ -512,7 +513,7 @@ def extract_dbf_generic(
 
 def extract_xbrl_generic(
     table_names: list[str],
-    io_manager: FercXbrlSQLiteIOManager,
+    io_manager: FercXbrlSQLiteConfigurableIOManager,
     dataset_settings: DatasetsSettings,
     period: Literal["duration", "instant"],
 ) -> pd.DataFrame:
@@ -558,7 +559,13 @@ def extract_dbf(dataset_settings: DatasetsSettings) -> dict[str, pd.DataFrame]:
     ferc1_dbf_raw_dfs = {}
 
     io_manager = ferc1_dbf_sqlite_io_manager.model_copy(
-        update={"etl_settings": EtlSettings(datasets=dataset_settings)}
+        update={
+            "etl_settings": EtlSettings(
+                datasets=dataset_settings,
+                ferc_to_sqlite_settings=FercToSqliteSettings(),
+            ),
+            "zenodo_dois": ZenodoDoiSettings(),
+        },
     )
 
     for table_name, raw_table_mapping in TABLE_NAME_MAP_FERC1.items():
@@ -593,7 +600,13 @@ def extract_xbrl(
     ferc1_xbrl_raw_dfs = {}
 
     io_manager = ferc1_xbrl_sqlite_io_manager.model_copy(
-        update={"etl_settings": EtlSettings(datasets=dataset_settings)}
+        update={
+            "etl_settings": EtlSettings(
+                datasets=dataset_settings,
+                ferc_to_sqlite_settings=FercToSqliteSettings(),
+            ),
+            "zenodo_dois": ZenodoDoiSettings(),
+        },
     )
 
     for table_name, raw_table_mapping in TABLE_NAME_MAP_FERC1.items():

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -104,7 +104,11 @@ def xbrl2sqlite_op_factory(form: XbrlFormNumber) -> Callable:
     def inner_op(context) -> None:
         output_path = PudlPaths().output_dir
         rs: RuntimeSettings = context.resources.runtime_settings
-        settings = context.resources.etl_settings.get_xbrl_dataset_settings(form)
+        settings = (
+            context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_settings(
+                dataset=f"ferc{form.value}", data_format="xbrl"
+            )
+        )
         datastore = FercXbrlDatastore(context.resources.datastore)
 
         logger.info(f"====== xbrl2sqlite runtime_settings: {rs}")

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -104,10 +104,8 @@ def xbrl2sqlite_op_factory(form: XbrlFormNumber) -> Callable:
     def inner_op(context) -> None:
         output_path = PudlPaths().output_dir
         rs: RuntimeSettings = context.resources.runtime_settings
-        settings = (
-            context.resources.etl_settings.ferc_to_sqlite_settings.get_dataset_settings(
-                dataset=f"ferc{form.value}", data_format="xbrl"
-            )
+        settings = context.resources.etl_settings.ferc_to_sqlite.get_dataset_settings(
+            dataset=f"ferc{form.value}", data_format="xbrl"
         )
         datastore = FercXbrlDatastore(context.resources.datastore)
 

--- a/src/pudl/ferc_sqlite_provenance.py
+++ b/src/pudl/ferc_sqlite_provenance.py
@@ -8,7 +8,7 @@ and does the FERC SQLite DB contain all the years needed by the downstream run?
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import Any, Literal
 
 import dagster as dg
 from pydantic import BaseModel
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 import pudl
 
 logger = pudl.logging_helpers.get_logger(__name__)
+FERC_TO_SQLITE_METADATA_KEY = "ferc_to_sqlite"
 
 
 @dataclass(frozen=True)
@@ -40,29 +41,7 @@ class FercSQLiteProvenance:
 
 
 class FercSQLiteProvenanceRecord(BaseModel):
-    """The provenance data recorded when a FERC SQLite prerequisite was materialized.
-
-    Written to Dagster materialization metadata when a raw FERC SQLite asset is
-    built. :func:`assert_ferc_sqlite_compatible` reads it back and compares it
-    against :class:`FercSQLiteProvenance` (the current run's requirements) to
-    decide whether the stored DB can be reused or must be rebuilt.
-
-    For assets whose extraction was skipped (e.g. an XBRL form with no
-    configured years), only ``dataset`` and ``status`` are populated.
-
-    Pydantic is used here rather than a plain dataclass so that the
-    ``status: Literal[...]`` constraint is enforced at construction time, not
-    just by the type checker.
-    """
-
-    # Dagster materialization metadata keys -- stable across runs.
-    _dataset: ClassVar[str] = "pudl_ferc_sqlite_dataset"
-    _data_format: ClassVar[str] = "pudl_ferc_sqlite_data_format"
-    _status: ClassVar[str] = "pudl_ferc_sqlite_status"
-    _zenodo_doi: ClassVar[str] = "pudl_ferc_sqlite_zenodo_doi"
-    _settings: ClassVar[str] = "pudl_ferc_sqlite_etl_settings"
-    _years: ClassVar[str] = "pudl_ferc_sqlite_years"
-    _path: ClassVar[str] = "pudl_ferc_sqlite_path"
+    """Stored provenance + extra debugging fields from materialization time."""
 
     dataset: str
     data_format: Literal["dbf", "xbrl"]
@@ -71,48 +50,6 @@ class FercSQLiteProvenanceRecord(BaseModel):
     years: list[int] | None = None
     settings_json: dict[str, Any] | None = None
     sqlite_path: Path | None = None
-
-    def to_dagster_metadata(self) -> dict[str, dg.MetadataValue]:
-        """Serialize to a Dagster metadata dict suitable for MaterializeResult."""
-        metadata: dict[str, dg.MetadataValue] = {
-            self._dataset: dg.MetadataValue.text(self.dataset),
-            self._data_format: dg.MetadataValue.text(self.data_format),
-            self._status: dg.MetadataValue.text(self.status),
-        }
-        if self.zenodo_doi is not None:
-            metadata[self._zenodo_doi] = dg.MetadataValue.text(self.zenodo_doi)
-        if self.years is not None:
-            metadata[self._years] = dg.MetadataValue.json(self.years)
-        if self.settings_json is not None:
-            metadata[self._settings] = dg.MetadataValue.json(self.settings_json)
-        if self.sqlite_path is not None:
-            metadata[self._path] = dg.MetadataValue.path(str(self.sqlite_path))
-        return metadata
-
-    @classmethod
-    def from_dagster_metadata(
-        cls, metadata: dict[str, Any]
-    ) -> "FercSQLiteProvenanceRecord":
-        """Reconstruct a provenance record from stored Dagster materialization metadata."""
-
-        def _unwrap(value: Any) -> Any:
-            return value.value if hasattr(value, "value") else value
-
-        return cls(
-            dataset=_unwrap(metadata.get(cls._dataset, "")),
-            data_format=_unwrap(metadata.get(cls._data_format, "")),
-            status=_unwrap(metadata.get(cls._status, "skipped")),
-            zenodo_doi=_unwrap(metadata[cls._zenodo_doi])
-            if cls._zenodo_doi in metadata
-            else None,
-            years=_unwrap(metadata[cls._years]) if cls._years in metadata else None,
-            settings_json=_unwrap(metadata[cls._settings])
-            if cls._settings in metadata
-            else None,
-            sqlite_path=Path(_unwrap(metadata[cls._path]))
-            if cls._path in metadata
-            else None,
-        )
 
 
 def assert_ferc_sqlite_compatible(
@@ -163,15 +100,19 @@ def assert_ferc_sqlite_compatible(
 
     event = instance.get_latest_materialization_event(provenance.asset_key)
     materialization = None if event is None else event.asset_materialization
-    if materialization is None:
+    raw_payload = (
+        None
+        if materialization is None
+        else materialization.metadata.get(FERC_TO_SQLITE_METADATA_KEY)
+    )
+    payload = raw_payload.value if hasattr(raw_payload, "value") else raw_payload
+    if not isinstance(payload, dict):
         raise RuntimeError(
             "No Dagster provenance metadata is available for "
             f"{provenance.asset_key.to_user_string()}. Refresh the FERC SQLite assets."
         )
 
-    stored: FercSQLiteProvenanceRecord = (
-        FercSQLiteProvenanceRecord.from_dagster_metadata(materialization.metadata or {})
-    )
+    stored = FercSQLiteProvenanceRecord.model_validate(payload)
 
     if stored.status == "not_configured":
         raise RuntimeError(

--- a/src/pudl/ferc_sqlite_provenance.py
+++ b/src/pudl/ferc_sqlite_provenance.py
@@ -6,7 +6,6 @@ and does the FERC SQLite DB contain all the years needed by the downstream run?
 """
 
 import os
-import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar, Literal
@@ -15,27 +14,8 @@ import dagster as dg
 from pydantic import BaseModel
 
 import pudl
-from pudl.settings import EtlSettings
-from pudl.workspace.datastore import ZenodoDoiSettings
 
 logger = pudl.logging_helpers.get_logger(__name__)
-
-
-def _parse_db_name(db_name: str) -> tuple[str, str]:
-    """Parse a FERC SQLite db_name like 'ferc1_dbf' into (dataset, data_format)."""
-    match: re.Match[str] | None = re.search(r"ferc\d+", db_name)
-    if match is None:
-        raise ValueError(f"Could not determine FERC dataset from db_name={db_name!r}.")
-
-    dataset: str = match.group()
-    if db_name.endswith("_dbf"):
-        return dataset, "dbf"
-    if db_name.endswith("_xbrl"):
-        return dataset, "xbrl"
-
-    raise ValueError(
-        f"Could not determine FERC sqlite format from db_name={db_name!r}."
-    )
 
 
 @dataclass(frozen=True)
@@ -48,33 +28,15 @@ class FercSQLiteProvenance:
     :class:`FercSQLiteProvenanceRecord` that was written when the DB was built.
     """
 
-    asset_key: dg.AssetKey
     dataset: str
     data_format: str
     zenodo_doi: str
     years: list[int]
 
-    @classmethod
-    def from_dataset_and_format(
-        cls,
-        *,
-        dataset: str,
-        data_format: str,
-        etl_settings: EtlSettings,
-        zenodo_dois: ZenodoDoiSettings,
-    ) -> "FercSQLiteProvenance":
-        """Build a provenance fingerprint from explicit dataset and format names."""
-        settings_attr = f"{dataset}_{data_format}_to_sqlite_settings"
-        settings = etl_settings.ferc_to_sqlite.model_dump(mode="json")[settings_attr]
-        if settings is None:
-            raise ValueError(f"Missing {settings_attr} in ETL settings.")
-        return cls(
-            asset_key=dg.AssetKey(f"raw_{dataset}_{data_format}__sqlite"),
-            dataset=dataset,
-            data_format=data_format,
-            zenodo_doi=str(zenodo_dois.model_dump()[dataset]),
-            years=sorted(settings["years"]),
-        )
+    @property
+    def asset_key(self) -> dg.AssetKey:
+        """The AssetKey corresponding to the extracted SQLite database."""
+        return dg.AssetKey(f"raw_{self.dataset}_{self.data_format}__sqlite")
 
 
 class FercSQLiteProvenanceRecord(BaseModel):
@@ -95,6 +57,7 @@ class FercSQLiteProvenanceRecord(BaseModel):
 
     # Dagster materialization metadata keys -- stable across runs.
     _dataset: ClassVar[str] = "pudl_ferc_sqlite_dataset"
+    _data_format: ClassVar[str] = "pudl_ferc_sqlite_data_format"
     _status: ClassVar[str] = "pudl_ferc_sqlite_status"
     _zenodo_doi: ClassVar[str] = "pudl_ferc_sqlite_zenodo_doi"
     _settings: ClassVar[str] = "pudl_ferc_sqlite_etl_settings"
@@ -102,6 +65,7 @@ class FercSQLiteProvenanceRecord(BaseModel):
     _path: ClassVar[str] = "pudl_ferc_sqlite_path"
 
     dataset: str
+    data_format: Literal["dbf", "xbrl"]
     status: Literal["complete", "skipped", "not_configured"]
     zenodo_doi: str | None = None
     years: list[int] | None = None
@@ -112,6 +76,7 @@ class FercSQLiteProvenanceRecord(BaseModel):
         """Serialize to a Dagster metadata dict suitable for MaterializeResult."""
         metadata: dict[str, dg.MetadataValue] = {
             self._dataset: dg.MetadataValue.text(self.dataset),
+            self._data_format: dg.MetadataValue.text(self.data_format),
             self._status: dg.MetadataValue.text(self.status),
         }
         if self.zenodo_doi is not None:
@@ -135,6 +100,7 @@ class FercSQLiteProvenanceRecord(BaseModel):
 
         return cls(
             dataset=_unwrap(metadata.get(cls._dataset, "")),
+            data_format=_unwrap(metadata.get(cls._data_format, "")),
             status=_unwrap(metadata.get(cls._status, "skipped")),
             zenodo_doi=_unwrap(metadata[cls._zenodo_doi])
             if cls._zenodo_doi in metadata
@@ -149,50 +115,10 @@ class FercSQLiteProvenanceRecord(BaseModel):
         )
 
 
-def build_ferc_sqlite_provenance_metadata(
-    *,
-    dataset: str,
-    data_format: str,
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
-    sqlite_path: Path | None,
-    status: Literal["complete", "skipped", "not_configured"],
-) -> FercSQLiteProvenanceRecord:
-    """Build a provenance record for a FERC SQLite prerequisite asset.
-
-    Args:
-        dataset: FERC dataset name, e.g. ``"ferc1"`` or ``"ferc714"``.
-        data_format: Source format, either ``"dbf"`` or ``"xbrl"``.
-        etl_settings: Full ETL settings for the current run.
-        zenodo_dois: Current Zenodo DOI settings.
-        sqlite_path: Path to the written SQLite file, if available.
-        status: ``"complete"`` if extraction ran; ``"skipped"`` if bypassed.
-
-    Returns:
-        A :class:`FercSQLiteProvenanceRecord` ready to be serialized via
-        :meth:`~FercSQLiteProvenanceRecord.to_dagster_metadata`.
-    """
-    settings_attr = f"{dataset}_{data_format}_to_sqlite_settings"
-    settings = etl_settings.ferc_to_sqlite.model_dump(mode="json")[settings_attr]
-    if settings is None:
-        raise ValueError(f"Missing {settings_attr} in ETL settings.")
-
-    return FercSQLiteProvenanceRecord(
-        dataset=dataset,
-        status=status,
-        zenodo_doi=str(zenodo_dois.model_dump()[dataset]),
-        years=sorted(settings["years"]),
-        settings_json=settings,
-        sqlite_path=sqlite_path,
-    )
-
-
 def assert_ferc_sqlite_compatible(
     *,
     instance: Any | None,
-    db_name: str,
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
+    provenance: FercSQLiteProvenance,
 ) -> None:
     """Ensure a persisted FERC SQLite prerequisite is compatible with this run.
 
@@ -215,30 +141,26 @@ def assert_ferc_sqlite_compatible(
     """
     skip_env = os.environ.get("PUDL_SKIP_FERC_SQLITE_PROVENANCE", "").strip().lower()
     if skip_env in {"1", "true", "yes"}:
+        # TODO should we just fstring these logger calls
         logger.warning(
             "PUDL_SKIP_FERC_SQLITE_PROVENANCE is set: skipping FERC SQLite provenance "
-            "check for %s. Stale or incompatible prerequisites may cause downstream "
+            "check for %s_%s. Stale or incompatible prerequisites may cause downstream "
             "failures.",
-            db_name,
+            provenance.dataset,
+            provenance.data_format,
         )
         return
 
     if instance is None:
         logger.warning(
             "No Dagster instance is available; skipping FERC SQLite provenance check "
-            "for %s. This is expected when running assets outside a Dagster execution "
+            "for %s_%s. This is expected when running assets outside a Dagster execution "
             "context (e.g. in unit tests).",
-            db_name,
+            provenance.dataset,
+            provenance.data_format,
         )
         return
 
-    dataset, data_format = _parse_db_name(db_name)
-    provenance: FercSQLiteProvenance = FercSQLiteProvenance.from_dataset_and_format(
-        dataset=dataset,
-        data_format=data_format,
-        etl_settings=etl_settings,
-        zenodo_dois=zenodo_dois,
-    )
     event = instance.get_latest_materialization_event(provenance.asset_key)
     materialization = None if event is None else event.asset_materialization
     if materialization is None:

--- a/src/pudl/ferc_sqlite_provenance.py
+++ b/src/pudl/ferc_sqlite_provenance.py
@@ -78,23 +78,19 @@ def assert_ferc_sqlite_compatible(
     """
     skip_env = os.environ.get("PUDL_SKIP_FERC_SQLITE_PROVENANCE", "").strip().lower()
     if skip_env in {"1", "true", "yes"}:
-        # TODO should we just fstring these logger calls
         logger.warning(
-            "PUDL_SKIP_FERC_SQLITE_PROVENANCE is set: skipping FERC SQLite provenance "
-            "check for %s_%s. Stale or incompatible prerequisites may cause downstream "
-            "failures.",
-            provenance.dataset,
-            provenance.data_format,
+            f"PUDL_SKIP_FERC_SQLITE_PROVENANCE is set: skipping FERC SQLite "
+            f"provenance check for {provenance.dataset}_{provenance.data_format}. "
+            "Stale or incompatible prerequisites may cause downstream failures."
         )
         return
 
     if instance is None:
         logger.warning(
-            "No Dagster instance is available; skipping FERC SQLite provenance check "
-            "for %s_%s. This is expected when running assets outside a Dagster execution "
-            "context (e.g. in unit tests).",
-            provenance.dataset,
-            provenance.data_format,
+            f"No Dagster instance is available; skipping FERC SQLite provenance "
+            f"check for {provenance.dataset}_{provenance.data_format}. This is "
+            "expected when running assets outside a Dagster execution context "
+            "(e.g. in unit tests)."
         )
         return
 

--- a/src/pudl/ferc_sqlite_provenance.py
+++ b/src/pudl/ferc_sqlite_provenance.py
@@ -48,7 +48,7 @@ class FercSQLiteProvenanceRecord(BaseModel):
     status: Literal["complete", "skipped", "not_configured"]
     zenodo_doi: str | None = None
     years: list[int] | None = None
-    settings_json: dict[str, Any] | None = None
+    settings: dict[str, Any] | None = None
     sqlite_path: Path | None = None
 
 

--- a/src/pudl/ferc_sqlite_provenance.py
+++ b/src/pudl/ferc_sqlite_provenance.py
@@ -14,6 +14,7 @@ import dagster as dg
 from pydantic import BaseModel
 
 import pudl
+from pudl.settings import FercToSqliteSettings
 
 logger = pudl.logging_helpers.get_logger(__name__)
 FERC_TO_SQLITE_METADATA_KEY = "ferc_to_sqlite"
@@ -48,7 +49,7 @@ class FercSQLiteProvenanceRecord(BaseModel):
     status: Literal["complete", "skipped", "not_configured"]
     zenodo_doi: str | None = None
     years: list[int] | None = None
-    settings: dict[str, Any] | None = None
+    settings: FercToSqliteSettings | None = None
     sqlite_path: Path | None = None
 
 

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -741,7 +741,7 @@ class _FercSQLiteConfigurableIOManagerBase(ConfigurableIOManager):
             dataset=self.dataset,
             data_format=self.data_format,
             zenodo_doi=zenodo_doi,
-            years=self.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+            years=self.etl_settings.ferc_to_sqlite.get_dataset_years(
                 self.dataset, self.data_format
             ),
         )

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -696,7 +696,7 @@ class _FercSQLiteConfigurableIOManagerBase(ConfigurableIOManager):
     Holds the shared resource dependencies (``etl_settings``, ``zenodo_dois``,
     ``db_name``) and provides default delegation for ``engine``, ``handle_output``,
     and ``load_input``. Subclasses must define ``_manager`` (a ``cached_property``
-        returning the appropriate underlying IO manager) and ``data_format``
+    returning the appropriate underlying IO manager) and ``data_format``
     (``dbf`` or ``xbrl``).
 
     Note:

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -5,7 +5,7 @@ import re
 from functools import cached_property
 from pathlib import Path
 from sqlite3 import sqlite_version
-from typing import ClassVar
+from typing import Literal
 
 import dagster as dg
 import geopandas as gpd  # noqa: ICN002
@@ -27,7 +27,10 @@ from packaging import version
 from pydantic import model_validator
 
 import pudl
-from pudl.ferc_sqlite_provenance import assert_ferc_sqlite_compatible
+from pudl.ferc_sqlite_provenance import (
+    FercSQLiteProvenance,
+    assert_ferc_sqlite_compatible,
+)
 from pudl.helpers import get_parquet_table, get_parquet_table_polars
 from pudl.metadata.classes import PUDL_PACKAGE, Package, Resource
 from pudl.resources import (
@@ -562,7 +565,6 @@ class FercSQLiteIOManager(SQLiteIOManager):
     """
 
     _db_path: Path  # set during _setup_database(); typed here for IDE and type-checker visibility
-    _years_key: ClassVar[str]  # "dbf_years" or "xbrl_years"; set by each subclass
 
     def __init__(
         self,
@@ -650,23 +652,6 @@ class FercSQLiteIOManager(SQLiteIOManager):
             "implement the handle_output method."
         )
 
-    def load_input(self, context: InputContext) -> pd.DataFrame:
-        """Load a dataframe from the FERC SQLite database.
-
-        Args:
-            context: dagster keyword that provides access output information like asset
-                name.
-        """
-        self._ensure_database_ready()
-        ferc_settings = getattr(
-            context.resources.etl_settings.dataset_settings,
-            get_ferc_form_name(self.db_name),
-        )
-        table_name = get_table_name_from_context(context).replace(
-            f"raw_{self.db_name}__", ""
-        )
-        return self._query(table_name, getattr(ferc_settings, self._years_key))
-
 
 class FercDbfSQLiteIOManager(FercSQLiteIOManager):
     """IO Manager for reading tables from FERC DBF SQLite databases.
@@ -679,8 +664,6 @@ class FercDbfSQLiteIOManager(FercSQLiteIOManager):
     a single class serves all FERC DBF datasets (ferc1_dbf, ferc2_dbf, etc.) as long as
     the corresponding settings object exposes a ``dbf_years`` attribute.
     """
-
-    _years_key: ClassVar[str] = "dbf_years"
 
     def handle_output(self, context: OutputContext, obj: pd.DataFrame | str) -> None:
         """Handle an op or asset output."""
@@ -713,9 +696,8 @@ class _FercSQLiteConfigurableIOManagerBase(ConfigurableIOManager):
     Holds the shared resource dependencies (``etl_settings``, ``zenodo_dois``,
     ``db_name``) and provides default delegation for ``engine``, ``handle_output``,
     and ``load_input``. Subclasses must define ``_manager`` (a ``cached_property``
-    returning the appropriate underlying IO manager) and ``_years_key`` (the name
-    of the ``ferc_settings`` attribute holding the relevant year list, e.g.
-    ``"dbf_years"`` or ``"xbrl_years"``).
+        returning the appropriate underlying IO manager) and ``data_format``
+    (``dbf`` or ``xbrl``).
 
     Note:
         This wrapper pattern is a temporary workaround for nested ``etl_settings``
@@ -730,8 +712,16 @@ class _FercSQLiteConfigurableIOManagerBase(ConfigurableIOManager):
 
     etl_settings: dg.ResourceDependency[PudlEtlSettingsResource]
     zenodo_dois: dg.ResourceDependency[ZenodoDoiSettingsResource]
-    db_name: str
-    _years_key: ClassVar[str]  # "dbf_years" or "xbrl_years"; set by each subclass
+    dataset: str
+    data_format: Literal["dbf", "xbrl"]
+
+    @property
+    def _years_key(self) -> str:
+        return f"{self.data_format}_years"
+
+    @property
+    def db_name(self) -> str:
+        return f"{self.dataset}_{self.data_format}"
 
     @property
     def engine(self) -> sa.Engine:
@@ -745,11 +735,19 @@ class _FercSQLiteConfigurableIOManagerBase(ConfigurableIOManager):
     def _prepare(self, context: InputContext) -> None:
         """Ensure the database is ready and provenance is compatible with this run."""
         self._manager._ensure_database_ready()
+        zenodo_doi = getattr(self.zenodo_dois, self.dataset)
+
+        provenance = FercSQLiteProvenance(
+            dataset=self.dataset,
+            data_format=self.data_format,
+            zenodo_doi=zenodo_doi,
+            years=self.etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                self.dataset, self.data_format
+            ),
+        )
+
         assert_ferc_sqlite_compatible(
-            instance=_get_dagster_instance_if_available(context),
-            db_name=self.db_name,
-            etl_settings=self.etl_settings,
-            zenodo_dois=self.zenodo_dois,
+            instance=_get_dagster_instance_if_available(context), provenance=provenance
         )
 
     def load_input(self, context: InputContext) -> pd.DataFrame:
@@ -757,7 +755,7 @@ class _FercSQLiteConfigurableIOManagerBase(ConfigurableIOManager):
         self._prepare(context)
         ferc_settings = getattr(
             self.etl_settings.dataset_settings,
-            get_ferc_form_name(self.db_name),
+            self.dataset,
         )
         table_name = get_table_name_from_context(context).replace(
             f"raw_{self.db_name}__", ""
@@ -768,12 +766,10 @@ class _FercSQLiteConfigurableIOManagerBase(ConfigurableIOManager):
 class FercDbfSQLiteConfigurableIOManager(_FercSQLiteConfigurableIOManagerBase):
     """Configurable IO manager for reading tables from FERC DBF SQLite databases.
 
-    The form name is inferred from ``self.db_name`` via :func:`get_ferc_form_name`, so
-    a single class serves all FERC DBF datasets. Instantiate with the appropriate
-    ``db_name`` (e.g. ``"ferc1_dbf"``, ``"ferc2_dbf"``) to target a specific form.
+    Instantiate with ``dataset`` (``ferc1``, ``ferc714``, etc.)
     """
 
-    _years_key: ClassVar[str] = "dbf_years"
+    data_format: Literal["dbf"] = "dbf"
 
     @cached_property
     def _manager(self) -> FercDbfSQLiteIOManager:
@@ -834,8 +830,6 @@ class FercXbrlSQLiteIOManager(FercSQLiteIOManager):
             .reset_index(drop=True)
         )
 
-    _years_key: ClassVar[str] = "xbrl_years"
-
     def handle_output(self, context: OutputContext, obj: pd.DataFrame | str) -> None:
         """Handle an op or asset output."""
         raise NotImplementedError("FercXbrlSQLiteIOManager can't write outputs yet.")
@@ -865,9 +859,12 @@ class FercXbrlSQLiteIOManager(FercSQLiteIOManager):
 
 
 class FercXbrlSQLiteConfigurableIOManager(_FercSQLiteConfigurableIOManagerBase):
-    """Configurable IO manager for reading tables from a FERC XBRL SQLite database."""
+    """Configurable IO manager for reading tables from a FERC XBRL SQLite database.
 
-    _years_key: ClassVar[str] = "xbrl_years"
+    Instantiate with ``dataset`` (``ferc1``, ``ferc714``, etc.).
+    """
+
+    data_format: Literal["xbrl"] = "xbrl"
 
     @cached_property
     def _manager(self) -> FercXbrlSQLiteIOManager:
@@ -881,15 +878,15 @@ class FercXbrlSQLiteConfigurableIOManager(_FercSQLiteConfigurableIOManagerBase):
 ferc1_dbf_sqlite_io_manager = FercDbfSQLiteConfigurableIOManager(
     etl_settings=etl_settings,
     zenodo_dois=zenodo_dois,
-    db_name="ferc1_dbf",
+    dataset="ferc1",
 )
 ferc1_xbrl_sqlite_io_manager = FercXbrlSQLiteConfigurableIOManager(
     etl_settings=etl_settings,
     zenodo_dois=zenodo_dois,
-    db_name="ferc1_xbrl",
+    dataset="ferc1",
 )
 ferc714_xbrl_sqlite_io_manager = FercXbrlSQLiteConfigurableIOManager(
     etl_settings=etl_settings,
     zenodo_dois=zenodo_dois,
-    db_name="ferc714_xbrl",
+    dataset="ferc714",
 )

--- a/src/pudl/io_managers.py
+++ b/src/pudl/io_managers.py
@@ -733,9 +733,14 @@ class _FercSQLiteConfigurableIOManagerBase(ConfigurableIOManager):
         return self._manager.handle_output(context, obj)
 
     def _prepare(self, context: InputContext) -> None:
-        """Ensure the database is ready and provenance is compatible with this run."""
+        """Make sure extracted FERC database is valid for this run.
+
+        * does the database exist?
+        * do the FERC SQLite provenance check
+        """
         self._manager._ensure_database_ready()
-        zenodo_doi = getattr(self.zenodo_dois, self.dataset)
+
+        zenodo_doi = self.zenodo_dois.get_doi(self.dataset)
 
         provenance = FercSQLiteProvenance(
             dataset=self.dataset,

--- a/src/pudl/resources.py
+++ b/src/pudl/resources.py
@@ -3,10 +3,7 @@
 import dagster as dg
 from dagster import ConfigurableResource
 
-from pudl.settings import (
-    EtlSettings,
-    load_etl_settings,
-)
+from pudl.settings import EtlSettings
 from pudl.workspace.datastore import Datastore, ZenodoDoiSettings
 from pudl.workspace.setup import PudlPaths
 
@@ -27,7 +24,7 @@ class PudlEtlSettingsResource(ConfigurableResource):
     def create_resource(self, context) -> EtlSettings:
         """Create runtime ETL settings from the configured ETL settings file."""
         del context  # Required by Dagster's hook signature; intentionally unused here.
-        return load_etl_settings(self.etl_settings_path)
+        return EtlSettings.from_yaml(self.etl_settings_path)
 
 
 class ZenodoDoiSettingsResource(ConfigurableResource):

--- a/src/pudl/settings.py
+++ b/src/pudl/settings.py
@@ -812,7 +812,6 @@ class Ferc714XbrlToSqliteSettings(FercGenericXbrlToSqliteSettings):
 class FercToSqliteSettings(BaseSettings):
     """An immutable pydantic model to validate FERC XBRL to SQLite settings."""
 
-    # TODO this seems like an insane way to set defaults.
     ferc1_dbf_to_sqlite_settings: Ferc1DbfToSqliteSettings | None = None
     ferc1_xbrl_to_sqlite_settings: Ferc1XbrlToSqliteSettings | None = None
     ferc2_dbf_to_sqlite_settings: Ferc2DbfToSqliteSettings | None = None

--- a/src/pudl/settings.py
+++ b/src/pudl/settings.py
@@ -1,12 +1,10 @@
 """Module for validating pudl etl settings."""
 
-import importlib.resources
 import json
 from enum import Enum, StrEnum, auto, unique
 from pathlib import Path
 from typing import Any, ClassVar, Literal, Self
 
-import fsspec
 import pandas as pd
 import yaml
 from dagster import StaticPartitionsDefinition
@@ -872,16 +870,17 @@ class EtlSettings(BaseSettings):
     version: str | None = None
 
     @classmethod
-    def from_yaml(cls, path: str) -> "EtlSettings":
-        """Create an EtlSettings instance from a yaml_file path.
+    def from_yaml(cls, path: str | Path) -> "EtlSettings":
+        """Create validated ETL settings from a local YAML file path.
 
         Args:
-            path: path to a yaml file; this could be remote.
+            path: Path to a YAML file. Relative paths are resolved against the
+                current working directory and ``~`` is expanded.
 
         Returns:
             An ETL settings object.
         """
-        with fsspec.open(path) as f:
+        with Path(path).expanduser().resolve().open() as f:
             yaml_file = yaml.safe_load(f)
         return cls.model_validate(yaml_file)
 
@@ -932,33 +931,6 @@ class EtlSettings(BaseSettings):
         if self.datasets is None:
             raise ValueError("Missing datasets settings in ETL settings.")
         return self.datasets
-
-
-def load_etl_settings(path: str | Path) -> EtlSettings:
-    """Load ETL settings from an arbitrary path.
-
-    Expands ``~`` and resolves the path relative to the current working directory
-    before passing it to :meth:`EtlSettings.from_yaml`, which expects an absolute
-    path or a URI. This wrapper exists so callers can pass relative or user-expanded
-    paths without knowing those normalisation details.
-    """
-    return EtlSettings.from_yaml(str(Path(path).expanduser().resolve()))
-
-
-def load_packaged_etl_settings(setting_filename: str) -> EtlSettings:
-    """Load a named ETL settings profile from ``pudl.package_data.settings``.
-
-    Uses :mod:`importlib.resources` to locate the YAML file inside the installed
-    package, so the lookup works correctly regardless of the current working directory
-    or whether the package is installed as a zip. This wrapper exists so callers can
-    refer to profiles by short name (e.g. ``"etl_full"``) without knowing the
-    package-data path or the ``.yml`` extension.
-    """
-    settings_path = (
-        importlib.resources.files("pudl.package_data.settings")
-        / f"{setting_filename}.yml"
-    )
-    return EtlSettings.from_yaml(str(settings_path))
 
 
 def _zenodo_doi_to_url(doi: ZenodoDoi) -> AnyHttpUrl:

--- a/src/pudl/settings.py
+++ b/src/pudl/settings.py
@@ -4,7 +4,7 @@ import importlib.resources
 import json
 from enum import Enum, StrEnum, auto, unique
 from pathlib import Path
-from typing import Any, ClassVar, Self
+from typing import Any, ClassVar, Literal, Self
 
 import fsspec
 import pandas as pd
@@ -814,6 +814,7 @@ class Ferc714XbrlToSqliteSettings(FercGenericXbrlToSqliteSettings):
 class FercToSqliteSettings(BaseSettings):
     """An immutable pydantic model to validate FERC XBRL to SQLite settings."""
 
+    # TODO this seems like an insane way to set defaults.
     ferc1_dbf_to_sqlite_settings: Ferc1DbfToSqliteSettings | None = None
     ferc1_xbrl_to_sqlite_settings: Ferc1XbrlToSqliteSettings | None = None
     ferc2_dbf_to_sqlite_settings: Ferc2DbfToSqliteSettings | None = None
@@ -841,28 +842,22 @@ class FercToSqliteSettings(BaseSettings):
 
         return data
 
-    def get_xbrl_dataset_settings(
-        self, form_number: XbrlFormNumber
-    ) -> FercGenericXbrlToSqliteSettings | None:
-        """Return a list with all requested FERC XBRL to SQLite datasets.
+    def get_dataset_settings(
+        self, dataset: str, data_format: Literal["dbf", "xbrl"]
+    ) -> FercGenericXbrlToSqliteSettings:
+        """Look up extraction settings by dataset (``fercX``) and data format (``dbf`` or ``xbrl``).
 
-        Args:
-            form_number: Get settings by FERC form number.
+        Throws a KeyError if dataset/format is not configured.
         """
-        # Get requested settings object
-        match form_number:
-            case XbrlFormNumber.FORM1:
-                settings = self.ferc1_xbrl_to_sqlite_settings
-            case XbrlFormNumber.FORM2:
-                settings = self.ferc2_xbrl_to_sqlite_settings
-            case XbrlFormNumber.FORM6:
-                settings = self.ferc6_xbrl_to_sqlite_settings
-            case XbrlFormNumber.FORM60:
-                settings = self.ferc60_xbrl_to_sqlite_settings
-            case XbrlFormNumber.FORM714:
-                settings = self.ferc714_xbrl_to_sqlite_settings
+        key = f"{dataset}_{data_format}_to_sqlite_settings"
+        return dict(self)[key]
 
-        return settings
+    def get_dataset_years(
+        self, dataset: str, data_format: Literal["dbf", "xbrl"]
+    ) -> list[int]:
+        """Look up extraction *years* by dataset (``fercX``) and data format (``dbf`` or ``xbrl``)."""
+        settings = self.get_dataset_settings(dataset=dataset, data_format=data_format)
+        return sorted(settings.years)
 
 
 class EtlSettings(BaseSettings):
@@ -937,12 +932,6 @@ class EtlSettings(BaseSettings):
         if self.datasets is None:
             raise ValueError("Missing datasets settings in ETL settings.")
         return self.datasets
-
-    def get_xbrl_dataset_settings(
-        self, form_number: XbrlFormNumber
-    ) -> FercGenericXbrlToSqliteSettings | None:
-        """Proxy FERC XBRL settings lookup through the canonical ETL settings."""
-        return self.ferc_to_sqlite.get_xbrl_dataset_settings(form_number)
 
 
 def load_etl_settings(path: str | Path) -> EtlSettings:

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -237,6 +237,13 @@ class ZenodoDoiSettings(BaseSettings):
         yaml_data.update(data)
         super().__init__(**yaml_data)
 
+    def get_doi(self, dataset: str) -> ZenodoDoi:
+        """Look up configured DOI by dataset.
+
+        Throws a KeyError if dataset not configured.
+        """
+        return dict(self)[dataset]
+
     @classmethod
     def from_yaml(cls, path: str | Path) -> "ZenodoDoiSettings":
         """Create a ZenodoDoiSettings instance from a YAML file path.

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -107,7 +107,7 @@ def test_ferc_xbrl_datastore_get_filings(mocker):
         ),
     ],
 )
-def test_xbrl2sqlite(settings, forms, mocker, tmp_path):
+def test_xbrl2sqlite(settings, forms, mocker):
     convert_form_mock = mocker.MagicMock()
     mocker.patch("pudl.etl.ferc_to_sqlite_assets.convert_form", new=convert_form_mock)
 
@@ -144,7 +144,9 @@ def test_xbrl2sqlite(settings, forms, mocker, tmp_path):
 
     for form in forms:
         convert_form_mock.assert_any_call(
-            settings.get_xbrl_dataset_settings(form),
+            settings.get_dataset_settings(
+                dataset=f"ferc{form.value}", data_format="xbrl"
+            ),
             form,
             mock_datastore,
             output_path=PudlPaths().output_dir,

--- a/test/unit/ferc_sqlite_provenance_test.py
+++ b/test/unit/ferc_sqlite_provenance_test.py
@@ -5,9 +5,11 @@ import os
 from pathlib import Path
 from typing import Literal
 
+import dagster as dg
 import pytest
 
 from pudl.ferc_sqlite_provenance import (
+    FERC_TO_SQLITE_METADATA_KEY,
     FercSQLiteProvenance,
     FercSQLiteProvenanceRecord,
     assert_ferc_sqlite_compatible,
@@ -30,8 +32,15 @@ def test_ferc_sqlite_provenance_record_round_trip() -> None:
         settings_json=json.loads(FercToSqliteSettings().model_dump_json()),
         sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
     )
-    dagster_meta = record.to_dagster_metadata()
-    recovered = FercSQLiteProvenanceRecord.from_dagster_metadata(dagster_meta)
+    dagster_meta = {
+        FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
+            record.model_dump(mode="json")
+        )
+    }
+    assert set(dagster_meta) == {FERC_TO_SQLITE_METADATA_KEY}
+    recovered = FercSQLiteProvenanceRecord.model_validate(
+        dagster_meta[FERC_TO_SQLITE_METADATA_KEY].value
+    )
 
     assert recovered == record
 
@@ -40,13 +49,18 @@ def test_ferc_sqlite_provenance_record_round_trip() -> None:
 def test_ferc_sqlite_provenance_record_minimal_round_trip(
     status: Literal["skipped", "not_configured"],
 ) -> None:
-    """A skipped or not_configured record only stores dataset and status."""
-    # TODO do we need to assert non-existence of anything here?
+    """A minimal record still round-trips through the nested Dagster metadata."""
     record = FercSQLiteProvenanceRecord(
         dataset="ferc714", data_format="xbrl", status=status
     )
-    dagster_meta = record.to_dagster_metadata()
-    recovered = FercSQLiteProvenanceRecord.from_dagster_metadata(dagster_meta)
+    dagster_meta = {
+        FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
+            record.model_dump(mode="json")
+        )
+    }
+    recovered = FercSQLiteProvenanceRecord.model_validate(
+        dagster_meta[FERC_TO_SQLITE_METADATA_KEY].value
+    )
 
     assert recovered == record
 
@@ -138,7 +152,11 @@ def test_assert_ferc_sqlite_compatible_year_subset_check(
         dataset="ferc1", data_format="dbf", zenodo_doi="fake DOI", years=required_years
     )
 
-    stored_dagster_meta = stored.to_dagster_metadata()
+    stored_dagster_meta = {
+        FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
+            stored.model_dump(mode="json")
+        )
+    }
     instance = mocker.MagicMock()
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
         asset_materialization=mocker.MagicMock(metadata=stored_dagster_meta)
@@ -166,7 +184,11 @@ def test_assert_ferc_sqlite_compatible_rejects_doi_mismatch(
         dataset="ferc1", data_format="dbf", zenodo_doi="fake DOI", years=[]
     )
 
-    stored_dagster_meta = stored.to_dagster_metadata()
+    stored_dagster_meta = {
+        FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
+            stored.model_dump(mode="json")
+        )
+    }
     instance = mocker.MagicMock()
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
         asset_materialization=mocker.MagicMock(metadata=stored_dagster_meta)
@@ -206,9 +228,13 @@ def test_assert_ferc_sqlite_compatible_rejects_non_complete_status(
     populated, so downstream IO managers must refuse to read from it.
     """
 
-    dagster_meta = FercSQLiteProvenanceRecord(
-        dataset="ferc1", data_format="dbf", status=status
-    ).to_dagster_metadata()
+    dagster_meta = {
+        FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
+            FercSQLiteProvenanceRecord(
+                dataset="ferc1", data_format="dbf", status=status
+            ).model_dump(mode="json")
+        )
+    }
     instance = mocker.MagicMock()
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
         asset_materialization=mocker.MagicMock(metadata=dagster_meta)

--- a/test/unit/ferc_sqlite_provenance_test.py
+++ b/test/unit/ferc_sqlite_provenance_test.py
@@ -1,166 +1,54 @@
 """Unit tests for the FERC SQLite provenance helpers."""
 
+import json
 import os
 from pathlib import Path
+from typing import Literal
 
-import dagster as dg
 import pytest
 
 from pudl.ferc_sqlite_provenance import (
     FercSQLiteProvenance,
     FercSQLiteProvenanceRecord,
-    _parse_db_name,
     assert_ferc_sqlite_compatible,
-    build_ferc_sqlite_provenance_metadata,
 )
-from pudl.settings import EtlSettings, FercToSqliteSettings
-from pudl.workspace.datastore import ZenodoDoiSettings
-
-
-@pytest.fixture()
-def etl_settings() -> EtlSettings:
-    """Minimal ETL settings with FERC-to-SQLite config for provenance tests."""
-    return EtlSettings(ferc_to_sqlite_settings=FercToSqliteSettings())
-
-
-@pytest.fixture()
-def zenodo_dois() -> ZenodoDoiSettings:
-    """Default Zenodo DOI settings."""
-    return ZenodoDoiSettings()
-
-
-# ---------------------------------------------------------------------------
-# FercSQLiteProvenance factory tests
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("dataset", "data_format"),
-    [
-        ("ferc1", "dbf"),
-        ("ferc1", "xbrl"),
-        ("ferc714", "xbrl"),
-        ("ferc2", "dbf"),
-    ],
-)
-def test_ferc_sqlite_provenance_from_dataset_and_format(
-    dataset: str,
-    data_format: str,
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
-) -> None:
-    """from_dataset_and_format builds the correct provenance fingerprint."""
-    provenance = FercSQLiteProvenance.from_dataset_and_format(
-        dataset=dataset,
-        data_format=data_format,
-        etl_settings=etl_settings,
-        zenodo_dois=zenodo_dois,
-    )
-    assert isinstance(provenance, FercSQLiteProvenance)
-    assert provenance.dataset == dataset
-    assert provenance.data_format == data_format
-    assert provenance.asset_key == dg.AssetKey(f"raw_{dataset}_{data_format}__sqlite")
-
-
-@pytest.mark.parametrize(
-    ("db_name", "expected_dataset", "expected_format"),
-    [
-        ("ferc1_dbf", "ferc1", "dbf"),
-        ("ferc1_xbrl", "ferc1", "xbrl"),
-        ("ferc714_xbrl", "ferc714", "xbrl"),
-        ("ferc2_dbf", "ferc2", "dbf"),
-    ],
-)
-def test_parse_db_name(
-    db_name: str, expected_dataset: str, expected_format: str
-) -> None:
-    """_parse_db_name correctly splits a db_name into dataset and format."""
-    dataset, data_format = _parse_db_name(db_name)
-    assert dataset == expected_dataset
-    assert data_format == expected_format
-
-
-def test_ferc_sqlite_provenance_years_reflect_settings(
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
-) -> None:
-    """Years in the provenance fingerprint must match those in the ETL settings.
-
-    The compatibility check uses set equality, so order does not matter, and an
-    empty year list is a valid statement of provenance (no years were processed).
-    """
-    from pudl.settings import Ferc1DbfToSqliteSettings
-
-    configured_years = [2020, 2021]
-    settings = EtlSettings(
-        ferc_to_sqlite_settings=etl_settings.ferc_to_sqlite.model_copy(
-            update={
-                "ferc1_dbf_to_sqlite_settings": Ferc1DbfToSqliteSettings(
-                    years=configured_years
-                )
-            }
-        )
-    )
-    provenance = FercSQLiteProvenance.from_dataset_and_format(
-        dataset="ferc1",
-        data_format="dbf",
-        etl_settings=settings,
-        zenodo_dois=zenodo_dois,
-    )
-    assert set(provenance.years) == set(configured_years)
-
-
-@pytest.mark.parametrize(
-    "db_name",
-    [
-        "not_a_ferc_db",
-        "ferc1",  # missing _dbf or _xbrl suffix
-    ],
-)
-def test_parse_db_name_rejects_bad_input(db_name: str) -> None:
-    """Malformed db_names should raise ValueError."""
-    with pytest.raises(ValueError):
-        _parse_db_name(db_name)
-
+from pudl.settings import FercToSqliteSettings
 
 # ---------------------------------------------------------------------------
 # FercSQLiteProvenanceRecord serialization round-trip
 # ---------------------------------------------------------------------------
 
 
-def test_ferc_sqlite_provenance_record_round_trip(
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
-) -> None:
+def test_ferc_sqlite_provenance_record_round_trip() -> None:
     """A complete record round-trips through Dagster metadata without data loss."""
-    record = build_ferc_sqlite_provenance_metadata(
+    record = FercSQLiteProvenanceRecord(
         dataset="ferc1",
         data_format="dbf",
-        etl_settings=etl_settings,
-        zenodo_dois=zenodo_dois,
-        sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
         status="complete",
+        zenodo_doi="fake DOI",
+        years=[2018, 2019],
+        settings_json=json.loads(FercToSqliteSettings().model_dump_json()),
+        sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
     )
     dagster_meta = record.to_dagster_metadata()
     recovered = FercSQLiteProvenanceRecord.from_dagster_metadata(dagster_meta)
 
-    assert recovered.status == record.status
-    assert recovered.zenodo_doi == record.zenodo_doi
-    assert recovered.years == record.years
-    assert recovered.dataset == record.dataset
+    assert recovered == record
 
 
 @pytest.mark.parametrize("status", ["skipped", "not_configured"])
-def test_ferc_sqlite_provenance_record_minimal_round_trip(status: str) -> None:
+def test_ferc_sqlite_provenance_record_minimal_round_trip(
+    status: Literal["skipped", "not_configured"],
+) -> None:
     """A skipped or not_configured record only stores dataset and status."""
-    record = FercSQLiteProvenanceRecord(dataset="ferc714", status=status)
+    # TODO do we need to assert non-existence of anything here?
+    record = FercSQLiteProvenanceRecord(
+        dataset="ferc714", data_format="xbrl", status=status
+    )
     dagster_meta = record.to_dagster_metadata()
     recovered = FercSQLiteProvenanceRecord.from_dagster_metadata(dagster_meta)
 
-    assert recovered.status == status
-    assert recovered.dataset == "ferc714"
-    assert recovered.zenodo_doi is None
-    assert recovered.years is None
+    assert recovered == record
 
 
 # ---------------------------------------------------------------------------
@@ -169,38 +57,33 @@ def test_ferc_sqlite_provenance_record_minimal_round_trip(status: str) -> None:
 
 
 def test_assert_ferc_sqlite_compatible_skips_without_instance(
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
     mocker,
 ) -> None:
     """Provenance check is skipped with a warning when no Dagster instance is available."""
+    # TODO replace mocker with caplog
     mock_warn = mocker.patch("pudl.ferc_sqlite_provenance.logger.warning")
-    assert_ferc_sqlite_compatible(
-        instance=None,
-        db_name="ferc1_dbf",
-        etl_settings=etl_settings,
-        zenodo_dois=zenodo_dois,
+    provenance = FercSQLiteProvenance(
+        dataset="ferc1", data_format="dbf", zenodo_doi="fake DOI", years=[2018, 2019]
     )
+    assert_ferc_sqlite_compatible(instance=None, provenance=provenance)
     assert mock_warn.call_count == 1
     assert "No Dagster instance is available" in mock_warn.call_args[0][0]
 
 
 def test_assert_ferc_sqlite_compatible_skips_with_env_var(
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
     mocker,
 ) -> None:
     """Provenance check is skipped with a warning when PUDL_SKIP_FERC_SQLITE_PROVENANCE is set."""
+    # TODO use monkeypatch.setenv instead of mocker for the env, and caplog for the warning
     mocker.patch.dict(os.environ, {"PUDL_SKIP_FERC_SQLITE_PROVENANCE": "true"})
     mock_instance = mocker.MagicMock()
     mock_warn = mocker.patch("pudl.ferc_sqlite_provenance.logger.warning")
 
-    assert_ferc_sqlite_compatible(
-        instance=mock_instance,
-        db_name="ferc1_dbf",
-        etl_settings=etl_settings,
-        zenodo_dois=zenodo_dois,
+    provenance = FercSQLiteProvenance(
+        dataset="ferc1", data_format="dbf", zenodo_doi="fake DOI", years=[2018, 2019]
     )
+
+    assert_ferc_sqlite_compatible(instance=mock_instance, provenance=provenance)
 
     assert mock_warn.call_count == 1
     assert "PUDL_SKIP_FERC_SQLITE_PROVENANCE" in mock_warn.call_args[0][0]
@@ -210,48 +93,19 @@ def test_assert_ferc_sqlite_compatible_skips_with_env_var(
 @pytest.mark.parametrize("truthy_value", ["1", "true", "yes", "TRUE", "YES"])
 def test_assert_ferc_sqlite_compatible_env_var_truthy_values(
     truthy_value: str,
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
     mocker,
 ) -> None:
     """All recognised truthy env var values skip the check."""
+    # TODO combine parametrization with above test
     mocker.patch.dict(os.environ, {"PUDL_SKIP_FERC_SQLITE_PROVENANCE": truthy_value})
     mock_instance = mocker.MagicMock()
     # Should not raise.
-    assert_ferc_sqlite_compatible(
-        instance=mock_instance,
-        db_name="ferc1_dbf",
-        etl_settings=etl_settings,
-        zenodo_dois=zenodo_dois,
+    provenance = FercSQLiteProvenance(
+        dataset="ferc1", data_format="dbf", zenodo_doi="fake DOI", years=[2018, 2019]
     )
+
+    assert_ferc_sqlite_compatible(instance=mock_instance, provenance=provenance)
     mock_instance.get_latest_materialization_event.assert_not_called()
-
-
-def test_assert_ferc_sqlite_compatible_passes_matching_provenance(
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
-    mocker,
-) -> None:
-    """Compatible provenance should not raise."""
-    dagster_meta = build_ferc_sqlite_provenance_metadata(
-        dataset="ferc1",
-        data_format="dbf",
-        etl_settings=etl_settings,
-        zenodo_dois=zenodo_dois,
-        sqlite_path=None,
-        status="complete",
-    ).to_dagster_metadata()
-    instance = mocker.MagicMock()
-    instance.get_latest_materialization_event.return_value = mocker.MagicMock(
-        asset_materialization=mocker.MagicMock(metadata=dagster_meta)
-    )
-    # Should not raise.
-    assert_ferc_sqlite_compatible(
-        instance=instance,
-        db_name="ferc1_dbf",
-        etl_settings=etl_settings,
-        zenodo_dois=zenodo_dois,
-    )
 
 
 @pytest.mark.parametrize(
@@ -264,8 +118,6 @@ def test_assert_ferc_sqlite_compatible_passes_matching_provenance(
     ],
 )
 def test_assert_ferc_sqlite_compatible_year_subset_check(
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
     mocker,
     stored_years: list[int],
     required_years: list[int],
@@ -275,98 +127,65 @@ def test_assert_ferc_sqlite_compatible_year_subset_check(
 
     Passes when stored ⊇ required; raises RuntimeError when any required year is absent.
     """
-    from pudl.settings import Ferc1DbfToSqliteSettings
-
-    stored_settings = EtlSettings(
-        ferc_to_sqlite_settings=etl_settings.ferc_to_sqlite.model_copy(
-            update={
-                "ferc1_dbf_to_sqlite_settings": Ferc1DbfToSqliteSettings(
-                    years=stored_years
-                )
-            }
-        )
-    )
-    required_settings = EtlSettings(
-        ferc_to_sqlite_settings=etl_settings.ferc_to_sqlite.model_copy(
-            update={
-                "ferc1_dbf_to_sqlite_settings": Ferc1DbfToSqliteSettings(
-                    years=required_years
-                )
-            }
-        )
-    )
-    stored_dagster_meta = build_ferc_sqlite_provenance_metadata(
+    stored = FercSQLiteProvenanceRecord(
         dataset="ferc1",
         data_format="dbf",
-        etl_settings=stored_settings,
-        zenodo_dois=zenodo_dois,
-        sqlite_path=None,
         status="complete",
-    ).to_dagster_metadata()
+        zenodo_doi="fake DOI",
+        years=stored_years,
+    )
+    required = FercSQLiteProvenance(
+        dataset="ferc1", data_format="dbf", zenodo_doi="fake DOI", years=required_years
+    )
+
+    stored_dagster_meta = stored.to_dagster_metadata()
     instance = mocker.MagicMock()
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
         asset_materialization=mocker.MagicMock(metadata=stored_dagster_meta)
     )
     if should_raise:
         with pytest.raises(RuntimeError, match="missing required years"):
-            assert_ferc_sqlite_compatible(
-                instance=instance,
-                db_name="ferc1_dbf",
-                etl_settings=required_settings,
-                zenodo_dois=zenodo_dois,
-            )
+            assert_ferc_sqlite_compatible(instance=instance, provenance=required)
     else:
-        assert_ferc_sqlite_compatible(
-            instance=instance,
-            db_name="ferc1_dbf",
-            etl_settings=required_settings,
-            zenodo_dois=zenodo_dois,
-        )
+        assert_ferc_sqlite_compatible(instance=instance, provenance=required)
 
 
 def test_assert_ferc_sqlite_compatible_rejects_doi_mismatch(
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
     mocker,
 ) -> None:
     """A Zenodo DOI mismatch should raise a descriptive RuntimeError."""
-    stale_dois = ZenodoDoiSettings(ferc1="10.5281/zenodo.9999999")
-    dagster_meta = build_ferc_sqlite_provenance_metadata(
+
+    stored = FercSQLiteProvenanceRecord(
         dataset="ferc1",
         data_format="dbf",
-        etl_settings=etl_settings,
-        zenodo_dois=stale_dois,
-        sqlite_path=None,
         status="complete",
-    ).to_dagster_metadata()
+        zenodo_doi="stale DOI",
+        years=[],
+    )
+    required = FercSQLiteProvenance(
+        dataset="ferc1", data_format="dbf", zenodo_doi="fake DOI", years=[]
+    )
+
+    stored_dagster_meta = stored.to_dagster_metadata()
     instance = mocker.MagicMock()
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
-        asset_materialization=mocker.MagicMock(metadata=dagster_meta)
+        asset_materialization=mocker.MagicMock(metadata=stored_dagster_meta)
     )
     with pytest.raises(RuntimeError, match="Zenodo DOI mismatch"):
-        assert_ferc_sqlite_compatible(
-            instance=instance,
-            db_name="ferc1_dbf",
-            etl_settings=etl_settings,
-            zenodo_dois=zenodo_dois,
-        )
+        assert_ferc_sqlite_compatible(instance=instance, provenance=required)
 
 
 def test_assert_ferc_sqlite_compatible_rejects_missing_materialization(
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
     mocker,
 ) -> None:
     """Missing materialization event should raise a descriptive RuntimeError."""
+    required = FercSQLiteProvenance(
+        dataset="ferc1", data_format="dbf", zenodo_doi="fake DOI", years=[]
+    )
     instance = mocker.MagicMock()
     instance.get_latest_materialization_event.return_value = None
     with pytest.raises(RuntimeError, match="No Dagster provenance metadata"):
-        assert_ferc_sqlite_compatible(
-            instance=instance,
-            db_name="ferc1_dbf",
-            etl_settings=etl_settings,
-            zenodo_dois=zenodo_dois,
-        )
+        assert_ferc_sqlite_compatible(instance=instance, provenance=required)
 
 
 @pytest.mark.parametrize(
@@ -377,10 +196,8 @@ def test_assert_ferc_sqlite_compatible_rejects_missing_materialization(
     ],
 )
 def test_assert_ferc_sqlite_compatible_rejects_non_complete_status(
-    etl_settings: EtlSettings,
-    zenodo_dois: ZenodoDoiSettings,
     mocker,
-    status: str,
+    status: Literal["skipped", "not_configured"],
     expected_match: str,
 ) -> None:
     """A DB materialized with a non-complete status should raise RuntimeError.
@@ -388,18 +205,16 @@ def test_assert_ferc_sqlite_compatible_rejects_non_complete_status(
     Both 'skipped' and 'not_configured' mean the SQLite file was never fully
     populated, so downstream IO managers must refuse to read from it.
     """
+
     dagster_meta = FercSQLiteProvenanceRecord(
-        dataset="ferc1",
-        status=status,
+        dataset="ferc1", data_format="dbf", status=status
     ).to_dagster_metadata()
     instance = mocker.MagicMock()
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
         asset_materialization=mocker.MagicMock(metadata=dagster_meta)
     )
+    required = FercSQLiteProvenance(
+        dataset="ferc1", data_format="dbf", zenodo_doi="fake DOI", years=[]
+    )
     with pytest.raises(RuntimeError, match=expected_match):
-        assert_ferc_sqlite_compatible(
-            instance=instance,
-            db_name="ferc1_dbf",
-            etl_settings=etl_settings,
-            zenodo_dois=zenodo_dois,
-        )
+        assert_ferc_sqlite_compatible(instance=instance, provenance=required)

--- a/test/unit/ferc_sqlite_provenance_test.py
+++ b/test/unit/ferc_sqlite_provenance_test.py
@@ -29,7 +29,7 @@ def test_ferc_sqlite_provenance_record_round_trip() -> None:
         status="complete",
         zenodo_doi="fake DOI",
         years=[2018, 2019],
-        settings_json=json.loads(FercToSqliteSettings().model_dump_json()),
+        settings=json.loads(FercToSqliteSettings().model_dump_json()),
         sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
     )
     dagster_meta = {

--- a/test/unit/ferc_sqlite_provenance_test.py
+++ b/test/unit/ferc_sqlite_provenance_test.py
@@ -1,6 +1,5 @@
 """Unit tests for the FERC SQLite provenance helpers."""
 
-import json
 import os
 from pathlib import Path
 from typing import Literal
@@ -23,13 +22,14 @@ from pudl.settings import FercToSqliteSettings
 
 def test_ferc_sqlite_provenance_record_round_trip() -> None:
     """A complete record round-trips through Dagster metadata without data loss."""
+    settings = FercToSqliteSettings()
     record = FercSQLiteProvenanceRecord(
         dataset="ferc1",
         data_format="dbf",
         status="complete",
         zenodo_doi="fake DOI",
         years=[2018, 2019],
-        settings=json.loads(FercToSqliteSettings().model_dump_json()),
+        settings=settings,
         sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
     )
     dagster_meta = {
@@ -43,6 +43,7 @@ def test_ferc_sqlite_provenance_record_round_trip() -> None:
     )
 
     assert recovered == record
+    assert recovered.settings == settings
 
 
 @pytest.mark.parametrize("status", ["skipped", "not_configured"])

--- a/test/unit/io_managers_test.py
+++ b/test/unit/io_managers_test.py
@@ -16,7 +16,7 @@ from pudl.etl.check_foreign_keys import (
     ForeignKeyErrors,
     check_foreign_keys,
 )
-from pudl.ferc_sqlite_provenance import build_ferc_sqlite_provenance_metadata
+from pudl.ferc_sqlite_provenance import FercSQLiteProvenanceRecord
 from pudl.io_managers import (
     FercDbfSQLiteConfigurableIOManager,
     FercDbfSQLiteIOManager,
@@ -355,15 +355,18 @@ def test_ferc_dbf_io_manager_uses_injected_dataset_settings(mocker):
     )
     instance: DagsterInstance = mocker.MagicMock()
     instance.is_ephemeral = False
+
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
         asset_materialization=mocker.MagicMock(
-            metadata=build_ferc_sqlite_provenance_metadata(
+            metadata=FercSQLiteProvenanceRecord(
                 dataset="ferc1",
                 data_format="dbf",
-                etl_settings=etl_settings,
-                zenodo_dois=zenodo_dois,
-                sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
                 status="complete",
+                years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                    "ferc1", "dbf"
+                ),
+                zenodo_doi=zenodo_dois.get_doi("ferc1"),
+                sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
             ).to_dagster_metadata()
         )
     )
@@ -404,13 +407,15 @@ def test_ferc_xbrl_io_manager_uses_injected_dataset_settings(mocker):
     instance.is_ephemeral = False
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
         asset_materialization=mocker.MagicMock(
-            metadata=build_ferc_sqlite_provenance_metadata(
+            metadata=FercSQLiteProvenanceRecord(
                 dataset="ferc1",
-                data_format="xbrl",
-                etl_settings=etl_settings,
-                zenodo_dois=zenodo_dois,
-                sqlite_path=Path("test-data/ferc1_xbrl.sqlite"),
+                data_format="dbf",
                 status="complete",
+                years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                    "ferc1", "xbrl"
+                ),
+                zenodo_doi=zenodo_dois.get_doi("ferc1"),
+                sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
             ).to_dagster_metadata()
         )
     )
@@ -429,7 +434,7 @@ def test_ferc_xbrl_io_manager_uses_injected_dataset_settings(mocker):
     )
 
 
-def test_ferc_dbf_io_manager_rejects_incompatible_provenance(mocker):
+def test_ferc_dbf_io_manager_rejects_stale_provenance(mocker):
     """The migrated FERC DBF IO manager should fail fast on stale prerequisites."""
     dataset_settings = DatasetsSettings(ferc1=Ferc1Settings(years=[2020, 2021]))
     etl_settings = EtlSettings(
@@ -437,7 +442,6 @@ def test_ferc_dbf_io_manager_rejects_incompatible_provenance(mocker):
         ferc_to_sqlite_settings=FercToSqliteSettings(),
     )
     zenodo_dois = ZenodoDoiSettings()
-    stale_zenodo_dois = ZenodoDoiSettings(ferc1="10.5281/zenodo.9999999")
 
     fake_engine = mocker.MagicMock()
     fake_engine.begin.return_value.__enter__.return_value = mocker.MagicMock()
@@ -451,13 +455,13 @@ def test_ferc_dbf_io_manager_rejects_incompatible_provenance(mocker):
             update={"etl_settings": etl_settings, "zenodo_dois": zenodo_dois}
         )
     )
-    stale_metadata = build_ferc_sqlite_provenance_metadata(
+    stale_metadata = FercSQLiteProvenanceRecord(
         dataset="ferc1",
         data_format="dbf",
-        etl_settings=etl_settings,
-        zenodo_dois=stale_zenodo_dois,
-        sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
         status="complete",
+        years=etl_settings.ferc_to_sqlite_settings.get_dataset_years("ferc1", "dbf"),
+        zenodo_doi="stale DOI",
+        sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
     ).to_dagster_metadata()
     instance: DagsterInstance = mocker.MagicMock()
     instance.is_ephemeral = False

--- a/test/unit/io_managers_test.py
+++ b/test/unit/io_managers_test.py
@@ -366,9 +366,7 @@ def test_ferc_dbf_io_manager_uses_injected_dataset_settings(mocker):
                     dataset="ferc1",
                     data_format="dbf",
                     status="complete",
-                    years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
-                        "ferc1", "dbf"
-                    ),
+                    years=etl_settings.ferc_to_sqlite.get_dataset_years("ferc1", "dbf"),
                     zenodo_doi=zenodo_dois.get_doi("ferc1"),
                     sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
                 ).model_dump(mode="json")
@@ -417,7 +415,7 @@ def test_ferc_xbrl_io_manager_uses_injected_dataset_settings(mocker):
                     dataset="ferc1",
                     data_format="dbf",
                     status="complete",
-                    years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                    years=etl_settings.ferc_to_sqlite.get_dataset_years(
                         "ferc1", "xbrl"
                     ),
                     zenodo_doi=zenodo_dois.get_doi("ferc1"),
@@ -467,9 +465,7 @@ def test_ferc_dbf_io_manager_rejects_stale_provenance(mocker):
             dataset="ferc1",
             data_format="dbf",
             status="complete",
-            years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
-                "ferc1", "dbf"
-            ),
+            years=etl_settings.ferc_to_sqlite.get_dataset_years("ferc1", "dbf"),
             zenodo_doi="stale DOI",
             sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
         ).model_dump(mode="json")

--- a/test/unit/io_managers_test.py
+++ b/test/unit/io_managers_test.py
@@ -16,7 +16,10 @@ from pudl.etl.check_foreign_keys import (
     ForeignKeyErrors,
     check_foreign_keys,
 )
-from pudl.ferc_sqlite_provenance import FercSQLiteProvenanceRecord
+from pudl.ferc_sqlite_provenance import (
+    FERC_TO_SQLITE_METADATA_KEY,
+    FercSQLiteProvenanceRecord,
+)
 from pudl.io_managers import (
     FercDbfSQLiteConfigurableIOManager,
     FercDbfSQLiteIOManager,
@@ -358,16 +361,18 @@ def test_ferc_dbf_io_manager_uses_injected_dataset_settings(mocker):
 
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
         asset_materialization=mocker.MagicMock(
-            metadata=FercSQLiteProvenanceRecord(
-                dataset="ferc1",
-                data_format="dbf",
-                status="complete",
-                years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
-                    "ferc1", "dbf"
-                ),
-                zenodo_doi=zenodo_dois.get_doi("ferc1"),
-                sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
-            ).to_dagster_metadata()
+            metadata={
+                FERC_TO_SQLITE_METADATA_KEY: FercSQLiteProvenanceRecord(
+                    dataset="ferc1",
+                    data_format="dbf",
+                    status="complete",
+                    years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                        "ferc1", "dbf"
+                    ),
+                    zenodo_doi=zenodo_dois.get_doi("ferc1"),
+                    sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
+                ).model_dump(mode="json")
+            }
         )
     )
     context: InputContext = build_input_context(
@@ -407,16 +412,18 @@ def test_ferc_xbrl_io_manager_uses_injected_dataset_settings(mocker):
     instance.is_ephemeral = False
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(
         asset_materialization=mocker.MagicMock(
-            metadata=FercSQLiteProvenanceRecord(
-                dataset="ferc1",
-                data_format="dbf",
-                status="complete",
-                years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
-                    "ferc1", "xbrl"
-                ),
-                zenodo_doi=zenodo_dois.get_doi("ferc1"),
-                sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
-            ).to_dagster_metadata()
+            metadata={
+                FERC_TO_SQLITE_METADATA_KEY: FercSQLiteProvenanceRecord(
+                    dataset="ferc1",
+                    data_format="dbf",
+                    status="complete",
+                    years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                        "ferc1", "xbrl"
+                    ),
+                    zenodo_doi=zenodo_dois.get_doi("ferc1"),
+                    sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
+                ).model_dump(mode="json")
+            }
         )
     )
     context: InputContext = build_input_context(
@@ -455,14 +462,18 @@ def test_ferc_dbf_io_manager_rejects_stale_provenance(mocker):
             update={"etl_settings": etl_settings, "zenodo_dois": zenodo_dois}
         )
     )
-    stale_metadata = FercSQLiteProvenanceRecord(
-        dataset="ferc1",
-        data_format="dbf",
-        status="complete",
-        years=etl_settings.ferc_to_sqlite_settings.get_dataset_years("ferc1", "dbf"),
-        zenodo_doi="stale DOI",
-        sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
-    ).to_dagster_metadata()
+    stale_metadata = {
+        FERC_TO_SQLITE_METADATA_KEY: FercSQLiteProvenanceRecord(
+            dataset="ferc1",
+            data_format="dbf",
+            status="complete",
+            years=etl_settings.ferc_to_sqlite_settings.get_dataset_years(
+                "ferc1", "dbf"
+            ),
+            zenodo_doi="stale DOI",
+            sqlite_path=Path("test-data/ferc1_dbf.sqlite"),
+        ).model_dump(mode="json")
+    }
     instance: DagsterInstance = mocker.MagicMock()
     instance.is_ephemeral = False
     instance.get_latest_materialization_event.return_value = mocker.MagicMock(

--- a/test/unit/settings_test.py
+++ b/test/unit/settings_test.py
@@ -31,7 +31,6 @@ from pudl.settings import (
     FercToSqliteSettings,
     GenericDatasetSettings,
     GridPathRAToolkitSettings,
-    load_etl_settings,
 )
 from pudl.workspace.datastore import Datastore
 from pudl.workspace.setup import PudlPaths
@@ -281,7 +280,7 @@ class TestGridPathRAToolkitSettings:
         with importlib.resources.as_file(
             importlib.resources.files("pudl.package_data.settings") / "etl_fast.yml"
         ) as path:
-            etl_settings: EtlSettings = load_etl_settings(str(path))
+            etl_settings: EtlSettings = EtlSettings.from_yaml(path)
         assert etl_settings.datasets is not None
 
         gridpath_settings: GridPathRAToolkitSettings | None = (


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

I found the FercSqliteProvenance code in #5071 to have some problems, so I fixed them:

* Lots of string parsing of `ferc<number>_<format>`. We already know, at the outermost layer of the call structure (`_FercSQLiteConfigurableIOManagerBase`'s subclasses), what the dataset name and database format are. So I store that on the class and thread that through the call stack.
* There were a couple factory functions (`build_ferc_sqlite_provenance_metadata`, `FercSQLiteProvenance.from_dataset_and_format`) that took the `etl_settings` and `zenodo_doi` resources as arguments. The core data structures here probably don't need to know about Dagster configuration data structures - instead we can pull the dagster configs apart and pass in the actual values we need. Removed these and their tests.
* `FercXbrlSQLiteIOManager.load_input()` was almost exactly the same as `FercXbrlSQLiteConfigurableIOManager.load_input()`, but... wasn't being called since the IO managers defined as resources are the configurable ones.
* Added a couple small helper functions to avoid annoying `getattr()` calls.
* The `FercSQLiteProvenanceRecord` was much more complicated than it needed to be, so I turned it into a simple Pydantic model and modified call sites to just use normal `model_dump` + Dagster metadata-handling facilities.
  * maintained a weird mapping of "dagster metadata field name" to "real field name"
  * bespoke de/serialization code that reconstructs "default is None" behavior
  * `settings_json` is not a JSON. It's just a dict that's serializable *to* JSON.
* removed `load_etl_settings`: this path expansion should just live in the `.from_yaml`. Also I don't think we use remote etl settings files anywhere, so I removed that as a possibility. Easy enough to add back in when we actually need it.
* removed `load_packaged_etl_settings`: "knowing where the specific ETL settings files for our default jobs live" clearly lives with the rest of the job construction in `etl/__init__.py`.

# Testing

How did you make sure this worked?

Ran `pixi run pytest-ci`.
