### PR TITLE
Fix oopsies typo from changelog/forensics table integration

### DIFF
--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2529,7 +2529,7 @@ def normalize_year_fragments(
 
 def make_changelog(df_all: pd.DataFrame, idx: list[str]):
     """Make a changelog table with unique instances of values over start report and max report date."""
-    idx_no_date = [c for c in idx if c != "r"]
+    idx_no_date = [c for c in idx if c != "report_date"]
     # assign a max report_date column for use in the valid_until_date column
     df_all["report_date_max"] = df_all.groupby(idx_no_date)["report_date"].transform(
         "max"


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

# Overview

In #5157 i... did an oopsies when i migrated the changelog behavior over into `helpers`... 

## What did you change?
actually spell out `report_date` instead of `r` 👍🏻 

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://catalystcoop-pudl.readthedocs.io/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [x] in `dg dev` materialize `core_eia860m__changelog_generators`
- [x] run `dbt_helper validate --asset-select "key:core_eia860m__changelog_generators"`
- [x] in `dg dev` run `key:"*forensics*"` and visually inspect in notebook
