### PR TITLE
(WIP) Integrate new xbrl -> parquet outputs

### DIFF
--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -163,9 +163,6 @@ def convert_form(
     Returns:
         None
     """
-    datapackage_path = output_path / f"ferc{form.value}_xbrl_datapackage.json"
-    metadata_path = output_path / f"ferc{form.value}_xbrl_taxonomy_metadata.json"
-
     taxonomy_archive = datastore.get_taxonomy(form)
     # Process XBRL filings for each year requested
     filings_archives = [
@@ -180,12 +177,11 @@ def convert_form(
     with _suppress_arelle_message_spam():
         run_main(
             filings=filings_archives,
+            output_dir=output_path,
             sqlite_path=sqlite_path,
             duckdb_path=duckdb_path,
             taxonomy=taxonomy_archive,
             form_number=form.value,
-            metadata_path=metadata_path,
-            datapackage_path=datapackage_path,
             workers=workers,
             batch_size=batch_size,
             loglevel=loglevel,

--- a/test/unit/extract/xbrl_test.py
+++ b/test/unit/extract/xbrl_test.py
@@ -194,12 +194,11 @@ def test_convert_form(mocker):
         filings: list[str] = [f"filings_{year}_{form.value}" for year in settings.years]
         extractor_mock.assert_called_with(
             filings=filings,
+            output_dir=output_path,
             sqlite_path=output_path / f"ferc{form.value}_xbrl.sqlite",
             duckdb_path=output_path / f"ferc{form.value}_xbrl.duckdb",
             taxonomy=f"raw_archive_{form.value}",
             form_number=form.value,
-            metadata_path=output_path / f"ferc{form.value}_xbrl_taxonomy_metadata.json",
-            datapackage_path=output_path / f"ferc{form.value}_xbrl_datapackage.json",
             workers=5,
             batch_size=10,
             loglevel="INFO",


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

Needs https://github.com/catalyst-cooperative/ferc-xbrl-extractor/pull/427

Closes #XXXX.

## What problem does this address?

## What did you change?

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run prek-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
