### PR TITLE
Add DBF datapackage

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -24,6 +24,8 @@ Enhancements
   asset check on any datapackage output. See issues :issue:`5122,5237` and PR
   :pr:`5270`. Also makes progress towards `catalyst-cooperative/agent-skills#14
   <https://github.com/catalyst-cooperative/agent-skills/issues/14>`__
+* Added a bare-bones datapackage for DBF SQLite outputs. See issue :issue:`5200`
+  and PR :pr:`5275`.
 
 New Data
 ^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,6 @@ usaddress = ">=0.5.16,<0.6"
 uv = ">=0.11"
 xlsxwriter = ">=3.2"
 zip = ">=3.0"
-dbf = ">=0.99.11,<0.100"
 
 [tool.pixi.pypi-dependencies]
 # Install the local package in editable mode. Assume dependencies are specified either

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,7 @@ usaddress = ">=0.5.16,<0.6"
 uv = ">=0.11"
 xlsxwriter = ">=3.2"
 zip = ">=3.0"
+dbf = ">=0.99.11,<0.100"
 
 [tool.pixi.pypi-dependencies]
 # Install the local package in editable mode. Assume dependencies are specified either

--- a/src/pudl/extract/dbf.py
+++ b/src/pudl/extract/dbf.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterator
 from functools import lru_cache
 from pathlib import Path
+from pydantic import BaseModel, Field
 from typing import IO, Any, Protocol, Self
 
 import pandas as pd
@@ -466,6 +467,10 @@ class FercDbfExtractor:
         """Returns the connection string for the sqlite database."""
         db_path = str(Path(self.output_path) / self.DATABASE_NAME)
         return f"sqlite:///{db_path}"
+    
+    def get_datapackage_path(self) -> Path:
+        """Returns the path to the datapackage for this resource."""
+        return Path(self.output_path) / f"{self.DATASET}_dbf_datapackage.json"
 
     @classmethod
     def get_dagster_op(cls) -> Callable:
@@ -505,6 +510,39 @@ class FercDbfExtractor:
         self.create_sqlite_tables()
         self.load_table_data()
         self.postprocess()
+
+    def as_pydantic(self):
+        """Generate a pydantic model based on the database schema."""
+        resources = []
+        for table in self.sqlite_meta.sorted_tables():
+            resources.append(Resource(
+                path=self.get_db_path(),
+                name=table.name,
+                dialect=Dialect(table=table.name),
+                title="??",
+                description=table.description,
+                schema=Schema(
+                    fields=[
+                        Field(
+                            name=c.name,
+                            type=c.type,
+                        )
+                        for c in table.columns
+                    ]
+                )
+            ))
+        
+        return Datapackage(
+            name=f"{self.DATASET}-extracted-dbf",
+            title=f"{self.DATASET} data extracted from DBF filings",
+            resources=resources
+        )
+        package = create_model(
+            profile=(str, "tabular-data-package"),
+            name=(str, f"{self.DATASET}-extracted-dbf"),
+            title=(str,f"{self.DATASET} data extracted from DBF filings"),
+            resources=(list[Resource],resources)
+        )
 
     def delete_schema(self):
         """Drops all tables from the existing sqlite database."""
@@ -665,3 +703,44 @@ def deduplicate_by_year(
         .drop_duplicates(subset=pk_column, keep="last")
         .drop(columns="report_yr")
     )
+
+class Field(BaseModel):
+    """A generic field descriptor, as per Frictionless Data specs.
+
+    See https://specs.frictionlessdata.io/table-schema/#field-descriptors.
+    """
+
+    name: str
+    type_: str = Field(alias="type", default="string")
+    format_: str = Field(alias="format", default="default")
+
+class Schema(BaseModel):
+    """A generic table schema, as per Frictionless Data specs.
+
+    See https://specs.frictionlessdata.io/table-schema/.
+    """
+
+    fields: list[Field]
+    primary_key: list[str]
+
+class Dialect(BaseModel):
+    """Dialect used for frictionless SQL resources."""
+
+    table: str
+
+class Resource(BaseModel):
+    path: str
+    profile: str = "tabular-data-resource"
+    name: str
+    dialect: Dialect
+    title: str
+    description: str
+    format_: str = Field(alias="format", default="sqlite")
+    mediatype: str = "application/vnd.sqlite3"
+    schema_: Schema = Field(alias="schema")
+
+class Datapackage(BaseModel):
+    profile: str = "tabular-data-package"
+    name: str
+    title: str
+    resources: list[Resource]

--- a/src/pudl/extract/dbf.py
+++ b/src/pudl/extract/dbf.py
@@ -9,13 +9,13 @@ from collections import defaultdict
 from collections.abc import Callable, Iterator
 from functools import lru_cache
 from pathlib import Path
-from pydantic import BaseModel, Field
 from typing import IO, Any, Protocol, Self
 
 import pandas as pd
 import sqlalchemy as sa
 from dagster import op
 from dbfread import DBF, FieldParser
+from pydantic import BaseModel, Field
 from sqlalchemy.engine.base import Engine
 
 import pudl.helpers
@@ -467,7 +467,7 @@ class FercDbfExtractor:
         """Returns the connection string for the sqlite database."""
         db_path = str(Path(self.output_path) / self.DATABASE_NAME)
         return f"sqlite:///{db_path}"
-    
+
     def get_datapackage_path(self) -> Path:
         """Returns the path to the datapackage for this resource."""
         return Path(self.output_path) / f"{self.DATASET}_dbf_datapackage.json"
@@ -511,38 +511,44 @@ class FercDbfExtractor:
         self.load_table_data()
         self.postprocess()
 
+    # TODO: who should call as_pydantic?
     def as_pydantic(self):
         """Generate a pydantic model based on the database schema."""
         resources = []
         for table in self.sqlite_meta.sorted_tables():
-            resources.append(Resource(
-                path=self.get_db_path(),
-                name=table.name,
-                dialect=Dialect(table=table.name),
-                title="??",
-                description=table.description,
-                schema=Schema(
-                    fields=[
-                        Field(
-                            name=c.name,
-                            type=c.type,
-                        )
-                        for c in table.columns
-                    ]
+            resources.append(
+                Resource(
+                    path=self.get_db_path(),
+                    name=table.name,
+                    dialect=Dialect(table=table.name),
+                    # TODO: what is in table.description?
+                    # should title be table.description, and description be empty?
+                    title="??",
+                    description=table.description,
+                    schema=Schema(
+                        fields=[
+                            Field(
+                                name=c.name,
+                                type=c.type,
+                            )
+                            for c in table.columns
+                        ]
+                    ),
                 )
-            ))
-        
+            )
+
         return Datapackage(
             name=f"{self.DATASET}-extracted-dbf",
             title=f"{self.DATASET} data extracted from DBF filings",
-            resources=resources
+            resources=resources,
         )
-        package = create_model(
-            profile=(str, "tabular-data-package"),
-            name=(str, f"{self.DATASET}-extracted-dbf"),
-            title=(str,f"{self.DATASET} data extracted from DBF filings"),
-            resources=(list[Resource],resources)
-        )
+        ## Alt approach: dynamic model definition
+        # package = create_model(
+        #     profile=(str, "tabular-data-package"),
+        #     name=(str, f"{self.DATASET}-extracted-dbf"),
+        #     title=(str,f"{self.DATASET} data extracted from DBF filings"),
+        #     resources=(list[Resource],resources)
+        # )
 
     def delete_schema(self):
         """Drops all tables from the existing sqlite database."""
@@ -704,6 +710,7 @@ def deduplicate_by_year(
         .drop(columns="report_yr")
     )
 
+
 class Field(BaseModel):
     """A generic field descriptor, as per Frictionless Data specs.
 
@@ -714,6 +721,7 @@ class Field(BaseModel):
     type_: str = Field(alias="type", default="string")
     format_: str = Field(alias="format", default="default")
 
+
 class Schema(BaseModel):
     """A generic table schema, as per Frictionless Data specs.
 
@@ -723,23 +731,35 @@ class Schema(BaseModel):
     fields: list[Field]
     primary_key: list[str]
 
+
 class Dialect(BaseModel):
     """Dialect used for frictionless SQL resources."""
 
     table: str
 
+
 class Resource(BaseModel):
+    """Resource schema for sqlite, as per Frictionless Data specs."""
+
     path: str
     profile: str = "tabular-data-resource"
     name: str
     dialect: Dialect
     title: str
     description: str
+    # TODO: what's up with this:
+    # E   pydantic_core._pydantic_core.ValidationError: 1 validation error for Field
+    # E   name
+    # E     Field required [type=missing, input_value={'alias': 'format', 'default': 'sqlite'}, input_type=dict]
+    # E       For further information visit https://errors.pydantic.dev/2.13/v/missing
     format_: str = Field(alias="format", default="sqlite")
     mediatype: str = "application/vnd.sqlite3"
     schema_: Schema = Field(alias="schema")
 
+
 class Datapackage(BaseModel):
+    """Datapackage schema for tabular data, as per Frictionless Data specs."""
+
     profile: str = "tabular-data-package"
     name: str
     title: str

--- a/src/pudl/extract/dbf.py
+++ b/src/pudl/extract/dbf.py
@@ -3,6 +3,7 @@
 import contextlib
 import csv
 import importlib.resources
+import json
 import warnings
 import zipfile
 from collections import defaultdict
@@ -11,14 +12,13 @@ from functools import lru_cache
 from pathlib import Path
 from typing import IO, Any, Protocol, Self
 
+import frictionless
 import pandas as pd
 import sqlalchemy as sa
 from dagster import op
 from dbfread import DBF, FieldParser
-from pydantic import BaseModel, Field
 from sqlalchemy.engine.base import Engine
 
-import pudl.helpers
 import pudl.logging_helpers
 from pudl.metadata.classes import DataSource
 from pudl.settings import FercDbfToSqliteDataConfig, FercToSqliteDataConfig
@@ -468,9 +468,53 @@ class FercDbfExtractor:
         db_path = str(Path(self.output_path) / self.DATABASE_NAME)
         return f"sqlite:///{db_path}"
 
-    def get_datapackage_path(self) -> Path:
+    def _clean_frictionless_types(self, type_: str) -> str:
+        """Normalize types from SQLite to frictionless."""
+        type_ = type_.lower()
+        type_ = "string" if type_.startswith(("varchar", "text")) else type_
+        type_ = "number" if type_.startswith("float") else type_
+        return type_
+
+    @property
+    def datapackage_path(self) -> Path:
         """Returns the path to the datapackage for this resource."""
         return Path(self.output_path) / f"{self.DATASET}_dbf_datapackage.json"
+
+    def to_frictionless(self):
+        """Create a frictionless DataPackage describing the DBF DB and write to a JSON file."""
+        resources = []
+        types = []
+        for table in self.sqlite_meta.sorted_tables:
+            for c in table.columns:
+                types.append(str(c.type))
+
+        for table in self.sqlite_meta.sorted_tables:
+            resources.append(
+                frictionless.Resource(
+                    path=self.get_db_path(),
+                    name=table.name,
+                    title=table.name,
+                    description=table.description,
+                    schema=frictionless.Schema(
+                        fields=[
+                            frictionless.Field.from_descriptor(
+                                {
+                                    "name": c.name,
+                                    "type": self._clean_frictionless_types(str(c.type)),
+                                }
+                            )
+                            for c in table.columns
+                        ]
+                    ),
+                )
+            )
+
+        package = frictionless.Package(
+            name=self.datapackage_path.stem,
+            title=f"{self.DATASET} data extracted from DBF filings",
+            resources=resources,
+        )
+        self.datapackage_path.write_text(json.dumps(package.to_dict(), indent=2))
 
     @classmethod
     def get_dagster_op(cls) -> Callable:
@@ -507,54 +551,19 @@ class FercDbfExtractor:
             return
 
         self.delete_schema()
+        self.initialize_database()
         self.create_sqlite_tables()
         self.load_table_data()
         self.postprocess()
-
-    # TODO: who should call as_pydantic?
-    def as_pydantic(self):
-        """Generate a pydantic model based on the database schema."""
-        resources = []
-        for table in self.sqlite_meta.sorted_tables():
-            resources.append(
-                Resource(
-                    path=self.get_db_path(),
-                    name=table.name,
-                    dialect=Dialect(table=table.name),
-                    # TODO: what is in table.description?
-                    # should title be table.description, and description be empty?
-                    title="??",
-                    description=table.description,
-                    schema=Schema(
-                        fields=[
-                            Field(
-                                name=c.name,
-                                type=c.type,
-                            )
-                            for c in table.columns
-                        ]
-                    ),
-                )
-            )
-
-        return Datapackage(
-            name=f"{self.DATASET}-extracted-dbf",
-            title=f"{self.DATASET} data extracted from DBF filings",
-            resources=resources,
-        )
-        ## Alt approach: dynamic model definition
-        # package = create_model(
-        #     profile=(str, "tabular-data-package"),
-        #     name=(str, f"{self.DATASET}-extracted-dbf"),
-        #     title=(str,f"{self.DATASET} data extracted from DBF filings"),
-        #     resources=(list[Resource],resources)
-        # )
+        self.to_frictionless()
 
     def delete_schema(self):
         """Drops all tables from the existing sqlite database."""
         with contextlib.suppress(sa.exc.OperationalError):
             pudl.helpers.drop_tables(self.sqlite_engine, clobber=True)
 
+    def initialize_database(self):
+        """Create sqlalchemy engine and metadata."""
         self.sqlite_engine = sa.create_engine(self.get_db_path())
         self.sqlite_meta = sa.MetaData()
         self.sqlite_meta.reflect(self.sqlite_engine)
@@ -709,58 +718,3 @@ def deduplicate_by_year(
         .drop_duplicates(subset=pk_column, keep="last")
         .drop(columns="report_yr")
     )
-
-
-class Field(BaseModel):
-    """A generic field descriptor, as per Frictionless Data specs.
-
-    See https://specs.frictionlessdata.io/table-schema/#field-descriptors.
-    """
-
-    name: str
-    type_: str = Field(alias="type", default="string")
-    format_: str = Field(alias="format", default="default")
-
-
-class Schema(BaseModel):
-    """A generic table schema, as per Frictionless Data specs.
-
-    See https://specs.frictionlessdata.io/table-schema/.
-    """
-
-    fields: list[Field]
-    primary_key: list[str]
-
-
-class Dialect(BaseModel):
-    """Dialect used for frictionless SQL resources."""
-
-    table: str
-
-
-class Resource(BaseModel):
-    """Resource schema for sqlite, as per Frictionless Data specs."""
-
-    path: str
-    profile: str = "tabular-data-resource"
-    name: str
-    dialect: Dialect
-    title: str
-    description: str
-    # TODO: what's up with this:
-    # E   pydantic_core._pydantic_core.ValidationError: 1 validation error for Field
-    # E   name
-    # E     Field required [type=missing, input_value={'alias': 'format', 'default': 'sqlite'}, input_type=dict]
-    # E       For further information visit https://errors.pydantic.dev/2.13/v/missing
-    format_: str = Field(alias="format", default="sqlite")
-    mediatype: str = "application/vnd.sqlite3"
-    schema_: Schema = Field(alias="schema")
-
-
-class Datapackage(BaseModel):
-    """Datapackage schema for tabular data, as per Frictionless Data specs."""
-
-    profile: str = "tabular-data-package"
-    name: str
-    title: str
-    resources: list[Resource]


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://docs.catalyst.coop/pudl/en/nightly/CONTRIBUTING.html
* code of conduct: https://docs.catalyst.coop/pudl/en/nightly/code_of_conduct.html
-->

# Overview

Closes #5200.

## What problem does this address?

We need a datapackage for the DBF outputs and we don't have one yet!

## What did you change?

* Add and call `to_frictionless()` in pudl.extract.dbf

This is a straight copy-paste from ferc-caching (#5264), but I added `delete_schema` back in bc without all the other ferc-caching infrastructure it is still needed.

## Documentation

Make sure to update relevant aspects of the documentation:

- [x] Update the [release notes](https://docs.catalyst.coop/pudl/en/nightly/release_notes.html): reference the PR and related issues.

# Testing

How did you make sure this worked? How can a reviewer verify this?

Search `key:"*dbf*sqlite*"` in the asset catalog and materialize. Examine dbf datapackage output in $PUDL_OUTPUT.

## To-do list

- [x] Run `pixi run prek-run` to run linters and static code analysis checks.
- [x] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [x] Review the PR yourself and call out any questions or issues you have.
