### PR TITLE
Be in the right directory for zipping

### DIFF
--- a/builds/pudl_batch.sh
+++ b/builds/pudl_batch.sh
@@ -319,11 +319,11 @@ function prep_outputs_for_distribution() {
         # Move the parquet datapackage to the output directory also!
         mv ./pudl_parquet_datapackage.json "$PUDL_OUTPUT" &&
         popd &&
-        zip -0 "$PUDL_OUTPUT/ferc1_xbrl.zip" ./ferc1_xbrl &&
-        zip -0 "$PUDL_OUTPUT/ferc2_xbrl.zip" ./ferc2_xbrl &&
-        zip -0 "$PUDL_OUTPUT/ferc6_xbrl.zip" ./ferc6_xbrl &&
-        zip -0 "$PUDL_OUTPUT/ferc60_xbrl.zip" ./ferc60_xbrl &&
-        zip -0 "$PUDL_OUTPUT/ferc714_xbrl.zip" ./ferc714_xbrl &&
+        zip -0 "$PUDL_OUTPUT/ferc1_xbrl.zip" ./ferc1_xbrl/* &&
+        zip -0 "$PUDL_OUTPUT/ferc2_xbrl.zip" ./ferc2_xbrl/* &&
+        zip -0 "$PUDL_OUTPUT/ferc6_xbrl.zip" ./ferc6_xbrl/* &&
+        zip -0 "$PUDL_OUTPUT/ferc60_xbrl.zip" ./ferc60_xbrl/* &&
+        zip -0 "$PUDL_OUTPUT/ferc714_xbrl.zip" ./ferc714_xbrl/* &&
         # Remove any remaining files and directories we don't want to distribute
         rm -rf "$PUDL_OUTPUT/parquet" &&
         rm -f "$PUDL_OUTPUT/pudl_dbt_tests.duckdb"

--- a/builds/pudl_batch.sh
+++ b/builds/pudl_batch.sh
@@ -319,11 +319,13 @@ function prep_outputs_for_distribution() {
         # Move the parquet datapackage to the output directory also!
         mv ./pudl_parquet_datapackage.json "$PUDL_OUTPUT" &&
         popd &&
-        zip -0 "$PUDL_OUTPUT/ferc1_xbrl.zip" ./ferc1_xbrl/* &&
-        zip -0 "$PUDL_OUTPUT/ferc2_xbrl.zip" ./ferc2_xbrl/* &&
-        zip -0 "$PUDL_OUTPUT/ferc6_xbrl.zip" ./ferc6_xbrl/* &&
-        zip -0 "$PUDL_OUTPUT/ferc60_xbrl.zip" ./ferc60_xbrl/* &&
-        zip -0 "$PUDL_OUTPUT/ferc714_xbrl.zip" ./ferc714_xbrl/* &&
+        pushd "$PUDL_OUTPUT" &&
+        zip -0 "$PUDL_OUTPUT/ferc1_xbrl.zip" ./ferc1_xbrl/*.parquet ./ferc1_xbrl/*.json &&
+        zip -0 "$PUDL_OUTPUT/ferc2_xbrl.zip" ./ferc2_xbrl/*.parquet ./ferc2_xbrl/*.json &&
+        zip -0 "$PUDL_OUTPUT/ferc6_xbrl.zip" ./ferc6_xbrl/*.parquet ./ferc6_xbrl/*.json &&
+        zip -0 "$PUDL_OUTPUT/ferc60_xbrl.zip" ./ferc60_xbrl/*.parquet ./ferc60_xbrl/*.json &&
+        zip -0 "$PUDL_OUTPUT/ferc714_xbrl.zip" ./ferc714_xbrl/*.parquet ./ferc714_xbrl/*.json &&
+        popd &&
         # Remove any remaining files and directories we don't want to distribute
         rm -rf "$PUDL_OUTPUT/parquet" &&
         rm -f "$PUDL_OUTPUT/pudl_dbt_tests.duckdb"


### PR DESCRIPTION
get into the right directory before doing the FERC XBRL derived parquet zipping. Hopefully.