### PR TITLE
Document FERC SQLite Provenance; Update RTD docs links

### DIFF
--- a/.github/ISSUE_TEMPLATE/existing_data_updates.md
+++ b/.github/ISSUE_TEMPLATE/existing_data_updates.md
@@ -6,17 +6,17 @@ labels: data-update
 assignees: ""
 ---
 
-### New year of data integration check-list:
+## New year of data integration check-list
 
-Based on the [Existing Data Updates Docs](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html)
+Based on the [Existing Data Updates Docs](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html)
 
-- [ ] [Obtain fresh data](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#obtain-fresh-data)
-- [ ] [Map the structure of the new data](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#map-the-structure-of-the-new-data)
-- [ ] [Test data extraction](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#test-data-extraction)
-- [ ] [Update table and column transformations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#update-table-column-transformations)
-- [ ] [Update the PUDL db schema](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#update-the-pudl-db-schema)
-- [ ] [Connect datasets](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#connect-datasets)
-- [ ] [Update the output routines](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#update-the-output-routines-and-run-full-tests)
-- [ ] [Run the ETL](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#run-the-etl)
-- [ ] [Run and update data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#run-and-update-data-validations)
-- [ ] [Update the documentation](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html#update-the-documentation)
+- [ ] [Obtain fresh data](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#obtain-fresh-data)
+- [ ] [Map the structure of the new data](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#map-the-structure-of-the-new-data)
+- [ ] [Test data extraction](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#test-data-extraction)
+- [ ] [Update table and column transformations](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#update-table-column-transformations)
+- [ ] [Update the PUDL db schema](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#update-the-pudl-db-schema)
+- [ ] [Connect datasets](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#connect-datasets)
+- [ ] [Update the output routines](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#update-the-output-routines-and-run-full-tests)
+- [ ] [Run the ETL](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#run-the-etl)
+- [ ] [Run and update data validations](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#run-and-update-data-validations)
+- [ ] [Update the documentation](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html#update-the-documentation)

--- a/.github/ISSUE_TEMPLATE/quarterly_updates.md
+++ b/.github/ISSUE_TEMPLATE/quarterly_updates.md
@@ -6,11 +6,11 @@ labels: data-update
 assignees: ""
 ---
 
-### Quarterly Update Check-list
+## Quarterly Update Check-list
 
 Once the new archives have been vetted and published, you can begin the process of integrating the new quarterly update data into PUDL.
 
-Follow the steps in [Existing Data Updates Docs](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/existing_data_updates.html)
+Follow the steps in [Existing Data Updates Docs](https://docs.catalyst.coop/pudl/en/nightly/dev/existing_data_updates.html)
 
 - [ ] EIA 860m {{ date | date('[Q]Q YYYY') }} Update
 - [ ] EIA 923 {{ date | date('[Q]Q YYYY') }} Update

--- a/.github/ISSUE_TEMPLATE/versioned_release.md
+++ b/.github/ISSUE_TEMPLATE/versioned_release.md
@@ -10,7 +10,7 @@ labels:
 assignees: ""
 ---
 
-[Additional release process documentation](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/run_a_release.html).
+[Additional release process documentation](https://docs.catalyst.coop/pudl/en/nightly/dev/run_a_release.html).
 
 <details><summary>Blank release notes template</summary>
 ```
@@ -50,7 +50,7 @@ Quality of Life Improvements
 - [ ] Set a release date & notify team
 - [ ] Update our CITATION.cff file with the new release date and current Catalyst membership.
 - [ ] Update our .zenodo.json file with current Catalyst membership.
-- [ ] Close out the [PUDL Release Notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html) with an overview of the changes in this release. Check [PRs merged since the last release](https://github.com/catalyst-cooperative/pudl/pulls?q=is%3Apr+is%3Amerged+merged%3A%3EYYYY-MM-DD) to make sure all changes since the last release are listed somewhere in the notes.
+- [ ] Close out the [PUDL Release Notes](https://docs.catalyst.coop/pudl/en/nightly/release_notes.html) with an overview of the changes in this release. Check [PRs merged since the last release](https://github.com/catalyst-cooperative/pudl/pulls?q=is%3Apr+is%3Amerged+merged%3A%3EYYYY-MM-DD) to make sure all changes since the last release are listed somewhere in the notes.
 - [ ] Merge those changes into `main`
 - [ ] Verify that all `stable` commits are on `main` with `git fetch && git log origin/main..origin/stable`
 - [ ] Tag the release `git tag -as -m "PUDL vYYYY.M.x" vYYYY.M.x`
@@ -59,10 +59,9 @@ Quality of Life Improvements
 - [ ] Verify that [PUDL repo archive on Zenodo](https://zenodo.org/doi/10.5281/zenodo.3404014) has been updated w/ new version
 - [ ] Wait several hours for a successful build to complete ([monitor here](https://console.cloud.google.com/monitoring/dashboards/builder/992bbe3f-17e6-49c4-a9e8-8f1925d4ec24))
 - [ ] Verify that the corresponding `zenodo-data-release` GHA completed successfully. If it times out less than halfway through, re-run manually (production, vYYYY.M.x, default regex, no-publish). If Zenodo is extra cranky, ignore the GHA and upload the remaining files manually.
-- [ ] Activate new version on the [RTD admin panel](https://app.readthedocs.org/projects/catalystcoop-pudl/) and verify that it builds successfully.
 - [ ] Use GitHub to [edit `available_versions.json`](https://github.com/catalyst-cooperative/pudl/blob/gh-pages/available_versions.json) and add an entry for the new version (automate!)
 - [ ] Verify that `stable` and the version tag point at same git ref
-- [ ] Verify that [`stable` docs on RTD](https://catalystcoop-pudl.readthedocs.io/en/stable/) have been updated
+- [ ] Verify that [`stable` docs](https://docs.catalyst.coop/pudl/en/stable/) have been updated
 - [ ] Verify `gs://pudl.catalyst.coop/vYYYY.M.x` has the new expected data.
 - [ ] Verify `gs://pudl.catalyst.coop/stable` has the new expected data.
 - [ ] Verify `s3://pudl.catalyst.coop/vYYYY.M.x` has the new expected data.
@@ -72,7 +71,7 @@ Quality of Life Improvements
 - [ ] Manually publish the new Zenodo deposition with the updated metadata
 - [ ] Notify team we're clear of the release, and remind them to move any release notes in open PRs to the next release section
 - [ ] Create an Announcement for the release in [our GitHub Discussions](https://github.com/orgs/catalyst-cooperative/discussions)
-- [ ] Update the [release documentation](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/run_a_release.html) to better reflect the actual process for next time
+- [ ] Update the [release documentation](https://docs.catalyst.coop/pudl/en/nightly/dev/run_a_release.html) to better reflect the actual process for next time
 
 ### Zenodo Metadata Tasks
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 <!--
 Resources:
-* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
-* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
+* contributing guidelines: https://docs.catalyst.coop/pudl/en/nightly/CONTRIBUTING.html
+* code of conduct: https://docs.catalyst.coop/pudl/en/nightly/code_of_conduct.html
 -->
 
 # Overview
@@ -16,7 +16,7 @@ Closes #XXXX.
 
 Make sure to update relevant aspects of the documentation:
 
-- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
+- [ ] Update the [release notes](https://docs.catalyst.coop/pudl/en/nightly/release_notes.html): reference the PR and related issues.
 - [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
 - [ ] Update relevant table or source description metadata (see `src/metadata`).
 - [ ] Review and update any other aspects of the documentation that might be affected by this PR.
@@ -31,4 +31,4 @@ How did you make sure this worked? How can a reviewer verify this?
 - [ ] Run `pixi run prek-run` to run linters and static code analysis checks.
 - [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
 - [ ] Review the PR yourself and call out any questions or issues you have.
-- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
+- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://docs.catalyst.coop/pudl/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
           as well as s3://pudl.catalyst.coop/'${{ github.ref_name }}'.
 
           ## Changes:
-          See [Release Notes](https://catalystcoop-pudl.readthedocs.io/en/latest/release_notes.html) for details." \
+          See [Release Notes](https://docs.catalyst.coop/pudl/en/latest/release_notes.html) for details." \
               --repo '${{ github.repository }}'
       - name: Attach conda package to GitHub Release
         env:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -28,7 +28,7 @@ Your first contribution
 **Setup**
 
 You'll need to fork this repository and get the
-`dev environment set up <https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/dev_setup.html>`__.
+`dev environment set up <https://docs.catalyst.coop/pudl/en/nightly/dev/dev_setup.html>`__.
 
 **Pick an issue**
 

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,9 @@ The Public Utility Data Liberation Project (PUDL)
 .. |codecov| image:: https://img.shields.io/codecov/c/github/catalyst-cooperative/pudl?style=flat&logo=codecov
    :target: https://codecov.io/gh/catalyst-cooperative/pudl
    :alt: Codecov Test Coverage
-.. |rtd| image:: https://img.shields.io/readthedocs/catalystcoop-pudl?style=flat&logo=readthedocs
-   :target: https://catalystcoop-pudl.readthedocs.io/en/nightly/
-   :alt: Read the Docs Build Status
+.. |docs| image:: https://github.com/catalyst-cooperative/pudl/actions/workflows/build-deploy-docs.yml/badge.svg
+   :target: https://docs.catalyst.coop/pudl/en/latest
+   :alt: Docs Build Status
 .. |oc| image:: https://opencollective.com/pudl/tiers/badge.svg
    :target: https://opencollective.com/pudl
 .. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
@@ -23,8 +23,8 @@ The Public Utility Data Liberation Project (PUDL)
 .. |pre-commit-ci| image:: https://results.pre-commit.ci/badge/github/catalyst-cooperative/pudl/main.svg
    :target: https://results.pre-commit.ci/latest/github/catalyst-cooperative/pudl/main
    :alt: pre-commit CI
-.. |zenodo-doi| image:: https://zenodo.org/badge/80646423.svg
-   :target: https://zenodo.org/badge/latestdoi/80646423
+.. |zenodo-doi| image:: https://zenodo.org/badge/doi/10.5281/zenodo.3404014.svg
+   :target: https://doi.org/10.5281/zenodo.3404014
    :alt: Zenodo DOI
 .. |office-hours| image:: https://img.shields.io/badge/calend.ly-officehours-darkgreen
    :target: https://calend.ly/catalyst-cooperative/pudl-office-hours
@@ -50,9 +50,9 @@ The Public Utility Data Liberation Project (PUDL)
    :target: https://registry.opendata.aws/catalyst-cooperative-pudl/
    :alt: PUDL in the AWS Open Data Registry
 
-|repo-status| |pytest| |codecov| |rtd| |oc| |ruff| |pre-commit-ci|
-|zenodo-doi| |office-hours| |mastodon| |linkedin| |bluesky| |kaggle| |slack| |youtube|
-|aws|
+|repo-status|\ |pytest|\ |codecov|\ |docs|\ |oc|\ |ruff|\ |pre-commit-ci|
+|zenodo-doi|\ |office-hours|\ |mastodon|\ |linkedin|\ |bluesky|\ |kaggle|\ |slack|
+|youtube|\ |aws|
 
 What is PUDL?
 -------------
@@ -88,7 +88,7 @@ publishes data or deletes old files, the data processing pipeline will still hav
 to the original inputs. Each of the data inputs may have several different versions
 archived, and all are assigned a unique DOI (digital object identifier) and made
 available through Zenodo's REST API.  You can read more about the Raw Data Archives in
-the `docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/#raw-data-archives>`__.
+the `docs <https://docs.catalyst.coop/pudl/en/nightly/#raw-data-archives>`__.
 
 Data Pipeline
 ^^^^^^^^^^^^^
@@ -98,7 +98,7 @@ Parquet <https://parquet.apache.org/>`__ files, with some accompanying metadata 
 JSON.  Each release of the PUDL software contains a set of DOIs indicating which
 versions of the raw inputs it processes. This helps ensure that the outputs are
 replicable. You can read more about our ETL (extract, transform, load) process in the
-`PUDL documentation <https://catalystcoop-pudl.readthedocs.io/en/nightly/#the-etl-process>`__.
+`PUDL documentation <https://docs.catalyst.coop/pudl/en/nightly/#the-etl-process>`__.
 
 Data Warehouse
 ^^^^^^^^^^^^^^
@@ -108,7 +108,7 @@ archived so that users can access the data without having to install and run our
 processing system. These outputs contain hundreds of tables and comprise a small
 file-based data warehouse that can be used for a variety of energy system analyses.
 Learn more about `how to access the PUDL data
-<https://catalystcoop-pudl.readthedocs.io/en/nightly/data_access.html>`__.
+<https://docs.catalyst.coop/pudl/en/nightly/data_access.html>`__.
 
 What data is available?
 -----------------------
@@ -117,33 +117,33 @@ PUDL currently integrates data from:
 
 * **EIA Form 176** (a few tables -- work in progress):
   - `Source Docs <https://www.eia.gov/dnav/ng/TblDefs/NG_DataSources.html#s176>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/eia176.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/eia176.html>`__
 * **EIA Form 860**:
   - `Source Docs <https://www.eia.gov/electricity/data/eia860/>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/eia860.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/eia860.html>`__
 * **EIA Form 860m**:
   - `Source Docs <https://www.eia.gov/electricity/data/eia860m/>`__
 * **EIA Form 861**:
   - `Source Docs <https://www.eia.gov/electricity/data/eia861/>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/eia861.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/eia861.html>`__
 * **EIA Form 923**:
   - `Source Docs <https://www.eia.gov/electricity/data/eia923/>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/eia923.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/eia923.html>`__
 * **EIA Form 930**:
   - `Source Docs <https://www.eia.gov/electricity/gridmonitor/>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/eia930.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/eia930.html>`__
 * **EIA Annual Energy Outlook (AEO)** (a few tables):
   - `Source Docs <https://www.eia.gov/outlooks/aeo/>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/eiaaeo.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/eiaaeo.html>`__
 * **EPA Continuous Emissions Monitoring System (CEMS)**:
   - `Source Docs <https://campd.epa.gov/>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/epacems.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/epacems.html>`__
 * **FERC Form 1** (dozens of fully processed tables, plus raw data converted to SQLite):
   - `Source Docs <https://www.ferc.gov/industries-data/electric/general-information/electric-industry-forms/form-1-electric-utility-annual>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/ferc1.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/ferc1.html>`__
 * **FERC Form 714** (a few fully processed tables):
   - `Source Docs <https://www.ferc.gov/industries-data/electric/general-information/electric-industry-forms/form-no-714-annual-electric/data>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/ferc714.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/ferc714.html>`__
 * **FERC Form 2** (raw data converted to SQLite):
   - `Source Docs <https://www.ferc.gov/industries-data/natural-gas/industry-forms/form-2-2a-3-q-gas-historical-vfp-data>`__
 * **FERC Form 6** (raw data converted to SQLite):
@@ -152,13 +152,13 @@ PUDL currently integrates data from:
   - `Source Docs <https://www.ferc.gov/form-60-annual-report-centralized-service-companies>`__
 * **NREL Annual Technology Baseline (ATB) for Electricity**:
   - `Source Docs <https://atb.nrel.gov/electricity/2024/data>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/nrelatb.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/nrelatb.html>`__
 * **GridPath Resource Adequacy Toolkit** (partial):
   - `Source Docs <https://gridlab.org/gridpathratoolkit/>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/gridpathratoolkit.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/gridpathratoolkit.html>`__
 * **US Census Demographic Profile 1 Geodatabase**:
   - `Source Docs <https://www.census.gov/geographies/mapping-files/2010/geo/tiger-data.html>`__
-  - `PUDL Docs <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_sources/censusdp1tract.html>`__
+  - `PUDL Docs <https://docs.catalyst.coop/pudl/en/nightly/data_sources/censusdp1tract.html>`__
 
 High Priority Target Datasets
 -----------------------------
@@ -179,22 +179,22 @@ How do I access the data?
 -------------------------
 
 For details on how to access PUDL data, see the `data access documentation
-<https://catalystcoop-pudl.readthedocs.io/en/nightly/data_access.html>`__. A quick
+<https://docs.catalyst.coop/pudl/en/nightly/data_access.html>`__. A quick
 summary:
 
 * `PUDL Data Viewer <https://data.catalyst.coop>`__ provides search, live preview,
   and CSV export for our processed data. Currently it doesn't provide access to
   the *raw* FERC data, but we are working on adding the FERC databases ASAP.
-* `Kaggle <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_access.html#access-kaggle>`__
+* `Kaggle <https://docs.catalyst.coop/pudl/en/nightly/data_access.html#access-kaggle>`__
   provides easy Jupyter notebook access to the PUDL data, updated weekly:
   https://www.kaggle.com/datasets/catalystcooperative/pudl-project
-* `Cloud storage <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_access.html#access-cloud>`__
+* `Cloud storage <https://docs.catalyst.coop/pudl/en/nightly/data_access.html#access-cloud>`__
   is populated by our nightly data builds, and is free to access thanks to the `AWS
   Open Data Registry <https://registry.opendata.aws/catalyst-cooperative-pudl/>`__.
-* `Zenodo <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_access.html#access-zenodo>`__
+* `Zenodo <https://docs.catalyst.coop/pudl/en/nightly/data_access.html#access-zenodo>`__
   provides stable long-term access to our versioned data releases with a citeable DOI:
   https://doi.org/10.5281/zenodo.3653158
-* `The PUDL Development Environment <https://catalystcoop-pudl.readthedocs.io/en/nightly/dev/dev_setup.html>`__
+* `The PUDL Development Environment <https://docs.catalyst.coop/pudl/en/nightly/dev/dev_setup.html>`__
   lets you run the PUDL data processing pipeline locally.
 
 Organizations using PUDL
@@ -223,8 +223,8 @@ Contributing to PUDL
 
 Find PUDL useful? Want to help make it better? There are lots of ways to help!
 
-* Check out our `contribution guide <https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html>`__
-  including our `Code of Conduct <https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html>`__.
+* Check out our `contribution guide <https://docs.catalyst.coop/pudl/en/nightly/CONTRIBUTING.html>`__
+  including our `Code of Conduct <https://docs.catalyst.coop/pudl/en/nightly/code_of_conduct.html>`__.
 * You can file a bug report, make a feature request, or ask questions in the
   `Github issue tracker <https://github.com/catalyst-cooperative/pudl/issues>`__.
 * Feel free to fork the project and make a pull request with new code, better

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ The Public Utility Data Liberation Project (PUDL)
    :alt: Docs Build Status
 .. |oc| image:: https://img.shields.io/badge/Open%20Collective-donate-3385FF?logo=opencollective&logoColor=white
    :target: https://opencollective.com/pudl
-.. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+.. |ruff| image:: https://img.shields.io/badge/lint-ruff-46A758?logo=ruff&logoColor=white
    :target: https://github.com/astral-sh/ruff
 .. |pre-commit-ci| image:: https://results.pre-commit.ci/badge/github/catalyst-cooperative/pudl/main.svg
    :target: https://results.pre-commit.ci/latest/github/catalyst-cooperative/pudl/main

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ The Public Utility Data Liberation Project (PUDL)
 .. |pre-commit-ci| image:: https://results.pre-commit.ci/badge/github/catalyst-cooperative/pudl/main.svg
    :target: https://results.pre-commit.ci/latest/github/catalyst-cooperative/pudl/main
    :alt: pre-commit CI
-.. |zenodo-doi| image:: https://zenodo.org/badge/doi/10.5281/zenodo.3404014.svg
+.. |zenodo-doi| image:: https://img.shields.io/badge/DOI-10.5281%2Fzenodo.3404014-1682D4?logo=zenodo&logoColor=white
    :target: https://doi.org/10.5281/zenodo.3404014
    :alt: Zenodo DOI
 .. |office-hours| image:: https://img.shields.io/badge/calend.ly-officehours-darkgreen

--- a/README.rst
+++ b/README.rst
@@ -32,8 +32,6 @@ The Public Utility Data Liberation Project (PUDL)
 .. |mastodon| image:: https://img.shields.io/mastodon/follow/110855618428885893?domain=https%3A%2F%2Fmastodon.energy&style=social&color=%23000000&link=https%3A%2F%2Fmastodon.energy%2F%40catalystcoop
    :target: https://mastodon.energy/@catalystcoop
    :alt: Follow Catalyst Cooperative on Mastodon
-.. |slack| image:: https://img.shields.io/badge/Slack-4A154B?logo=slack&logoColor=fff
-   :target: https://join.slack.com/t/catalystcooperative/shared_invite/zt-2yg1v2sb7-GsoGlA9Ojc_LCJ00vPWKbQ
 .. |linkedin| image:: https://img.shields.io/badge/LinkedIn-0077B5?style=flat&logo=linkedin&logoColor=white
    :target: https://linkedin.com/company/catalyst-cooperative/
    :alt: Follow Catalyst Cooperative on LinkedIn
@@ -50,9 +48,21 @@ The Public Utility Data Liberation Project (PUDL)
    :target: https://registry.opendata.aws/catalyst-cooperative-pudl/
    :alt: PUDL in the AWS Open Data Registry
 
-|repo-status|\ |pytest|\ |codecov|\ |docs|\ |oc|\ |ruff|\ |pre-commit-ci|
-|zenodo-doi|\ |office-hours|\ |mastodon|\ |linkedin|\ |bluesky|\ |kaggle|\ |slack|
-|youtube|\ |aws|
+|repo-status|
+|pytest|
+|codecov|
+|docs|
+|oc|
+|ruff|
+|pre-commit-ci|
+|zenodo-doi|
+|office-hours|
+|mastodon|
+|linkedin|
+|bluesky|
+|kaggle|
+|youtube|
+|aws|
 
 What is PUDL?
 -------------

--- a/README.rst
+++ b/README.rst
@@ -4,19 +4,19 @@ The Public Utility Data Liberation Project (PUDL)
 
 .. readme-intro
 
-.. |repo-status| image:: https://www.repostatus.org/badges/latest/active.svg
+.. |repo-status| image:: https://img.shields.io/badge/repo%20status-active-success
    :target: https://www.repostatus.org/#active
    :alt: Project Status: Active
-.. |pytest| image:: https://github.com/catalyst-cooperative/pudl/workflows/pytest/badge.svg
+.. |pytest| image:: https://img.shields.io/github/actions/workflow/status/catalyst-cooperative/pudl/pytest.yml?branch=main&label=pytest
    :target: https://github.com/catalyst-cooperative/pudl/actions?query=workflow%3Apytest
    :alt: PyTest Status
 .. |codecov| image:: https://img.shields.io/codecov/c/github/catalyst-cooperative/pudl?style=flat&logo=codecov
    :target: https://codecov.io/gh/catalyst-cooperative/pudl
    :alt: Codecov Test Coverage
-.. |docs| image:: https://github.com/catalyst-cooperative/pudl/actions/workflows/build-deploy-docs.yml/badge.svg
+.. |docs| image:: https://img.shields.io/github/actions/workflow/status/catalyst-cooperative/pudl/build-deploy-docs.yml?branch=main&label=docs
    :target: https://docs.catalyst.coop/pudl/en/latest
    :alt: Docs Build Status
-.. |oc| image:: https://opencollective.com/pudl/tiers/badge.svg
+.. |oc| image:: https://img.shields.io/badge/Open%20Collective-donate-3385FF?logo=opencollective&logoColor=white
    :target: https://opencollective.com/pudl
 .. |ruff| image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
    :target: https://github.com/astral-sh/ruff

--- a/README.rst
+++ b/README.rst
@@ -7,13 +7,13 @@ The Public Utility Data Liberation Project (PUDL)
 .. |repo-status| image:: https://img.shields.io/badge/repo%20status-active-success
    :target: https://www.repostatus.org/#active
    :alt: Project Status: Active
-.. |pytest| image:: https://img.shields.io/github/actions/workflow/status/catalyst-cooperative/pudl/pytest.yml?branch=main&label=pytest
+.. |pytest| image:: https://img.shields.io/github/actions/workflow/status/catalyst-cooperative/pudl/pytest.yml?event=merge_group&label=pytest
    :target: https://github.com/catalyst-cooperative/pudl/actions?query=workflow%3Apytest
    :alt: PyTest Status
 .. |codecov| image:: https://img.shields.io/codecov/c/github/catalyst-cooperative/pudl?style=flat&logo=codecov
    :target: https://codecov.io/gh/catalyst-cooperative/pudl
    :alt: Codecov Test Coverage
-.. |docs| image:: https://img.shields.io/github/actions/workflow/status/catalyst-cooperative/pudl/build-deploy-docs.yml?branch=main&label=docs
+.. |docs| image:: https://img.shields.io/github/actions/workflow/status/catalyst-cooperative/pudl/build-deploy-docs.yml?branch=main&event=push&label=docs
    :target: https://docs.catalyst.coop/pudl/en/latest
    :alt: Docs Build Status
 .. |oc| image:: https://img.shields.io/badge/Open%20Collective-donate-3385FF?logo=opencollective&logoColor=white

--- a/README.rst
+++ b/README.rst
@@ -18,8 +18,6 @@ The Public Utility Data Liberation Project (PUDL)
    :alt: Docs Build Status
 .. |oc| image:: https://img.shields.io/badge/Open%20Collective-donate-3385FF?logo=opencollective&logoColor=white
    :target: https://opencollective.com/pudl
-.. |ruff| image:: https://img.shields.io/badge/lint-ruff-46A758?logo=ruff&logoColor=white
-   :target: https://github.com/astral-sh/ruff
 .. |pre-commit-ci| image:: https://results.pre-commit.ci/badge/github/catalyst-cooperative/pudl/main.svg
    :target: https://results.pre-commit.ci/latest/github/catalyst-cooperative/pudl/main
    :alt: pre-commit CI

--- a/devtools/pudl_id_mapping_help.ipynb
+++ b/devtools/pudl_id_mapping_help.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# PUDL ID Mapping Help\n",
     "\n",
-    "This notebook helps to support the manual mapping of FERC to EIA plant IDs. See the [PUDL ID mapping](https://catalystcoop-pudl.readthedocs.io/en/latest/dev/pudl_id_mapping.html) documentation for more information."
+    "This notebook helps to support the manual mapping of FERC to EIA plant IDs. See the [PUDL ID mapping](https://docs.catalyst.coop/pudl/en/latest/dev/pudl_id_mapping.html) documentation for more information."
    ]
   },
   {

--- a/docs/data_access.rst
+++ b/docs/data_access.rst
@@ -417,7 +417,7 @@ From Zenodo you can download individual SQLite databases and a zipfile containin
 the Parquet files bundled together.
 
 The documentation for the latest such stable build is `here
-<https://catalystcoop-pudl.readthedocs.io/en/stable/>`__. You can access the
+<https://docs.catalyst.coop/pudl/en/stable/>`__. You can access the
 documentation for a specific version by hovering over the version selector at the bottom
 left of the page.
 

--- a/docs/data_dictionaries/usage_warnings.rst
+++ b/docs/data_dictionaries/usage_warnings.rst
@@ -37,7 +37,7 @@ FERC:
   FERC data is notoriously difficult to extract cleanly, and often contains
   free-form strings, non-labeled total rows and lack of IDs. See `Notable
   Irregularities
-  <https://catalystcoop-pudl.readthedocs.io/en/latest/data_sources/ferc1.html#notable-irregularities>`__
+  <https://docs.catalyst.coop/pudl/en/latest/data_sources/ferc1.html#notable-irregularities>`__
   for details.
 
 Free text:

--- a/docs/dev/clone_ferc1.rst
+++ b/docs/dev/clone_ferc1.rst
@@ -96,3 +96,65 @@ for all available FERC Data, which includes Forms 1, 2, 6, 60 and 714. You can a
 choose to materialize any combination of form an format (DBF or XBRL). Note that the
 earlier FERC 714 data (2006-2020) is distributed as CSVs, and PUDL does not yet load
 all available tables.
+
+FERC SQLite provenance compatibility
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+PUDL records provenance metadata when FERC SQLite assets are materialized and checks
+that metadata before downstream ``pudl`` assets use those databases. This helps avoid
+scenarios where local databases were built with different inputs or settings than the
+current run.
+
+Incompatible provenance metadata
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The provenance check looks at two things:
+
+* Whether the Zenodo DOI changed for a FERC dataset. This would  mean that the expected
+  raw input data is different from what was used to build the existing SQLite DB.
+* Whether the current ETL config requests years of FERC data that are not present in the
+  existing SQLite DB.
+
+When either of these criteria aren't met, Dagster raises an error telling you to refresh
+the FERC SQLite assets.
+
+Regenerating FERC SQLite prerequisites
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To rebuild FERC SQLite databases so they match the current input data and configuration,
+rerun the raw FERC conversion step:
+
+.. code-block:: console
+
+  # Our task shortcut
+  $ pixi run ferc-to-sqlite
+  # Equivalent to
+  $ pixi run dg launch --job ferc_to_sqlite --config src/pudl/package_data/settings/dg_full.yml
+
+You can also materialize just the specific FERC SQLite assets that are out of date,
+either in the Dagster UI or using the command line:
+
+.. code-block:: console
+
+   $ pixi run dg launch --assets raw_ferc1_xbrl__sqlite --config src/pudl/package_data/settings/dg_full.yml
+
+After the FERC databases are refreshed, rerun the ``pudl`` job or selected downstream
+assets.
+
+Bypassing provenance checks for development
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you need to use externally-downloaded FERC SQLite databases (for example, from
+nightly build outputs), you can bypass compatibility checks by setting:
+
+.. code-block:: console
+
+  $ export PUDL_SKIP_FERC_SQLITE_PROVENANCE=1
+
+Truthy values ``1``, ``true``, and ``yes`` are accepted.
+
+.. warning::
+
+  Skipping provenance checks is a development escape hatch. It can cause runtime
+  failures or incorrect results if your local prerequisites do not actually match the
+  current ETL configuration.

--- a/docs/dev/clone_ferc1.rst
+++ b/docs/dev/clone_ferc1.rst
@@ -101,8 +101,8 @@ FERC SQLite provenance compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 PUDL records provenance metadata when FERC SQLite assets are materialized, including
-the Zenodo DOI and the years extracted. 
-Before downstream ``pudl`` assets use those databases, 
+the Zenodo DOI and the years extracted.
+Before downstream ``pudl`` assets use those databases,
 PUDL checks the metadata to make sure they are compatible with the current run.
 This helps avoid scenarios where the FERC databases were built with old inputs
 or don't have all the years needed by the current run.

--- a/docs/dev/clone_ferc1.rst
+++ b/docs/dev/clone_ferc1.rst
@@ -101,8 +101,8 @@ FERC SQLite provenance compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 PUDL records provenance metadata when FERC SQLite assets are materialized, including
-the Zenodo DOI and the years extracted. 
-Before downstream ``pudl`` assets use those databases, 
+the Zenodo DOI and the years extracted.
+Before downstream ``pudl`` assets use those databases,
 PUDL checks the metadata to make sure they are compatible with the current run.
 This helps avoid scenarios where the FERC databases were built with old inputs
 or don't have all the years needed by the current run.
@@ -113,7 +113,8 @@ Incompatible provenance metadata
 The provenance check looks at two things:
 
 * Whether the Zenodo DOI changed for a FERC dataset. This would mean that the
-  raw input data used to build the existing SQLite DB is different from what is expected.
+  raw input data used to build the existing SQLite DB is different from what is
+  expected.
 * Whether the current ETL config requests years of FERC data that are not present in the
   existing SQLite DB.
 
@@ -121,7 +122,7 @@ When either of these criteria aren't met, Dagster raises an error telling you to
 the FERC SQLite assets.
 
 Regenerating FERC SQLite assets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To rebuild FERC SQLite databases so they match the current input data and configuration,
 rerun the raw FERC conversion step:

--- a/docs/dev/clone_ferc1.rst
+++ b/docs/dev/clone_ferc1.rst
@@ -100,25 +100,27 @@ all available tables.
 FERC SQLite provenance compatibility
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-PUDL records provenance metadata when FERC SQLite assets are materialized and checks
-that metadata before downstream ``pudl`` assets use those databases. This helps avoid
-scenarios where local databases were built with different inputs or settings than the
-current run.
+PUDL records provenance metadata when FERC SQLite assets are materialized, including
+the Zenodo DOI and the years extracted. 
+Before downstream ``pudl`` assets use those databases, 
+PUDL checks the metadata to make sure they are compatible with the current run.
+This helps avoid scenarios where the FERC databases were built with old inputs
+or don't have all the years needed by the current run.
 
 Incompatible provenance metadata
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The provenance check looks at two things:
 
-* Whether the Zenodo DOI changed for a FERC dataset. This would  mean that the expected
-  raw input data is different from what was used to build the existing SQLite DB.
+* Whether the Zenodo DOI changed for a FERC dataset. This would mean that the
+  raw input data used to build the existing SQLite DB is different from what is expected.
 * Whether the current ETL config requests years of FERC data that are not present in the
   existing SQLite DB.
 
 When either of these criteria aren't met, Dagster raises an error telling you to refresh
 the FERC SQLite assets.
 
-Regenerating FERC SQLite prerequisites
+Regenerating FERC SQLite assets
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To rebuild FERC SQLite databases so they match the current input data and configuration,

--- a/docs/dev/metadata.rst
+++ b/docs/dev/metadata.rst
@@ -231,7 +231,7 @@ Example:
              PK [True]: respondent_id_ferc714, datetime_utc
        Warnings [2]:
     custom - The datetime_utc timestamps have been cleaned due to inconsistent datetime reporting. See below for additional details.
-    ferc_is_hard - FERC data is notoriously difficult to extract cleanly, and often contains free-form strings, non-labeled total rows and lack of IDs. See `Notable Irregularities <https://catalystcoop-pudl.readthedocs.io/en/latest/data_sources/ferc1.html#notable-irregularities>`_ for details.
+    ferc_is_hard - FERC data is notoriously difficult to extract cleanly, and often contains free-form strings, non-labeled total rows and lack of IDs. See `Notable Irregularities <https://docs.catalyst.coop/pudl/en/latest/data_sources/ferc1.html#notable-irregularities>`_ for details.
         Details [True]:
    This table includes data from the pre-2021 CSV raw source as well as the
    newer 2021 through present XBRL raw source.

--- a/docs/dev/run_the_etl.rst
+++ b/docs/dev/run_the_etl.rst
@@ -207,11 +207,30 @@ Cloning the FERC databases
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The raw FERC SQLite databases are part of the ``raw_ferc_to_sqlite`` asset group.  If
-you only need those outputs, select the ``ferc_to_sqlite`` job and hit ``Materialize
-All``, or you can select the specific FERC Form you actually need. If you want to run
+you only need those outputs, select the ``ferc_to_sqlite`` job and hit "Materialize
+All", or you can select the specific FERC Form you actually need. If you want to run
 the whole ETL from scratch, use the ``pudl_with_ferc_to_sqlite`` job. The ``pudl`` job
 is intended for day-to-day development once compatible raw FERC outputs have been
 materialized locally. See :doc:`/dev/clone_ferc1` for more background on this process.
+
+PUDL checks that your existing FERC SQLite databases are compatible with the current run
+configuration before downstream assets read them. Incompatible databases usually mean
+the FERC SQLite assets need to be rematerialized. This will happen when:
+
+* The configured Zenodo DOI for a FERC dataset changed.
+* The set of FERC years requested by your current ETL config includes years that are
+  missing from the existing FERC SQLite database.
+
+When this happens, refresh the FERC databases by materializing ``ferc_to_sqlite`` again,
+then rerun the ``pudl`` job or selected downstream assets. You can also choose to
+materialize only the FERC Form 1 and Form 714 databases in the Dagster UI, since those
+are the only ones that feed directly into the PUDL ETL.
+
+If you intentionally want to skip this compatibility check (for example, when using
+prebuilt FERC SQLite files downloaded from nightly outputs), set
+``PUDL_SKIP_FERC_SQLITE_PROVENANCE=1`` in your shell before running the ETL. This bypass
+is intended for development workflows and can lead to downstream failures if the
+FERC databases are stale.
 
 Running the PUDL ETL
 ^^^^^^^^^^^^^^^^^^^^

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -449,7 +449,7 @@ FERC EQR
   :pr:`4967`. Also, note that the actual FERC EQR data is available on `PUDL
   Viewer <https://data.catalyst.coop/search?q=ferceqr>`__ as well as `on S3 for
   direct download
-  <https://catalystcoop-pudl.readthedocs.io/en/nightly/data_access.html#ferc-eqr-experimental>`__
+  <https://docs.catalyst.coop/pudl/en/nightly/data_access.html#ferc-eqr-experimental>`__
 
 Expanded Data Coverage
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/pixi.lock
+++ b/pixi.lock
@@ -5914,8 +5914,8 @@ packages:
   timestamp: 1766416416791
 - pypi: ./
   name: catalystcoop-pudl
-  version: 2026.4.1.dev38
-  sha256: 85024ab42e122c6fea2edb93931e598e2daaf7b3bbdfcbe995c0cbc45e633431
+  version: 2026.4.1.dev24
+  sha256: 36906f0d181e1d5a6fbdd4cc556d72f5e4e399ccff4136a29dfc066836d11879
   requires_python: '>=3.13,<3.14.0a0'
 - conda: https://conda.anaconda.org/conda-forge/noarch/catalystcoop.dbfread-3.0.0-pyhd8ed1ab_1.conda
   sha256: 7a706fefa47027ab14cac7572dbddadaf9a12fc13a1222ad1e75f43f8fd9dcfb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = []
 [project.urls]
 "Homepage" = "https://github.com/catalyst-cooperative/pudl"
 "Source" = "https://github.com/catalyst-cooperative/pudl"
-"Documentation" = "https://catalystcoop-pudl.readthedocs.io"
+"Documentation" = "https://docs.catalyst.coop/pudl"
 "Issue Tracker" = "https://github.com/catalyst-cooperative/pudl/issues"
 "Support" = "https://github.com/catalyst-cooperative/pudl/discussions"
 "Funding" = "https://catalyst.coop/support-the-pudl-project/"

--- a/src/pudl/extract/eia930.py
+++ b/src/pudl/extract/eia930.py
@@ -3,7 +3,7 @@
 EIA Form 930 is reported in half-year increments. Each half-year has three
 separate pages, which are stored as separate CSVs:
 "balance", "interchange", and "subregion." See
-https://catalystcoop-pudl.readthedocs.io/en/latest/data_sources/eia930.html for
+https://docs.catalyst.coop/pudl/en/latest/data_sources/eia930.html for
 more information.
 
 We extract these CSVs into DuckDB, rename the columns as per the column map, and

--- a/src/pudl/metadata/descriptions.py
+++ b/src/pudl/metadata/descriptions.py
@@ -45,7 +45,7 @@ LAYER_DESCRIPTIONS: dict = {
 }
 """Standard descriptive text to appear in the Processing section of resource descriptions."""
 
-# TODO: add link to https://catalystcoop-pudl.readthedocs.io/en/latest/data_sources/{datasource_name}.html
+# TODO: add link to https://docs.catalyst.coop/pudl/en/latest/data_sources/{datasource_name}.html
 # if we have a data_sources page for it.
 SOURCE_DESCRIPTIONS: dict = {
     source_name: SOURCES[source_name]["title"] for source_name in SOURCES


### PR DESCRIPTION
# Overview

- Add documentation explaining the FERC SQLite provenance tracking we're doing with Dagster. What will cause it to fail, how to regenerate upstream FERC data, and how to bypass the checks in development if need be.
- Update Read The Docs URLs to our new `docs.catalyst.coop` URLs. 
- Fix some formatting weirdness with the badges in our README 
- I also updated the docs links on the website, primarily in the top navbar and the [PUDL Page](https://catalyst.coop/pudl/)

# Testing

Built the docs locally and inspected them.

## To-do list

- [x] Review the PR yourself and call out any questions or issues you have.