### PR TITLE
chore: add 'good first issue' issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/good-first-issue.md
+++ b/.github/ISSUE_TEMPLATE/good-first-issue.md
@@ -1,0 +1,31 @@
+---
+name: Good first issue
+about: A beginner-friendly task for new contributors
+title: ''
+labels: good first issue
+assignees: ''
+---
+
+### Overview
+
+What is the problem we're solving? For very simple items, this can be encapsulated in the success criteria.
+
+### Success Criteria
+
+How will we know that we're done?
+
+* [ ] ...
+
+### Get set up
+
+- [ ] Fork the PUDL repository and follow the steps to set up the [PUDL development environment](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/dev_setup.html)
+- [ ] Activate the pudl-dev environment: `pixi shell`
+- [ ] Grab the latest raw data for any relevant tables: `pudl_datastore --dataset <dataset_name>`
+
+### Next steps
+
+* [ ] ...
+
+### Resources
+
+Links to relevant documentation, PDFs, or other helpful references.


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #5193.

## What problem does this address?

PUDL's "good first issues" are currently created in an ad-hoc way, with inconsistent structure across issues. This makes it harder for new contributors to understand what's expected and get set up quickly.

## What did you change?

Created a new `.github/ISSUE_TEMPLATE/good-first-issue.md` template that provides:
- A consistent **Overview** section for problem description
- A **Success Criteria** checklist for clear completion signals
- A **Get set up** section with PUDL-specific dev environment setup (pixi shell, pudl_datastore)
- A **Next steps** section for task breakdown
- A **Resources** section for links to docs, PDFs, and references

The template follows the same structure used in existing GFI issues (#5081, #4352, #4081) while being flexible enough to cover many different use cases.

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that may be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run prek-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
