### PR TITLE
Remove fercN_xbrl regex; actually ignore directories

### DIFF
--- a/.github/workflows/zenodo-data-release.yml
+++ b/.github/workflows/zenodo-data-release.yml
@@ -19,7 +19,7 @@ on:
       ignore_regex:
         description: "Ignore files matching this regex:"
         required: false
-        default: '(^.*\.parquet$|^pudl_parquet_datapackage\.json$|^ferc\d{1,3}_xbrl$)'
+        default: '(^.*\.parquet$|^pudl_parquet_datapackage\.json$)'
       publish:
         description: "Automatically publish Zenodo record?"
         required: true

--- a/builds/pudl_batch.sh
+++ b/builds/pudl_batch.sh
@@ -335,7 +335,7 @@ function prep_outputs_for_distribution() {
 # MAIN SCRIPT
 ########################################################################################
 LOGFILE="${PUDL_OUTPUT}/${BUILD_ID}.log"
-ZENODO_IGNORE_REGEX="(^.*\\\\.parquet$|^.*pudl_parquet_datapackage\\\\.json$|^ferc\d{1,3}_xbrl$)"
+ZENODO_IGNORE_REGEX="(^.*\\\\.parquet$|^.*pudl_parquet_datapackage\\\\.json$)"
 STAGE_SKIPPED="skipped"
 BUILD_START_EPOCH_SECONDS=$(date +%s)
 

--- a/src/pudl/scripts/zenodo_data_release.py
+++ b/src/pudl/scripts/zenodo_data_release.py
@@ -368,6 +368,24 @@ class EmptyDraft(State):
     """We can only sync the directory once we've gotten an empty draft."""
 
     @staticmethod
+    def _top_level_files(dir_fs: fsspec.AbstractFileSystem, dir_path: str) -> list[str]:
+        """Return only top-level files from ``dir_path``.
+
+        Zenodo's bucket API only accepts a flat list of files. Some filesystems return
+        top-level directories from ``ls()``, so we must filter them out explicitly
+        before handing paths to ``fsspec.open_files()``.
+        """
+        file_paths: list[str] = []
+        for entry in dir_fs.ls(dir_path, detail=True):
+            entry_path = entry["name"]
+            entry_type = entry.get("type")
+            if entry_type == "directory":
+                continue
+            if entry_type == "file" or dir_fs.isfile(entry_path):
+                file_paths.append(entry_path)
+        return file_paths
+
+    @staticmethod
     def _sync_local_path(
         openable_file: fsspec.core.OpenFile, staging_dir: Path
     ) -> Path:
@@ -429,7 +447,10 @@ class EmptyDraft(State):
             protocol[0] if isinstance(protocol, (list, tuple)) else protocol
         )
         files = fsspec.open_files(
-            [f"{protocol_prefix}://{path}" for path in dir_fs.ls(dir_path)]
+            [
+                f"{protocol_prefix}://{path}"
+                for path in self._top_level_files(dir_fs, dir_path)
+            ]
         )
         all_ignore_regex = re.compile("|".join(ignore)) if ignore else None
 

--- a/src/pudl/scripts/zenodo_data_release.py
+++ b/src/pudl/scripts/zenodo_data_release.py
@@ -368,24 +368,6 @@ class EmptyDraft(State):
     """We can only sync the directory once we've gotten an empty draft."""
 
     @staticmethod
-    def _top_level_files(dir_fs: fsspec.AbstractFileSystem, dir_path: str) -> list[str]:
-        """Return only top-level files from ``dir_path``.
-
-        Zenodo's bucket API only accepts a flat list of files. Some filesystems return
-        top-level directories from ``ls()``, so we must filter them out explicitly
-        before handing paths to ``fsspec.open_files()``.
-        """
-        file_paths: list[str] = []
-        for entry in dir_fs.ls(dir_path, detail=True):
-            entry_path = entry["name"]
-            entry_type = entry.get("type")
-            if entry_type == "directory":
-                continue
-            if entry_type == "file" or dir_fs.isfile(entry_path):
-                file_paths.append(entry_path)
-        return file_paths
-
-    @staticmethod
     def _sync_local_path(
         openable_file: fsspec.core.OpenFile, staging_dir: Path
     ) -> Path:
@@ -448,8 +430,11 @@ class EmptyDraft(State):
         )
         files = fsspec.open_files(
             [
-                f"{protocol_prefix}://{path}"
-                for path in self._top_level_files(dir_fs, dir_path)
+                f"{protocol_prefix}://{entry['name']}"
+                for entry in dir_fs.ls(dir_path, detail=True)
+                # Only upload files, not subdirectories.
+                # Zenodo doesn't support nested folders.
+                if entry.get("type") == "file" or dir_fs.isfile(entry["name"])
             ]
         )
         all_ignore_regex = re.compile("|".join(ignore)) if ignore else None

--- a/tests/unit/scripts/zenodo_data_release_test.py
+++ b/tests/unit/scripts/zenodo_data_release_test.py
@@ -9,6 +9,7 @@ import requests
 from pudl.scripts.zenodo_data_release import (
     RETRYABLE_STATUS_CODES,
     SANDBOX,
+    EmptyDraft,
     ZenodoClient,
 )
 
@@ -157,3 +158,35 @@ def test_create_bucket_file_reopens_stream(mocker, zenodo_client, tmp_path):
     assert len(calls) == 2
     assert all(payload == data for payload in calls)
     assert response.status_code == 200
+
+
+def test_sync_directory_skips_top_level_directories_and_ignored_files(
+    mocker, zenodo_client, tmp_path
+):
+    """Ensure only top-level files that survive ignore regexes are uploaded."""
+
+    keep_file = tmp_path / "keep.txt"
+    keep_file.write_text("keep", encoding="utf-8")
+    ignored_file = tmp_path / "ignore.parquet"
+    ignored_file.write_text("ignored", encoding="utf-8")
+    nested_dir = tmp_path / "ferc1_xbrl"
+    nested_dir.mkdir()
+    (nested_dir / "nested.txt").write_text("nested", encoding="utf-8")
+
+    zenodo_client.get_deposition = mocker.Mock(  # type: ignore[method-assign]
+        return_value=SimpleNamespace(
+            links=SimpleNamespace(bucket="https://sandbox.zenodo.org/api/files/123")
+        )
+    )
+    zenodo_client.create_bucket_file = mocker.Mock(  # type: ignore[method-assign]
+        return_value=_fake_response(200)
+    )
+
+    draft = EmptyDraft(record_id=123, zenodo_client=zenodo_client)
+    draft.sync_directory(str(tmp_path), ignore=(r".*\.parquet$",))
+
+    uploaded_paths = [
+        call.kwargs["file_path"].name
+        for call in zenodo_client.create_bucket_file.call_args_list
+    ]
+    assert uploaded_paths == ["keep.txt"]


### PR DESCRIPTION
# Overview

Debugging Zenodo data release script issues w/ new FERC XBRL parquet outputs / directory structures.

- Remove the `ignore_regex` component that was meant to skip the `fercN_xbrl/` directories, because the script is supposed to automatically skip ALL directories (as Zenodo needs a flat filesystem hierarchy)

## Debugging Notes

- The Zenodo data release action is failing when trying to upload `ferc1_xbrl` to Zenodo.
- This is confusing because the script is supposed to skip all directories, and that sure looks like a directory.
- This is extra confusing, because after seeing the directory it's not supposed to see, it then says "No such file or directory"
- See [failed run log here](https://github.com/catalyst-cooperative/pudl/actions/runs/26047732589/job/76576207844)

<details><summary>Stack trace from failed Zenodo data release</summary>

```
2026-05-18 16:57:13 INFO dagster.builtin.catalystcoop.pudl.scripts.zenodo_data_release Uploading file to https://sandbox.zenodo.org/api/files/d7a3154b-6495-4a39-9d10-29cce60335ad/ferc1_xbrl
Traceback (most recent call last):
  File "/home/runner/work/pudl/pudl/.pixi/envs/default/bin/zenodo_data_release", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/runner/work/pudl/pudl/.pixi/envs/default/lib/python3.13/site-packages/click/core.py", line 1514, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/runner/work/pudl/pudl/.pixi/envs/default/lib/python3.13/site-packages/click/core.py", line 1435, in main
    rv = self.invoke(ctx)
  File "/home/runner/work/pudl/pudl/.pixi/envs/default/lib/python3.13/site-packages/click/core.py", line 1298, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/pudl/pudl/.pixi/envs/default/lib/python3.13/site-packages/click/core.py", line 853, in invoke
    return callback(*args, **kwargs)
  File "/home/runner/work/pudl/pudl/src/pudl/scripts/zenodo_data_release.py", line 557, in main
    .sync_directory(source_dir, ignore)
     ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/pudl/pudl/src/pudl/scripts/zenodo_data_release.py", line 448, in sync_directory
    response = self.zenodo_client.create_bucket_file(
        bucket_url=bucket_url,
        file_path=local_path,
    )
  File "/home/runner/work/pudl/pudl/src/pudl/scripts/zenodo_data_release.py", line 303, in create_bucket_file
    size = file_path.stat().st_size
           ~~~~~~~~~~~~~~^^
  File "/home/runner/work/pudl/pudl/.pixi/envs/default/lib/python3.13/pathlib/_local.py", line 515, in stat
    return os.stat(self, follow_symlinks=follow_symlinks)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpcby_i6xt/ferc1_xbrl'
```

</details>

- It looks like the problem was we weren't *actually* ignoring top-level directories when compiling the list of files to upload.
- The `FileNotFoundError` was coming up because it found a directory, not a file.
- I've updated `zenodo_data_release.py` to try and actually ignore directories, as we thought we were doing already.
- It [seems to be working](https://github.com/catalyst-cooperative/pudl/actions/runs/26050706179/job/76586352375)