### PR TITLE
chore: remove lazy re-export from pudl.dagster

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,8 +18,13 @@ from pybtex.plugin import register_plugin
 from pybtex.style.formatting.plain import Style as PlainStyle
 from pybtex.style.sorting import BaseSortingStyle
 
-from pudl.metadata import PUDL_PACKAGE
-from pudl.metadata.classes import CodeMetadata, DataSource, Package, Resource
+from pudl.metadata.classes import (
+    PUDL_PACKAGE,
+    CodeMetadata,
+    DataSource,
+    Package,
+    Resource,
+)
 from pudl.metadata.codes import CODE_METADATA
 from pudl.metadata.resources import RESOURCE_METADATA
 from pudl.workspace.datastore import Datastore

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -4,7 +4,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from pudl.metadata import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE
 from pudl.workspace.setup import PudlPaths
 
 # this is the Alembic Config object, which provides

--- a/src/pudl/__init__.py
+++ b/src/pudl/__init__.py
@@ -12,19 +12,6 @@ warnings.filterwarnings(
     category=PreviewWarning,
 )
 
-from . import (  # noqa: E402
-    analysis,
-    extract,
-    glue,
-    helpers,
-    logging_helpers,
-    metadata,
-    output,
-    transform,
-    validate,
-    workspace,
-)
-
 configure_root_logger()
 
 __author__ = "Catalyst Cooperative"

--- a/src/pudl/analysis/allocate_gen_fuel.py
+++ b/src/pudl/analysis/allocate_gen_fuel.py
@@ -141,7 +141,9 @@ import numpy as np
 import pandas as pd
 from dagster import AssetIn, AssetsDefinition, Field, asset
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
+import pudl.output.eia923
 from pudl.metadata.fields import apply_pudl_dtypes
 
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/analysis/mcoe.py
+++ b/src/pudl/analysis/mcoe.py
@@ -14,7 +14,7 @@ from dagster import (
     asset_check,
 )
 
-import pudl
+import pudl.helpers
 from pudl.metadata.fields import apply_pudl_dtypes
 from pudl.validate import quality as pv
 

--- a/src/pudl/analysis/ml_tools/experiment_tracking.py
+++ b/src/pudl/analysis/ml_tools/experiment_tracking.py
@@ -16,7 +16,7 @@ import mlflow
 from dagster import Config, op
 from pydantic import BaseModel
 
-import pudl
+import pudl.logging_helpers
 
 logger = pudl.logging_helpers.get_logger(__name__)
 

--- a/src/pudl/analysis/ml_tools/models.py
+++ b/src/pudl/analysis/ml_tools/models.py
@@ -54,7 +54,7 @@ from dagster import (
     graph_asset,
 )
 
-import pudl
+import pudl.logging_helpers
 
 from . import experiment_tracking
 

--- a/src/pudl/analysis/plant_parts_eia.py
+++ b/src/pudl/analysis/plant_parts_eia.py
@@ -173,7 +173,8 @@ import numpy as np
 import pandas as pd
 from dagster import AssetIn, AssetKey, AssetsDefinition, asset
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.metadata.classes import Resource
 
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/analysis/record_linkage/classify_plants_ferc1.py
+++ b/src/pudl/analysis/record_linkage/classify_plants_ferc1.py
@@ -12,7 +12,7 @@ import mlflow
 import pandas as pd
 from dagster import graph, op
 
-import pudl
+import pudl.logging_helpers
 from pudl.analysis.ml_tools import experiment_tracking, models
 from pudl.analysis.record_linkage import embed_dataframe
 from pudl.analysis.record_linkage.link_cross_year import link_ids_cross_year

--- a/src/pudl/analysis/record_linkage/eia_ferc1_inputs.py
+++ b/src/pudl/analysis/record_linkage/eia_ferc1_inputs.py
@@ -5,7 +5,9 @@ from typing import Literal
 
 import pandas as pd
 
-import pudl
+import pudl.analysis.plant_parts_eia
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.analysis.plant_parts_eia import match_to_single_plant_part
 
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
+++ b/src/pudl/analysis/record_linkage/eia_ferc1_record_linkage.py
@@ -39,7 +39,7 @@ import pandas as pd
 from dagster import Out, graph, op
 from splink import DuckDBAPI, Linker, SettingsCreator
 
-import pudl
+import pudl.logging_helpers
 from pudl.analysis.ml_tools import experiment_tracking, models
 from pudl.analysis.record_linkage import embed_dataframe, name_cleaner
 from pudl.analysis.record_linkage.eia_ferc1_inputs import (

--- a/src/pudl/analysis/record_linkage/eia_ferc1_train.py
+++ b/src/pudl/analysis/record_linkage/eia_ferc1_train.py
@@ -22,7 +22,7 @@ from typing import Literal
 import numpy as np
 import pandas as pd
 
-import pudl
+import pudl.logging_helpers
 
 # Create a logger to output any messages we might have...
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/analysis/record_linkage/embed_dataframe.py
+++ b/src/pudl/analysis/record_linkage/embed_dataframe.py
@@ -21,7 +21,9 @@ from sklearn.preprocessing import (
     OneHotEncoder,
 )
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
+import pudl.metadata.codes
 from pudl.analysis.ml_tools import experiment_tracking
 from pudl.analysis.record_linkage.name_cleaner import CompanyNameCleaner
 

--- a/src/pudl/analysis/record_linkage/link_cross_year.py
+++ b/src/pudl/analysis/record_linkage/link_cross_year.py
@@ -13,7 +13,7 @@ from sklearn.cluster import DBSCAN, AgglomerativeClustering
 from sklearn.metrics import pairwise_distances_chunked
 from sklearn.neighbors import NearestNeighbors
 
-import pudl
+import pudl.logging_helpers
 from pudl.analysis.ml_tools import experiment_tracking
 from pudl.analysis.record_linkage.embed_dataframe import FeatureMatrix
 

--- a/src/pudl/analysis/service_territory.py
+++ b/src/pudl/analysis/service_territory.py
@@ -16,7 +16,7 @@ import pandas as pd
 from dagster import AssetsDefinition, Field, asset
 from matplotlib import pyplot as plt
 
-import pudl
+import pudl.logging_helpers
 
 logger = pudl.logging_helpers.get_logger(__name__)
 

--- a/src/pudl/dagster/__init__.py
+++ b/src/pudl/dagster/__init__.py
@@ -1,11 +1,1 @@
-"""Canonical Dagster orchestration package for PUDL.
-
-This package is the main import surface for the Dagster objects that make up the PUDL
-code location. It should expose the assembled ``Definitions`` object along with the
-default assets, asset checks, jobs, resources, and sensors that other modules or tools
-need to load. Import concrete submodules directly instead of relying on package-level
-re-exports so this package can stay free of import-time wiring and side effects.
-
-For the underlying Dagster concept, see
-https://docs.dagster.io/getting-started/concepts#definitions
-"""
+"""Top-level Dagster orchestration package for PUDL."""

--- a/src/pudl/dagster/__init__.py
+++ b/src/pudl/dagster/__init__.py
@@ -3,68 +3,9 @@
 This package is the main import surface for the Dagster objects that make up the PUDL
 code location. It should expose the assembled ``Definitions`` object along with the
 default assets, asset checks, jobs, resources, and sensors that other modules or tools
-need to load. Keep this module focused on package-level exports and lazy import wiring
-rather than the implementation details of individual Dagster abstractions.
+need to load. Import concrete submodules directly instead of relying on package-level
+re-exports so this package can stay free of import-time wiring and side effects.
 
 For the underlying Dagster concept, see
 https://docs.dagster.io/getting-started/concepts#definitions
 """
-
-from importlib import import_module
-from typing import TYPE_CHECKING, Any
-
-if TYPE_CHECKING:
-    import dagster as dg
-
-    from pudl.dagster.asset_checks import default_asset_checks
-    from pudl.dagster.assets import default_assets
-    from pudl.dagster.build import build_defs
-    from pudl.dagster.io_managers import default_io_managers
-    from pudl.dagster.jobs import default_jobs
-    from pudl.dagster.resources import default_resources
-    from pudl.dagster.sensors import default_sensors
-
-_EXPORTS = {
-    "build_defs": ("pudl.dagster.build", "build_defs"),
-    "default_asset_checks": ("pudl.dagster.asset_checks", "default_asset_checks"),
-    "default_assets": ("pudl.dagster.assets", "default_assets"),
-    "default_io_managers": ("pudl.dagster.io_managers", "default_io_managers"),
-    "default_jobs": ("pudl.dagster.jobs", "default_jobs"),
-    "default_resources": ("pudl.dagster.resources", "default_resources"),
-    "default_sensors": ("pudl.dagster.sensors", "default_sensors"),
-}
-
-
-def __getattr__(name: str) -> Any:
-    """Resolve public Dagster exports lazily to avoid eager package imports."""
-    if name == "defs":
-        from pudl.dagster.build import build_defs as _build_defs
-
-        value: dg.Definitions = _build_defs()
-        globals()["defs"] = value
-        return value
-    try:
-        module_name, attribute_name = _EXPORTS[name]
-    except KeyError as err:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from err
-
-    value = getattr(import_module(module_name), attribute_name)
-    globals()[name] = value
-    return value
-
-
-def __dir__() -> list[str]:
-    """Expose lazily loaded public exports in interactive contexts."""
-    return sorted(set(globals()) | set(__all__))
-
-
-__all__ = [
-    "build_defs",
-    "default_asset_checks",
-    "default_assets",
-    "default_io_managers",
-    "default_jobs",
-    "default_resources",
-    "default_sensors",
-    "defs",  # noqa: F822 - lazily resolved via __getattr__
-]

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -34,8 +34,7 @@ from pandera.errors import SchemaErrors
 from pudl.dagster.assets import all_asset_modules, asset_keys
 from pudl.dagster.partitions import ferceqr_year_quarters
 from pudl.helpers import ParquetData, get_parquet_table_polars
-from pudl.metadata import PUDL_PACKAGE
-from pudl.metadata.classes import Package, Resource
+from pudl.metadata.classes import PUDL_PACKAGE, Package, Resource
 
 
 def _collect_asset_metadata(asset_value) -> dict[str, Any]:

--- a/src/pudl/dagster/assets/__init__.py
+++ b/src/pudl/dagster/assets/__init__.py
@@ -21,6 +21,10 @@ import os
 import dagster as dg
 
 import pudl
+import pudl.analysis
+import pudl.extract
+import pudl.output
+import pudl.transform
 from pudl.dagster.assets.core import eiaapi_electricity, glue, static
 from pudl.dagster.assets.deploy import ferceqr as deploy_ferceqr
 from pudl.dagster.assets.raw import ferc_to_sqlite

--- a/src/pudl/dagster/assets/__init__.py
+++ b/src/pudl/dagster/assets/__init__.py
@@ -20,7 +20,6 @@ import os
 
 import dagster as dg
 
-import pudl
 import pudl.analysis
 import pudl.extract
 import pudl.output

--- a/src/pudl/dagster/assets/core/eiaapi_electricity.py
+++ b/src/pudl/dagster/assets/core/eiaapi_electricity.py
@@ -7,7 +7,9 @@ core asset graph.
 
 import dagster as dg
 
-import pudl
+import pudl.extract.eiaapi
+import pudl.logging_helpers
+import pudl.transform.eiaapi
 
 logger = pudl.logging_helpers.get_logger(__name__)
 

--- a/src/pudl/dagster/assets/core/glue.py
+++ b/src/pudl/dagster/assets/core/glue.py
@@ -10,7 +10,11 @@ import dagster as dg
 import networkx as nx
 import pandas as pd
 
-import pudl
+import pudl.glue.ferc1_eia
+import pudl.glue.ferc714
+import pudl.helpers
+import pudl.logging_helpers
+import pudl.metadata.fields
 from pudl.metadata.classes import DataSource, Package
 
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/dagster/assets/core/static.py
+++ b/src/pudl/dagster/assets/core/static.py
@@ -11,7 +11,8 @@ from typing import Literal
 import dagster as dg
 import pandas as pd
 
-import pudl
+import pudl.logging_helpers
+import pudl.metadata.dfs
 from pudl.metadata.classes import Package
 from pudl.metadata.dfs import (
     FERC_ACCOUNTS,

--- a/src/pudl/dagster/assets/raw/ferc_to_sqlite.py
+++ b/src/pudl/dagster/assets/raw/ferc_to_sqlite.py
@@ -8,7 +8,7 @@ databases, rather than the downstream transforms that consume them.
 
 import dagster as dg
 
-import pudl
+import pudl.logging_helpers
 from pudl.dagster.provenance import (
     FERC_TO_SQLITE_METADATA_KEY,
     FercSqliteProvenanceRecord,

--- a/src/pudl/dagster/io_managers.py
+++ b/src/pudl/dagster/io_managers.py
@@ -36,7 +36,7 @@ from packaging import version
 from pydantic import model_validator
 from sqlalchemy.exc import IntegrityError
 
-import pudl
+import pudl.logging_helpers
 from pudl.dagster.provenance import (
     FercSqliteProvenance,
     assert_ferc_sqlite_compatible,

--- a/src/pudl/dagster/provenance.py
+++ b/src/pudl/dagster/provenance.py
@@ -18,7 +18,7 @@ from typing import Any, Literal
 import dagster as dg
 from pydantic import BaseModel
 
-import pudl
+import pudl.logging_helpers
 from pudl.settings import FercToSqliteSettings
 
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/definitions.py
+++ b/src/pudl/definitions.py
@@ -1,10 +1,12 @@
 """Stable Dagster code location module for dg-compatible loading.
 
 This module stays lightweight on purpose. The canonical Dagster assembly lives in
-``pudl.dagster`` and this module remains the stable top-level entrypoint configured for
-``dg``.
+``pudl.dagster.build`` and this module remains the stable top-level entrypoint
+configured for ``dg``.
 """
 
-from pudl.dagster import defs
+from pudl.dagster.build import build_defs
+
+defs = build_defs()
 
 __all__ = ["defs"]

--- a/src/pudl/extract/censusdp1tract.py
+++ b/src/pudl/extract/censusdp1tract.py
@@ -14,7 +14,7 @@ from tempfile import TemporaryDirectory
 
 from dagster import Field, asset
 
-import pudl
+import pudl.logging_helpers
 from pudl.workspace.datastore import Datastore
 from pudl.workspace.setup import PudlPaths
 

--- a/src/pudl/extract/dbf.py
+++ b/src/pudl/extract/dbf.py
@@ -16,7 +16,7 @@ import sqlalchemy as sa
 from dagster import op
 from dbfread import DBF, FieldParser
 
-import pudl
+import pudl.helpers
 import pudl.logging_helpers
 from pudl.metadata.classes import DataSource
 from pudl.settings import FercDbfToSqliteSettings, FercToSqliteSettings

--- a/src/pudl/extract/eia860.py
+++ b/src/pudl/extract/eia860.py
@@ -8,7 +8,7 @@ This code is for use analyzing EIA Form 860 data.
 import pandas as pd
 from dagster import AssetOut, Output, multi_asset
 
-import pudl
+import pudl.extract.eia860m
 import pudl.logging_helpers
 from pudl.extract import excel
 from pudl.extract.extractor import raw_df_factory

--- a/src/pudl/extract/excel.py
+++ b/src/pudl/extract/excel.py
@@ -6,7 +6,8 @@ from io import BytesIO
 import dbfread
 import pandas as pd
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.extract.extractor import GenericExtractor, GenericMetadata, PartitionSelection
 
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/extract/extractor.py
+++ b/src/pudl/extract/extractor.py
@@ -18,7 +18,8 @@ from dagster import (
     op,
 )
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.workspace.datastore import Datastore
 
 StrInt = str | int

--- a/src/pudl/extract/ferc.py
+++ b/src/pudl/extract/ferc.py
@@ -1,6 +1,6 @@
 """Hooks to integrate ferc to sqlite functionality into dagster graph."""
 
-import pudl
+import pudl.logging_helpers
 from pudl.extract.ferc1 import Ferc1DbfExtractor
 from pudl.extract.ferc2 import Ferc2DbfExtractor
 from pudl.extract.ferc6 import Ferc6DbfExtractor

--- a/src/pudl/extract/ferc1.py
+++ b/src/pudl/extract/ferc1.py
@@ -80,7 +80,7 @@ from dagster import (
     build_input_context,
 )
 
-import pudl
+import pudl.logging_helpers
 from pudl.dagster.io_managers import (
     FercDbfSqliteConfigurableIOManager,
     FercXbrlSqliteConfigurableIOManager,

--- a/src/pudl/extract/ferc2.py
+++ b/src/pudl/extract/ferc2.py
@@ -15,7 +15,7 @@ from typing import Any, Self
 import pandas as pd
 import sqlalchemy as sa
 
-import pudl
+import pudl.logging_helpers
 from pudl.extract.dbf import (
     FercDbfExtractor,
     PartitionedDataFrame,

--- a/src/pudl/extract/ferc714.py
+++ b/src/pudl/extract/ferc714.py
@@ -9,7 +9,7 @@ from typing import Any
 import pandas as pd
 from dagster import AssetKey, AssetsDefinition, AssetSpec, asset
 
-import pudl
+import pudl.logging_helpers
 from pudl.workspace.setup import PudlPaths
 
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/extract/gridpathratoolkit.py
+++ b/src/pudl/extract/gridpathratoolkit.py
@@ -20,7 +20,7 @@ from pathlib import Path
 import pandas as pd
 from dagster import AssetsDefinition, Output, asset
 
-import pudl
+import pudl.logging_helpers
 from pudl.settings import DataSource
 from pudl.workspace.datastore import Datastore
 

--- a/src/pudl/extract/xbrl.py
+++ b/src/pudl/extract/xbrl.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from dagster import op
 from ferc_xbrl_extractor.cli import run_main
 
-import pudl
+import pudl.logging_helpers
 from pudl.dagster.resources import FercXbrlRuntimeSettings
 from pudl.settings import FercGenericXbrlToSqliteSettings, XbrlFormNumber
 from pudl.workspace.datastore import Datastore

--- a/src/pudl/glue/ferc1_eia.py
+++ b/src/pudl/glue/ferc1_eia.py
@@ -34,7 +34,8 @@ import pandas as pd
 import sqlalchemy as sa
 from dagster import AssetIn, Definitions, JobDefinition, asset, define_asset_job
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.dagster.io_managers import (
     ferc1_dbf_sqlite_io_manager,
     ferc1_xbrl_sqlite_io_manager,

--- a/src/pudl/glue/ferc714.py
+++ b/src/pudl/glue/ferc714.py
@@ -4,7 +4,7 @@ import importlib.resources
 
 import pandas as pd
 
-import pudl
+import pudl.logging_helpers
 
 logger = pudl.logging_helpers.get_logger(__name__)
 

--- a/src/pudl/metadata/__init__.py
+++ b/src/pudl/metadata/__init__.py
@@ -1,15 +1,1 @@
 """Metadata constants and methods."""
-
-from . import (
-    classes,
-    codes,
-    constants,
-    dfs,
-    enums,
-    fields,
-    helpers,
-    labels,
-    resources,
-    sources,
-)
-from .classes import PUDL_PACKAGE

--- a/src/pudl/output/censusdp1tract.py
+++ b/src/pudl/output/censusdp1tract.py
@@ -7,7 +7,7 @@ import pandas as pd
 import sqlalchemy as sa
 from dagster import AssetIn, AssetsDefinition, asset
 
-import pudl
+import pudl.logging_helpers
 
 logger = pudl.logging_helpers.get_logger(__name__)
 

--- a/src/pudl/output/eia.py
+++ b/src/pudl/output/eia.py
@@ -4,7 +4,8 @@ import numpy as np
 import pandas as pd
 from dagster import Field, asset
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.transform.eia import occurrence_consistency
 from pudl.transform.eia861 import add_backfilled_ba_code_column
 

--- a/src/pudl/output/eia860.py
+++ b/src/pudl/output/eia860.py
@@ -3,7 +3,7 @@
 import pandas as pd
 from dagster import asset
 
-import pudl
+import pudl.helpers
 from pudl.metadata.codes import CODE_METADATA
 
 

--- a/src/pudl/output/eia923.py
+++ b/src/pudl/output/eia923.py
@@ -6,7 +6,8 @@ import numpy as np
 import pandas as pd
 from dagster import AssetsDefinition, Field, asset
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.metadata.fields import apply_pudl_dtypes
 
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/output/eiaapi.py
+++ b/src/pudl/output/eiaapi.py
@@ -3,7 +3,7 @@
 import pandas as pd
 from dagster import asset
 
-import pudl
+import pudl.logging_helpers
 
 logger = pudl.logging_helpers.get_logger(__name__)
 

--- a/src/pudl/output/ferc1.py
+++ b/src/pudl/output/ferc1.py
@@ -31,7 +31,10 @@ from pydantic import (
     model_validator,
 )
 
-import pudl
+import pudl.analysis.fuel_by_plant
+import pudl.helpers
+import pudl.logging_helpers
+import pudl.transform.ferc1
 from pudl.transform.ferc1 import (
     GroupMetricChecks,
     GroupMetricTolerances,

--- a/src/pudl/output/ferc714.py
+++ b/src/pudl/output/ferc714.py
@@ -11,7 +11,8 @@ import numpy as np
 import pandas as pd
 from dagster import Field, asset
 
-import pudl
+import pudl.analysis.service_territory
+import pudl.logging_helpers
 from pudl.analysis.service_territory import utility_ids_all_eia
 from pudl.analysis.timeseries_cleaning import (
     ImputeTimeseriesSettings,

--- a/src/pudl/scripts/dbt_helper.py
+++ b/src/pudl/scripts/dbt_helper.py
@@ -15,6 +15,7 @@ import yaml
 from deepdiff import DeepDiff
 from pydantic import BaseModel
 
+from pudl.dagster.build import build_defs
 from pudl.logging_helpers import configure_root_logger, get_logger
 from pudl.metadata.classes import PUDL_PACKAGE
 from pudl.validate.dbt import DBT_DIR, build_with_context, dagster_to_dbt_selection
@@ -710,7 +711,7 @@ def validate(
         node_selection = select
     else:
         if asset_select is not None:
-            node_selection = dagster_to_dbt_selection(asset_select)
+            node_selection = dagster_to_dbt_selection(asset_select, build_defs())
         else:
             node_selection = "*"
 

--- a/src/pudl/settings.py
+++ b/src/pudl/settings.py
@@ -19,6 +19,7 @@ from pydantic import (
 from pydantic_settings import BaseSettings
 
 import pudl
+import pudl.logging_helpers
 from pudl.metadata.classes import DataSource
 from pudl.workspace.datastore import Datastore, ZenodoDoi
 

--- a/src/pudl/transform/classes.py
+++ b/src/pudl/transform/classes.py
@@ -87,7 +87,7 @@ from pydantic import (
 
 import pudl.logging_helpers
 import pudl.transform.params.ferc1
-from pudl.metadata import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE
 
 logger = pudl.logging_helpers.get_logger(__name__)
 

--- a/src/pudl/transform/eia.py
+++ b/src/pudl/transform/eia.py
@@ -34,9 +34,9 @@ from dagster import (
     multi_asset,
 )
 
-import pudl
+import pudl.logging_helpers
 from pudl.helpers import convert_cols_dtypes, make_changelog
-from pudl.metadata import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE
 from pudl.metadata.enums import APPROXIMATE_TIMEZONES
 from pudl.metadata.fields import apply_pudl_dtypes, get_pudl_dtypes
 from pudl.metadata.resources import ENTITIES

--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -4,7 +4,6 @@ import numpy as np
 import pandas as pd
 from dagster import asset, asset_check
 
-import pudl
 import pudl.helpers
 import pudl.logging_helpers
 from pudl.helpers import drop_records_with_null_in_column
@@ -12,6 +11,7 @@ from pudl.metadata.classes import PUDL_PACKAGE, DataSource
 from pudl.metadata.codes import CODE_METADATA
 from pudl.metadata.dfs import POLITICAL_SUBDIVISIONS
 from pudl.metadata.fields import apply_pudl_dtypes
+from pudl.settings import Eia860Settings
 from pudl.transform.eia861 import clean_nerc
 
 logger = pudl.logging_helpers.get_logger(__name__)
@@ -111,9 +111,7 @@ def _core_eia860__ownership(raw_eia860__ownership: pd.DataFrame) -> pd.DataFrame
             own_df.report_date.isin(
                 [
                     f"{year}-01-01"
-                    for year in range(
-                        2018, max(pudl.settings.Eia860Settings().years) + 1
-                    )
+                    for year in range(2018, max(Eia860Settings().years) + 1)
                 ]
             )
         )

--- a/src/pudl/transform/eia860.py
+++ b/src/pudl/transform/eia860.py
@@ -5,9 +5,10 @@ import pandas as pd
 from dagster import asset, asset_check
 
 import pudl
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.helpers import drop_records_with_null_in_column
-from pudl.metadata import PUDL_PACKAGE
-from pudl.metadata.classes import DataSource
+from pudl.metadata.classes import PUDL_PACKAGE, DataSource
 from pudl.metadata.codes import CODE_METADATA
 from pudl.metadata.dfs import POLITICAL_SUBDIVISIONS
 from pudl.metadata.fields import apply_pudl_dtypes

--- a/src/pudl/transform/eia861.py
+++ b/src/pudl/transform/eia861.py
@@ -7,7 +7,8 @@ All transformations include:
 import pandas as pd
 from dagster import AssetIn, AssetOut, Output, asset, multi_asset
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.helpers import (
     add_fips_ids,
     clean_eia_counties,
@@ -15,7 +16,7 @@ from pudl.helpers import (
     convert_to_date,
     standardize_na_values,
 )
-from pudl.metadata import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE
 from pudl.metadata.enums import (
     CUSTOMER_CLASSES,
     FUEL_CLASSES,

--- a/src/pudl/transform/eia923.py
+++ b/src/pudl/transform/eia923.py
@@ -10,9 +10,10 @@ from dagster import (
     multi_asset,
 )
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
 from pudl.helpers import convert_col_to_bool, normalize_year_fragments
-from pudl.metadata import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE
 from pudl.metadata.codes import CODE_METADATA
 from pudl.metadata.fields import apply_pudl_dtypes
 from pudl.transform.classes import InvalidRows, drop_invalid_rows

--- a/src/pudl/transform/eia930.py
+++ b/src/pudl/transform/eia930.py
@@ -5,7 +5,7 @@ import re
 import duckdb
 from dagster import AssetOut, Output, asset, multi_asset
 
-import pudl
+import pudl.logging_helpers
 from pudl.helpers import (
     ParquetData,
     df_from_parquet,

--- a/src/pudl/transform/ferc.py
+++ b/src/pudl/transform/ferc.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 import pandas as pd
 
-import pudl
+import pudl.logging_helpers
 from pudl.workspace.setup import PudlPaths
 
 logger = pudl.logging_helpers.get_logger(__name__)

--- a/src/pudl/transform/ferc1.py
+++ b/src/pudl/transform/ferc1.py
@@ -26,7 +26,9 @@ from dagster import AssetIn, AssetsDefinition, asset
 from pandas.core.groupby import DataFrameGroupBy
 from pydantic import BaseModel, Field, field_validator
 
-import pudl
+import pudl.helpers
+import pudl.logging_helpers
+import pudl.metadata.classes
 from pudl.extract.ferc1 import TABLE_NAME_MAP_FERC1
 from pudl.helpers import (
     assert_cols_areclose,
@@ -35,7 +37,7 @@ from pudl.helpers import (
     parse_address,
     standardize_phone_column,
 )
-from pudl.metadata import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE
 from pudl.metadata.dfs import POLITICAL_SUBDIVISIONS
 from pudl.metadata.fields import apply_pudl_dtypes
 from pudl.settings import Ferc1Settings
@@ -3086,6 +3088,10 @@ class Ferc1AbstractTableTransformer(AbstractTableTransformer):
         logger.debug(
             f"{self.table_id.value}: Assigning {source_ferc1.value} source utility IDs."
         )
+        # NOTE (2026-05-27): pudl.glue.ferc1_eia imports pudl.transform.ferc1
+        # so we we need to move this import into function level to avoid circular dependency.
+        import pudl.glue.ferc1_eia
+
         utility_map_ferc1 = pudl.glue.ferc1_eia.get_utility_map_ferc1()
         # use the source utility ID column to get a unique map and for merging
         util_id_col = f"utility_id_ferc1_{source_ferc1.value}"

--- a/src/pudl/transform/gridpathratoolkit.py
+++ b/src/pudl/transform/gridpathratoolkit.py
@@ -8,7 +8,7 @@ association tables for various technology types are also concatenated together.
 import pandas as pd
 from dagster import asset
 
-import pudl
+import pudl.helpers
 
 
 def _transform_capacity_factors(

--- a/src/pudl/transform/vcerare.py
+++ b/src/pudl/transform/vcerare.py
@@ -10,7 +10,7 @@ from dagster import (
     asset,
 )
 
-import pudl
+import pudl.logging_helpers
 from pudl.helpers import (
     ParquetData,
     cleanstrings_snake,

--- a/src/pudl/validate/__init__.py
+++ b/src/pudl/validate/__init__.py
@@ -12,7 +12,3 @@ Submodules are exported here so callers can use the namespace-qualified idiom::
     from pudl.validate import quality as pv
     pv.no_null_rows(df)
 """
-
-from pudl.validate import dbt, integrity, quality
-
-__all__ = ["dbt", "integrity", "quality"]

--- a/src/pudl/validate/dbt.py
+++ b/src/pudl/validate/dbt.py
@@ -14,7 +14,6 @@ from dbt.artifacts.schemas.run import RunExecutionResult
 from dbt.cli.main import dbtRunner, dbtRunnerResult
 from dbt.contracts.graph.nodes import GenericTestNode
 
-import pudl.dagster
 from pudl.logging_helpers import get_logger
 from pudl.workspace.setup import DBT_DIR, PUDL_ROOT_PATH, PudlPaths
 
@@ -188,7 +187,7 @@ def build_with_context(
 
 
 def dagster_to_dbt_selection(
-    selection: str, defs: dg.Definitions | None = None, manifest=None
+    selection: str, defs: dg.Definitions, manifest=None
 ) -> str:
     """Translate dagster asset selection to db node selection.
 
@@ -200,9 +199,6 @@ def dagster_to_dbt_selection(
     * turn asset keys into node names
     * turn node names into selection string
     """
-    if defs is None:
-        defs = pudl.dagster.defs
-
     asset_keys = dg.AssetSelection.from_string(selection).resolve(
         defs.resolve_asset_graph()
     )

--- a/src/pudl/workspace/__init__.py
+++ b/src/pudl/workspace/__init__.py
@@ -7,5 +7,3 @@ to that collection of raw inputs, which we refer to as the PUDL datastore.
 These tools are available both as a library module, and via a command line
 interface installed as an entrypoint script called ``pudl_datastore``.
 """
-
-from . import datastore, resource_cache, setup

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -23,7 +23,7 @@ from requests.adapters import HTTPAdapter
 from upath import UPath
 from urllib3.util.retry import Retry
 
-import pudl
+import pudl.logging_helpers
 from pudl.helpers import retry
 from pudl.workspace import resource_cache
 from pudl.workspace.resource_cache import PudlResourceKey, UPathCache

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,8 +20,9 @@ from dagster import (
     materialize_to_memory,
 )
 
-import pudl
-from pudl.dagster import build_defs, resources
+import pudl.dagster.resources as resources
+import pudl.logging_helpers
+from pudl.dagster.build import build_defs
 from pudl.dagster.io_managers import (
     PudlMixedFormatIOManager,
     _FercSqliteConfigurableIOManagerBase,
@@ -32,7 +33,7 @@ from pudl.dagster.io_managers import (
 )
 from pudl.extract.ferc1 import raw_ferc1_xbrl__metadata_json
 from pudl.extract.ferc714 import raw_ferc714_xbrl__metadata_json
-from pudl.metadata import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE
 from pudl.settings import (
     DatasetsSettings,
     EtlSettings,

--- a/tests/integration/analysis/plant_parts_eia_test.py
+++ b/tests/integration/analysis/plant_parts_eia_test.py
@@ -5,7 +5,7 @@ import logging
 import pandas as pd
 import pytest
 
-import pudl
+import pudl.helpers
 from pudl.analysis.plant_parts_eia import (
     IDX_OWN_TO_ADD,
     IDX_TO_ADD,

--- a/tests/integration/analysis/record_linkage_test.py
+++ b/tests/integration/analysis/record_linkage_test.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import pudl
+import pudl.logging_helpers
 from pudl.analysis.ml_tools import get_ml_models_config
 from pudl.analysis.record_linkage.classify_plants_ferc1 import (
     _FUEL_COLS,

--- a/tests/integration/extract/csv_test.py
+++ b/tests/integration/extract/csv_test.py
@@ -1,6 +1,8 @@
 """Integration tests for CSV-based extractors."""
 
-import pudl
+import pudl.extract.eia176
+import pudl.extract.eia191
+import pudl.extract.eia757a
 
 
 class TestCsvExtractor:

--- a/tests/integration/extract/excel_test.py
+++ b/tests/integration/extract/excel_test.py
@@ -1,6 +1,7 @@
 """Integration tests for Excel-based extractors."""
 
-import pudl
+import pudl.extract.eia860
+import pudl.extract.eia923
 
 
 class TestExcelExtractor:

--- a/tests/integration/extract/ferc1_test.py
+++ b/tests/integration/extract/ferc1_test.py
@@ -5,7 +5,7 @@ from typing import Literal
 import pandas as pd
 import pytest
 
-import pudl
+import pudl.extract.ferc1
 from pudl.settings import DatasetsSettings, Ferc1Settings
 
 

--- a/tests/unit/analysis/plant_parts_eia_test.py
+++ b/tests/unit/analysis/plant_parts_eia_test.py
@@ -4,8 +4,8 @@ from importlib import resources
 
 import pandas as pd
 
-import pudl
 import pudl.analysis.plant_parts_eia
+import pudl.helpers
 
 GENS_MEGA = pd.DataFrame(
     {

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -43,7 +43,7 @@ from pudl.dagster.asset_checks import (
     group_mean_continuity_check,
 )
 from pudl.helpers import ParquetData
-from pudl.metadata import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/dagster/io_managers_test.py
+++ b/tests/unit/dagster/io_managers_test.py
@@ -27,8 +27,7 @@ from pudl.dagster.provenance import (
     FERC_TO_SQLITE_METADATA_KEY,
     FercSqliteProvenanceRecord,
 )
-from pudl.metadata import PUDL_PACKAGE
-from pudl.metadata.classes import Package, Resource
+from pudl.metadata.classes import PUDL_PACKAGE, Package, Resource
 from pudl.settings import (
     DatasetsSettings,
     EtlSettings,

--- a/tests/unit/helpers_test.py
+++ b/tests/unit/helpers_test.py
@@ -8,7 +8,7 @@ import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
 from pandas.tseries.offsets import BYearEnd
 
-import pudl
+import pudl.helpers
 from pudl.helpers import (
     ParquetData,
     add_fips_ids,

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -12,8 +12,8 @@ import polars as pl
 import pytest
 from shapely import Point
 
-from pudl.metadata import PUDL_PACKAGE
 from pudl.metadata.classes import (
+    PUDL_PACKAGE,
     DataSource,
     Field,
     Package,


### PR DESCRIPTION
This was adding a bunch of machinery for little benefit.

Tried to keep this minimal, but there were some extra threads that came loose in the process:

This exposed some circular dependencies that stemmed from a similar eager re-export patterin in `pudl.__init__` - so cleared that up as well.

That included some further re-export cleanup in submodules.

<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/nightly/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/nightly/code_of_conduct.html
-->

## Testing

I ran `dg dev` and also `pytest-unit` but haven't run `pytest-ci`. 

## To-do list

- [x] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
