### PR TITLE
Fix Zenodo DOI update action

### DIFF
--- a/.github/workflows/update-dois.yml
+++ b/.github/workflows/update-dois.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Run Zenodo DOI updater
         id: update
         run: |
-          pixi run update_zenodo_dois "${{ github.event.inputs.datasets }}"
+          pixi run update_zenodo_dois ${{ github.event.inputs.datasets }}
 
           # Check if any changes were made
           if git diff --quiet; then


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Closes #5213 

## What problem does this address?
The Zenodo DOI updater action was incorrectly quoting the datasets input via the schedule, resulting in an invalid run that updated nothing.

## What did you change?
Removed the quotes from the GHA.

# Testing

How did you make sure this worked? How can a reviewer verify this?
See https://github.com/catalyst-cooperative/pudl/actions/runs/25335269452 and https://github.com/catalyst-cooperative/pudl/pull/5216

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run prek-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [x] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
