### PR TITLE
chore: avoid `f'ferc{form.value}'` everywhere

### DIFF
--- a/src/pudl/etl/ferc_to_sqlite_assets.py
+++ b/src/pudl/etl/ferc_to_sqlite_assets.py
@@ -78,23 +78,21 @@ def xbrl_to_sqlite_asset_factory(
             "runtime_settings",
             "zenodo_dois",
         },
-        tags={"dataset": f"ferc{form.value}", "data_format": "xbrl"},
+        tags={"dataset": str(form), "data_format": "xbrl"},
     )
     def _asset(context) -> dg.MaterializeResult[str]:
         runtime_settings = context.resources.runtime_settings
         settings = context.resources.etl_settings.ferc_to_sqlite.get_dataset_settings(
-            dataset=f"ferc{form.value}", data_format="xbrl"
+            dataset=form, data_format="xbrl"
         )
         if settings is None or not settings.years:
-            logger.info(
-                f"No years configured for ferc{form.value}_xbrl: skipping extraction."
-            )
+            logger.info(f"No years configured for {form}_xbrl: skipping extraction.")
             return dg.MaterializeResult(
                 value="not_configured",
                 metadata={
                     FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
                         FercSQLiteProvenanceRecord(
-                            dataset=f"ferc{form.value}",
+                            dataset=str(form),
                             data_format="xbrl",
                             status="not_configured",
                         ).model_dump(mode="json")
@@ -103,10 +101,10 @@ def xbrl_to_sqlite_asset_factory(
             )
 
         output_path = PudlPaths().output_dir
-        sqlite_path = PudlPaths().sqlite_db_path(f"ferc{form.value}_xbrl")
+        sqlite_path = PudlPaths().sqlite_db_path(f"{form}_xbrl")
         if sqlite_path.exists():
             sqlite_path.unlink()
-        duckdb_path = PudlPaths().duckdb_db_path(f"ferc{form.value}_xbrl")
+        duckdb_path = PudlPaths().duckdb_db_path(f"{form}_xbrl")
         if duckdb_path.exists():
             duckdb_path.unlink()
 
@@ -127,19 +125,15 @@ def xbrl_to_sqlite_asset_factory(
             metadata={
                 FERC_TO_SQLITE_METADATA_KEY: dg.MetadataValue.json(
                     FercSQLiteProvenanceRecord(
-                        dataset=f"ferc{form.value}",
+                        dataset=str(form),
                         data_format="xbrl",
                         status="complete",
-                        zenodo_doi=context.resources.zenodo_dois.get_doi(
-                            f"ferc{form.value}"
-                        ),
+                        zenodo_doi=context.resources.zenodo_dois.get_doi(str(form)),
                         years=context.resources.etl_settings.ferc_to_sqlite.get_dataset_years(
-                            dataset=f"ferc{form.value}", data_format="xbrl"
+                            dataset=form, data_format="xbrl"
                         ),
                         settings=context.resources.etl_settings.ferc_to_sqlite,
-                        sqlite_path=PudlPaths().sqlite_db_path(
-                            f"ferc{form.value}_xbrl"
-                        ),
+                        sqlite_path=PudlPaths().sqlite_db_path(f"{form}_xbrl"),
                     ).model_dump(mode="json")
                 )
             },

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -74,7 +74,7 @@ class FercXbrlDatastore:
     def get_taxonomy(self, form: XbrlFormNumber) -> io.BytesIO:
         """Returns the path to the taxonomy entry point within the an archive."""
         raw_archive = self.datastore.get_unique_resource(
-            f"ferc{form.value}",
+            str(form),
             data_format="xbrl_taxonomy",
         )
 
@@ -83,9 +83,7 @@ class FercXbrlDatastore:
     def get_filings(self, year: int, form: XbrlFormNumber) -> io.BytesIO:
         """Return the corresponding archive full of XBRL filings."""
         return io.BytesIO(
-            self.datastore.get_unique_resource(
-                f"ferc{form.value}", year=year, data_format="xbrl"
-            )
+            self.datastore.get_unique_resource(str(form), year=year, data_format="xbrl")
         )
 
 
@@ -93,33 +91,33 @@ def xbrl2sqlite_op_factory(form: XbrlFormNumber) -> Callable:
     """Generates xbrl2sqlite op for a given FERC form."""
 
     @op(
-        name=f"ferc{form.value}_xbrl",
+        name=f"{form}_xbrl",
         required_resource_keys={
             "etl_settings",
             "datastore",
             "runtime_settings",
         },
-        tags={"data_format": "xbrl", "dataset": f"ferc{form.value}"},
+        tags={"data_format": "xbrl", "dataset": str(form)},
     )
     def inner_op(context) -> None:
         output_path = PudlPaths().output_dir
         rs: RuntimeSettings = context.resources.runtime_settings
         settings = context.resources.etl_settings.ferc_to_sqlite.get_dataset_settings(
-            dataset=f"ferc{form.value}", data_format="xbrl"
+            dataset=form, data_format="xbrl"
         )
         datastore = FercXbrlDatastore(context.resources.datastore)
 
         logger.info(f"====== xbrl2sqlite runtime_settings: {rs}")
         if settings is None or not settings.years:
             logger.info(
-                f"Skipping dataset ferc{form.value}_xbrl: no config or no years configured."
+                f"Skipping dataset {form}_xbrl: no config or no years configured."
             )
             return
 
-        sqlite_path = PudlPaths().sqlite_db_path(f"ferc{form.value}_xbrl")
+        sqlite_path = PudlPaths().sqlite_db_path(f"{form}_xbrl")
         if sqlite_path.exists():
             sqlite_path.unlink()
-        duckdb_path = PudlPaths().duckdb_db_path(f"ferc{form.value}_xbrl")
+        duckdb_path = PudlPaths().duckdb_db_path(f"{form}_xbrl")
         if duckdb_path.exists():
             duckdb_path.unlink()
 
@@ -163,8 +161,8 @@ def convert_form(
     Returns:
         None
     """
-    datapackage_path = output_path / f"ferc{form.value}_xbrl_datapackage.json"
-    metadata_path = output_path / f"ferc{form.value}_xbrl_taxonomy_metadata.json"
+    datapackage_path = output_path / f"{form}_xbrl_datapackage.json"
+    metadata_path = output_path / f"{form}_xbrl_taxonomy_metadata.json"
 
     taxonomy_archive = datastore.get_taxonomy(form)
     # Process XBRL filings for each year requested

--- a/src/pudl/settings.py
+++ b/src/pudl/settings.py
@@ -39,6 +39,10 @@ class XbrlFormNumber(Enum):
     FORM60 = 60
     FORM714 = 714
 
+    def __str__(self):
+        """Format this as ``fercX``, the way we use it everywhere else."""
+        return f"ferc{self.value}"
+
 
 class FrozenBaseModel(BaseModel):
     """BaseModel with global configuration."""
@@ -840,7 +844,7 @@ class FercToSqliteSettings(BaseSettings):
         return data
 
     def get_dataset_settings(
-        self, dataset: str, data_format: Literal["dbf", "xbrl"]
+        self, dataset: str | XbrlFormNumber, data_format: Literal["dbf", "xbrl"]
     ) -> FercGenericXbrlToSqliteSettings:
         """Look up extraction settings by dataset (``fercX``) and data format (``dbf`` or ``xbrl``).
 
@@ -850,7 +854,7 @@ class FercToSqliteSettings(BaseSettings):
         return dict(self)[key]
 
     def get_dataset_years(
-        self, dataset: str, data_format: Literal["dbf", "xbrl"]
+        self, dataset: str | XbrlFormNumber, data_format: Literal["dbf", "xbrl"]
     ) -> list[int]:
         """Look up extraction *years* by dataset (``fercX``) and data format (``dbf`` or ``xbrl``)."""
         settings = self.get_dataset_settings(dataset=dataset, data_format=data_format)

--- a/test/integration/ferc_xbrl_extract_test.py
+++ b/test/integration/ferc_xbrl_extract_test.py
@@ -10,13 +10,11 @@ import pytest
 import sqlalchemy as sa
 
 from pudl.extract.ferc1 import TABLE_NAME_MAP_FERC1
-from pudl.settings import FercToSqliteSettings
+from pudl.settings import FercToSqliteSettings, XbrlFormNumber
 from pudl.transform.ferc import filter_for_freshest_data_xbrl, get_primary_key_raw_xbrl
 from pudl.workspace.setup import PudlPaths
 
 logger = logging.getLogger(__name__)
-
-FERC_FORMS = [1, 2, 6, 60, 714]
 
 
 def _get_tables(conn) -> set[str]:
@@ -40,17 +38,17 @@ def test_sqlite_duckdb_equivalence(
     ferc_to_sqlite_settings: FercToSqliteSettings,
 ):
     """Ensure that the XBRL-derived FERC SQLite and DuckDB databases are equivalent."""
-    for form in FERC_FORMS:
-        if not ferc_to_sqlite_settings.__getattribute__(
-            f"ferc{form}_xbrl_to_sqlite_settings"
-        ).years:
+    for form in XbrlFormNumber:
+        if not ferc_to_sqlite_settings.get_dataset_years(
+            dataset=form, data_format="xbrl"
+        ):
             logger.info(
-                f"Skipping FERC Form {form} sqlite vs duckdb equivalence test: no years configured."
+                f"Skipping {form} sqlite vs duckdb equivalence test: no years configured."
             )
             continue
-        logger.info(f"Comparing FERC Form {form} SQLite vs. DuckDB outputs...")
-        sqlite_path = PudlPaths().sqlite_db_path(f"ferc{form}_xbrl")
-        duckdb_path = PudlPaths().duckdb_db_path(f"ferc{form}_xbrl")
+        logger.info(f"Comparing {form} SQLite vs. DuckDB outputs...")
+        sqlite_path = PudlPaths().sqlite_db_path(f"{form}_xbrl")
+        duckdb_path = PudlPaths().duckdb_db_path(f"{form}_xbrl")
 
         with (
             duckdb.connect(sqlite_path) as sqlite_conn,

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -144,14 +144,12 @@ def test_xbrl2sqlite(settings, forms, mocker):
 
     for form in forms:
         convert_form_mock.assert_any_call(
-            settings.get_dataset_settings(
-                dataset=f"ferc{form.value}", data_format="xbrl"
-            ),
+            settings.get_dataset_settings(dataset=form, data_format="xbrl"),
             form,
             mock_datastore,
             output_path=PudlPaths().output_dir,
-            sqlite_path=PudlPaths().output_dir / f"ferc{form.value}_xbrl.sqlite",
-            duckdb_path=PudlPaths().output_dir / f"ferc{form.value}_xbrl.duckdb",
+            sqlite_path=PudlPaths().output_dir / f"{form}_xbrl.sqlite",
+            duckdb_path=PudlPaths().output_dir / f"{form}_xbrl.duckdb",
             batch_size=20,
             workers=10,
             loglevel="INFO",
@@ -184,8 +182,8 @@ def test_convert_form(mocker):
             form,
             FakeDatastore(),
             output_path=output_path,
-            sqlite_path=output_path / f"ferc{form.value}_xbrl.sqlite",
-            duckdb_path=output_path / f"ferc{form.value}_xbrl.duckdb",
+            sqlite_path=output_path / f"{form}_xbrl.sqlite",
+            duckdb_path=output_path / f"{form}_xbrl.duckdb",
             batch_size=10,
             workers=5,
         )
@@ -194,12 +192,12 @@ def test_convert_form(mocker):
         filings: list[str] = [f"filings_{year}_{form.value}" for year in settings.years]
         extractor_mock.assert_called_with(
             filings=filings,
-            sqlite_path=output_path / f"ferc{form.value}_xbrl.sqlite",
-            duckdb_path=output_path / f"ferc{form.value}_xbrl.duckdb",
+            sqlite_path=output_path / f"{form}_xbrl.sqlite",
+            duckdb_path=output_path / f"{form}_xbrl.duckdb",
             taxonomy=f"raw_archive_{form.value}",
             form_number=form.value,
-            metadata_path=output_path / f"ferc{form.value}_xbrl_taxonomy_metadata.json",
-            datapackage_path=output_path / f"ferc{form.value}_xbrl_datapackage.json",
+            metadata_path=output_path / f"{form}_xbrl_taxonomy_metadata.json",
+            datapackage_path=output_path / f"{form}_xbrl_datapackage.json",
             workers=5,
             batch_size=10,
             loglevel="INFO",


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Noticed a lot of `f"ferc{form.value}` floating around, figured it might be nice to encapsulate that in a `__str__` method. 

If this doesn't seem worth it we can also just close.

# Testing

Ran unit tests, pytest-ci running now.

## To-do list
- [ ] Review the PR yourself and call out any questions or issues you have.

