### PR TITLE
Add hook for regenerating dbt schema files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -196,6 +196,16 @@ repos:
         always_run: true
         entry: pixi run pytest --no-cov --doctest-modules src/pudl tests/unit -m "not slow"
 
+      - id: schema-check
+        name: schema-check
+        stages: [pre-commit]
+        language: system
+        verbose: true
+        files: "^(src/pudl/metadata/resources/[^_].*\\.py|dbt/schema_inputs/.*schema\\.human\\.yml)$"
+        pass_filenames: false
+        always_run: false
+        entry: pixi run dbt_helper update-tables --schema all
+
 # Configuration for pre-commit.ci
 ci:
   autofix_commit_msg: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -202,9 +202,20 @@ repos:
         language: system
         verbose: true
         files: "^(src/pudl/metadata/resources/[^_].*\\.py|dbt/schema_inputs/.*schema\\.human\\.yml)$"
-        pass_filenames: false
+        pass_filenames: true
         always_run: false
-        entry: pixi run dbt_helper update-tables --schema all
+        # 1. convert filenames inputs from space-delimited to newline-delimited so we can use grep/sed/etc
+        # 2. split inputs into just-metadata and just-human-schemas
+        # 3. extract tables from each set
+        # 4. combine both lists of tables and deduplicate
+        # 5. regenerate schema files
+        entry: bash -c '
+          JUST_METADATA_FILES=`echo "$@" | tr " " "\n" | grep metadata`;
+          JUST_HUMAN_SCHEMAS=`echo "$@" | tr " " "\n" | grep human`;
+          METADATA_TABLES=`if [ -n "${JUST_METADATA_FILES}" ]; then what_tables ${JUST_METADATA_FILES}; fi`;
+          HUSCHEMA_TABLES=`echo "${JUST_HUMAN_SCHEMAS}" | sed "s%/schema.human.yml$%%;s%.*/%%"`;
+          UNIQUE_TABLES=`echo -e "${METADATA_TABLES}\n${HUSCHEMA_TABLES}" | sort -u`;
+          pixi run dbt_helper update-tables --schema ${UNIQUE_TABLES}' --
 
 # Configuration for pre-commit.ci
 ci:

--- a/dbt/models/eia/core_eia__entity_boilers/schema.yml
+++ b/dbt/models/eia/core_eia__entity_boilers/schema.yml
@@ -5,12 +5,9 @@ sources:
       - name: core_eia__entity_boilers
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                The boiler manufacturer and boiler manufacturer code columns are only
-                reported in a single year, but assumed to be static (and thus are
-                included in the entity table). However, if the one year in which they
-                were reported isn't processed, then they end up being entirely null, so
-                they are excluded from the null check.
+              description: 'The boiler manufacturer and boiler manufacturer code columns are only reported in a single year, but assumed to be static (and thus are included in the entity table). However, if the one year in which they were reported isn''t processed, then they end up being entirely null, so they are excluded from the null check.
+
+                '
               arguments:
                 exclude_columns:
                   - boiler_manufacturer

--- a/dbt/models/eia/core_eia__entity_generators/schema.yml
+++ b/dbt/models/eia/core_eia__entity_generators/schema.yml
@@ -5,11 +5,9 @@ sources:
       - name: core_eia__entity_generators
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                The can_switch_when_operating column is only reported in a single year,
-                but assumed to be static (and thus is included in the entity table).
-                However, if the one year in which it was reported isn't processed, then
-                it ends up being entirely null, so it is excluded from the null check.
+              description: 'The can_switch_when_operating column is only reported in a single year, but assumed to be static (and thus is included in the entity table). However, if the one year in which it was reported isn''t processed, then it ends up being entirely null, so it is excluded from the null check.
+
+                '
               arguments:
                 exclude_columns:
                   - can_switch_when_operating

--- a/dbt/models/eia/core_eia__yearly_fuel_receipts_costs_aggs/schema.yml
+++ b/dbt/models/eia/core_eia__yearly_fuel_receipts_costs_aggs/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia__yearly_fuel_receipts_costs_aggs
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: fuel_agg
           - name: geo_agg

--- a/dbt/models/eia/out_eia__yearly_assn_plant_parts_plant_gen/schema.yml
+++ b/dbt/models/eia/out_eia__yearly_assn_plant_parts_plant_gen/schema.yml
@@ -13,7 +13,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia__yearly_assn_plant_parts_plant_gen
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_includes_all_value_combinations_from:
               arguments:
                 compare_table_name: out_eia__yearly_plant_parts

--- a/dbt/models/eia/out_eia__yearly_boilers/schema.yml
+++ b/dbt/models/eia/out_eia__yearly_boilers/schema.yml
@@ -5,13 +5,9 @@ sources:
       - name: out_eia__yearly_boilers
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                Excluded mercury control strategies are very infrequently used, since
-                few boilers have more than three. It's fine if they're null. The boiler
-                manufacturer and code are static attributes which were only reported in
-                a single year and are effectively forward/back filled because they are
-                part of the boiler entity table. This means they're fully populated if
-                that year of data is included, and entirely null if it's not.
+              description: 'Excluded mercury control strategies are very infrequently used, since few boilers have more than three. It''s fine if they''re null. The boiler manufacturer and code are static attributes which were only reported in a single year and are effectively forward/back filled because they are part of the boiler entity table. This means they''re fully populated if that year of data is included, and entirely null if it''s not.
+
+                '
               arguments:
                 ignore_eia860m_nulls: true
                 exclude_columns:
@@ -108,7 +104,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia__yearly_boilers
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_date_frequency_ratio:
               arguments:
                 compare_model: source("pudl", "out_eia__yearly_generators")

--- a/dbt/models/eia/out_eia__yearly_generators_by_ownership/schema.yml
+++ b/dbt/models/eia/out_eia__yearly_generators_by_ownership/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia__yearly_generators_by_ownership
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_expectations.expect_compound_columns_to_be_unique:
               arguments:
                 column_list:

--- a/dbt/models/eia/out_eia__yearly_plants/schema.yml
+++ b/dbt/models/eia/out_eia__yearly_plants/schema.yml
@@ -37,7 +37,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia__yearly_plants
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_date_frequency_ratio:
               arguments:
                 compare_model: source("pudl", "out_eia__yearly_generators")

--- a/dbt/models/eia/out_eia__yearly_utilities/schema.yml
+++ b/dbt/models/eia/out_eia__yearly_utilities/schema.yml
@@ -29,7 +29,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia__yearly_utilities
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_date_frequency_ratio:
               arguments:
                 compare_model: source("pudl", "out_eia__yearly_generators")

--- a/dbt/models/eia176/core_eia176__yearly_gas_disposition/schema.yml
+++ b/dbt/models/eia176/core_eia176__yearly_gas_disposition/schema.yml
@@ -3,14 +3,12 @@ sources:
   - name: pudl
     tables:
       - name: core_eia176__yearly_gas_disposition
-
         data_tests:
           - expect_columns_not_all_null
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia176__yearly_gas_disposition
-                partition_expr: "report_year"
-
+                partition_expr: report_year
         columns:
           - name: operator_id_eia
           - name: report_year
@@ -19,7 +17,7 @@ sources:
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   config:
-                    error_if: ">300"
+                    error_if: '>300'
                   arguments:
                     min_value: 0.8
                     max_value: 1.2
@@ -53,6 +51,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
+          - name: operational_consumption_other_detail
           - name: operational_storage_underground_mcf
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -73,17 +72,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-          - name: losses_mcf
-            data_tests:
-              - dbt_expectations.expect_column_min_to_be_between:
-                  arguments:
-                    min_value: 0.0
           - name: disposition_distribution_companies_mcf
-            data_tests:
-              - dbt_expectations.expect_column_min_to_be_between:
-                  arguments:
-                    min_value: 0.0
-          - name: disposition_other_pipelines_mcf
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
@@ -92,16 +81,15 @@ sources:
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   config:
-                    error_if: ">1"
+                    error_if: '>1'
                   arguments:
                     min_value: 0.0
-                  description: "This is currently failing for one record, ID 17690211AL in 2014."
-          - name: total_disposition_mcf
+                  description: This is currently failing for one record, ID 17690211AL in 2014.
+          - name: disposition_other_pipelines_mcf
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-          - name: unaccounted_for_mcf
           - name: disposition_out_of_state_mcf
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -112,4 +100,14 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-          - name: operational_consumption_other_detail
+          - name: total_disposition_mcf
+            data_tests:
+              - dbt_expectations.expect_column_min_to_be_between:
+                  arguments:
+                    min_value: 0.0
+          - name: losses_mcf
+            data_tests:
+              - dbt_expectations.expect_column_min_to_be_between:
+                  arguments:
+                    min_value: 0.0
+          - name: unaccounted_for_mcf

--- a/dbt/models/eia176/core_eia176__yearly_gas_disposition_by_consumer/schema.yml
+++ b/dbt/models/eia176/core_eia176__yearly_gas_disposition_by_consumer/schema.yml
@@ -3,14 +3,12 @@ sources:
   - name: pudl
     tables:
       - name: core_eia176__yearly_gas_disposition_by_consumer
-
         data_tests:
           - expect_columns_not_all_null
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia176__yearly_gas_disposition_by_consumer
-                partition_expr: "report_year"
-
+                partition_expr: report_year
         columns:
           - name: report_year
           - name: operator_id_eia

--- a/dbt/models/eia191/core_eia191__monthly_gas_storage/schema.yml
+++ b/dbt/models/eia191/core_eia191__monthly_gas_storage/schema.yml
@@ -3,13 +3,12 @@ sources:
   - name: pudl
     tables:
       - name: core_eia191__monthly_gas_storage
-
         data_tests:
           - expect_columns_not_all_null
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia191__monthly_gas_storage
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_sum_close_to_total_column:
               arguments:
                 sum_columns:
@@ -18,14 +17,9 @@ sources:
                 total_column: total_field_capacity_mcf
                 discrepancy_threshold: 0.01
                 max_discrepancy_rate: 0.25
-              description: >
-                total_field_capacity_mcf is reported as design capacity (base + working gas)
-                but is not reliably additive: approximately 23% of records have
-                total_field_capacity_mcf != working_gas_capacity_mcf + base_gas_mcf. This
-                reflects loose EIA definitions and operator self-reporting practices. The
-                threshold is set just above the observed ~23% failure rate so regressions
-                are flagged but existing failures do not hard-fail.
+              description: 'total_field_capacity_mcf is reported as design capacity (base + working gas) but is not reliably additive: approximately 23% of records have total_field_capacity_mcf != working_gas_capacity_mcf + base_gas_mcf. This reflects loose EIA definitions and operator self-reporting practices. The threshold is set just above the observed ~23% failure rate so regressions are flagged but existing failures do not hard-fail.
 
+                '
         columns:
           - name: storage_field_id_eia
           - name: report_date

--- a/dbt/models/eia860/_core_eia860__cooling_equipment/schema.yml
+++ b/dbt/models/eia860/_core_eia860__cooling_equipment/schema.yml
@@ -5,22 +5,22 @@ sources:
       - name: _core_eia860__cooling_equipment
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                Excluded columns are 3rd and 4th tier categories that are very
-                infrequently used. It's fine for them to be null.
+              description: 'Excluded columns are 3rd and 4th tier categories that are very infrequently used. It''s fine for them to be null.
+
+                '
               arguments:
                 exclude_columns:
                   - tower_type_3
                   - tower_type_4
                   - cooling_type_4
                 row_conditions:
-                  county: "extract(year from report_date) <= 2010"
-                  plant_summer_capacity_mw: "extract(year from report_date) <= 2010"
-                  water_source: "extract(year from report_date) <= 2010"
+                  county: extract(year from report_date) <= 2010
+                  plant_summer_capacity_mw: extract(year from report_date) <= 2010
+                  water_source: extract(year from report_date) <= 2010
           - check_row_counts_per_partition:
               arguments:
                 table_name: _core_eia860__cooling_equipment
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia860/_core_eia860__fgd_equipment/schema.yml
+++ b/dbt/models/eia860/_core_eia860__fgd_equipment/schema.yml
@@ -5,9 +5,9 @@ sources:
       - name: _core_eia860__fgd_equipment
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                These excluded columns are 3rd and 4th tier categories that are very
-                infrequently used. It's fine for them to be null.
+              description: 'These excluded columns are 3rd and 4th tier categories that are very infrequently used. It''s fine for them to be null.
+
+                '
               arguments:
                 exclude_columns:
                   - sorbent_type_3
@@ -27,7 +27,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: _core_eia860__fgd_equipment
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_fgd_cost_totals_to_agree
         columns:
           - name: report_date

--- a/dbt/models/eia860/core_eia860__assn_boiler_cooling/schema.yml
+++ b/dbt/models/eia860/core_eia860__assn_boiler_cooling/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__assn_boiler_cooling
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia860/core_eia860__assn_boiler_generator/schema.yml
+++ b/dbt/models/eia860/core_eia860__assn_boiler_generator/schema.yml
@@ -13,7 +13,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__assn_boiler_generator
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_date_frequency_ratio:
               arguments:
                 compare_model: source("pudl", "out_eia__yearly_generators")

--- a/dbt/models/eia860/core_eia860__assn_boiler_stack_flue/schema.yml
+++ b/dbt/models/eia860/core_eia860__assn_boiler_stack_flue/schema.yml
@@ -13,7 +13,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__assn_boiler_stack_flue
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia860/core_eia860__assn_yearly_boiler_emissions_control_equipment/schema.yml
+++ b/dbt/models/eia860/core_eia860__assn_yearly_boiler_emissions_control_equipment/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__assn_yearly_boiler_emissions_control_equipment
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia860/core_eia860__scd_boilers/schema.yml
+++ b/dbt/models/eia860/core_eia860__scd_boilers/schema.yml
@@ -5,11 +5,9 @@ sources:
       - name: core_eia860__scd_boilers
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                This table has a lot of row_conditions because it has a few columns that
-                are found in the EIA-860M generators table (and so appear in the most
-                recent monthly data) but most of the columns are specific to boilers,
-                which are not reported in the EIA-860M.
+              description: 'This table has a lot of row_conditions because it has a few columns that are found in the EIA-860M generators table (and so appear in the most recent monthly data) but most of the columns are specific to boilers, which are not reported in the EIA-860M.
+
+                '
               arguments:
                 ignore_eia860m_nulls: true
                 row_conditions:
@@ -103,7 +101,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__scd_boilers
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: boiler_id

--- a/dbt/models/eia860/core_eia860__scd_generators/schema.yml
+++ b/dbt/models/eia860/core_eia860__scd_generators/schema.yml
@@ -59,7 +59,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__scd_generators
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: generator_id

--- a/dbt/models/eia860/core_eia860__scd_generators_energy_storage/schema.yml
+++ b/dbt/models/eia860/core_eia860__scd_generators_energy_storage/schema.yml
@@ -5,10 +5,9 @@ sources:
       - name: core_eia860__scd_generators_energy_storage
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                Excluded columns have yet to be used in any year, but as more energy
-                storage technologies become available, we might want to stop excluding
-                them.
+              description: 'Excluded columns have yet to be used in any year, but as more energy storage technologies become available, we might want to stop excluding them.
+
+                '
               arguments:
                 exclude_columns:
                   - storage_technology_code_3
@@ -16,7 +15,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__scd_generators_energy_storage
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: generator_id

--- a/dbt/models/eia860/core_eia860__scd_generators_multifuel/schema.yml
+++ b/dbt/models/eia860/core_eia860__scd_generators_multifuel/schema.yml
@@ -42,7 +42,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__scd_generators_multifuel
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: utility_id_eia

--- a/dbt/models/eia860/core_eia860__scd_generators_solar/schema.yml
+++ b/dbt/models/eia860/core_eia860__scd_generators_solar/schema.yml
@@ -20,7 +20,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__scd_generators_solar
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: generator_id

--- a/dbt/models/eia860/core_eia860__scd_generators_wind/schema.yml
+++ b/dbt/models/eia860/core_eia860__scd_generators_wind/schema.yml
@@ -11,7 +11,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__scd_generators_wind
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: generator_id

--- a/dbt/models/eia860/core_eia860__scd_ownership/schema.yml
+++ b/dbt/models/eia860/core_eia860__scd_ownership/schema.yml
@@ -8,13 +8,13 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__scd_ownership
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: owner_utility_id_eia
+          - name: operator_utility_id_eia
           - name: plant_id_eia
           - name: generator_id
-          - name: operator_utility_id_eia
           - name: owner_utility_name_eia
           - name: owner_state
           - name: owner_city

--- a/dbt/models/eia860/core_eia860__scd_plants/schema.yml
+++ b/dbt/models/eia860/core_eia860__scd_plants/schema.yml
@@ -38,7 +38,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__scd_plants
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: report_date

--- a/dbt/models/eia860/core_eia860__scd_utilities/schema.yml
+++ b/dbt/models/eia860/core_eia860__scd_utilities/schema.yml
@@ -29,7 +29,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860__scd_utilities
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: utility_id_eia
           - name: report_date

--- a/dbt/models/eia860m/core_eia860m__changelog_generators/schema.yml
+++ b/dbt/models/eia860m/core_eia860m__changelog_generators/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia860m__changelog_generators
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: valid_until_date

--- a/dbt/models/eia861/core_eia861__assn_balancing_authority/schema.yml
+++ b/dbt/models/eia861/core_eia861__assn_balancing_authority/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__assn_balancing_authority
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: balancing_authority_id_eia

--- a/dbt/models/eia861/core_eia861__assn_utility/schema.yml
+++ b/dbt/models/eia861/core_eia861__assn_utility/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__assn_utility
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: utility_id_eia

--- a/dbt/models/eia861/core_eia861__yearly_advanced_metering_infrastructure/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_advanced_metering_infrastructure/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_advanced_metering_infrastructure
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: advanced_metering_infrastructure
             data_tests:
@@ -48,7 +48,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">1"
+                    error_if: '>1'
           - name: report_date
           - name: short_form
           - name: state

--- a/dbt/models/eia861/core_eia861__yearly_balancing_authority/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_balancing_authority/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_balancing_authority
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: balancing_authority_id_eia

--- a/dbt/models/eia861/core_eia861__yearly_demand_response/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_demand_response/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_demand_response
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: actual_peak_demand_savings_mw
             data_tests:
@@ -22,7 +22,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">3"
+                    error_if: '>3'
           - name: customers
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -38,7 +38,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">2"
+                    error_if: '>2'
           - name: potential_peak_demand_savings_mw
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/eia861/core_eia861__yearly_demand_response_water_heater/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_demand_response_water_heater/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_demand_response_water_heater
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: balancing_authority_code_eia
           - name: report_date
@@ -19,5 +19,5 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">1"
+                    error_if: '>1'
           - name: data_maturity

--- a/dbt/models/eia861/core_eia861__yearly_demand_side_management_ee_dr/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_demand_side_management_ee_dr/schema.yml
@@ -8,14 +8,14 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_demand_side_management_ee_dr
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: annual_indirect_program_cost
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">1"
+                    error_if: '>1'
           - name: annual_total_cost
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -37,13 +37,13 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">1"
+                    error_if: '>1'
           - name: energy_efficiency_annual_incentive_cost
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">1"
+                    error_if: '>1'
           - name: energy_efficiency_incremental_actual_peak_reduction_mw
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -69,7 +69,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">10"
+                    error_if: '>10'
           - name: load_management_annual_incentive_cost
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -85,19 +85,19 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">2"
+                    error_if: '>2'
           - name: load_management_incremental_effects_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">6"
+                    error_if: '>6'
           - name: load_management_incremental_potential_peak_reduction_mw
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">4"
+                    error_if: '>4'
           - name: nerc_region
           - name: price_responsiveness_customers
             data_tests:

--- a/dbt/models/eia861/core_eia861__yearly_demand_side_management_misc/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_demand_side_management_misc/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_demand_side_management_misc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: energy_savings_estimates_independently_verified
           - name: energy_savings_independently_verified

--- a/dbt/models/eia861/core_eia861__yearly_demand_side_management_sales/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_demand_side_management_sales/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_demand_side_management_sales
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: nerc_region
           - name: report_date
@@ -17,7 +17,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">1"
+                    error_if: '>1'
           - name: sales_to_ultimate_consumers_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/eia861/core_eia861__yearly_distributed_generation_fuel/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_distributed_generation_fuel/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_distributed_generation_fuel
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: estimated_or_actual_fuel_data
           - name: fuel_class

--- a/dbt/models/eia861/core_eia861__yearly_distributed_generation_misc/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_distributed_generation_misc/schema.yml
@@ -8,13 +8,13 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_distributed_generation_misc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_expectations.expect_column_pair_values_A_to_be_greater_than_B:
               arguments:
                 column_A: generators_number
                 column_B: generators_num_less_1_mw
-                or_equal: True
-                error_if: ">8"
+                or_equal: true
+                error_if: '>8'
         columns:
           - name: backup_capacity_mw
             data_tests:

--- a/dbt/models/eia861/core_eia861__yearly_distributed_generation_tech/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_distributed_generation_tech/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_distributed_generation_tech
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: capacity_mw
             data_tests:

--- a/dbt/models/eia861/core_eia861__yearly_distribution_systems/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_distribution_systems/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_distribution_systems
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_expectations.expect_column_pair_values_A_to_be_greater_than_B:
               arguments:
                 column_A: distribution_circuits
                 column_B: circuits_with_voltage_optimization
-                or_equal: True
+                or_equal: true
         columns:
           - name: circuits_with_voltage_optimization
             data_tests:

--- a/dbt/models/eia861/core_eia861__yearly_dynamic_pricing/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_dynamic_pricing/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_dynamic_pricing
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: balancing_authority_code_eia
           - name: critical_peak_pricing

--- a/dbt/models/eia861/core_eia861__yearly_energy_efficiency/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_energy_efficiency/schema.yml
@@ -8,13 +8,13 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_energy_efficiency
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_expectations.expect_column_pair_values_A_to_be_greater_than_B:
               arguments:
                 column_A: incremental_life_cycle_energy_savings_mwh
                 column_B: incremental_energy_savings_mwh
-                or_equal: True
-                error_if: ">29"
+                or_equal: true
+                error_if: '>29'
         columns:
           - name: balancing_authority_code_eia
           - name: customer_class

--- a/dbt/models/eia861/core_eia861__yearly_green_pricing/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_green_pricing/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_green_pricing
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: customer_class
           - name: customers
@@ -21,7 +21,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">2"
+                    error_if: '>2'
           - name: rec_revenue
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/eia861/core_eia861__yearly_mergers/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_mergers/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_mergers
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: entity_type
           - name: merge_address

--- a/dbt/models/eia861/core_eia861__yearly_net_metering_customer_fuel_class/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_net_metering_customer_fuel_class/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_net_metering_customer_fuel_class
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: balancing_authority_code_eia
           - name: capacity_mw
@@ -16,7 +16,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    row_condition: "utility_id_eia != 99999"
+                    row_condition: utility_id_eia != 99999
           - name: energy_capacity_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -35,7 +35,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">2"
+                    error_if: '>2'
           - name: state
           - name: tech_class
           - name: utility_id_eia

--- a/dbt/models/eia861/core_eia861__yearly_net_metering_misc/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_net_metering_misc/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_net_metering_misc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: balancing_authority_code_eia
           - name: pv_current_flow_type

--- a/dbt/models/eia861/core_eia861__yearly_non_net_metering_customer_fuel_class/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_non_net_metering_customer_fuel_class/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_non_net_metering_customer_fuel_class
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: balancing_authority_code_eia
           - name: capacity_mw
@@ -16,7 +16,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    row_condition: "utility_id_eia != 99999"
+                    row_condition: utility_id_eia != 99999
           - name: energy_capacity_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/eia861/core_eia861__yearly_non_net_metering_misc/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_non_net_metering_misc/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_non_net_metering_misc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: backup_capacity_mw
             data_tests:

--- a/dbt/models/eia861/core_eia861__yearly_operational_data_misc/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_operational_data_misc/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_operational_data_misc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: consumed_by_facility_mwh
             data_tests:
@@ -20,7 +20,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">5"
+                    error_if: '>5'
           - name: data_observed
           - name: entity_type
           - name: exchange_energy_delivered_mwh
@@ -28,33 +28,33 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">6"
+                    error_if: '>6'
           - name: exchange_energy_received_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">7"
+                    error_if: '>7'
           - name: furnished_without_charge_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">2"
+                    error_if: '>2'
           - name: nerc_region
           - name: net_generation_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">331"
+                    error_if: '>331'
           - name: net_power_exchanged_mwh
           - name: net_wheeled_power_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">63"
+                    error_if: '>63'
           - name: report_date
           - name: retail_sales_mwh
             data_tests:
@@ -66,7 +66,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">4"
+                    error_if: '>4'
           - name: short_form
           - name: state
           - name: summer_peak_demand_mw
@@ -84,7 +84,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0
-                    error_if: ">18"
+                    error_if: '>18'
           - name: total_sources_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -108,7 +108,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0
-                    error_if: ">1"
+                    error_if: '>1'
           - name: winter_peak_demand_mw
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/eia861/core_eia861__yearly_operational_data_revenue/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_operational_data_revenue/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_operational_data_revenue
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: nerc_region
           - name: report_date
@@ -17,8 +17,8 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    row_condition: "revenue_class != 'credits_or_adjustments'"
-                    error_if: ">764" # Relatively high, worth investigating
+                    row_condition: revenue_class != 'credits_or_adjustments'
+                    error_if: '>764'
           - name: revenue_class
           - name: state
           - name: utility_id_eia

--- a/dbt/models/eia861/core_eia861__yearly_reliability/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_reliability/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_reliability
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: caidi_w_major_event_days_minus_loss_of_service_minutes
             data_tests:
@@ -65,7 +65,7 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    error_if: ">1"
+                    error_if: '>1'
           - name: saifi_wo_major_event_days_customers
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/eia861/core_eia861__yearly_sales/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_sales/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_sales
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: utility_id_eia
           - name: state
@@ -26,19 +26,19 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    row_condition: "utility_id_eia != 99999"
+                    row_condition: utility_id_eia != 99999
           - name: sales_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    row_condition: "utility_id_eia != 99999"
-                    error_if: ">30"
+                    row_condition: utility_id_eia != 99999
+                    error_if: '>30'
           - name: sales_revenue
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-                    row_condition: "utility_id_eia != 99999"
-                    error_if: ">300" # Relatively large, worth investigating
+                    row_condition: utility_id_eia != 99999
+                    error_if: '>300'
           - name: data_maturity

--- a/dbt/models/eia861/core_eia861__yearly_service_territory/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_service_territory/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_service_territory
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: county
           - name: short_form

--- a/dbt/models/eia861/core_eia861__yearly_short_form/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_short_form/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_short_form
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: utility_id_eia

--- a/dbt/models/eia861/core_eia861__yearly_utility_data_misc/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_utility_data_misc/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_utility_data_misc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: alternative_fuel_vehicle_2_activity
           - name: alternative_fuel_vehicle_activity

--- a/dbt/models/eia861/core_eia861__yearly_utility_data_nerc/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_utility_data_nerc/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_utility_data_nerc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: nerc_region
           - name: nerc_regions_of_operation

--- a/dbt/models/eia861/core_eia861__yearly_utility_data_rto/schema.yml
+++ b/dbt/models/eia861/core_eia861__yearly_utility_data_rto/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia861__yearly_utility_data_rto
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: nerc_region
           - name: report_date

--- a/dbt/models/eia861/out_eia861__yearly_balancing_authority_service_territory/schema.yml
+++ b/dbt/models/eia861/out_eia861__yearly_balancing_authority_service_territory/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia861__yearly_balancing_authority_service_territory
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: county_id_fips
           - name: county_name_census

--- a/dbt/models/eia861/out_eia861__yearly_utility_service_territory/schema.yml
+++ b/dbt/models/eia861/out_eia861__yearly_utility_service_territory/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia861__yearly_utility_service_territory
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: county_id_fips
           - name: county_name_census

--- a/dbt/models/eia923/_core_eia923__monthly_cooling_system_information/schema.yml
+++ b/dbt/models/eia923/_core_eia923__monthly_cooling_system_information/schema.yml
@@ -35,10 +35,10 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: _core_eia923__monthly_cooling_system_information
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_sum_close_to_total_column:
               name: monthly_withdrawal_discrepancy_rate
-              description: "Discrepancy rate on etl-fast observed April 2025: 0.1002"
+              description: 'Discrepancy rate on etl-fast observed April 2025: 0.1002'
               arguments:
                 sum_columns:
                   - monthly_average_consumption_rate_gallons_per_minute

--- a/dbt/models/eia923/_core_eia923__yearly_emissions_control/schema.yml
+++ b/dbt/models/eia923/_core_eia923__yearly_emissions_control/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: _core_eia923__yearly_emissions_control
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: report_date
@@ -77,14 +77,14 @@ sources:
                   arguments:
                     min_value: 0.0
                     max_value: 1.0
-                    warn_if: ">0"
-                    error_if: ">66" # A few records have efficiencies between 1 and 10.
+                    warn_if: '>0'
+                    error_if: '>66'
           - name: particulate_test_date
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
-                    min_value: "DATE '1950-01-01'"
-                    max_value: "current_date"
+                    min_value: DATE '1950-01-01'
+                    max_value: current_date
           - name: so2_control_id_eia
           - name: so2_removal_efficiency_tested
             data_tests:
@@ -102,5 +102,5 @@ sources:
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
-                    min_value: "DATE '1975-01-01'"
-                    max_value: "current_date"
+                    min_value: DATE '1975-01-01'
+                    max_value: current_date

--- a/dbt/models/eia923/_core_eia923__yearly_fgd_operation_maintenance/schema.yml
+++ b/dbt/models/eia923/_core_eia923__yearly_fgd_operation_maintenance/schema.yml
@@ -20,7 +20,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: _core_eia923__yearly_fgd_operation_maintenance
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_sum_close_to_total_column:
               name: opex_cost_discrepancy_rate
               arguments:
@@ -64,6 +64,6 @@ sources:
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
-                    min_value: "DATE '1950-01-01'"
-                    max_value: "current_date"
+                    min_value: DATE '1950-01-01'
+                    max_value: current_date
           - name: data_maturity

--- a/dbt/models/eia923/core_eia923__entity_coalmine/schema.yml
+++ b/dbt/models/eia923/core_eia923__entity_coalmine/schema.yml
@@ -5,14 +5,9 @@ sources:
       - name: core_eia923__entity_coalmine
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                Because this is an entity table, it only describes attributes that are
-                constant across time. However, the county FIPS code is only available in
-                some reporting years. If one of those years is processed, then it is
-                non-null in this table. If none of those years are processed, then it
-                will be entirely null here, and there is no column that we can
-                aggregate across to identify when it should be null or non-null, so it
-                is excluded from the test.
+              description: 'Because this is an entity table, it only describes attributes that are constant across time. However, the county FIPS code is only available in some reporting years. If one of those years is processed, then it is non-null in this table. If none of those years are processed, then it will be entirely null here, and there is no column that we can aggregate across to identify when it should be null or non-null, so it is excluded from the test.
+
+                '
               arguments:
                 exclude_columns:
                   - county_id_fips
@@ -22,18 +17,9 @@ sources:
                 partition_expr:
         columns:
           - name: mine_id_pudl
-            tests:
-              - not_null
-              - unique
           - name: mine_name
-            tests:
-              - not_null
           - name: mine_type_code
           - name: state
-            tests:
-              - not_null
           - name: county_id_fips
           - name: mine_id_msha
           - name: data_maturity
-            tests:
-              - not_null

--- a/dbt/models/eia923/core_eia923__fuel_receipts_costs/schema.yml
+++ b/dbt/models/eia923/core_eia923__fuel_receipts_costs/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia923__fuel_receipts_costs
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: report_date

--- a/dbt/models/eia923/core_eia923__monthly_boiler_fuel/schema.yml
+++ b/dbt/models/eia923/core_eia923__monthly_boiler_fuel/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia923__monthly_boiler_fuel
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: boiler_id

--- a/dbt/models/eia923/core_eia923__monthly_energy_storage/schema.yml
+++ b/dbt/models/eia923/core_eia923__monthly_energy_storage/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia923__monthly_energy_storage
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: report_date

--- a/dbt/models/eia923/core_eia923__monthly_generation/schema.yml
+++ b/dbt/models/eia923/core_eia923__monthly_generation/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia923__monthly_generation
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: plant_id_eia
           - name: generator_id

--- a/dbt/models/eia923/core_eia923__monthly_generation_fuel/schema.yml
+++ b/dbt/models/eia923/core_eia923__monthly_generation_fuel/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia923__monthly_generation_fuel
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia923/core_eia923__monthly_generation_fuel_nuclear/schema.yml
+++ b/dbt/models/eia923/core_eia923__monthly_generation_fuel_nuclear/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia923__monthly_generation_fuel_nuclear
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_nuclear_units_are_generators:
               arguments:
                 generator_model: source('pudl', 'out_eia__yearly_generators')
@@ -21,7 +21,9 @@ sources:
             data_tests:
               - dbt_expectations.expect_column_values_to_be_in_set:
                   arguments:
-                    value_set: ["nuclear", "oil"]
+                    value_set:
+                      - nuclear
+                      - oil
           - name: fuel_type_code_agg
           - name: prime_mover_code
           - name: fuel_consumed_units

--- a/dbt/models/eia923/out_eia923__boiler_fuel/schema.yml
+++ b/dbt/models/eia923/out_eia923__boiler_fuel/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__boiler_fuel
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia923/out_eia923__generation/schema.yml
+++ b/dbt/models/eia923/out_eia923__generation/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__generation
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia923/out_eia923__generation_fuel_combined/schema.yml
+++ b/dbt/models/eia923/out_eia923__generation_fuel_combined/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__generation_fuel_combined
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia923/out_eia923__monthly_boiler_fuel/schema.yml
+++ b/dbt/models/eia923/out_eia923__monthly_boiler_fuel/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__monthly_boiler_fuel
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_date_frequency_ratio:
               arguments:
                 compare_model: source("pudl", "out_eia__yearly_generators")

--- a/dbt/models/eia923/out_eia923__monthly_generation/schema.yml
+++ b/dbt/models/eia923/out_eia923__monthly_generation/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__monthly_generation
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_date_frequency_ratio:
               arguments:
                 compare_model: source("pudl", "out_eia__yearly_generators")

--- a/dbt/models/eia923/out_eia923__monthly_generation_fuel_by_generator/schema.yml
+++ b/dbt/models/eia923/out_eia923__monthly_generation_fuel_by_generator/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__monthly_generation_fuel_by_generator
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_date_frequency_ratio:
               arguments:
                 compare_model: source("pudl", "out_eia__yearly_generators")

--- a/dbt/models/eia923/out_eia923__monthly_generation_fuel_by_generator_energy_source/schema.yml
+++ b/dbt/models/eia923/out_eia923__monthly_generation_fuel_by_generator_energy_source/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__monthly_generation_fuel_by_generator_energy_source
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_date_frequency_ratio:
               arguments:
                 compare_model: source("pudl", "out_eia__yearly_generators")

--- a/dbt/models/eia923/out_eia923__monthly_generation_fuel_combined/schema.yml
+++ b/dbt/models/eia923/out_eia923__monthly_generation_fuel_combined/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__monthly_generation_fuel_combined
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_date_frequency_ratio:
               arguments:
                 compare_model: source("pudl", "out_eia__yearly_generators")
@@ -46,17 +46,17 @@ sources:
                   arguments:
                     numerator_row_condition: fuel_type_code_pudl='coal'
                     min_fraction: 0.15
-                    max_fraction: 0.40
+                    max_fraction: 0.4
               - expect_column_fraction_with_condition:
                   arguments:
                     numerator_row_condition: fuel_type_code_pudl='gas'
                     min_fraction: 0.25
-                    max_fraction: 0.50
+                    max_fraction: 0.5
               - expect_column_fraction_with_condition:
                   arguments:
                     numerator_row_condition: fuel_type_code_pudl='hydro'
                     min_fraction: 0.04
-                    max_fraction: 0.10
+                    max_fraction: 0.1
               - expect_column_fraction_with_condition:
                   arguments:
                     numerator_row_condition: fuel_type_code_pudl='wind'
@@ -65,6 +65,6 @@ sources:
               - expect_column_fraction_with_condition:
                   arguments:
                     numerator_row_condition: fuel_type_code_pudl='solar'
-                    min_fraction: 0.00
-                    max_fraction: 0.10
+                    min_fraction: 0.0
+                    max_fraction: 0.1
           - name: data_maturity

--- a/dbt/models/eia923/out_eia923__yearly_boiler_fuel/schema.yml
+++ b/dbt/models/eia923/out_eia923__yearly_boiler_fuel/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__yearly_boiler_fuel
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia923/out_eia923__yearly_generation/schema.yml
+++ b/dbt/models/eia923/out_eia923__yearly_generation/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__yearly_generation
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia923/out_eia923__yearly_generation_fuel_by_generator/schema.yml
+++ b/dbt/models/eia923/out_eia923__yearly_generation_fuel_by_generator/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__yearly_generation_fuel_by_generator
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia923/out_eia923__yearly_generation_fuel_by_generator_energy_source/schema.yml
+++ b/dbt/models/eia923/out_eia923__yearly_generation_fuel_by_generator_energy_source/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__yearly_generation_fuel_by_generator_energy_source
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia923/out_eia923__yearly_generation_fuel_by_generator_energy_source_owner/schema.yml
+++ b/dbt/models/eia923/out_eia923__yearly_generation_fuel_by_generator_energy_source_owner/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__yearly_generation_fuel_by_generator_energy_source_owner
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: plant_id_eia

--- a/dbt/models/eia923/out_eia923__yearly_generation_fuel_combined/schema.yml
+++ b/dbt/models/eia923/out_eia923__yearly_generation_fuel_combined/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia923__yearly_generation_fuel_combined
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_expectations.expect_column_pair_values_A_to_be_greater_than_B:
               arguments:
                 column_A: fuel_consumed_mmbtu

--- a/dbt/models/eia930/core_eia930__hourly_interchange/schema.yml
+++ b/dbt/models/eia930/core_eia930__hourly_interchange/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia930__hourly_interchange
-                partition_expr: "EXTRACT(YEAR FROM datetime_utc)"
+                partition_expr: EXTRACT(YEAR FROM datetime_utc)
         columns:
           - name: datetime_utc
           - name: balancing_authority_code_eia

--- a/dbt/models/eia930/core_eia930__hourly_net_generation_by_energy_source/schema.yml
+++ b/dbt/models/eia930/core_eia930__hourly_net_generation_by_energy_source/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia930__hourly_net_generation_by_energy_source
-                partition_expr: "EXTRACT(YEAR FROM datetime_utc)"
+                partition_expr: EXTRACT(YEAR FROM datetime_utc)
         columns:
           - name: datetime_utc
           - name: balancing_authority_code_eia

--- a/dbt/models/eia930/core_eia930__hourly_operations/schema.yml
+++ b/dbt/models/eia930/core_eia930__hourly_operations/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia930__hourly_operations
-                partition_expr: "EXTRACT(YEAR FROM datetime_utc)"
+                partition_expr: EXTRACT(YEAR FROM datetime_utc)
         columns:
           - name: datetime_utc
           - name: balancing_authority_code_eia

--- a/dbt/models/eia930/core_eia930__hourly_subregion_demand/schema.yml
+++ b/dbt/models/eia930/core_eia930__hourly_subregion_demand/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_eia930__hourly_subregion_demand
-                partition_expr: "EXTRACT(YEAR FROM datetime_utc)"
+                partition_expr: EXTRACT(YEAR FROM datetime_utc)
         columns:
           - name: datetime_utc
           - name: balancing_authority_code_eia

--- a/dbt/models/eia930/out_eia930__hourly_aggregated_demand/schema.yml
+++ b/dbt/models/eia930/out_eia930__hourly_aggregated_demand/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia930__hourly_aggregated_demand
-                partition_expr: "EXTRACT(YEAR FROM datetime_utc)"
+                partition_expr: EXTRACT(YEAR FROM datetime_utc)
         columns:
           - name: datetime_utc
           - name: aggregation_level

--- a/dbt/models/eia930/out_eia930__hourly_operations/schema.yml
+++ b/dbt/models/eia930/out_eia930__hourly_operations/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia930__hourly_operations
-                partition_expr: "EXTRACT(YEAR FROM datetime_utc)"
+                partition_expr: EXTRACT(YEAR FROM datetime_utc)
           - expect_columns_are_close:
               arguments:
                 column_a: demand_reported_mwh
                 column_b: demand_imputed_pudl_mwh
-                row_condition: "demand_imputed_pudl_mwh_imputation_code IS NULL"
+                row_condition: demand_imputed_pudl_mwh_imputation_code IS NULL
                 atol: 1.0
         columns:
           - name: datetime_utc
@@ -51,7 +51,8 @@ sources:
             data_tests:
               - dbt_expectations.expect_column_values_to_not_be_in_set:
                   arguments:
-                    value_set: ["simulated"]
+                    value_set:
+                      - simulated
               - expect_missingness_between:
                   arguments:
                     lower_bound: 0.75

--- a/dbt/models/eia930/out_eia930__hourly_subregion_demand/schema.yml
+++ b/dbt/models/eia930/out_eia930__hourly_subregion_demand/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_eia930__hourly_subregion_demand
-                partition_expr: "EXTRACT(YEAR FROM datetime_utc)"
+                partition_expr: EXTRACT(YEAR FROM datetime_utc)
           - expect_columns_are_close:
               arguments:
                 column_a: demand_reported_mwh
                 column_b: demand_imputed_pudl_mwh
-                row_condition: "demand_imputed_pudl_mwh_imputation_code IS NULL"
+                row_condition: demand_imputed_pudl_mwh_imputation_code IS NULL
                 atol: 1.0
         columns:
           - name: datetime_utc
@@ -35,7 +35,8 @@ sources:
             data_tests:
               - dbt_expectations.expect_column_values_to_not_be_in_set:
                   arguments:
-                    value_set: ["simulated"]
+                    value_set:
+                      - simulated
               - expect_missingness_between:
                   arguments:
                     lower_bound: 0.85

--- a/dbt/models/epa/core_epa__assn_eia_epacamd_subplant_ids/schema.yml
+++ b/dbt/models/epa/core_epa__assn_eia_epacamd_subplant_ids/schema.yml
@@ -16,7 +16,7 @@ sources:
                   - generator_id
                   - subplant_id
                   - emissions_unit_id_epa
-                description: "Each association should be unique, but some generator_id values are null so this cannot be used as a natural primary key."
+                description: Each association should be unique, but some generator_id values are null so this cannot be used as a natural primary key.
         columns:
           - name: plant_id_eia
           - name: plant_id_epa

--- a/dbt/models/ferc/core_ferc__entity_companies/schema.yml
+++ b/dbt/models/ferc/core_ferc__entity_companies/schema.yml
@@ -11,8 +11,8 @@ sources:
               - unique
               - dbt_expectations.expect_column_values_to_match_regex:
                   arguments:
-                    regex: "^C\\d{6}$"
-                    is_raw: True
+                    regex: ^C\d{6}$
+                    is_raw: true
           - name: company_name
           - name: program
           - name: company_website

--- a/dbt/models/ferc1/out_ferc1__yearly_all_plants/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_all_plants/schema.yml
@@ -5,19 +5,9 @@ sources:
       - name: out_ferc1__yearly_all_plants
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                Exactly which years have rolling averages will depend on what years
-                of data have been processed, since the moving window will exclude the
-                first couple of years in the range. This means we can't define a simple
-                range of years in which we expect them to be non-null. The
-                capex_annual_addition column is calculated by taking the difference
-                between adjacent capex_total values, so it will always be null in the
-                first year of data... at least in the case of the DBF data -- the XBRL
-                data (2021 and later) includes both the current and previous year's
-                values, so even if we only process a single recent year of data, we will
-                still end up with a non-null value. The capex_annual_per_* columns are
-                all derived from the capex_annual_addition column, so they have the same
-                pattern of null values.
+              description: 'Exactly which years have rolling averages will depend on what years of data have been processed, since the moving window will exclude the first couple of years in the range. This means we can''t define a simple range of years in which we expect them to be non-null. The capex_annual_addition column is calculated by taking the difference between adjacent capex_total values, so it will always be null in the first year of data... at least in the case of the DBF data -- the XBRL data (2021 and later) includes both the current and previous year''s values, so even if we only process a single recent year of data, we will still end up with a non-null value. The capex_annual_per_* columns are all derived from the capex_annual_addition column, so they have the same pattern of null values.
+
+                '
               arguments:
                 exclude_columns:
                   - capex_annual_addition_rolling

--- a/dbt/models/ferc1/out_ferc1__yearly_income_statements_sched114/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_income_statements_sched114/schema.yml
@@ -11,12 +11,12 @@ sources:
                 partition_expr: report_year
         columns:
           - name: record_id
+          - name: report_year
           - name: utility_id_ferc1
           - name: utility_id_ferc1_dbf
           - name: utility_id_ferc1_xbrl
           - name: utility_id_pudl
           - name: utility_name_ferc1
-          - name: report_year
           - name: utility_type
           - name: income_type
           - name: dollar_value

--- a/dbt/models/ferc1/out_ferc1__yearly_retained_earnings_sched118/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_retained_earnings_sched118/schema.yml
@@ -10,12 +10,12 @@ sources:
                 table_name: out_ferc1__yearly_retained_earnings_sched118
                 partition_expr: report_year
         columns:
+          - name: report_year
           - name: utility_id_ferc1
           - name: utility_id_ferc1_dbf
           - name: utility_id_ferc1_xbrl
           - name: utility_id_pudl
           - name: utility_name_ferc1
-          - name: report_year
           - name: record_id
           - name: earnings_type
           - name: starting_balance

--- a/dbt/models/ferc1/out_ferc1__yearly_steam_plants_sched402/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_steam_plants_sched402/schema.yml
@@ -5,11 +5,9 @@ sources:
       - name: out_ferc1__yearly_steam_plants_sched402
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                Exactly which years have rolling averages will depend on what years
-                of data have been processed, since the moving window will exclude the
-                first couple of years in the range. This means we can't define a simple
-                range of years in which we expect them to be non-null.
+              description: 'Exactly which years have rolling averages will depend on what years of data have been processed, since the moving window will exclude the first couple of years in the range. This means we can''t define a simple range of years in which we expect them to be non-null.
+
+                '
               arguments:
                 exclude_columns:
                   - capex_annual_addition_rolling
@@ -159,11 +157,11 @@ sources:
           - name: water_limited_capacity_mw
 models:
   - name: validate_ferc1__yearly_steam_plants_sched402
-    description: >
-      This is a validation model which takes the above table as input and computes
-      values more convenient for testing, including:
+    description: 'This is a validation model which takes the above table as input and computes values more convenient for testing, including:
 
       - capacity ratios; not currently tested
+
+      '
     columns:
       - name: report_year
       - name: plant_capability_mw

--- a/dbt/models/ferc1/out_ferc1__yearly_transmission_lines_sched422/schema.yml
+++ b/dbt/models/ferc1/out_ferc1__yearly_transmission_lines_sched422/schema.yml
@@ -11,12 +11,12 @@ sources:
                 partition_expr: report_year
         columns:
           - name: record_id
+          - name: report_year
           - name: utility_id_ferc1
           - name: utility_id_ferc1_dbf
           - name: utility_id_ferc1_xbrl
           - name: utility_id_pudl
           - name: utility_name_ferc1
-          - name: report_year
           - name: start_point
           - name: end_point
           - name: operating_voltage_kv

--- a/dbt/models/ferc714/core_ferc714__hourly_planning_area_demand/schema.yml
+++ b/dbt/models/ferc714/core_ferc714__hourly_planning_area_demand/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_ferc714__hourly_planning_area_demand
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_consistent_years:
               arguments:
                 datetime_column: datetime_utc

--- a/dbt/models/ferc714/out_ferc714__hourly_estimated_state_demand/schema.yml
+++ b/dbt/models/ferc714/out_ferc714__hourly_estimated_state_demand/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_ferc714__hourly_estimated_state_demand
-                partition_expr: "EXTRACT(YEAR FROM datetime_utc)"
+                partition_expr: EXTRACT(YEAR FROM datetime_utc)
         columns:
           - name: state_id_fips
           - name: datetime_utc

--- a/dbt/models/ferc714/out_ferc714__hourly_planning_area_demand/schema.yml
+++ b/dbt/models/ferc714/out_ferc714__hourly_planning_area_demand/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_ferc714__hourly_planning_area_demand
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_columns_are_close:
               arguments:
                 column_a: demand_reported_mwh
                 column_b: demand_imputed_pudl_mwh
-                row_condition: "demand_imputed_pudl_mwh_imputation_code IS NULL"
+                row_condition: demand_imputed_pudl_mwh_imputation_code IS NULL
                 atol: 1.0
           - expect_consistent_years:
               arguments:
@@ -55,7 +55,8 @@ sources:
             data_tests:
               - dbt_expectations.expect_column_values_to_not_be_in_set:
                   arguments:
-                    value_set: ["simulated"]
+                    value_set:
+                      - simulated
               - expect_missingness_between:
                   arguments:
                     lower_bound: 0.95

--- a/dbt/models/ferc714/out_ferc714__respondents_with_fips/schema.yml
+++ b/dbt/models/ferc714/out_ferc714__respondents_with_fips/schema.yml
@@ -8,10 +8,10 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_ferc714__respondents_with_fips
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_expectations.expect_compound_columns_to_be_unique:
               arguments:
-                description: "Each county should only appear once per respondent per year. There are a handful of duplicates that need to be investigated."
+                description: Each county should only appear once per respondent per year. There are a handful of duplicates that need to be investigated.
                 column_list:
                   - respondent_id_ferc714
                   - report_date

--- a/dbt/models/ferc714/out_ferc714__summarized_demand/schema.yml
+++ b/dbt/models/ferc714/out_ferc714__summarized_demand/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_ferc714__summarized_demand
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: respondent_id_ferc714

--- a/dbt/models/ferceqr/core_ferceqr__quarterly_identity/schema.yml
+++ b/dbt/models/ferceqr/core_ferceqr__quarterly_identity/schema.yml
@@ -4,8 +4,9 @@ sources:
     tables:
       - name: core_ferceqr__quarterly_identity
         columns:
-          - name: filer_unique_id
+          - name: year_quarter
           - name: company_id_ferc
+          - name: filer_unique_id
           - name: company_name
           - name: contact_name
           - name: contact_title
@@ -17,4 +18,3 @@ sources:
           - name: contact_phone
           - name: contact_email
           - name: transactions_reported_to_index_price_publishers
-          - name: year_quarter

--- a/dbt/models/gridpathratoolkit/out_gridpathratoolkit__hourly_available_capacity_factor/schema.yml
+++ b/dbt/models/gridpathratoolkit/out_gridpathratoolkit__hourly_available_capacity_factor/schema.yml
@@ -8,19 +8,15 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_gridpathratoolkit__hourly_available_capacity_factor
-                partition_expr: "EXTRACT(YEAR FROM datetime_utc)"
+                partition_expr: EXTRACT(YEAR FROM datetime_utc)
         columns:
           - name: datetime_utc
           - name: aggregation_group
             data_tests:
               - relationships:
-                  description: >
-                    Check that every capacity factor aggregation key appears in the
-                    aggregations. This isn't a normal foreign-key relationship, since
-                    the aggregation group isn't the primary key in the aggregation
-                    tables, and is not unique in either of these tables, but if an
-                    aggregation group appears in the capacity factor time series and
-                    never appears in the aggregation table, then something is wrong.
+                  description: 'Check that every capacity factor aggregation key appears in the aggregations. This isn''t a normal foreign-key relationship, since the aggregation group isn''t the primary key in the aggregation tables, and is not unique in either of these tables, but if an aggregation group appears in the capacity factor time series and never appears in the aggregation table, then something is wrong.
+
+                    '
                   arguments:
                     to: source('pudl', 'core_gridpathratoolkit__assn_generator_aggregation_group')
                     field: aggregation_group

--- a/dbt/models/nrelatb/core_nrelatb__yearly_projected_financial_cases_by_scenario/schema.yml
+++ b/dbt/models/nrelatb/core_nrelatb__yearly_projected_financial_cases_by_scenario/schema.yml
@@ -19,7 +19,7 @@ sources:
                   - technology_description
                   - scenario_atb
                   - cost_recovery_period_years
-                description: "A handful of values in the cost_recovery_period_years column are null, so this cannot be used as a natural primary key."
+                description: A handful of values in the cost_recovery_period_years column are null, so this cannot be used as a natural primary key.
         columns:
           - name: report_year
           - name: model_case_nrelatb

--- a/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_by_install_decade/schema.yml
+++ b/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_by_install_decade/schema.yml
@@ -3,18 +3,18 @@ sources:
   - name: pudl
     tables:
       - name: _core_phmsagas__yearly_distribution_by_install_decade
+        data_tests:
+          - expect_columns_not_all_null
+          - check_row_counts_per_partition:
+              arguments:
+                table_name: _core_phmsagas__yearly_distribution_by_install_decade
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: report_date
           - name: report_id
+          - name: report_date
           - name: operator_id_phmsa
           - name: commodity
           - name: operating_state
           - name: install_decade
           - name: mains_miles
           - name: services
-        data_tests:
-          - expect_columns_not_all_null
-          - check_row_counts_per_partition:
-              arguments:
-                table_name: _core_phmsagas__yearly_distribution_by_install_decade
-                partition_expr: "EXTRACT(YEAR FROM report_date)"

--- a/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_by_material/schema.yml
+++ b/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_by_material/schema.yml
@@ -3,21 +3,12 @@ sources:
   - name: pudl
     tables:
       - name: _core_phmsagas__yearly_distribution_by_material
-        columns:
-          - name: report_date
-          - name: report_id
-          - name: operator_id_phmsa
-          - name: commodity
-          - name: operating_state
-          - name: material
-          - name: mains_miles
-          - name: services
         data_tests:
           - expect_columns_not_all_null
           - check_row_counts_per_partition:
               arguments:
                 table_name: _core_phmsagas__yearly_distribution_by_material
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_expectations.expect_compound_columns_to_be_unique:
               arguments:
                 column_list:
@@ -25,4 +16,13 @@ sources:
                   - operator_id_phmsa
                   - operating_state
                   - material
-                description: "There are a handful of NULL operating_state values in this table, so this cannot be used as a natural primary key."
+                description: There are a handful of NULL operating_state values in this table, so this cannot be used as a natural primary key.
+        columns:
+          - name: report_id
+          - name: report_date
+          - name: operator_id_phmsa
+          - name: commodity
+          - name: operating_state
+          - name: material
+          - name: mains_miles
+          - name: services

--- a/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_by_material_and_size/schema.yml
+++ b/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_by_material_and_size/schema.yml
@@ -3,6 +3,21 @@ sources:
   - name: pudl
     tables:
       - name: _core_phmsagas__yearly_distribution_by_material_and_size
+        data_tests:
+          - expect_columns_not_all_null
+          - check_row_counts_per_partition:
+              arguments:
+                table_name: _core_phmsagas__yearly_distribution_by_material_and_size
+                partition_expr: EXTRACT(YEAR FROM report_date)
+          - dbt_expectations.expect_compound_columns_to_be_unique:
+              arguments:
+                column_list:
+                  - report_id
+                  - operator_id_phmsa
+                  - operating_state
+                  - main_size
+                  - material
+                description: There are NULL operating_state values across several years of data in this table, so these columns cannot be used as a natural primary key.
         columns:
           - name: report_date
           - name: report_id
@@ -14,18 +29,3 @@ sources:
           - name: mains_miles
           - name: services
           - name: main_other_material_detail
-        data_tests:
-          - expect_columns_not_all_null
-          - check_row_counts_per_partition:
-              arguments:
-                table_name: _core_phmsagas__yearly_distribution_by_material_and_size
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
-          - dbt_expectations.expect_compound_columns_to_be_unique:
-              arguments:
-                column_list:
-                  - report_id
-                  - operator_id_phmsa
-                  - operating_state
-                  - main_size
-                  - material
-                description: "There are NULL operating_state values across several years of data in this table, so these columns cannot be used as a natural primary key."

--- a/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_excavation_damages/schema.yml
+++ b/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_excavation_damages/schema.yml
@@ -3,24 +3,24 @@ sources:
   - name: pudl
     tables:
       - name: _core_phmsagas__yearly_distribution_excavation_damages
-        columns:
-          - name: report_date
-          - name: report_id
-          - name: operator_id_phmsa
-          - name: commodity
-          - name: operating_state
-          - name: damage_type
-          - name: damage_sub_type
-          - name: damages
         data_tests:
           - expect_columns_not_all_null
           - check_row_counts_per_partition:
               arguments:
                 table_name: _core_phmsagas__yearly_distribution_excavation_damages
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_expectations.expect_compound_columns_to_be_unique:
               arguments:
                 column_list:
                   - report_id
                   - damage_type
                   - damage_sub_type
+        columns:
+          - name: report_id
+          - name: report_date
+          - name: operator_id_phmsa
+          - name: commodity
+          - name: operating_state
+          - name: damage_type
+          - name: damage_sub_type
+          - name: damages

--- a/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_filings/schema.yml
+++ b/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_filings/schema.yml
@@ -3,6 +3,15 @@ sources:
   - name: pudl
     tables:
       - name: _core_phmsagas__yearly_distribution_filings
+        data_tests:
+          - expect_columns_not_all_null:
+              arguments:
+                row_conditions:
+                  filing_correction_date: EXTRACT(year FROM report_date) BETWEEN 1990 AND 1999
+          - check_row_counts_per_partition:
+              arguments:
+                table_name: _core_phmsagas__yearly_distribution_filings
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_id
           - name: operator_id_phmsa
@@ -18,12 +27,3 @@ sources:
           - name: preparer_phone
           - name: preparer_fax
           - name: preparer_email
-        data_tests:
-          - expect_columns_not_all_null:
-              arguments:
-                row_conditions:
-                  filing_correction_date: EXTRACT(year FROM report_date) BETWEEN 1990 AND 1999
-          - check_row_counts_per_partition:
-              arguments:
-                table_name: _core_phmsagas__yearly_distribution_filings
-                partition_expr: "EXTRACT(YEAR FROM report_date)"

--- a/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_leaks/schema.yml
+++ b/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_leaks/schema.yml
@@ -3,22 +3,12 @@ sources:
   - name: pudl
     tables:
       - name: _core_phmsagas__yearly_distribution_leaks
-        columns:
-          - name: report_date
-          - name: report_id
-          - name: operator_id_phmsa
-          - name: commodity
-          - name: operating_state
-          - name: leak_severity
-          - name: leak_source
-          - name: mains
-          - name: services
         data_tests:
           - expect_columns_not_all_null
           - check_row_counts_per_partition:
               arguments:
                 table_name: _core_phmsagas__yearly_distribution_leaks
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_expectations.expect_compound_columns_to_be_unique:
               arguments:
                 column_list:
@@ -27,4 +17,14 @@ sources:
                   - operating_state
                   - leak_severity
                   - leak_source
-                description: "There are a NULL operating_state values across several years of data, so this cannot be used as a natural primary key."
+                description: There are a NULL operating_state values across several years of data, so this cannot be used as a natural primary key.
+        columns:
+          - name: report_id
+          - name: report_date
+          - name: operator_id_phmsa
+          - name: commodity
+          - name: operating_state
+          - name: leak_severity
+          - name: leak_source
+          - name: mains
+          - name: services

--- a/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_misc/schema.yml
+++ b/dbt/models/phmsagas/_core_phmsagas__yearly_distribution_misc/schema.yml
@@ -21,7 +21,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: _core_phmsagas__yearly_distribution_misc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: report_id
@@ -32,16 +32,16 @@ sources:
           - name: hazardous_leaks_mechanical_joint_failure
           - name: federal_land_leaks_repaired_or_scheduled
           - name: average_service_length_feet
+          - name: services_efv_in_system
+          - name: services_efv_installed
+          - name: services_shutoff_valve_in_system
+          - name: services_shutoff_valve_installed
           - name: unaccounted_for_gas_fraction
             data_tests:
               - expect_quantile_constraints:
-                  description: "Accept negative values in at most 17% of rows"
+                  description: Accept negative values in at most 17% of rows
                   arguments:
                     constraints:
                       - quantile: 0.17
                         min_value: 0
-          - name: services_shutoff_valve_installed
-          - name: services_efv_installed
-          - name: services_shutoff_valve_in_system
-          - name: services_efv_in_system
           - name: excavation_tickets

--- a/dbt/models/phmsagas/core_phmsagas__yearly_distribution_operators/schema.yml
+++ b/dbt/models/phmsagas/core_phmsagas__yearly_distribution_operators/schema.yml
@@ -11,7 +11,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_phmsagas__yearly_distribution_operators
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_id
           - name: report_date

--- a/dbt/models/pudl/core_pudl__assn_eia_pudl_utilities/schema.yml
+++ b/dbt/models/pudl/core_pudl__assn_eia_pudl_utilities/schema.yml
@@ -11,12 +11,5 @@ sources:
                 partition_expr:
         columns:
           - name: utility_id_eia
-            tests:
-              - not_null
-              - one_value_per_key:
-                  arguments:
-                    other_column_name: utility_id_pudl
           - name: utility_name_eia
           - name: utility_id_pudl
-            tests:
-              - not_null

--- a/dbt/models/pudl/core_pudl__assn_ferc1_pudl_utilities/schema.yml
+++ b/dbt/models/pudl/core_pudl__assn_ferc1_pudl_utilities/schema.yml
@@ -11,12 +11,5 @@ sources:
                 partition_expr:
         columns:
           - name: utility_id_ferc1
-            tests:
-              - not_null
-              - one_value_per_key:
-                  arguments:
-                    other_column_name: utility_id_pudl
           - name: utility_name_ferc1
           - name: utility_id_pudl
-            tests:
-              - not_null

--- a/dbt/models/pudl/core_pudl__assn_utilities_plants/schema.yml
+++ b/dbt/models/pudl/core_pudl__assn_utilities_plants/schema.yml
@@ -12,10 +12,3 @@ sources:
         columns:
           - name: utility_id_pudl
           - name: plant_id_pudl
-            tests:
-              - one_value_per_key:
-                  arguments:
-                    other_column_name: utility_id_pudl
-                  description: We expect each plant to only be assigned to one utility, but we still need to deduplicate ID assignment. See issue 4988.
-                  config:
-                    severity: warn

--- a/dbt/models/pudl/out_pudl__yearly_assn_eia_ferc1_plant_parts/schema.yml
+++ b/dbt/models/pudl/out_pudl__yearly_assn_eia_ferc1_plant_parts/schema.yml
@@ -5,11 +5,9 @@ sources:
       - name: out_pudl__yearly_assn_eia_ferc1_plant_parts
         data_tests:
           - expect_columns_not_all_null:
-              description: >
-                Exactly which years have rolling averages will depend on what years
-                of data have been processed, since the moving window will exclude the
-                first couple of years in the range. This means we can't define a simple
-                range of years in which we expect them to be non-null.
+              description: 'Exactly which years have rolling averages will depend on what years of data have been processed, since the moving window will exclude the first couple of years in the range. This means we can''t define a simple range of years in which we expect them to be non-null.
+
+                '
               arguments:
                 exclude_columns:
                   - capex_annual_addition_rolling

--- a/dbt/models/rus12/core_rus12__monthly_demand_and_energy_at_delivery_points/schema.yml
+++ b/dbt/models/rus12/core_rus12__monthly_demand_and_energy_at_delivery_points/schema.yml
@@ -7,7 +7,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__monthly_demand_and_energy_at_delivery_points
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus12/core_rus12__monthly_demand_and_energy_at_power_sources/schema.yml
+++ b/dbt/models/rus12/core_rus12__monthly_demand_and_energy_at_power_sources/schema.yml
@@ -7,7 +7,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__monthly_demand_and_energy_at_power_sources
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
                 expression: date_trunc('month', report_date) >= date_trunc('month', peak_demand_date) AND date_trunc('year', report_date) == date_trunc('year', peak_demand_date)
@@ -25,5 +25,5 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-          - name: is_peak_coincident
           - name: peak_demand_date
+          - name: is_peak_coincident

--- a/dbt/models/rus12/core_rus12__yearly_balance_sheet_assets/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_balance_sheet_assets/schema.yml
@@ -7,7 +7,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_balance_sheet_assets
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus12/core_rus12__yearly_balance_sheet_liabilities/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_balance_sheet_liabilities/schema.yml
@@ -7,7 +7,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_balance_sheet_liabilities
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus12/core_rus12__yearly_depreciation_changes/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_depreciation_changes/schema.yml
@@ -8,46 +8,54 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_depreciation_changes
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
                 expression: accruals + retirements_less_net_salvage + adjustments_and_transfers <= ending_balance
                 config:
-                  error_if: ">18"
+                  error_if: '>18'
                   where: depreciation_and_amortization_item != 'retirement_work_in_progress'
-              description: "Check that annual changes don't exceed ending balance."
+              description: Check that annual changes don't exceed ending balance.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: depreciation_and_amortization_group
                 value_column: accruals
-                total_label: "total_depreciation"
+                total_label: total_depreciation
               row_condition: depreciation_and_amortization_group='electric_plant_in_service'
-              description: "Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components."
+              description: Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: depreciation_and_amortization_group
                 value_column: retirements_less_net_salvage
-                total_label: "total_depreciation"
+                total_label: total_depreciation
               row_condition: depreciation_and_amortization_group='electric_plant_in_service'
-              description: "Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components."
+              description: Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: depreciation_and_amortization_group
                 value_column: adjustments_and_transfers
-                total_label: "total_depreciation"
+                total_label: total_depreciation
               row_condition: depreciation_and_amortization_group='electric_plant_in_service'
-              description: "Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components."
+              description: Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: depreciation_and_amortization_group
                 value_column: ending_balance
-                total_label: "total_depreciation"
+                total_label: total_depreciation
               row_condition: depreciation_and_amortization_group='electric_plant_in_service'
-              description: "Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components."
+              description: Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components.
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -61,8 +69,8 @@ sources:
                     max_value: 100.0
                   row_condition: depreciation_and_amortization_item !='retirement_work_in_progress'
                   config:
-                    error_if: ">1"
-                  description: "Check that most of the composite_depreciation_rate's within 0-100."
+                    error_if: '>1'
+                  description: Check that most of the composite_depreciation_rate's within 0-100.
           - name: accruals
           - name: retirements_less_net_salvage
           - name: adjustments_and_transfers
@@ -73,6 +81,6 @@ sources:
                     min_value: 0.0
                   row_condition: depreciation_and_amortization_item !='retirement_work_in_progress'
                   config:
-                    error_if: ">34"
-                  description: "Check that most of the ending_balance's are positive - excluding the retirement_work_in_progress."
+                    error_if: '>34'
+                  description: Check that most of the ending_balance's are positive - excluding the retirement_work_in_progress.
           - name: is_total

--- a/dbt/models/rus12/core_rus12__yearly_depreciation_misc/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_depreciation_misc/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_depreciation_misc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -19,5 +19,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">126"
-                  description: "Check that most of the ending_balance's are positive. About 4% of the table is negative, which seems reasonable."
+                    error_if: '>126'
+                  description: Check that most of the ending_balance's are positive. About 4% of the table is negative, which seems reasonable.

--- a/dbt/models/rus12/core_rus12__yearly_external_financial_risk_ratio/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_external_financial_risk_ratio/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_external_financial_risk_ratio
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus12/core_rus12__yearly_investments/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_investments/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_investments
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus12/core_rus12__yearly_lines_stations_labor_materials_cost/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_lines_stations_labor_materials_cost/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_lines_stations_labor_materials_cost
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -21,5 +21,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">10"
+                    error_if: '>10'
                   description: No values should be negative here. Investigate.

--- a/dbt/models/rus12/core_rus12__yearly_loans/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_loans/schema.yml
@@ -11,16 +11,16 @@ sources:
                 column_B: loan_balance
                 or_equal: true
               config:
-                error_if: ">1" #TODO: Investigate 1 case where loan balance exceeds original amount.
-              description: "The original amount of the loan should be greater than or equal to the current balance of the loan."
+                error_if: '>1'
+              description: The original amount of the loan should be greater than or equal to the current balance of the loan.
           - dbt_utils.expression_is_true:
               arguments:
                 expression: date_trunc('year', report_date) <= date_trunc('year', loan_maturity_date)
-              description: "The report date year should be before or equal to the loan maturity date year."
+              description: The report date year should be before or equal to the loan maturity date year.
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_loans
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -37,7 +37,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
                   description: Two instances of negative loan balance, which could be overpayment. Investigate.
           - name: for_rural_development
           - name: is_loan_guarantee

--- a/dbt/models/rus12/core_rus12__yearly_long_term_debt/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_long_term_debt/schema.yml
@@ -9,12 +9,12 @@ sources:
               arguments:
                 expression: debt_interest + debt_principal = debt_total
               config:
-                error_if: ">78"
+                error_if: '>78'
               description: Examine ~80 cases where interest + principal != total
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_long_term_debt
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -25,7 +25,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">32"
+                    error_if: '>32'
                   description: Investigate negative values.
           - name: debt_interest
             data_tests:
@@ -33,7 +33,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">21"
+                    error_if: '>21'
                   description: Investigate negative values.
           - name: debt_principal
             data_tests:
@@ -41,7 +41,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">5"
+                    error_if: '>5'
                   description: Investigate negative values.
           - name: debt_total
             data_tests:
@@ -49,5 +49,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">21"
+                    error_if: '>21'
                   description: Investigate negative values.

--- a/dbt/models/rus12/core_rus12__yearly_meeting_and_board/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_meeting_and_board/schema.yml
@@ -9,7 +9,7 @@ sources:
               arguments:
                 expression: date_trunc('month', report_date) >= date_trunc('month', last_annual_meeting_date)
               config:
-                error_if: ">8"
+                error_if: '>8'
               description: Some utilities report meetings after the date range of the filing.
           - expect_summed_columns_not_exceed_threshold:
               arguments:
@@ -18,12 +18,12 @@ sources:
                 threshold_column: members_num
                 multiplier: 1
               config:
-                error_if: ">1"
+                error_if: '>1'
               description: AZ0028 reports 8 members but 14 present in 2006.
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_meeting_and_board
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus12/core_rus12__yearly_non_utility_plant_changes/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_non_utility_plant_changes/schema.yml
@@ -8,13 +8,13 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_non_utility_plant_changes
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
                 expression: retirements + additions + adjustments_and_transfers <= ending_balance
-              description: "Check that annual changes don't exceed ending balance."
+              description: Check that annual changes don't exceed ending balance.
               config:
-                error_if: ">2"
+                error_if: '>2'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -25,16 +25,16 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
-                  description: "Check that most of the additions are positive."
+                    error_if: '>1'
+                  description: Check that most of the additions are positive.
           - name: retirements
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
-                  description: "Check that most of the retirements are positive."
+                    error_if: '>1'
+                  description: Check that most of the retirements are positive.
           - name: adjustments_and_transfers
           - name: ending_balance
             data_tests:

--- a/dbt/models/rus12/core_rus12__yearly_plant_costs/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_plant_costs/schema.yml
@@ -8,152 +8,172 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_plant_costs
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_columns_ratio:
               arguments:
                 numerator_column: cost_per_mwh
                 denominator_column: cost_per_mmbtu
                 min_ratio: 3.412142
               config:
-                error_if: ">96" # ~6% of the data
-          # CALCULATE FUEL COST SUBTOTALS BY PLANT TYPE
+                error_if: '>96'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  ["coal_fuel", "oil_fuel", "gas_fuel", "other_fuel"]
-                total_label: "total_fuel"
+                  - coal_fuel
+                  - oil_fuel
+                  - gas_fuel
+                  - other_fuel
+                total_label: total_fuel
                 tolerance: 10
-              row_condition: "plant_type == 'steam'"
-              description: "Check that steam fuel subcomponents sum to total."
+              row_condition: plant_type == 'steam'
+              description: Check that steam fuel subcomponents sum to total.
               config:
-                error_if: ">8"
+                error_if: '>8'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "energy_for_compressed_air",
-                    "oil_fuel",
-                    "gas_fuel",
-                    "other_fuel",
-                  ]
-                total_label: "total_fuel"
+                  - energy_for_compressed_air
+                  - oil_fuel
+                  - gas_fuel
+                  - other_fuel
+                total_label: total_fuel
                 tolerance: 10
-              row_condition: "plant_type IN ('internal_combustion', 'combined_cycle')"
-              description: "Check that IC fuel subcomponents sum to total."
+              row_condition: plant_type IN ('internal_combustion', 'combined_cycle')
+              description: Check that IC fuel subcomponents sum to total.
               config:
-                error_if: ">1"
+                error_if: '>1'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
-                subcomponents_list: ["fuel", "less_fuel_acquisition_adjustment"]
-                total_label: "total_fuel"
+                subcomponents_list:
+                  - fuel
+                  - less_fuel_acquisition_adjustment
+                total_label: total_fuel
                 tolerance: 10
-              row_condition: "plant_type == 'nuclear'"
-              description: "Check that nuclear fuel subcomponents sum to total."
+              row_condition: plant_type == 'nuclear'
+              description: Check that nuclear fuel subcomponents sum to total.
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "supervision_and_engineering",
-                    "steam",
-                    "electric",
-                    "miscellaneous_power_generation",
-                    "generation",
-                    "allowances",
-                    "rents",
-                  ]
-                total_label: "non_fuels_total"
+                  - supervision_and_engineering
+                  - steam
+                  - electric
+                  - miscellaneous_power_generation
+                  - generation
+                  - allowances
+                  - rents
+                total_label: non_fuels_total
                 tolerance: 0
-              row_condition: "plant_type IN ('steam', 'combined_cycle')"
-              description: "Check that steam non-fuel subcomponents sum to total."
+              row_condition: plant_type IN ('steam', 'combined_cycle')
+              description: Check that steam non-fuel subcomponents sum to total.
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "supervision_and_engineering",
-                    "generation",
-                    "miscellaneous_power_generation",
-                    "rents",
-                  ]
-                total_label: "non_fuels_total"
+                  - supervision_and_engineering
+                  - generation
+                  - miscellaneous_power_generation
+                  - rents
+                total_label: non_fuels_total
                 tolerance: 0
-              row_condition: "plant_type == 'internal_combustion'"
-              description: "Check that steam non-fuel subcomponents sum to total."
+              row_condition: plant_type == 'internal_combustion'
+              description: Check that steam non-fuel subcomponents sum to total.
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
-                subcomponents_list: ["total_fuel", "non_fuels_total"]
-                total_label: "operations_total"
+                subcomponents_list:
+                  - total_fuel
+                  - non_fuels_total
+                total_label: operations_total
                 tolerance: 0
-              row_condition: "plant_type IN ('steam', 'internal_combustion', 'combined_cycle')"
-              description: "Check that steam, IC and CC operation subcomponents sum to total."
+              row_condition: plant_type IN ('steam', 'internal_combustion', 'combined_cycle')
+              description: Check that steam, IC and CC operation subcomponents sum to total.
               config:
-                error_if: ">2300" # This is almost all of them, INVESTIGATE!
+                error_if: '>2300'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "supervision_and_engineering",
-                    "water_for_power",
-                    "energy_for_pumped_storage",
-                    "hydraulic",
-                    "electric",
-                    "miscellaneous_power_generation",
-                    "rents",
-                  ]
-                total_label: "operations_total"
+                  - supervision_and_engineering
+                  - water_for_power
+                  - energy_for_pumped_storage
+                  - hydraulic
+                  - electric
+                  - miscellaneous_power_generation
+                  - rents
+                total_label: operations_total
                 tolerance: 0
-              row_condition: "plant_type == 'hydro'"
-              description: "Check that hydro operation subcomponents sum to total."
+              row_condition: plant_type == 'hydro'
+              description: Check that hydro operation subcomponents sum to total.
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "supervision_and_engineering",
-                    "net_fuel",
-                    "coolants_and_water",
-                    "steam",
-                    "steam_other_sources",
-                    "electric",
-                    "miscellaneous_power_generation",
-                    "rents",
-                  ]
-                total_label: "operations_total"
+                  - supervision_and_engineering
+                  - net_fuel
+                  - coolants_and_water
+                  - steam
+                  - steam_other_sources
+                  - electric
+                  - miscellaneous_power_generation
+                  - rents
+                total_label: operations_total
                 tolerance: 0
-              row_condition: "plant_type == 'nuclear'"
-              description: "Check that nuclear operation subcomponents sum to total."
+              row_condition: plant_type == 'nuclear'
+              description: Check that nuclear operation subcomponents sum to total.
               config:
-                error_if: ">129" # This is almost all of them, INVESTIGATE!
+                error_if: '>129'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -167,19 +187,19 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">213" # 0.4% of the data
+                    error_if: '>213'
           - name: cost_per_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">381" # 0.7% of the data
+                    error_if: '>381'
           - name: cost_per_mmbtu
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">23"
+                    error_if: '>23'
           - name: is_total

--- a/dbt/models/rus12/core_rus12__yearly_plant_factors_and_maximum_demand/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_plant_factors_and_maximum_demand/schema.yml
@@ -7,7 +7,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_plant_factors_and_maximum_demand
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -20,7 +20,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">13" # Investigate 13 instances of cap fac > 1 for nuclear plants
+                    error_if: '>13'
           - name: capacity_factor_running
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -28,7 +28,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">121" # Investigate 121 instances of cap fac running > 1
+                    error_if: '>121'
           - name: load_factor
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -36,7 +36,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">2" # Investigate 2 instances of load fac > 1
+                    error_if: '>2'
           - name: peak_gross_demand_mw
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/models/rus12/core_rus12__yearly_plant_labor/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_plant_labor/schema.yml
@@ -10,17 +10,17 @@ sources:
                 expression: (employees_full_time_num + employees_part_time_num) * 8766 > employee_hours_worked_total
               description: Expect that full time and part time employees aren't reported as working more hours than exist in a year.
               config:
-                error_if: ">186"
+                error_if: '>186'
           - dbt_utils.expression_is_true:
               arguments:
                 expression: (employees_full_time_num + employees_part_time_num) * 2080 >= employee_hours_worked_total
               description: Expect that even with overtime, full time and part time employees combined work less than an average of a FTE workload annually.
               config:
-                error_if: ">526"
+                error_if: '>526'
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_plant_labor
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -47,7 +47,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
+                    error_if: '>1'
                   description: Possible bad value for MS0053 in 2021.
           - name: payroll_operations
             data_tests:
@@ -55,7 +55,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
                   description: Possible bad values for MS0053 in 2021.
           - name: payroll_other_accounts
             data_tests:
@@ -63,5 +63,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">10"
+                    error_if: '>10'
                   description: Some negative values need further investigation.

--- a/dbt/models/rus12/core_rus12__yearly_plant_operations_by_borrower/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_plant_operations_by_borrower/schema.yml
@@ -8,19 +8,21 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_plant_operations_by_borrower
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
-                expression: "(operating_hours_in_service + operating_hours_on_standby + operating_hours_out_of_service_scheduled + operating_hours_out_of_service_unscheduled) <= 8785"
-              description: "Plants shouldn't report more hours across all fields than there are in a calendar year (8784 is a leap year, and we allow for rounding)."
+                expression: (operating_hours_in_service + operating_hours_on_standby + operating_hours_out_of_service_scheduled + operating_hours_out_of_service_unscheduled) <= 8785
+              description: Plants shouldn't report more hours across all fields than there are in a calendar year (8784 is a leap year, and we allow for rounding).
           - dbt_utils.expression_is_true:
               arguments:
-                expression: "is_partly_owned_by_borrower IS FALSE"
+                expression: is_partly_owned_by_borrower IS FALSE
               config:
-                where: |
-                  is_full_ownership_portion IS TRUE
+                where: 'is_full_ownership_portion IS TRUE
+
                   AND is_partly_owned_by_borrower IS NOT NULL
-              description: "Partial ownership and full ownership are mutually exclusive."
+
+                  '
+              description: Partial ownership and full ownership are mutually exclusive.
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus12/core_rus12__yearly_plant_operations_by_plant/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_plant_operations_by_plant/schema.yml
@@ -8,11 +8,11 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_plant_operations_by_plant
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
-                expression: "(operating_hours_in_service + operating_hours_on_standby + operating_hours_out_of_service_scheduled + operating_hours_out_of_service_unscheduled) <= 8785"
-              description: "Plants shouldn't report more hours across all fields than there are in a calendar year (8784 is a leap year, and we allow for rounding)."
+                expression: (operating_hours_in_service + operating_hours_on_standby + operating_hours_out_of_service_scheduled + operating_hours_out_of_service_unscheduled) <= 8785
+              description: Plants shouldn't report more hours across all fields than there are in a calendar year (8784 is a leap year, and we allow for rounding).
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus12/core_rus12__yearly_renewable_plants/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_renewable_plants/schema.yml
@@ -11,12 +11,12 @@ sources:
                 column_B: rus_funding
                 or_equal: true
               config:
-                error_if: ">14"
+                error_if: '>14'
               description: Expect that RUS will generally not invest more than is invested in a plant.
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_renewable_plants
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -62,7 +62,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
+                    error_if: '>1'
                   description: Expect opex investments per mwh to be negative. Investigate IN0106 in 2021 as the only exception.
           - name: power_cost_per_mwh
             data_tests:

--- a/dbt/models/rus12/core_rus12__yearly_sources_and_distribution/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_sources_and_distribution/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_sources_and_distribution
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -20,7 +20,7 @@ sources:
                     min_value: 0.0
                   row_condition: source_of_energy != 'net_interchange'
                   config:
-                    error_if: ">22"
+                    error_if: '>22'
           - name: cost
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -28,4 +28,4 @@ sources:
                     min_value: 0.0
                   row_condition: net_energy_received_mwh >= 0
                   config:
-                    error_if: ">8"
+                    error_if: '>8'

--- a/dbt/models/rus12/core_rus12__yearly_sources_and_distribution_by_plant_type/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_sources_and_distribution_by_plant_type/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_sources_and_distribution_by_plant_type
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -34,4 +34,4 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">24"
+                    error_if: '>24'

--- a/dbt/models/rus12/core_rus12__yearly_statement_of_operations/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_statement_of_operations/schema.yml
@@ -12,7 +12,7 @@ sources:
                 min_ratio: 0.05
                 max_ratio: 0.2
               config:
-                error_if: ">4300" # ~20% of records
+                error_if: '>4300'
               description: Monthly spending should roughly equal 1/12 of the YTD budget (5-20% range).
           - expect_columns_ratio:
               arguments:
@@ -21,247 +21,274 @@ sources:
                 min_ratio: 0.75
                 max_ratio: 1.25
               config:
-                error_if: ">3667" # ~15% of records
+                error_if: '>3667'
               description: Budgeted spending and YTD spending should be roughly equivalent.
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_statement_of_operations
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
-                total_label: "total_operation_revenues_and_patronage_capital"
+                total_label: total_operation_revenues_and_patronage_capital
                 tolerance: 10
-              row_condition: "opex_group == 'operation_revenue_and_patronage_capital'"
+              row_condition: opex_group == 'operation_revenue_and_patronage_capital'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
-                total_label: "total_operation_revenues_and_patronage_capital"
+                total_label: total_operation_revenues_and_patronage_capital
                 tolerance: 10
-              row_condition: "opex_group == 'operation_revenue_and_patronage_capital'"
+              row_condition: opex_group == 'operation_revenue_and_patronage_capital'
               config:
-                error_if: ">201" # About 25% of data
+                error_if: '>201'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
-                total_label: "total_operation_revenues_and_patronage_capital"
+                total_label: total_operation_revenues_and_patronage_capital
                 tolerance: 10
-              row_condition: "opex_group == 'operation_revenue_and_patronage_capital'"
+              row_condition: opex_group == 'operation_revenue_and_patronage_capital'
               config:
-                error_if: ">184" # About 25% of data
+                error_if: '>184'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
-                total_label: "total_operating_expense"
+                total_label: total_operating_expense
                 tolerance: 10
-              row_condition: "opex_group == 'operation_expense'"
+              row_condition: opex_group == 'operation_expense'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
-                total_label: "total_operating_expense"
+                total_label: total_operating_expense
                 tolerance: 10
-              row_condition: "opex_group == 'operation_expense'"
+              row_condition: opex_group == 'operation_expense'
               config:
-                error_if: ">165"
+                error_if: '>165'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
-                total_label: "total_operating_expense"
+                total_label: total_operating_expense
                 tolerance: 10
-              row_condition: "opex_group == 'operation_expense'"
+              row_condition: opex_group == 'operation_expense'
               config:
-                error_if: ">138"
+                error_if: '>138'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
-                total_label: "total_maintenance_expense"
+                total_label: total_maintenance_expense
                 tolerance: 10
-              row_condition: "opex_group == 'maintenance_expense'"
+              row_condition: opex_group == 'maintenance_expense'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
-                total_label: "total_maintenance_expense"
+                total_label: total_maintenance_expense
                 tolerance: 10
-              row_condition: "opex_group == 'maintenance_expense'"
+              row_condition: opex_group == 'maintenance_expense'
               config:
-                error_if: ">1"
+                error_if: '>1'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
-                total_label: "total_maintenance_expense"
+                total_label: total_maintenance_expense
                 tolerance: 10
-              row_condition: "opex_group == 'maintenance_expense'"
+              row_condition: opex_group == 'maintenance_expense'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
-                categorical_column: opex_type
-                value_column: opex_report_month
-                subcomponents_list:
-                  [
-                    "total_operating_expense",
-                    "total_maintenance_expense",
-                    "depreciation_and_amortization_expense",
-                    "taxes",
-                    "interest_on_long_term_debt",
-                    "interest_charged_to_construction_credit",
-                    "other_interest_expense",
-                    "asset_retirement_obligations",
-                    "other_deductions",
-                  ]
-                total_label: "total_cost_of_electric_service"
-                tolerance: 10
-          - subcomponents_sum_to_total:
-              arguments:
-                group_by_columns: [borrower_id_rus, report_date]
-                categorical_column: opex_type
-                value_column: opex_ytd
-                subcomponents_list:
-                  [
-                    "total_operating_expense",
-                    "total_maintenance_expense",
-                    "depreciation_and_amortization_expense",
-                    "taxes",
-                    "interest_on_long_term_debt",
-                    "interest_charged_to_construction_credit",
-                    "other_interest_expense",
-                    "asset_retirement_obligations",
-                    "other_deductions",
-                  ]
-                total_label: "total_cost_of_electric_service"
-                tolerance: 10
-              config:
-                error_if: ">202" #~25% of records
-          - subcomponents_sum_to_total:
-              arguments:
-                group_by_columns: [borrower_id_rus, report_date]
-                categorical_column: opex_type
-                value_column: opex_ytd_budget
-                subcomponents_list:
-                  [
-                    "total_operating_expense",
-                    "total_maintenance_expense",
-                    "depreciation_and_amortization_expense",
-                    "taxes",
-                    "interest_on_long_term_debt",
-                    "interest_charged_to_construction_credit",
-                    "other_interest_expense",
-                    "asset_retirement_obligations",
-                    "other_deductions",
-                  ]
-                total_label: "total_cost_of_electric_service"
-                tolerance: 10
-              config:
-                error_if: ">160" #~20% of records
-          - subcomponents_sum_to_total:
-              arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
                 subcomponents_list:
-                  ["total_operation_revenues_and_patronage_capital"]
-                negative_subcomponents_list: ["total_cost_of_electric_service"]
-                total_label: "operating_margins"
+                  - total_operating_expense
+                  - total_maintenance_expense
+                  - depreciation_and_amortization_expense
+                  - taxes
+                  - interest_on_long_term_debt
+                  - interest_charged_to_construction_credit
+                  - other_interest_expense
+                  - asset_retirement_obligations
+                  - other_deductions
+                total_label: total_cost_of_electric_service
                 tolerance: 10
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
                 subcomponents_list:
-                  ["total_operation_revenues_and_patronage_capital"]
-                negative_subcomponents_list: ["total_cost_of_electric_service"]
-                total_label: "operating_margins"
+                  - total_operating_expense
+                  - total_maintenance_expense
+                  - depreciation_and_amortization_expense
+                  - taxes
+                  - interest_on_long_term_debt
+                  - interest_charged_to_construction_credit
+                  - other_interest_expense
+                  - asset_retirement_obligations
+                  - other_deductions
+                total_label: total_cost_of_electric_service
                 tolerance: 10
               config:
-                error_if: ">204" # ~26% of records
+                error_if: '>202'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
                 subcomponents_list:
-                  ["total_operation_revenues_and_patronage_capital"]
-                negative_subcomponents_list: ["total_cost_of_electric_service"]
-                total_label: "operating_margins"
+                  - total_operating_expense
+                  - total_maintenance_expense
+                  - depreciation_and_amortization_expense
+                  - taxes
+                  - interest_on_long_term_debt
+                  - interest_charged_to_construction_credit
+                  - other_interest_expense
+                  - asset_retirement_obligations
+                  - other_deductions
+                total_label: total_cost_of_electric_service
                 tolerance: 10
               config:
-                error_if: ">155" # ~20% of records
+                error_if: '>160'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
                 subcomponents_list:
-                  [
-                    "operating_margins",
-                    "allowance_for_funds_used_during_construction",
-                    "extraordinary_items",
-                    "generation_and_transmission_capital_credits",
-                    "income_or_loss_from_equity_investments",
-                    "interest_income",
-                    "operating_margins",
-                    "other_capital_credits_and_patronage_dividends",
-                    "other_nonoperating_income",
-                  ]
-                total_label: "total_net_patronage_capital_or_margins"
+                  - total_operation_revenues_and_patronage_capital
+                negative_subcomponents_list:
+                  - total_cost_of_electric_service
+                total_label: operating_margins
                 tolerance: 10
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
                 subcomponents_list:
-                  [
-                    "operating_margins",
-                    "allowance_for_funds_used_during_construction",
-                    "extraordinary_items",
-                    "generation_and_transmission_capital_credits",
-                    "income_or_loss_from_equity_investments",
-                    "interest_income",
-                    "operating_margins",
-                    "other_capital_credits_and_patronage_dividends",
-                    "other_nonoperating_income",
-                  ]
-                total_label: "total_net_patronage_capital_or_margins"
+                  - total_operation_revenues_and_patronage_capital
+                negative_subcomponents_list:
+                  - total_cost_of_electric_service
+                total_label: operating_margins
                 tolerance: 10
               config:
-                error_if: ">2"
+                error_if: '>204'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
                 subcomponents_list:
-                  [
-                    "operating_margins",
-                    "allowance_for_funds_used_during_construction",
-                    "extraordinary_items",
-                    "generation_and_transmission_capital_credits",
-                    "income_or_loss_from_equity_investments",
-                    "interest_income",
-                    "operating_margins",
-                    "other_capital_credits_and_patronage_dividends",
-                    "other_nonoperating_income",
-                  ]
-                total_label: "total_net_patronage_capital_or_margins"
+                  - total_operation_revenues_and_patronage_capital
+                negative_subcomponents_list:
+                  - total_cost_of_electric_service
+                total_label: operating_margins
+                tolerance: 10
+              config:
+                error_if: '>155'
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: opex_type
+                value_column: opex_report_month
+                subcomponents_list:
+                  - operating_margins
+                  - allowance_for_funds_used_during_construction
+                  - extraordinary_items
+                  - generation_and_transmission_capital_credits
+                  - income_or_loss_from_equity_investments
+                  - interest_income
+                  - operating_margins
+                  - other_capital_credits_and_patronage_dividends
+                  - other_nonoperating_income
+                total_label: total_net_patronage_capital_or_margins
+                tolerance: 10
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: opex_type
+                value_column: opex_ytd
+                subcomponents_list:
+                  - operating_margins
+                  - allowance_for_funds_used_during_construction
+                  - extraordinary_items
+                  - generation_and_transmission_capital_credits
+                  - income_or_loss_from_equity_investments
+                  - interest_income
+                  - operating_margins
+                  - other_capital_credits_and_patronage_dividends
+                  - other_nonoperating_income
+                total_label: total_net_patronage_capital_or_margins
+                tolerance: 10
+              config:
+                error_if: '>2'
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: opex_type
+                value_column: opex_ytd_budget
+                subcomponents_list:
+                  - operating_margins
+                  - allowance_for_funds_used_during_construction
+                  - extraordinary_items
+                  - generation_and_transmission_capital_credits
+                  - income_or_loss_from_equity_investments
+                  - interest_income
+                  - operating_margins
+                  - other_capital_credits_and_patronage_dividends
+                  - other_nonoperating_income
+                total_label: total_net_patronage_capital_or_margins
                 tolerance: 10
         columns:
           - name: report_date
@@ -275,7 +302,7 @@ sources:
                     min_value: 0.0
                   row_condition: opex_type != 'interest_charged_to_construction_credit'
                   config:
-                    error_if: ">307"
+                    error_if: '>307'
           - name: opex_ytd
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -283,7 +310,7 @@ sources:
                     min_value: 0.0
                   row_condition: opex_type != 'interest_charged_to_construction_credit'
                   config:
-                    error_if: ">135"
+                    error_if: '>135'
           - name: opex_ytd_budget
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -291,5 +318,5 @@ sources:
                     min_value: 0.0
                   row_condition: opex_type != 'interest_charged_to_construction_credit'
                   config:
-                    error_if: ">43"
+                    error_if: '>43'
           - name: is_total

--- a/dbt/models/rus12/core_rus12__yearly_utility_plant_changes/schema.yml
+++ b/dbt/models/rus12/core_rus12__yearly_utility_plant_changes/schema.yml
@@ -8,45 +8,53 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus12__yearly_utility_plant_changes
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: retirements
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group NOT IN ('electric_plant_in_service', 'utility_plant_in_service', 'total_utility_plant')
-              description: "Check the totals for all of the utility_plant_group's that are just the sum of the components."
+              description: Check the totals for all of the utility_plant_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: additions
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group NOT IN ('electric_plant_in_service', 'utility_plant_in_service', 'total_utility_plant')
-              description: "Check the totals for all of the utility_plant_group's that are just the sum of the components."
+              description: Check the totals for all of the utility_plant_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: adjustments_and_transfers
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group NOT IN ('electric_plant_in_service', 'utility_plant_in_service', 'total_utility_plant')
-              description: "Check the totals for all of the utility_plant_group's that are just the sum of the components."
+              description: Check the totals for all of the utility_plant_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: ending_balance
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group NOT IN ('electric_plant_in_service', 'utility_plant_in_service', 'total_utility_plant')
-              description: "Check the totals for all of the utility_plant_group's that are just the sum of the components."
+              description: Check the totals for all of the utility_plant_group's that are just the sum of the components.
           - dbt_utils.expression_is_true:
               arguments:
                 expression: retirements + additions + adjustments_and_transfers <= ending_balance
-              description: "Check that annual changes don't exceed ending balance."
+              description: Check that annual changes don't exceed ending balance.
               config:
-                error_if: ">72"
+                error_if: '>72'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -58,8 +66,8 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">21"
-                  description: "Check that most of the retirements are positive."
+                    error_if: '>21'
+                  description: Check that most of the retirements are positive.
           - name: additions
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -67,8 +75,8 @@ sources:
                     min_value: 0.0
                   row_condition: utility_plant_item!='construction_work_in_progress'
                   config:
-                    error_if: ">199"
-                  description: "Check that most of the additions are positive - expect construction_work_in_progress. This is about 1% of the table."
+                    error_if: '>199'
+                  description: Check that most of the additions are positive - expect construction_work_in_progress. This is about 1% of the table.
           - name: adjustments_and_transfers
           - name: ending_balance
             data_tests:
@@ -76,6 +84,6 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">19"
-                  description: "Check that most of the ending balances are positive."
+                    error_if: '>19'
+                  description: Check that most of the ending balances are positive.
           - name: is_total

--- a/dbt/models/rus12/out_rus12__monthly_demand_and_energy_at_delivery_points/schema.yml
+++ b/dbt/models/rus12/out_rus12__monthly_demand_and_energy_at_delivery_points/schema.yml
@@ -7,7 +7,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__monthly_demand_and_energy_at_delivery_points
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus12/out_rus12__monthly_demand_and_energy_at_power_sources/schema.yml
+++ b/dbt/models/rus12/out_rus12__monthly_demand_and_energy_at_power_sources/schema.yml
@@ -7,7 +7,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__monthly_demand_and_energy_at_power_sources
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
                 expression: date_trunc('month', report_date) >= date_trunc('month', peak_demand_date) AND date_trunc('year', report_date) == date_trunc('year', peak_demand_date)
@@ -27,5 +27,5 @@ sources:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
-          - name: is_peak_coincident
           - name: peak_demand_date
+          - name: is_peak_coincident

--- a/dbt/models/rus12/out_rus12__yearly_balance_sheet_assets/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_balance_sheet_assets/schema.yml
@@ -7,12 +7,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_balance_sheet_assets
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: asset_type
           - name: ending_balance
           - name: is_total

--- a/dbt/models/rus12/out_rus12__yearly_balance_sheet_liabilities/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_balance_sheet_liabilities/schema.yml
@@ -7,12 +7,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_balance_sheet_liabilities
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: liability_type
           - name: ending_balance
           - name: is_total

--- a/dbt/models/rus12/out_rus12__yearly_depreciation_changes/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_depreciation_changes/schema.yml
@@ -8,46 +8,54 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_depreciation_changes
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
                 expression: accruals + retirements_less_net_salvage + adjustments_and_transfers <= ending_balance
                 config:
-                  error_if: ">18"
+                  error_if: '>18'
                   where: depreciation_and_amortization_item != 'retirement_work_in_progress'
-              description: "Check that annual changes don't exceed ending balance."
+              description: Check that annual changes don't exceed ending balance.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: depreciation_and_amortization_group
                 value_column: accruals
-                total_label: "total_depreciation"
+                total_label: total_depreciation
               row_condition: depreciation_and_amortization_group='electric_plant_in_service'
-              description: "Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components."
+              description: Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: depreciation_and_amortization_group
                 value_column: retirements_less_net_salvage
-                total_label: "total_depreciation"
+                total_label: total_depreciation
               row_condition: depreciation_and_amortization_group='electric_plant_in_service'
-              description: "Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components."
+              description: Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: depreciation_and_amortization_group
                 value_column: adjustments_and_transfers
-                total_label: "total_depreciation"
+                total_label: total_depreciation
               row_condition: depreciation_and_amortization_group='electric_plant_in_service'
-              description: "Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components."
+              description: Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: depreciation_and_amortization_group
                 value_column: ending_balance
-                total_label: "total_depreciation"
+                total_label: total_depreciation
               row_condition: depreciation_and_amortization_group='electric_plant_in_service'
-              description: "Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components."
+              description: Check the totals for all of the depreciation_and_amortization_group's that are just the sum of the components.
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -63,8 +71,8 @@ sources:
                     max_value: 100.0
                   row_condition: depreciation_and_amortization_item !='retirement_work_in_progress'
                   config:
-                    error_if: ">1"
-                  description: "Check that most of the composite_depreciation_rate's within 0-100."
+                    error_if: '>1'
+                  description: Check that most of the composite_depreciation_rate's within 0-100.
           - name: accruals
           - name: retirements_less_net_salvage
           - name: adjustments_and_transfers
@@ -75,6 +83,6 @@ sources:
                     min_value: 0.0
                   row_condition: depreciation_and_amortization_item !='retirement_work_in_progress'
                   config:
-                    error_if: ">34"
-                  description: "Check that most of the ending_balance's are positive - excluding the retirement_work_in_progress."
+                    error_if: '>34'
+                  description: Check that most of the ending_balance's are positive - excluding the retirement_work_in_progress.
           - name: is_total

--- a/dbt/models/rus12/out_rus12__yearly_depreciation_misc/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_depreciation_misc/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_depreciation_misc
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -21,5 +21,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">126"
-                  description: "Check that most of the ending_balance's are positive. About 4% of the table is negative, which seems reasonable."
+                    error_if: '>126'
+                  description: Check that most of the ending_balance's are positive. About 4% of the table is negative, which seems reasonable.

--- a/dbt/models/rus12/out_rus12__yearly_external_financial_risk_ratio/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_external_financial_risk_ratio/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_external_financial_risk_ratio
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: external_financial_risk_ratio
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/rus12/out_rus12__yearly_investments/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_investments/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_investments
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: investment_description
           - name: investment_type_code
           - name: included_investments

--- a/dbt/models/rus12/out_rus12__yearly_lines_stations_labor_materials_cost/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_lines_stations_labor_materials_cost/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_lines_stations_labor_materials_cost
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: labor_or_material
           - name: operation_or_maintenance
           - name: lines_or_stations
@@ -23,5 +23,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">10"
+                    error_if: '>10'
                   description: No values should be negative here. Investigate.

--- a/dbt/models/rus12/out_rus12__yearly_loans/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_loans/schema.yml
@@ -11,21 +11,21 @@ sources:
                 column_B: loan_balance
                 or_equal: true
               config:
-                error_if: ">1" #TODO: Investigate 1 case where loan balance exceeds original amount.
-              description: "The original amount of the loan should be greater than or equal to the current balance of the loan."
+                error_if: '>1'
+              description: The original amount of the loan should be greater than or equal to the current balance of the loan.
           - dbt_utils.expression_is_true:
               arguments:
                 expression: date_trunc('year', report_date) <= date_trunc('year', loan_maturity_date)
-              description: "The report date year should be before or equal to the loan maturity date year."
+              description: The report date year should be before or equal to the loan maturity date year.
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_loans
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: loan_recipient
           - name: loan_maturity_date
           - name: loan_original_amount
@@ -39,7 +39,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
                   description: Two instances of negative loan balance, which could be overpayment. Investigate.
           - name: for_rural_development
           - name: is_loan_guarantee

--- a/dbt/models/rus12/out_rus12__yearly_long_term_debt/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_long_term_debt/schema.yml
@@ -9,17 +9,17 @@ sources:
               arguments:
                 expression: debt_interest + debt_principal = debt_total
               config:
-                error_if: ">78"
+                error_if: '>78'
               description: Examine ~80 cases where interest + principal != total
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_long_term_debt
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: debt_description
           - name: debt_ending_balance
             data_tests:
@@ -27,7 +27,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">32"
+                    error_if: '>32'
                   description: Investigate negative values.
           - name: debt_interest
             data_tests:
@@ -35,7 +35,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">21"
+                    error_if: '>21'
                   description: Investigate negative values.
           - name: debt_principal
             data_tests:
@@ -43,7 +43,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">5"
+                    error_if: '>5'
                   description: Investigate negative values.
           - name: debt_total
             data_tests:
@@ -51,5 +51,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">21"
+                    error_if: '>21'
                   description: Investigate negative values.

--- a/dbt/models/rus12/out_rus12__yearly_meeting_and_board/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_meeting_and_board/schema.yml
@@ -9,7 +9,7 @@ sources:
               arguments:
                 expression: date_trunc('month', report_date) >= date_trunc('month', last_annual_meeting_date)
               config:
-                error_if: ">8"
+                error_if: '>8'
               description: Some utilities report meetings after the date range of the filing.
           - expect_summed_columns_not_exceed_threshold:
               arguments:
@@ -18,17 +18,17 @@ sources:
                 threshold_column: members_num
                 multiplier: 1
               config:
-                error_if: ">1"
+                error_if: '>1'
               description: AZ0028 reports 8 members but 14 present in 2006.
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_meeting_and_board
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: last_annual_meeting_date
           - name: members_num
             data_tests:

--- a/dbt/models/rus12/out_rus12__yearly_non_utility_plant_changes/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_non_utility_plant_changes/schema.yml
@@ -8,13 +8,13 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_non_utility_plant_changes
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
                 expression: retirements + additions + adjustments_and_transfers <= ending_balance
-              description: "Check that annual changes don't exceed ending balance."
+              description: Check that annual changes don't exceed ending balance.
               config:
-                error_if: ">2"
+                error_if: '>2'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -27,16 +27,16 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
-                  description: "Check that most of the additions are positive."
+                    error_if: '>1'
+                  description: Check that most of the additions are positive.
           - name: retirements
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
-                  description: "Check that most of the retirements are positive."
+                    error_if: '>1'
+                  description: Check that most of the retirements are positive.
           - name: adjustments_and_transfers
           - name: ending_balance
             data_tests:

--- a/dbt/models/rus12/out_rus12__yearly_plant_costs/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_plant_costs/schema.yml
@@ -8,157 +8,177 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_plant_costs
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - expect_columns_ratio:
               arguments:
                 numerator_column: cost_per_mwh
                 denominator_column: cost_per_mmbtu
                 min_ratio: 3.412142
               config:
-                error_if: ">96" # ~6% of the data
-          # CALCULATE FUEL COST SUBTOTALS BY PLANT TYPE
+                error_if: '>96'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  ["coal_fuel", "oil_fuel", "gas_fuel", "other_fuel"]
-                total_label: "total_fuel"
+                  - coal_fuel
+                  - oil_fuel
+                  - gas_fuel
+                  - other_fuel
+                total_label: total_fuel
                 tolerance: 10
-              row_condition: "plant_type == 'steam'"
-              description: "Check that steam fuel subcomponents sum to total."
+              row_condition: plant_type == 'steam'
+              description: Check that steam fuel subcomponents sum to total.
               config:
-                error_if: ">8"
+                error_if: '>8'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "energy_for_compressed_air",
-                    "oil_fuel",
-                    "gas_fuel",
-                    "other_fuel",
-                  ]
-                total_label: "total_fuel"
+                  - energy_for_compressed_air
+                  - oil_fuel
+                  - gas_fuel
+                  - other_fuel
+                total_label: total_fuel
                 tolerance: 10
-              row_condition: "plant_type IN ('internal_combustion', 'combined_cycle')"
-              description: "Check that IC fuel subcomponents sum to total."
+              row_condition: plant_type IN ('internal_combustion', 'combined_cycle')
+              description: Check that IC fuel subcomponents sum to total.
               config:
-                error_if: ">1"
+                error_if: '>1'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
-                subcomponents_list: ["fuel", "less_fuel_acquisition_adjustment"]
-                total_label: "total_fuel"
+                subcomponents_list:
+                  - fuel
+                  - less_fuel_acquisition_adjustment
+                total_label: total_fuel
                 tolerance: 10
-              row_condition: "plant_type == 'nuclear'"
-              description: "Check that nuclear fuel subcomponents sum to total."
+              row_condition: plant_type == 'nuclear'
+              description: Check that nuclear fuel subcomponents sum to total.
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "supervision_and_engineering",
-                    "steam",
-                    "electric",
-                    "miscellaneous_power_generation",
-                    "generation",
-                    "allowances",
-                    "rents",
-                  ]
-                total_label: "non_fuels_total"
+                  - supervision_and_engineering
+                  - steam
+                  - electric
+                  - miscellaneous_power_generation
+                  - generation
+                  - allowances
+                  - rents
+                total_label: non_fuels_total
                 tolerance: 0
-              row_condition: "plant_type IN ('steam', 'combined_cycle')"
-              description: "Check that steam non-fuel subcomponents sum to total."
+              row_condition: plant_type IN ('steam', 'combined_cycle')
+              description: Check that steam non-fuel subcomponents sum to total.
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "supervision_and_engineering",
-                    "generation",
-                    "miscellaneous_power_generation",
-                    "rents",
-                  ]
-                total_label: "non_fuels_total"
+                  - supervision_and_engineering
+                  - generation
+                  - miscellaneous_power_generation
+                  - rents
+                total_label: non_fuels_total
                 tolerance: 0
-              row_condition: "plant_type == 'internal_combustion'"
-              description: "Check that steam non-fuel subcomponents sum to total."
+              row_condition: plant_type == 'internal_combustion'
+              description: Check that steam non-fuel subcomponents sum to total.
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
-                subcomponents_list: ["total_fuel", "non_fuels_total"]
-                total_label: "operations_total"
+                subcomponents_list:
+                  - total_fuel
+                  - non_fuels_total
+                total_label: operations_total
                 tolerance: 0
-              row_condition: "plant_type IN ('steam', 'internal_combustion', 'combined_cycle')"
-              description: "Check that steam, IC and CC operation subcomponents sum to total."
+              row_condition: plant_type IN ('steam', 'internal_combustion', 'combined_cycle')
+              description: Check that steam, IC and CC operation subcomponents sum to total.
               config:
-                error_if: ">2300" # This is almost all of them, INVESTIGATE!
+                error_if: '>2300'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "supervision_and_engineering",
-                    "water_for_power",
-                    "energy_for_pumped_storage",
-                    "hydraulic",
-                    "electric",
-                    "miscellaneous_power_generation",
-                    "rents",
-                  ]
-                total_label: "operations_total"
+                  - supervision_and_engineering
+                  - water_for_power
+                  - energy_for_pumped_storage
+                  - hydraulic
+                  - electric
+                  - miscellaneous_power_generation
+                  - rents
+                total_label: operations_total
                 tolerance: 0
-              row_condition: "plant_type == 'hydro'"
-              description: "Check that hydro operation subcomponents sum to total."
+              row_condition: plant_type == 'hydro'
+              description: Check that hydro operation subcomponents sum to total.
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, plant_name_rus, plant_type]
+                  - borrower_id_rus
+                  - report_date
+                  - plant_name_rus
+                  - plant_type
                 categorical_column: cost_type
                 value_column: cost
                 subcomponents_list:
-                  [
-                    "supervision_and_engineering",
-                    "net_fuel",
-                    "coolants_and_water",
-                    "steam",
-                    "steam_other_sources",
-                    "electric",
-                    "miscellaneous_power_generation",
-                    "rents",
-                  ]
-                total_label: "operations_total"
+                  - supervision_and_engineering
+                  - net_fuel
+                  - coolants_and_water
+                  - steam
+                  - steam_other_sources
+                  - electric
+                  - miscellaneous_power_generation
+                  - rents
+                total_label: operations_total
                 tolerance: 0
-              row_condition: "plant_type == 'nuclear'"
-              description: "Check that nuclear operation subcomponents sum to total."
+              row_condition: plant_type == 'nuclear'
+              description: Check that nuclear operation subcomponents sum to total.
               config:
-                error_if: ">129" # This is almost all of them, INVESTIGATE!
+                error_if: '>129'
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: plant_name_rus
           - name: plant_type
           - name: cost_group
@@ -169,19 +189,19 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">213" # 0.4% of the data
+                    error_if: '>213'
           - name: cost_per_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">381" # 0.7% of the data
+                    error_if: '>381'
           - name: cost_per_mmbtu
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">23"
+                    error_if: '>23'
           - name: is_total

--- a/dbt/models/rus12/out_rus12__yearly_plant_factors_and_maximum_demand/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_plant_factors_and_maximum_demand/schema.yml
@@ -7,7 +7,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_plant_factors_and_maximum_demand
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -22,7 +22,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">13" # Investigate 13 instances of cap fac > 1 for nuclear plants
+                    error_if: '>13'
           - name: capacity_factor_running
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -30,7 +30,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">121" # Investigate 121 instances of cap fac running > 1
+                    error_if: '>121'
           - name: load_factor
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -38,7 +38,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">2" # Investigate 2 instances of load fac > 1
+                    error_if: '>2'
           - name: peak_gross_demand_mw
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/models/rus12/out_rus12__yearly_plant_labor/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_plant_labor/schema.yml
@@ -10,22 +10,22 @@ sources:
                 expression: (employees_full_time_num + employees_part_time_num) * 8766 > employee_hours_worked_total
               description: Expect that full time and part time employees aren't reported as working more hours than exist in a year.
               config:
-                error_if: ">186"
+                error_if: '>186'
           - dbt_utils.expression_is_true:
               arguments:
                 expression: (employees_full_time_num + employees_part_time_num) * 2080 >= employee_hours_worked_total
               description: Expect that even with overtime, full time and part time employees combined work less than an average of a FTE workload annually.
               config:
-                error_if: ">526"
+                error_if: '>526'
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_plant_labor
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: plant_name_rus
           - name: plant_type
           - name: employees_full_time_num
@@ -49,7 +49,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
+                    error_if: '>1'
                   description: Possible bad value for MS0053 in 2021.
           - name: payroll_operations
             data_tests:
@@ -57,7 +57,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
                   description: Possible bad values for MS0053 in 2021.
           - name: payroll_other_accounts
             data_tests:
@@ -65,5 +65,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">10"
+                    error_if: '>10'
                   description: Some negative values need further investigation.

--- a/dbt/models/rus12/out_rus12__yearly_plant_operations_by_borrower/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_plant_operations_by_borrower/schema.yml
@@ -8,24 +8,26 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_plant_operations_by_borrower
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
-                expression: "(operating_hours_in_service + operating_hours_on_standby + operating_hours_out_of_service_scheduled + operating_hours_out_of_service_unscheduled) <= 8785"
-              description: "Plants shouldn't report more hours across all fields than there are in a calendar year (8784 is a leap year, and we allow for rounding)."
+                expression: (operating_hours_in_service + operating_hours_on_standby + operating_hours_out_of_service_scheduled + operating_hours_out_of_service_unscheduled) <= 8785
+              description: Plants shouldn't report more hours across all fields than there are in a calendar year (8784 is a leap year, and we allow for rounding).
           - dbt_utils.expression_is_true:
               arguments:
-                expression: "is_partly_owned_by_borrower IS FALSE"
+                expression: is_partly_owned_by_borrower IS FALSE
               config:
-                where: |
-                  is_full_ownership_portion IS TRUE
+                where: 'is_full_ownership_portion IS TRUE
+
                   AND is_partly_owned_by_borrower IS NOT NULL
-              description: "Partial ownership and full ownership are mutually exclusive."
+
+                  '
+              description: Partial ownership and full ownership are mutually exclusive.
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: plant_name_rus
           - name: unit_id_rus
           - name: plant_type

--- a/dbt/models/rus12/out_rus12__yearly_plant_operations_by_plant/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_plant_operations_by_plant/schema.yml
@@ -8,16 +8,16 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_plant_operations_by_plant
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
-                expression: "(operating_hours_in_service + operating_hours_on_standby + operating_hours_out_of_service_scheduled + operating_hours_out_of_service_unscheduled) <= 8785"
-              description: "Plants shouldn't report more hours across all fields than there are in a calendar year (8784 is a leap year, and we allow for rounding)."
+                expression: (operating_hours_in_service + operating_hours_on_standby + operating_hours_out_of_service_scheduled + operating_hours_out_of_service_unscheduled) <= 8785
+              description: Plants shouldn't report more hours across all fields than there are in a calendar year (8784 is a leap year, and we allow for rounding).
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: plant_name_rus
           - name: unit_id_rus
           - name: plant_type

--- a/dbt/models/rus12/out_rus12__yearly_renewable_plants/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_renewable_plants/schema.yml
@@ -11,17 +11,17 @@ sources:
                 column_B: rus_funding
                 or_equal: true
               config:
-                error_if: ">14"
+                error_if: '>14'
               description: Expect that RUS will generally not invest more than is invested in a plant.
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_renewable_plants
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: plant_name_rus
           - name: prime_mover_id
           - name: prime_mover_type
@@ -64,7 +64,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
+                    error_if: '>1'
                   description: Expect opex investments per mwh to be negative. Investigate IN0106 in 2021 as the only exception.
           - name: power_cost_per_mwh
             data_tests:

--- a/dbt/models/rus12/out_rus12__yearly_sources_and_distribution/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_sources_and_distribution/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_sources_and_distribution
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: source_of_energy
           - name: net_energy_received_mwh
             data_tests:
@@ -22,7 +22,7 @@ sources:
                     min_value: 0.0
                   row_condition: source_of_energy != 'net_interchange'
                   config:
-                    error_if: ">22"
+                    error_if: '>22'
           - name: cost
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -30,4 +30,4 @@ sources:
                     min_value: 0.0
                   row_condition: net_energy_received_mwh >= 0
                   config:
-                    error_if: ">8"
+                    error_if: '>8'

--- a/dbt/models/rus12/out_rus12__yearly_sources_and_distribution_by_plant_type/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_sources_and_distribution_by_plant_type/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_sources_and_distribution_by_plant_type
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: plant_type
           - name: capacity_mw
             data_tests:
@@ -36,4 +36,4 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">24"
+                    error_if: '>24'

--- a/dbt/models/rus12/out_rus12__yearly_statement_of_operations/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_statement_of_operations/schema.yml
@@ -12,7 +12,7 @@ sources:
                 min_ratio: 0.05
                 max_ratio: 0.2
               config:
-                error_if: ">4300"
+                error_if: '>4300'
               description: Monthly spending should roughly equal 1/12 of the YTD budget (5-20% range).
           - expect_columns_ratio:
               arguments:
@@ -21,253 +21,280 @@ sources:
                 min_ratio: 0.75
                 max_ratio: 1.25
               config:
-                error_if: ">3667"
+                error_if: '>3667'
               description: Budgeted spending and YTD spending should be roughly equivalent.
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_statement_of_operations
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
-                total_label: "total_operation_revenues_and_patronage_capital"
+                total_label: total_operation_revenues_and_patronage_capital
                 tolerance: 10
-              row_condition: "opex_group == 'operation_revenue_and_patronage_capital'"
+              row_condition: opex_group == 'operation_revenue_and_patronage_capital'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
-                total_label: "total_operation_revenues_and_patronage_capital"
+                total_label: total_operation_revenues_and_patronage_capital
                 tolerance: 10
-              row_condition: "opex_group == 'operation_revenue_and_patronage_capital'"
+              row_condition: opex_group == 'operation_revenue_and_patronage_capital'
               config:
-                error_if: ">201" # About 25% of data
+                error_if: '>201'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
-                total_label: "total_operation_revenues_and_patronage_capital"
+                total_label: total_operation_revenues_and_patronage_capital
                 tolerance: 10
-              row_condition: "opex_group == 'operation_revenue_and_patronage_capital'"
+              row_condition: opex_group == 'operation_revenue_and_patronage_capital'
               config:
-                error_if: ">184" # About 25% of data
+                error_if: '>184'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
-                total_label: "total_operating_expense"
+                total_label: total_operating_expense
                 tolerance: 10
-              row_condition: "opex_group == 'operation_expense'"
+              row_condition: opex_group == 'operation_expense'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
-                total_label: "total_operating_expense"
+                total_label: total_operating_expense
                 tolerance: 10
-              row_condition: "opex_group == 'operation_expense'"
+              row_condition: opex_group == 'operation_expense'
               config:
-                error_if: ">165"
+                error_if: '>165'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
-                total_label: "total_operating_expense"
+                total_label: total_operating_expense
                 tolerance: 10
-              row_condition: "opex_group == 'operation_expense'"
+              row_condition: opex_group == 'operation_expense'
               config:
-                error_if: ">138"
+                error_if: '>138'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
-                total_label: "total_maintenance_expense"
+                total_label: total_maintenance_expense
                 tolerance: 10
-              row_condition: "opex_group == 'maintenance_expense'"
+              row_condition: opex_group == 'maintenance_expense'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
-                total_label: "total_maintenance_expense"
+                total_label: total_maintenance_expense
                 tolerance: 10
-              row_condition: "opex_group == 'maintenance_expense'"
+              row_condition: opex_group == 'maintenance_expense'
               config:
-                error_if: ">1"
+                error_if: '>1'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
-                total_label: "total_maintenance_expense"
+                total_label: total_maintenance_expense
                 tolerance: 10
-              row_condition: "opex_group == 'maintenance_expense'"
+              row_condition: opex_group == 'maintenance_expense'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
-                categorical_column: opex_type
-                value_column: opex_report_month
-                subcomponents_list:
-                  [
-                    "total_operating_expense",
-                    "total_maintenance_expense",
-                    "depreciation_and_amortization_expense",
-                    "taxes",
-                    "interest_on_long_term_debt",
-                    "interest_charged_to_construction_credit",
-                    "other_interest_expense",
-                    "asset_retirement_obligations",
-                    "other_deductions",
-                  ]
-                total_label: "total_cost_of_electric_service"
-                tolerance: 10
-          - subcomponents_sum_to_total:
-              arguments:
-                group_by_columns: [borrower_id_rus, report_date]
-                categorical_column: opex_type
-                value_column: opex_ytd
-                subcomponents_list:
-                  [
-                    "total_operating_expense",
-                    "total_maintenance_expense",
-                    "depreciation_and_amortization_expense",
-                    "taxes",
-                    "interest_on_long_term_debt",
-                    "interest_charged_to_construction_credit",
-                    "other_interest_expense",
-                    "asset_retirement_obligations",
-                    "other_deductions",
-                  ]
-                total_label: "total_cost_of_electric_service"
-                tolerance: 10
-              config:
-                error_if: ">202" #~25% of records
-          - subcomponents_sum_to_total:
-              arguments:
-                group_by_columns: [borrower_id_rus, report_date]
-                categorical_column: opex_type
-                value_column: opex_ytd_budget
-                subcomponents_list:
-                  [
-                    "total_operating_expense",
-                    "total_maintenance_expense",
-                    "depreciation_and_amortization_expense",
-                    "taxes",
-                    "interest_on_long_term_debt",
-                    "interest_charged_to_construction_credit",
-                    "other_interest_expense",
-                    "asset_retirement_obligations",
-                    "other_deductions",
-                  ]
-                total_label: "total_cost_of_electric_service"
-                tolerance: 10
-              config:
-                error_if: ">160" #~20% of records
-          - subcomponents_sum_to_total:
-              arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
                 subcomponents_list:
-                  ["total_operation_revenues_and_patronage_capital"]
-                negative_subcomponents_list: ["total_cost_of_electric_service"]
-                total_label: "operating_margins"
+                  - total_operating_expense
+                  - total_maintenance_expense
+                  - depreciation_and_amortization_expense
+                  - taxes
+                  - interest_on_long_term_debt
+                  - interest_charged_to_construction_credit
+                  - other_interest_expense
+                  - asset_retirement_obligations
+                  - other_deductions
+                total_label: total_cost_of_electric_service
                 tolerance: 10
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
                 subcomponents_list:
-                  ["total_operation_revenues_and_patronage_capital"]
-                negative_subcomponents_list: ["total_cost_of_electric_service"]
-                total_label: "operating_margins"
+                  - total_operating_expense
+                  - total_maintenance_expense
+                  - depreciation_and_amortization_expense
+                  - taxes
+                  - interest_on_long_term_debt
+                  - interest_charged_to_construction_credit
+                  - other_interest_expense
+                  - asset_retirement_obligations
+                  - other_deductions
+                total_label: total_cost_of_electric_service
                 tolerance: 10
               config:
-                error_if: ">204" # ~26% of records
+                error_if: '>202'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
                 subcomponents_list:
-                  ["total_operation_revenues_and_patronage_capital"]
-                negative_subcomponents_list: ["total_cost_of_electric_service"]
-                total_label: "operating_margins"
+                  - total_operating_expense
+                  - total_maintenance_expense
+                  - depreciation_and_amortization_expense
+                  - taxes
+                  - interest_on_long_term_debt
+                  - interest_charged_to_construction_credit
+                  - other_interest_expense
+                  - asset_retirement_obligations
+                  - other_deductions
+                total_label: total_cost_of_electric_service
                 tolerance: 10
               config:
-                error_if: ">155" # ~20% of records
+                error_if: '>160'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
                 subcomponents_list:
-                  [
-                    "operating_margins",
-                    "allowance_for_funds_used_during_construction",
-                    "extraordinary_items",
-                    "generation_and_transmission_capital_credits",
-                    "income_or_loss_from_equity_investments",
-                    "interest_income",
-                    "operating_margins",
-                    "other_capital_credits_and_patronage_dividends",
-                    "other_nonoperating_income",
-                  ]
-                total_label: "total_net_patronage_capital_or_margins"
+                  - total_operation_revenues_and_patronage_capital
+                negative_subcomponents_list:
+                  - total_cost_of_electric_service
+                total_label: operating_margins
                 tolerance: 10
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
                 subcomponents_list:
-                  [
-                    "operating_margins",
-                    "allowance_for_funds_used_during_construction",
-                    "extraordinary_items",
-                    "generation_and_transmission_capital_credits",
-                    "income_or_loss_from_equity_investments",
-                    "interest_income",
-                    "operating_margins",
-                    "other_capital_credits_and_patronage_dividends",
-                    "other_nonoperating_income",
-                  ]
-                total_label: "total_net_patronage_capital_or_margins"
+                  - total_operation_revenues_and_patronage_capital
+                negative_subcomponents_list:
+                  - total_cost_of_electric_service
+                total_label: operating_margins
                 tolerance: 10
               config:
-                error_if: ">2"
+                error_if: '>204'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
                 subcomponents_list:
-                  [
-                    "operating_margins",
-                    "allowance_for_funds_used_during_construction",
-                    "extraordinary_items",
-                    "generation_and_transmission_capital_credits",
-                    "income_or_loss_from_equity_investments",
-                    "interest_income",
-                    "operating_margins",
-                    "other_capital_credits_and_patronage_dividends",
-                    "other_nonoperating_income",
-                  ]
-                total_label: "total_net_patronage_capital_or_margins"
+                  - total_operation_revenues_and_patronage_capital
+                negative_subcomponents_list:
+                  - total_cost_of_electric_service
+                total_label: operating_margins
+                tolerance: 10
+              config:
+                error_if: '>155'
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: opex_type
+                value_column: opex_report_month
+                subcomponents_list:
+                  - operating_margins
+                  - allowance_for_funds_used_during_construction
+                  - extraordinary_items
+                  - generation_and_transmission_capital_credits
+                  - income_or_loss_from_equity_investments
+                  - interest_income
+                  - operating_margins
+                  - other_capital_credits_and_patronage_dividends
+                  - other_nonoperating_income
+                total_label: total_net_patronage_capital_or_margins
+                tolerance: 10
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: opex_type
+                value_column: opex_ytd
+                subcomponents_list:
+                  - operating_margins
+                  - allowance_for_funds_used_during_construction
+                  - extraordinary_items
+                  - generation_and_transmission_capital_credits
+                  - income_or_loss_from_equity_investments
+                  - interest_income
+                  - operating_margins
+                  - other_capital_credits_and_patronage_dividends
+                  - other_nonoperating_income
+                total_label: total_net_patronage_capital_or_margins
+                tolerance: 10
+              config:
+                error_if: '>2'
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: opex_type
+                value_column: opex_ytd_budget
+                subcomponents_list:
+                  - operating_margins
+                  - allowance_for_funds_used_during_construction
+                  - extraordinary_items
+                  - generation_and_transmission_capital_credits
+                  - income_or_loss_from_equity_investments
+                  - interest_income
+                  - operating_margins
+                  - other_capital_credits_and_patronage_dividends
+                  - other_nonoperating_income
+                total_label: total_net_patronage_capital_or_margins
                 tolerance: 10
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: opex_group
           - name: opex_type
           - name: opex_report_month
@@ -277,7 +304,7 @@ sources:
                     min_value: 0.0
                   row_condition: opex_type != 'interest_charged_to_construction_credit'
                   config:
-                    error_if: ">307"
+                    error_if: '>307'
           - name: opex_ytd
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -285,7 +312,7 @@ sources:
                     min_value: 0.0
                   row_condition: opex_type != 'interest_charged_to_construction_credit'
                   config:
-                    error_if: ">135"
+                    error_if: '>135'
           - name: opex_ytd_budget
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -293,5 +320,5 @@ sources:
                     min_value: 0.0
                   row_condition: opex_type != 'interest_charged_to_construction_credit'
                   config:
-                    error_if: ">43"
+                    error_if: '>43'
           - name: is_total

--- a/dbt/models/rus12/out_rus12__yearly_utility_plant_changes/schema.yml
+++ b/dbt/models/rus12/out_rus12__yearly_utility_plant_changes/schema.yml
@@ -8,45 +8,53 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus12__yearly_utility_plant_changes
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: retirements
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group NOT IN ('electric_plant_in_service', 'utility_plant_in_service', 'total_utility_plant')
-              description: "Check the totals for all of the utility_plant_group's that are just the sum of the components."
+              description: Check the totals for all of the utility_plant_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: additions
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group NOT IN ('electric_plant_in_service', 'utility_plant_in_service', 'total_utility_plant')
-              description: "Check the totals for all of the utility_plant_group's that are just the sum of the components."
+              description: Check the totals for all of the utility_plant_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: adjustments_and_transfers
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group NOT IN ('electric_plant_in_service', 'utility_plant_in_service', 'total_utility_plant')
-              description: "Check the totals for all of the utility_plant_group's that are just the sum of the components."
+              description: Check the totals for all of the utility_plant_group's that are just the sum of the components.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: ending_balance
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group NOT IN ('electric_plant_in_service', 'utility_plant_in_service', 'total_utility_plant')
-              description: "Check the totals for all of the utility_plant_group's that are just the sum of the components."
+              description: Check the totals for all of the utility_plant_group's that are just the sum of the components.
           - dbt_utils.expression_is_true:
               arguments:
                 expression: retirements + additions + adjustments_and_transfers <= ending_balance
-              description: "Check that annual changes don't exceed ending balance."
+              description: Check that annual changes don't exceed ending balance.
               config:
-                error_if: ">72"
+                error_if: '>72'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -60,8 +68,8 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">21"
-                  description: "Check that most of the retirements are positive."
+                    error_if: '>21'
+                  description: Check that most of the retirements are positive.
           - name: additions
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -69,8 +77,8 @@ sources:
                     min_value: 0.0
                   row_condition: utility_plant_item!='construction_work_in_progress'
                   config:
-                    error_if: ">199"
-                  description: "Check that most of the additions are positive - expect construction_work_in_progress. This is about 1% of the table."
+                    error_if: '>199'
+                  description: Check that most of the additions are positive - expect construction_work_in_progress. This is about 1% of the table.
           - name: adjustments_and_transfers
           - name: ending_balance
             data_tests:
@@ -78,6 +86,6 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">19"
-                  description: "Check that most of the ending balances are positive."
+                    error_if: '>19'
+                  description: Check that most of the ending balances are positive.
           - name: is_total

--- a/dbt/models/rus7/core_rus7__yearly_balance_sheet_assets/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_balance_sheet_assets/schema.yml
@@ -8,41 +8,44 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_balance_sheet_assets
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: asset_type
                 value_column: ending_balance
                 subcomponents_list:
-                  ["utility_plant_in_service", "construction_work_in_progress"]
-                total_label: "total_utility_plant"
+                  - utility_plant_in_service
+                  - construction_work_in_progress
+                total_label: total_utility_plant
                 tolerance: 10
               config:
-                error_if: ">545"
+                error_if: '>545'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: asset_type
                 value_column: ending_balance
                 subcomponents_list:
-                  [
-                    "cash_general_funds",
-                    "cash_construction_funds_trustee",
-                    "special_deposits",
-                    "investments_temporary",
-                    "notes_receivable",
-                    "accounts_receivable_other",
-                    "accounts_receivable_sales_of_energy",
-                    "renewable_energy_credits",
-                    "materials_and_supplies",
-                    "prepayments",
-                    "other_current_and_accrued",
-                  ]
-                total_label: "total_current_and_accrued"
+                  - cash_general_funds
+                  - cash_construction_funds_trustee
+                  - special_deposits
+                  - investments_temporary
+                  - notes_receivable
+                  - accounts_receivable_other
+                  - accounts_receivable_sales_of_energy
+                  - renewable_energy_credits
+                  - materials_and_supplies
+                  - prepayments
+                  - other_current_and_accrued
+                total_label: total_current_and_accrued
                 tolerance: 10
               config:
-                error_if: ">5"
+                error_if: '>5'
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus7/core_rus7__yearly_balance_sheet_liabilities/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_balance_sheet_liabilities/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_balance_sheet_liabilities
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus7/core_rus7__yearly_customer_energy_efficiency_and_conservation_loans/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_customer_energy_efficiency_and_conservation_loans/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_customer_energy_efficiency_and_conservation_loans
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -20,7 +20,7 @@ sources:
                     min_value: 0.0
                     max_value: 100.0
                   config:
-                    error_if: ">1"
+                    error_if: '>1'
           - name: anticipated_pct
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -28,7 +28,7 @@ sources:
                     min_value: 0.0
                     max_value: 100.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
           - name: ytd_dollars
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/rus7/core_rus7__yearly_distribution_services/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_distribution_services/schema.yml
@@ -8,8 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_distribution_services
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
-        # TODO: VALIDATE STATUSES SUM TO TOTAL
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -20,5 +19,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">3"
+                    error_if: '>3'
           - name: is_total

--- a/dbt/models/rus7/core_rus7__yearly_employee_statistics/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_employee_statistics/schema.yml
@@ -21,7 +21,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_employee_statistics
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -36,8 +36,8 @@ sources:
                     order_by: report_date
                     max_pct_change: 0.3
                   config:
-                    warn_if: ">0"
-                    error_if: ">50"
+                    warn_if: '>0'
+                    error_if: '>50'
           - name: employee_hours_worked_regular_time
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -49,8 +49,8 @@ sources:
                     order_by: report_date
                     max_pct_change: 0.3
                   config:
-                    warn_if: ">0"
-                    error_if: ">50"
+                    warn_if: '>0'
+                    error_if: '>50'
           - name: employee_hours_worked_over_time
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -67,8 +67,8 @@ sources:
                     order_by: report_date
                     max_pct_change: 0.5
                   config:
-                    warn_if: ">0"
-                    error_if: ">100"
+                    warn_if: '>0'
+                    error_if: '>100'
           - name: payroll_capitalized
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -80,8 +80,8 @@ sources:
                     order_by: report_date
                     max_pct_change: 0.5
                   config:
-                    warn_if: ">0"
-                    error_if: ">300"
+                    warn_if: '>0'
+                    error_if: '>300'
           - name: payroll_other
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/rus7/core_rus7__yearly_energy_efficiency/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_energy_efficiency/schema.yml
@@ -8,35 +8,41 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_energy_efficiency
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, observation_period]
+                  - borrower_id_rus
+                  - report_date
+                  - observation_period
                 categorical_column: customer_class
                 value_column: customers_num
-                total_label: "total"
+                total_label: total
                 tolerance: 0
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, observation_period]
+                  - borrower_id_rus
+                  - report_date
+                  - observation_period
                 categorical_column: customer_class
                 value_column: invested
-                total_label: "total"
+                total_label: total
                 tolerance: 1
               config:
-                error_if: ">6"
+                error_if: '>6'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, observation_period]
+                  - borrower_id_rus
+                  - report_date
+                  - observation_period
                 categorical_column: customer_class
                 value_column: savings_mmbtu
-                total_label: "total"
+                total_label: total
                 tolerance: 1
               config:
-                error_if: ">11"
+                error_if: '>11'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -59,5 +65,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">8"
+                    error_if: '>8'
                   description: KS0059 has negative values which don't follow from prior years of data.

--- a/dbt/models/rus7/core_rus7__yearly_energy_purchased/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_energy_purchased/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_energy_purchased
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -19,7 +19,7 @@ sources:
                     min_value: 0.0
                   row_condition: utility_name_eia != '*Adjustments'
                   config:
-                    error_if: ">33"
+                    error_if: '>33'
           - name: purchased_energy_cost_total
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -27,7 +27,7 @@ sources:
                     min_value: 0.0
                   row_condition: utility_name_eia != '*Adjustments'
                   config:
-                    error_if: ">99"
+                    error_if: '>99'
           - name: average_energy_cost_dollars_per_mwh
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -35,7 +35,7 @@ sources:
                     min_value: 0.0
                   row_condition: utility_name_eia != '*Adjustments'
                   config:
-                    error_if: ">30"
+                    error_if: '>30'
           - name: wheeling_and_other_charges
           - name: fuel_cost_adjustment
           - name: fuel_type_code_rus

--- a/dbt/models/rus7/core_rus7__yearly_external_financial_risk_ratio/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_external_financial_risk_ratio/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_external_financial_risk_ratio
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -18,4 +18,4 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">18" # TODO: Investigate negative original loan amount values
+                    error_if: '>18'

--- a/dbt/models/rus7/core_rus7__yearly_investments/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_investments/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_investments
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus7/core_rus7__yearly_loans/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_loans/schema.yml
@@ -9,20 +9,20 @@ sources:
               arguments:
                 column_A: loan_original_amount
                 column_B: loan_balance
-                or_equal: True
+                or_equal: true
               config:
-                error_if: ">38" # TODO: Investigate cases where loan balance exceeds original amount.
-              description: "The original amount of the loan guarantee should be greater than or equal to the current balance of the loan."
+                error_if: '>38'
+              description: The original amount of the loan guarantee should be greater than or equal to the current balance of the loan.
           - dbt_utils.expression_is_true:
               arguments:
                 expression: date_trunc('year', report_date) <= date_trunc('year', loan_maturity_date)
               config:
-                error_if: ">58"
-              description: "The report date year should be before or equal to the loan maturity date year."
+                error_if: '>58'
+              description: The report date year should be before or equal to the loan maturity date year.
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_loans
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -33,7 +33,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">4" # TODO: Investigate negative loan balance values
+                    error_if: '>4'
           - name: loan_maturity_date
           - name: loan_original_amount
             data_tests:
@@ -41,6 +41,6 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1" # TODO: Investigate negative original loan amount values
+                    error_if: '>1'
           - name: for_rural_development
           - name: is_loan_guarantee

--- a/dbt/models/rus7/core_rus7__yearly_long_term_debt/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_long_term_debt/schema.yml
@@ -9,12 +9,12 @@ sources:
               arguments:
                 expression: debt_interest + debt_principal = debt_total
               config:
-                error_if: ">5"
+                error_if: '>5'
               description: Examine a few cases where interest + principal != total
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_long_term_debt
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -25,7 +25,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">38"
+                    error_if: '>38'
                   description: Investigate negative values.
           - name: debt_interest
             data_tests:
@@ -33,7 +33,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">11"
+                    error_if: '>11'
                   description: Investigate negative values.
           - name: debt_principal
             data_tests:
@@ -46,5 +46,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">5"
+                    error_if: '>5'
                   description: Investigate negative values.

--- a/dbt/models/rus7/core_rus7__yearly_long_term_leases/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_long_term_leases/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_long_term_leases
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus7/core_rus7__yearly_materials_and_supplies/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_materials_and_supplies/schema.yml
@@ -14,7 +14,7 @@ sources:
                 expression: materials_purchased + materials_salvaged - materials_sold - materials_used + materials_adjustment <= materials_ending_balance
               description: Check that annual changes don't exceed ending balance.
               config:
-                error_if: ">3"
+                error_if: '>3'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -26,32 +26,32 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">12"
+                    error_if: '>12'
           - name: materials_purchased
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
           - name: materials_salvaged
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">16"
+                    error_if: '>16'
           - name: materials_sold
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">7"
+                    error_if: '>7'
           - name: materials_used
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">4"
+                    error_if: '>4'

--- a/dbt/models/rus7/core_rus7__yearly_meeting_and_board/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_meeting_and_board/schema.yml
@@ -9,7 +9,7 @@ sources:
               arguments:
                 expression: date_trunc('month', report_date) >= date_trunc('month', last_annual_meeting_date)
               config:
-                error_if: ">7"
+                error_if: '>7'
               description: Some utilities report meetings after the date range of the filing.
           - expect_summed_columns_not_exceed_threshold:
               arguments:
@@ -18,12 +18,12 @@ sources:
                 threshold_column: members_num
                 multiplier: 1
               config:
-                error_if: ">2"
+                error_if: '>2'
               description: MO0066 reports two bad values for 2020 and 2021.
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_meeting_and_board
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus7/core_rus7__yearly_owed_by_customers/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_owed_by_customers/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_owed_by_customers
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -18,11 +18,11 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">5"
+                    error_if: '>5'
           - name: amount_written_off_ytd
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">176"
+                    error_if: '>176'

--- a/dbt/models/rus7/core_rus7__yearly_patronage_capital/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_patronage_capital/schema.yml
@@ -11,63 +11,63 @@ sources:
                 column_B: patronage_report_year
                 or_equal: true
               config:
-                error_if: ">14"
-              description: "Some 0 cumulative values and a handful of other values causing failure. Investigate."
+                error_if: '>14'
+              description: Some 0 cumulative values and a handful of other values causing failure. Investigate.
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_patronage_capital
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: patronage_type
                 value_column: patronage_cumulative
                 subcomponents_list:
-                  [
-                    "distributions_general_retirements",
-                    "distributions_special_retirements",
-                  ]
-                total_label: "total_distributions_retirements"
+                  - distributions_general_retirements
+                  - distributions_special_retirements
+                total_label: total_distributions_retirements
                 tolerance: 1
               config:
-                error_if: ">435"
+                error_if: '>435'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: patronage_type
                 value_column: patronage_report_year
                 subcomponents_list:
-                  [
-                    "distributions_general_retirements",
-                    "distributions_special_retirements",
-                  ]
-                total_label: "total_distributions_retirements"
+                  - distributions_general_retirements
+                  - distributions_special_retirements
+                total_label: total_distributions_retirements
                 tolerance: 1
               config:
-                error_if: ">1"
+                error_if: '>1'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: patronage_type
                 value_column: patronage_cumulative
                 subcomponents_list:
-                  [
-                    "received_lenders_of_electric_power",
-                    "received_supplier_of_electric_power",
-                  ]
-                total_label: "total_received"
+                  - received_lenders_of_electric_power
+                  - received_supplier_of_electric_power
+                total_label: total_received
                 tolerance: 1
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: patronage_type
                 value_column: patronage_report_year
                 subcomponents_list:
-                  [
-                    "received_lenders_of_electric_power",
-                    "received_supplier_of_electric_power",
-                  ]
-                total_label: "total_received"
+                  - received_lenders_of_electric_power
+                  - received_supplier_of_electric_power
+                total_label: total_received
                 tolerance: 1
         columns:
           - name: report_date
@@ -79,7 +79,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
                   description: FL0026 and OH0071 each report one negative value. Investigate.
           - name: patronage_cumulative
             data_tests:

--- a/dbt/models/rus7/core_rus7__yearly_power_requirements/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_power_requirements/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_power_requirements
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -28,7 +28,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">400"
+                    error_if: '>400'
                   description: Commonly violated (~5% of data).
           - name: purchases_and_generation_cost
             data_tests:
@@ -56,7 +56,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">6"
+                    error_if: '>6'
                   description: VA0039 reports 4 negative generations, two other companies in 2006. Investigate.
           - name: interchange_mwh
             data_tests:

--- a/dbt/models/rus7/core_rus7__yearly_power_requirements_electric_customers/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_power_requirements_electric_customers/schema.yml
@@ -8,14 +8,16 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_power_requirements_electric_customers
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, observation_period]
+                  - borrower_id_rus
+                  - report_date
+                  - observation_period
                 categorical_column: customer_class
                 value_column: customers_num
-                total_label: "total"
+                total_label: total
                 tolerance: 0
         columns:
           - name: report_date

--- a/dbt/models/rus7/core_rus7__yearly_power_requirements_electric_sales/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_power_requirements_electric_sales/schema.yml
@@ -8,24 +8,28 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_power_requirements_electric_sales
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: customer_class
                 value_column: sales_mwh
-                total_label: "total"
+                total_label: total
                 tolerance: 1
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: customer_class
                 value_column: revenue
-                total_label: "total"
+                total_label: total
                 tolerance: 10
               config:
-                error_if: ">8472"
-              description: "Check if revenue of customer classes sums to total revenue. Note that this calculation is wrong for almost every borrower."
+                error_if: '>8472'
+              description: Check if revenue of customer classes sums to total revenue. Note that this calculation is wrong for almost every borrower.
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus7/core_rus7__yearly_statement_of_operations/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_statement_of_operations/schema.yml
@@ -12,7 +12,7 @@ sources:
                 min_ratio: 0.05
                 max_ratio: 0.2
               config:
-                error_if: ">46000"
+                error_if: '>46000'
               description: Monthly spending should roughly equal 1/12 of the YTD budget (5-20% range).
           - expect_columns_ratio:
               arguments:
@@ -21,82 +21,82 @@ sources:
                 min_ratio: 0.75
                 max_ratio: 1.25
               config:
-                error_if: ">42000"
+                error_if: '>42000'
               description: Budgeted spending and YTD spending should be roughly equivalent.
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_statement_of_operations
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
                 subcomponents_list:
-                  [
-                    "admin",
-                    "customer_accounts",
-                    "customer_service",
-                    "distribution_maintenance",
-                    "distribution_operation",
-                    "power_production",
-                    "purchased_power",
-                    "regional_market",
-                    "sales",
-                    "transmission",
-                  ]
-                total_label: "total"
+                  - admin
+                  - customer_accounts
+                  - customer_service
+                  - distribution_maintenance
+                  - distribution_operation
+                  - power_production
+                  - purchased_power
+                  - regional_market
+                  - sales
+                  - transmission
+                total_label: total
                 tolerance: 10
-              row_condition: "opex_group == 'opex'"
-              description: "Sum all opex expenses other than operating_revenue."
+              row_condition: opex_group == 'opex'
+              description: Sum all opex expenses other than operating_revenue.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
                 subcomponents_list:
-                  [
-                    "admin",
-                    "customer_accounts",
-                    "customer_service",
-                    "distribution_maintenance",
-                    "distribution_operation",
-                    "power_production",
-                    "purchased_power",
-                    "regional_market",
-                    "sales",
-                    "transmission",
-                  ]
-                total_label: "total"
+                  - admin
+                  - customer_accounts
+                  - customer_service
+                  - distribution_maintenance
+                  - distribution_operation
+                  - power_production
+                  - purchased_power
+                  - regional_market
+                  - sales
+                  - transmission
+                total_label: total
                 tolerance: 10
-              row_condition: "opex_group == 'opex'"
-              description: "Sum all opex expenses other than operating_revenue."
+              row_condition: opex_group == 'opex'
+              description: Sum all opex expenses other than operating_revenue.
               config:
-                error_if: ">74"
+                error_if: '>74'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
                 subcomponents_list:
-                  [
-                    "admin",
-                    "customer_accounts",
-                    "customer_service",
-                    "distribution_maintenance",
-                    "distribution_operation",
-                    "power_production",
-                    "purchased_power",
-                    "regional_market",
-                    "sales",
-                    "transmission",
-                  ]
-                total_label: "total"
+                  - admin
+                  - customer_accounts
+                  - customer_service
+                  - distribution_maintenance
+                  - distribution_operation
+                  - power_production
+                  - purchased_power
+                  - regional_market
+                  - sales
+                  - transmission
+                total_label: total
                 tolerance: 10
-              row_condition: "opex_group == 'opex'"
-              description: "Sum all opex expenses other than operating_revenue."
+              row_condition: opex_group == 'opex'
+              description: Sum all opex expenses other than operating_revenue.
               config:
-                error_if: ">70"
+                error_if: '>70'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -108,7 +108,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">6750"
+                    error_if: '>6750'
                   row_condition: opex_type != 'interest_charged_to_construction_credit' and opex_group != 'patronage_capital_or_margins'
           - name: opex_ytd
             data_tests:
@@ -116,7 +116,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1600"
+                    error_if: '>1600'
                   row_condition: opex_type != 'interest_charged_to_construction_credit' and opex_group != 'patronage_capital_or_margins'
           - name: opex_ytd_budget
             data_tests:
@@ -124,6 +124,6 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">810"
+                    error_if: '>810'
                   row_condition: opex_type != 'interest_charged_to_construction_credit' and opex_group != 'patronage_capital_or_margins'
           - name: is_total

--- a/dbt/models/rus7/core_rus7__yearly_utility_plant_changes/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_utility_plant_changes/schema.yml
@@ -8,20 +8,22 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_utility_plant_changes
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: ending_balance
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group='utility_plant_in_service'
           - dbt_utils.expression_is_true:
               arguments:
                 expression: retirements + additions + adjustments_and_transfers <= ending_balance
-              description: "Check that annual changes don't exceed ending balance."
+              description: Check that annual changes don't exceed ending balance.
               config:
-                error_if: ">62"
+                error_if: '>62'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -33,7 +35,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">11"
+                    error_if: '>11'
           - name: additions
           - name: adjustments_and_transfers
           - name: ending_balance

--- a/dbt/models/rus7/out_rus7__yearly_balance_sheet_assets/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_balance_sheet_assets/schema.yml
@@ -8,46 +8,49 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_balance_sheet_assets
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: asset_type
                 value_column: ending_balance
                 subcomponents_list:
-                  ["utility_plant_in_service", "construction_work_in_progress"]
-                total_label: "total_utility_plant"
+                  - utility_plant_in_service
+                  - construction_work_in_progress
+                total_label: total_utility_plant
                 tolerance: 10
               config:
-                error_if: ">545"
+                error_if: '>545'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: asset_type
                 value_column: ending_balance
                 subcomponents_list:
-                  [
-                    "cash_general_funds",
-                    "cash_construction_funds_trustee",
-                    "special_deposits",
-                    "investments_temporary",
-                    "notes_receivable",
-                    "accounts_receivable_other",
-                    "accounts_receivable_sales_of_energy",
-                    "renewable_energy_credits",
-                    "materials_and_supplies",
-                    "prepayments",
-                    "other_current_and_accrued",
-                  ]
-                total_label: "total_current_and_accrued"
+                  - cash_general_funds
+                  - cash_construction_funds_trustee
+                  - special_deposits
+                  - investments_temporary
+                  - notes_receivable
+                  - accounts_receivable_other
+                  - accounts_receivable_sales_of_energy
+                  - renewable_energy_credits
+                  - materials_and_supplies
+                  - prepayments
+                  - other_current_and_accrued
+                total_label: total_current_and_accrued
                 tolerance: 10
               config:
-                error_if: ">5"
+                error_if: '>5'
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: asset_type
           - name: ending_balance
           - name: is_total

--- a/dbt/models/rus7/out_rus7__yearly_balance_sheet_liabilities/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_balance_sheet_liabilities/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_balance_sheet_liabilities
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: liability_type
           - name: ending_balance
           - name: is_total

--- a/dbt/models/rus7/out_rus7__yearly_customer_energy_efficiency_and_conservation_loans/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_customer_energy_efficiency_and_conservation_loans/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_customer_energy_efficiency_and_conservation_loans
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: loan_status
           - name: actual_pct
             data_tests:
@@ -22,7 +22,7 @@ sources:
                     min_value: 0.0
                     max_value: 100.0
                   config:
-                    error_if: ">1"
+                    error_if: '>1'
           - name: anticipated_pct
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -30,7 +30,7 @@ sources:
                     min_value: 0.0
                     max_value: 100.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
           - name: ytd_dollars
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/rus7/out_rus7__yearly_distribution_services/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_distribution_services/schema.yml
@@ -8,13 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_distribution_services
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
-        # TODO: VALIDATE STATUSES SUM TO TOTAL
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: service_status
           - name: services
             data_tests:
@@ -22,5 +21,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">3"
+                    error_if: '>3'
           - name: is_total

--- a/dbt/models/rus7/out_rus7__yearly_employee_statistics/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_employee_statistics/schema.yml
@@ -21,12 +21,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_employee_statistics
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: employees_fte_num
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -38,8 +38,8 @@ sources:
                     order_by: report_date
                     max_pct_change: 0.3
                   config:
-                    warn_if: ">0"
-                    error_if: ">50"
+                    warn_if: '>0'
+                    error_if: '>50'
           - name: employee_hours_worked_regular_time
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -51,8 +51,8 @@ sources:
                     order_by: report_date
                     max_pct_change: 0.3
                   config:
-                    warn_if: ">0"
-                    error_if: ">50"
+                    warn_if: '>0'
+                    error_if: '>50'
           - name: employee_hours_worked_over_time
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -69,8 +69,8 @@ sources:
                     order_by: report_date
                     max_pct_change: 0.5
                   config:
-                    warn_if: ">0"
-                    error_if: ">100"
+                    warn_if: '>0'
+                    error_if: '>100'
           - name: payroll_capitalized
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -82,8 +82,8 @@ sources:
                     order_by: report_date
                     max_pct_change: 0.5
                   config:
-                    warn_if: ">0"
-                    error_if: ">300"
+                    warn_if: '>0'
+                    error_if: '>300'
           - name: payroll_other
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/models/rus7/out_rus7__yearly_energy_efficiency/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_energy_efficiency/schema.yml
@@ -8,40 +8,46 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_energy_efficiency
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, observation_period]
+                  - borrower_id_rus
+                  - report_date
+                  - observation_period
                 categorical_column: customer_class
                 value_column: customers_num
-                total_label: "total"
+                total_label: total
                 tolerance: 0
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, observation_period]
+                  - borrower_id_rus
+                  - report_date
+                  - observation_period
                 categorical_column: customer_class
                 value_column: invested
-                total_label: "total"
+                total_label: total
                 tolerance: 1
               config:
-                error_if: ">6"
+                error_if: '>6'
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, observation_period]
+                  - borrower_id_rus
+                  - report_date
+                  - observation_period
                 categorical_column: customer_class
                 value_column: savings_mmbtu
-                total_label: "total"
+                total_label: total
                 tolerance: 1
               config:
-                error_if: ">11"
+                error_if: '>11'
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: customer_class
           - name: observation_period
           - name: customers_num
@@ -61,5 +67,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">8"
+                    error_if: '>8'
                   description: KS0059 has negative values which don't follow from prior years of data.

--- a/dbt/models/rus7/out_rus7__yearly_energy_purchased/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_energy_purchased/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_energy_purchased
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -21,7 +21,7 @@ sources:
                     min_value: 0.0
                   row_condition: utility_name_eia != '*Adjustments'
                   config:
-                    error_if: ">33"
+                    error_if: '>33'
           - name: purchased_energy_cost_total
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -29,7 +29,7 @@ sources:
                     min_value: 0.0
                   row_condition: utility_name_eia != '*Adjustments'
                   config:
-                    error_if: ">99"
+                    error_if: '>99'
           - name: average_energy_cost_dollars_per_mwh
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -37,7 +37,7 @@ sources:
                     min_value: 0.0
                   row_condition: utility_name_eia != '*Adjustments'
                   config:
-                    error_if: ">30"
+                    error_if: '>30'
           - name: wheeling_and_other_charges
           - name: fuel_cost_adjustment
           - name: fuel_type_code_rus

--- a/dbt/models/rus7/out_rus7__yearly_external_financial_risk_ratio/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_external_financial_risk_ratio/schema.yml
@@ -8,16 +8,16 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_external_financial_risk_ratio
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: external_financial_risk_ratio
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">18" # TODO: Investigate negative original loan amount values
+                    error_if: '>18'

--- a/dbt/models/rus7/out_rus7__yearly_investments/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_investments/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_investments
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: investment_description
           - name: investment_type_code
           - name: included_investments

--- a/dbt/models/rus7/out_rus7__yearly_loans/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_loans/schema.yml
@@ -9,25 +9,25 @@ sources:
               arguments:
                 column_A: loan_original_amount
                 column_B: loan_balance
-                or_equal: True
+                or_equal: true
               config:
-                error_if: ">38" # TODO: Investigate cases where loan balance exceeds original amount.
-              description: "The original amount of the loan guarantee should be greater than or equal to the current balance of the loan."
+                error_if: '>38'
+              description: The original amount of the loan guarantee should be greater than or equal to the current balance of the loan.
           - dbt_utils.expression_is_true:
               arguments:
                 expression: date_trunc('year', report_date) <= date_trunc('year', loan_maturity_date)
               config:
-                error_if: ">58"
-              description: "The report date year should be before or equal to the loan maturity date year."
+                error_if: '>58'
+              description: The report date year should be before or equal to the loan maturity date year.
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_loans
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: loan_recipient
           - name: loan_balance
             data_tests:
@@ -35,7 +35,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">4" # TODO: Investigate negative loan balance values
+                    error_if: '>4'
           - name: loan_maturity_date
           - name: loan_original_amount
             data_tests:
@@ -43,6 +43,6 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1" # TODO: Investigate negative original loan amount values
+                    error_if: '>1'
           - name: for_rural_development
           - name: is_loan_guarantee

--- a/dbt/models/rus7/out_rus7__yearly_long_term_debt/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_long_term_debt/schema.yml
@@ -9,17 +9,17 @@ sources:
               arguments:
                 expression: debt_interest + debt_principal = debt_total
               config:
-                error_if: ">5"
+                error_if: '>5'
               description: Examine a few cases where interest + principal != total
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_long_term_debt
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: debt_description
           - name: debt_ending_balance
             data_tests:
@@ -27,7 +27,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">38"
+                    error_if: '>38'
                   description: Investigate negative values.
           - name: debt_interest
             data_tests:
@@ -35,7 +35,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">11"
+                    error_if: '>11'
                   description: Investigate negative values.
           - name: debt_principal
             data_tests:
@@ -48,5 +48,5 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">5"
+                    error_if: '>5'
                   description: Investigate negative values.

--- a/dbt/models/rus7/out_rus7__yearly_long_term_leases/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_long_term_leases/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_long_term_leases
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: lending_organization
           - name: property_type
           - name: rental_cost_ytd

--- a/dbt/models/rus7/out_rus7__yearly_materials_and_supplies/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_materials_and_supplies/schema.yml
@@ -8,13 +8,13 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_materials_and_supplies
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - dbt_utils.expression_is_true:
               arguments:
                 expression: materials_purchased + materials_salvaged - materials_sold - materials_used + materials_adjustment <= materials_ending_balance
-              description: "Check that annual changes don't exceed ending balance."
+              description: Check that annual changes don't exceed ending balance.
               config:
-                error_if: ">3"
+                error_if: '>3'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -28,32 +28,32 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">12"
+                    error_if: '>12'
           - name: materials_purchased
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
           - name: materials_salvaged
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">16"
+                    error_if: '>16'
           - name: materials_sold
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">7"
+                    error_if: '>7'
           - name: materials_used
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">4"
+                    error_if: '>4'

--- a/dbt/models/rus7/out_rus7__yearly_meeting_and_board/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_meeting_and_board/schema.yml
@@ -9,7 +9,7 @@ sources:
               arguments:
                 expression: date_trunc('month', report_date) >= date_trunc('month', last_annual_meeting_date)
               config:
-                error_if: ">7"
+                error_if: '>7'
               description: Some utilities report meetings after the date range of the filing.
           - expect_summed_columns_not_exceed_threshold:
               arguments:
@@ -18,17 +18,17 @@ sources:
                 threshold_column: members_num
                 multiplier: 1
               config:
-                error_if: ">2"
+                error_if: '>2'
               description: MO0066 reports two bad values for 2020 and 2021.
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_meeting_and_board
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: last_annual_meeting_date
           - name: members_num
             data_tests:

--- a/dbt/models/rus7/out_rus7__yearly_owed_by_customers/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_owed_by_customers/schema.yml
@@ -8,11 +8,11 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_owed_by_customers
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: amount_due_over_60_days
           - name: amount_written_off_ytd

--- a/dbt/models/rus7/out_rus7__yearly_patronage_capital/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_patronage_capital/schema.yml
@@ -11,69 +11,69 @@ sources:
                 column_B: patronage_report_year
                 or_equal: true
               config:
-                error_if: ">14"
+                error_if: '>14'
               description: Some 0 cumulative values and a handful of other values causing failure. Investigate.
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_patronage_capital
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: patronage_type
                 value_column: patronage_cumulative
                 subcomponents_list:
-                  [
-                    "distributions_general_retirements",
-                    "distributions_special_retirements",
-                  ]
-                total_label: "total_distributions_retirements"
+                  - distributions_general_retirements
+                  - distributions_special_retirements
+                total_label: total_distributions_retirements
                 tolerance: 1
               config:
-                error_if: ">435"
+                error_if: '>435'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: patronage_type
                 value_column: patronage_report_year
                 subcomponents_list:
-                  [
-                    "distributions_general_retirements",
-                    "distributions_special_retirements",
-                  ]
-                total_label: "total_distributions_retirements"
+                  - distributions_general_retirements
+                  - distributions_special_retirements
+                total_label: total_distributions_retirements
                 tolerance: 1
               config:
-                error_if: ">1"
+                error_if: '>1'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: patronage_type
                 value_column: patronage_cumulative
                 subcomponents_list:
-                  [
-                    "received_lenders_of_electric_power",
-                    "received_supplier_of_electric_power",
-                  ]
-                total_label: "total_received"
+                  - received_lenders_of_electric_power
+                  - received_supplier_of_electric_power
+                total_label: total_received
                 tolerance: 1
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: patronage_type
                 value_column: patronage_report_year
                 subcomponents_list:
-                  [
-                    "received_lenders_of_electric_power",
-                    "received_supplier_of_electric_power",
-                  ]
-                total_label: "total_received"
+                  - received_lenders_of_electric_power
+                  - received_supplier_of_electric_power
+                total_label: total_received
                 tolerance: 1
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: patronage_type
           - name: patronage_report_year
             data_tests:
@@ -81,7 +81,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">2"
+                    error_if: '>2'
                   description: FL0026 and OH0071 each report one negative value. Investigate.
           - name: patronage_cumulative
             data_tests:

--- a/dbt/models/rus7/out_rus7__yearly_power_requirements/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_power_requirements/schema.yml
@@ -8,12 +8,12 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_power_requirements
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: electric_sales_revenue
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
@@ -30,7 +30,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">400"
+                    error_if: '>400'
                   description: Commonly violated (~5% of data).
           - name: purchases_and_generation_cost
             data_tests:
@@ -58,7 +58,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">6"
+                    error_if: '>6'
                   description: VA0039 reports 4 negative generations, two other companies in 2006. Investigate.
           - name: interchange_mwh
             data_tests:

--- a/dbt/models/rus7/out_rus7__yearly_power_requirements_electric_customers/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_power_requirements_electric_customers/schema.yml
@@ -8,20 +8,22 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_power_requirements_electric_customers
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
-                  [borrower_id_rus, report_date, observation_period]
+                  - borrower_id_rus
+                  - report_date
+                  - observation_period
                 categorical_column: customer_class
                 value_column: customers_num
-                total_label: "total"
+                total_label: total
                 tolerance: 0
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: customer_class
           - name: observation_period
           - name: customers_num

--- a/dbt/models/rus7/out_rus7__yearly_power_requirements_electric_sales/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_power_requirements_electric_sales/schema.yml
@@ -8,29 +8,33 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_power_requirements_electric_sales
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: customer_class
                 value_column: sales_mwh
-                total_label: "total"
+                total_label: total
                 tolerance: 1
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: customer_class
                 value_column: revenue
-                total_label: "total"
+                total_label: total
                 tolerance: 10
               config:
-                error_if: ">8472"
-              description: "Check if revenue of customer classes sums to total revenue. Note that this calculation is wrong for almost every borrower."
+                error_if: '>8472'
+              description: Check if revenue of customer classes sums to total revenue. Note that this calculation is wrong for almost every borrower.
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: customer_class
           - name: sales_mwh
             data_tests:

--- a/dbt/models/rus7/out_rus7__yearly_statement_of_operations/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_statement_of_operations/schema.yml
@@ -12,7 +12,7 @@ sources:
                 min_ratio: 0.05
                 max_ratio: 0.2
               config:
-                error_if: ">46000"
+                error_if: '>46000'
               description: Monthly spending should roughly equal 1/12 of the YTD budget (5-20% range).
           - expect_columns_ratio:
               arguments:
@@ -21,87 +21,87 @@ sources:
                 min_ratio: 0.75
                 max_ratio: 1.25
               config:
-                error_if: ">42000"
+                error_if: '>42000'
               description: Budgeted spending and YTD spending should be roughly equivalent.
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_statement_of_operations
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_report_month
                 subcomponents_list:
-                  [
-                    "admin",
-                    "customer_accounts",
-                    "customer_service",
-                    "distribution_maintenance",
-                    "distribution_operation",
-                    "power_production",
-                    "purchased_power",
-                    "regional_market",
-                    "sales",
-                    "transmission",
-                  ]
-                total_label: "total"
+                  - admin
+                  - customer_accounts
+                  - customer_service
+                  - distribution_maintenance
+                  - distribution_operation
+                  - power_production
+                  - purchased_power
+                  - regional_market
+                  - sales
+                  - transmission
+                total_label: total
                 tolerance: 10
-              row_condition: "opex_group == 'opex'"
-              description: "Sum all opex expenses other than operating_revenue."
+              row_condition: opex_group == 'opex'
+              description: Sum all opex expenses other than operating_revenue.
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd
                 subcomponents_list:
-                  [
-                    "admin",
-                    "customer_accounts",
-                    "customer_service",
-                    "distribution_maintenance",
-                    "distribution_operation",
-                    "power_production",
-                    "purchased_power",
-                    "regional_market",
-                    "sales",
-                    "transmission",
-                  ]
-                total_label: "total"
+                  - admin
+                  - customer_accounts
+                  - customer_service
+                  - distribution_maintenance
+                  - distribution_operation
+                  - power_production
+                  - purchased_power
+                  - regional_market
+                  - sales
+                  - transmission
+                total_label: total
                 tolerance: 10
-              row_condition: "opex_group == 'opex'"
-              description: "Sum all opex expenses other than operating_revenue."
+              row_condition: opex_group == 'opex'
+              description: Sum all opex expenses other than operating_revenue.
               config:
-                error_if: ">74"
+                error_if: '>74'
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: opex_type
                 value_column: opex_ytd_budget
                 subcomponents_list:
-                  [
-                    "admin",
-                    "customer_accounts",
-                    "customer_service",
-                    "distribution_maintenance",
-                    "distribution_operation",
-                    "power_production",
-                    "purchased_power",
-                    "regional_market",
-                    "sales",
-                    "transmission",
-                  ]
-                total_label: "total"
+                  - admin
+                  - customer_accounts
+                  - customer_service
+                  - distribution_maintenance
+                  - distribution_operation
+                  - power_production
+                  - purchased_power
+                  - regional_market
+                  - sales
+                  - transmission
+                total_label: total
                 tolerance: 10
-              row_condition: "opex_group == 'opex'"
-              description: "Sum all opex expenses other than operating_revenue."
+              row_condition: opex_group == 'opex'
+              description: Sum all opex expenses other than operating_revenue.
               config:
-                error_if: ">70"
+                error_if: '>70'
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: opex_group
           - name: opex_type
           - name: opex_report_month
@@ -110,7 +110,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">6750"
+                    error_if: '>6750'
                   row_condition: opex_type != 'interest_charged_to_construction_credit' and opex_group != 'patronage_capital_or_margins'
           - name: opex_ytd
             data_tests:
@@ -118,7 +118,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1600"
+                    error_if: '>1600'
                   row_condition: opex_type != 'interest_charged_to_construction_credit' and opex_group != 'patronage_capital_or_margins'
           - name: opex_ytd_budget
             data_tests:
@@ -126,6 +126,6 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">810"
+                    error_if: '>810'
                   row_condition: opex_type != 'interest_charged_to_construction_credit' and opex_group != 'patronage_capital_or_margins'
           - name: is_total

--- a/dbt/models/rus7/out_rus7__yearly_utility_plant_changes/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_utility_plant_changes/schema.yml
@@ -8,20 +8,22 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_utility_plant_changes
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
           - subcomponents_sum_to_total:
               arguments:
-                group_by_columns: [borrower_id_rus, report_date]
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
                 categorical_column: utility_plant_group
                 value_column: ending_balance
-                total_label: "total"
+                total_label: total
               row_condition: utility_plant_group='utility_plant_in_service'
           - dbt_utils.expression_is_true:
               arguments:
                 expression: retirements + additions + adjustments_and_transfers <= ending_balance
-              description: "Check that annual changes don't exceed ending balance."
+              description: Check that annual changes don't exceed ending balance.
               config:
-                error_if: ">62"
+                error_if: '>62'
         columns:
           - name: report_date
           - name: borrower_id_rus
@@ -35,7 +37,7 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">11"
+                    error_if: '>11'
           - name: additions
           - name: adjustments_and_transfers
           - name: ending_balance

--- a/dbt/models/sec10k/core_sec10k__quarterly_company_information/schema.yml
+++ b/dbt/models/sec10k/core_sec10k__quarterly_company_information/schema.yml
@@ -11,14 +11,14 @@ sources:
                 partition_expr:
         columns:
           - name: filename_sec10k
-          - name: filer_count
           - name: central_index_key
+          - name: filer_count
           - name: company_name
           - name: fiscal_year_end
             data_tests:
               - dbt_expectations.expect_column_values_to_match_regex:
                   arguments:
-                    regex: '^(?:(?:0[1-9]|1[0-2])(?:0[1-9]|1\d|2\d|3[01])|(?:0[13-9]|1[0-2])(?:29|30)|(?:0[13578]|1[02])31)$'
+                    regex: ^(?:(?:0[1-9]|1[0-2])(?:0[1-9]|1\d|2\d|3[01])|(?:0[13-9]|1[0-2])(?:29|30)|(?:0[13578]|1[02])31)$
                     is_raw: true
           - name: taxpayer_id_irs
           - name: incorporation_state

--- a/dbt/models/sec10k/core_sec10k__quarterly_exhibit_21_company_ownership/schema.yml
+++ b/dbt/models/sec10k/core_sec10k__quarterly_exhibit_21_company_ownership/schema.yml
@@ -12,5 +12,5 @@ sources:
           - name: filename_sec10k
           - name: subsidiary_company_name
           - name: subsidiary_company_location
-          - name: fraction_owned
           - name: subsidiary_company_id_sec10k
+          - name: fraction_owned

--- a/dbt/models/sec10k/core_sec10k__quarterly_filings/schema.yml
+++ b/dbt/models/sec10k/core_sec10k__quarterly_filings/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_sec10k__quarterly_filings
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: filename_sec10k
           - name: central_index_key

--- a/dbt/models/sec10k/out_sec10k__parents_and_subsidiaries/schema.yml
+++ b/dbt/models/sec10k/out_sec10k__parents_and_subsidiaries/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_sec10k__parents_and_subsidiaries
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: filename_sec10k
           - name: subsidiary_company_name

--- a/dbt/models/sec10k/out_sec10k__quarterly_company_information/schema.yml
+++ b/dbt/models/sec10k/out_sec10k__quarterly_company_information/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_sec10k__quarterly_company_information
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: filename_sec10k
           - name: central_index_key
@@ -22,7 +22,7 @@ sources:
             data_tests:
               - dbt_expectations.expect_column_values_to_match_regex:
                   arguments:
-                    regex: '^(?:(?:0[1-9]|1[0-2])(?:0[1-9]|1\d|2\d|3[01])|(?:0[13-9]|1[0-2])(?:29|30)|(?:0[13578]|1[02])31)$'
+                    regex: ^(?:(?:0[1-9]|1[0-2])(?:0[1-9]|1\d|2\d|3[01])|(?:0[13-9]|1[0-2])(?:29|30)|(?:0[13578]|1[02])31)$
                     is_raw: true
           - name: taxpayer_id_irs
           - name: incorporation_state

--- a/dbt/models/sec10k/out_sec10k__quarterly_filings/schema.yml
+++ b/dbt/models/sec10k/out_sec10k__quarterly_filings/schema.yml
@@ -8,7 +8,7 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_sec10k__quarterly_filings
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
+                partition_expr: EXTRACT(YEAR FROM report_date)
         columns:
           - name: filename_sec10k
           - name: central_index_key

--- a/dbt/models/vcerare/out_vcerare__hourly_available_capacity_factor/schema.yml
+++ b/dbt/models/vcerare/out_vcerare__hourly_available_capacity_factor/schema.yml
@@ -15,7 +15,7 @@ sources:
                 column_list:
                   - county_id_fips
                   - datetime_utc
-                ignore_row_if: "any_value_is_missing"
+                ignore_row_if: any_value_is_missing
         columns:
           - name: state
             data_tests:
@@ -34,14 +34,14 @@ sources:
                   arguments:
                     value_set:
                       - oglala lakota
-                    row_condition: "county_id_fips = '46012'"
+                    row_condition: county_id_fips = '46012'
           - name: datetime_utc
             data_tests:
               - not_null
               - dbt_expectations.expect_column_values_to_not_be_in_set:
                   arguments:
                     value_set:
-                      - "{{ dbt_date.date(2020, 12, 31) }}"
+                      - '{{ dbt_date.date(2020, 12, 31) }}'
           - name: report_year
             data_tests:
               - not_null

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -429,6 +429,7 @@ resource_description = "pudl.scripts.resource_description:main"
 update_zenodo_dois = "pudl.scripts.update_zenodo_dois:main"
 zenodo_data_release = "pudl.scripts.zenodo_data_release:main"
 generate_ferc_provenance = "pudl.scripts.generate_ferc_provenance:main"
+what_tables = "pudl.scripts.what_tables:main"
 
 [tool.ruff]
 # Configurations that apply to both the `format` and `lint` subcommands.

--- a/src/pudl/dbt_schema.py
+++ b/src/pudl/dbt_schema.py
@@ -42,14 +42,26 @@ def _prettier_yaml_dumps(yaml_contents: dict[str, Any]) -> str:
         def increase_indent(self, flow=False, indentless=False):
             return super().increase_indent(flow, False)
 
-    return yaml.dump(
-        yaml_contents,
-        default_flow_style=False,
-        Dumper=PrettierCompatibleDumper,
-        indent=2,
-        sort_keys=False,
-        width=float("inf"),
-    )
+    class BlankNullRepresenter(yaml.representer.Representer):
+        def represent_none(self, *_):
+            return self.represent_scalar("tag:yaml.org,2002:null", "")
+
+        def __enter__(self):
+            self.prior = PrettierCompatibleDumper.yaml_representers[type(None)]
+            yaml.add_representer(type(None), self.represent_none)
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            PrettierCompatibleDumper.yaml_representers[type(None)] = self.prior
+
+    with BlankNullRepresenter():
+        return yaml.dump(
+            yaml_contents,
+            default_flow_style=False,
+            Dumper=PrettierCompatibleDumper,
+            indent=2,
+            sort_keys=False,
+            width=float("inf"),
+        )
 
 
 class DbtColumn(BaseModel):

--- a/src/pudl/scripts/what_tables.py
+++ b/src/pudl/scripts/what_tables.py
@@ -1,0 +1,41 @@
+"""Tiny CLI for telling you the table names defined in a particular resource metadata file."""
+
+import importlib
+import re
+import sys
+
+import click
+
+IS_RESOURCE_FILE = re.compile(r"[a-z0-9_]+\.py")
+
+
+@click.command(
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.argument("names", nargs=-1)
+def main(names: tuple[str]) -> int:
+    """Compute and display the tables whose metadata is defined in each file provided.
+
+    Each NAME should be a file in src/pudl/metadata/resources that defines metadata for a set of tables, e.g., eia.py.
+
+    Useful when figuring out what dbt schema files need to be rebuilt.
+    """
+    modules = []
+    # validate args so we don't try to import something hinky
+    for name in names:
+        _, _, name = name.rpartition("/")
+        if not IS_RESOURCE_FILE.match(name):
+            click.echo(
+                f"{name} not a resource file. Looking for a single filename, or a full path, ending in .py"
+            )
+            return 0
+        modules.append(name[:-3])
+
+    for mod in modules:
+        module = importlib.import_module(f"pudl.metadata.resources.{mod}")
+        click.echo("\n".join(module.RESOURCE_METADATA.keys()))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/dbt_schema_round_trip_test.py
+++ b/tests/integration/dbt_schema_round_trip_test.py
@@ -23,7 +23,7 @@ def test_merge_schema_roundtrip(resource_name):
     merged = merge_schema(machine_schema, human_schema)
     try:
         assert merged == reference
-    except AssertionError:
+    except AssertionError as e:
         # 2026-05 TODO: remove this warn and fail for real once we believe the ordering is stable
         warnings.warn(
             f"{resource_name} strict diff failed, trying order-insensitive",
@@ -32,4 +32,7 @@ def test_merge_schema_roundtrip(resource_name):
         diff = deepdiff.DeepDiff(
             merged, reference, ignore_order=True, report_repetition=True
         )
-        assert diff == {}
+        assert diff == {}, f"Strict and lax diff failed for {resource_name}"
+        raise AssertionError(
+            f"Strict diff failed for {resource_name} but lax diff was okay"
+        ) from e

--- a/tests/unit/dbt_schema_test.py
+++ b/tests/unit/dbt_schema_test.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 import pytest
 import yaml
 
-from pudl.dbt_schema import DbtSchema, merge_schema
+from pudl.dbt_schema import DbtSchema, _prettier_yaml_dumps, merge_schema
 
 
 def _schema_from_yaml(schema_yaml: str) -> DbtSchema:
@@ -249,3 +249,17 @@ def test_validate_humanity_invalid(schema_yaml, match):
     """Fail humanity check when specifying structures not permitted for humans."""
     with pytest.raises(AssertionError, match=match):
         _schema_from_yaml(schema_yaml).validate_humanity()
+
+
+def test__prettier_yaml_dumps():
+    """Ensure our yaml hacks for dbt_schema don't contaminate other yaml-ful processes in the codebase."""
+    has_null = {"a": None}
+
+    # default yaml dump behavior
+    assert yaml.dump(has_null).find("a: null") >= 0
+
+    # our custom yaml dump behavior
+    assert _prettier_yaml_dumps(has_null).find("a: null") < 0
+
+    # revert to default
+    assert yaml.dump(has_null).find("a: null") >= 0


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://docs.catalyst.coop/pudl/en/nightly/CONTRIBUTING.html
* code of conduct: https://docs.catalyst.coop/pudl/en/nightly/code_of_conduct.html
-->

# Overview

Closes #5268.

## What problem does this address?

* you have to remember to `dbt_helper update-tables --schema` with your human brain whenever you change a table schema or human-tended dbt tests
* dbt schema ordering differed from metadata schema ordering for some tables

## What did you change?

* add a pre-commit hook to regenerate affected dbt schema files when a metadata resource file is touched or a human-tended dbt schema stem is touched
* move over hashtag comments from dbt schema files whose ordering differs from that specified in metadata resource files, since they would be immediately lost on first hook
* add a null representer to our prettier yaml dumper to reduce differences between generated and hand-built yaml files
* regenerate dbt schema files whose ordering differs from that specified in metadata resource files so that the round-trip strict diffs pass
* fail round-trip test strict diffs

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://docs.catalyst.coop/pudl/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

* Add a comment to a metadata resource file
* `git add` the change
* `pixi run prek run schema-check`
* Only tables mentioned in the resource file are regenerated
* No schema files actually modified ⬅️ TODO

## To-do list

- [x] Try a little bit hard to resolve issues with this implementation:
  - [x] Regenerating *all* the schema files whenever *one* resource or human-tended file is touched takes a while and doesn't seem worth it
  - [x] When the hook runs it always fails the commit, even if the generated schema files exactly match what's already there
- [ ] **Critical:** Drop [e2f08ed](https://github.com/catalyst-cooperative/pudl/pull/5269/commits/e2f08ed1f8db9c8066afbef874d2025aa1a8f7d6), transfer all the other hashtag comments from all the other schema files, and push --force
- [ ] explore a small followup hook to scream if it finds hashtag comments in schema.yml

Remaining boilerplate

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run prek-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://docs.catalyst.coop/pudl/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
