### PR TITLE
Update defs reference in notebooks

### DIFF
--- a/devtools/inspect-assets.ipynb
+++ b/devtools/inspect-assets.ipynb
@@ -30,14 +30,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "c54503cc-19a2-4cd0-8724-f371eebf54e4",
-   "metadata": {},
-   "source": [
-    "## Inspect an asset that uses the `fs_io_manager`"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "d9d4dc6a-4539-436b-bc1a-c887cc5e9d57",
@@ -47,46 +39,21 @@
    "outputs": [],
    "source": [
     "from dagster import AssetKey\n",
+    "from pudl.dagster.build import build_interactive_defs\n",
+    "defs = build_interactive_defs()\n",
     "\n",
-    "from pudl.definitions import defs\n",
-    "\n",
-    "asset_key = \"_core_eia861__balancing_authority\"\n",
+    "asset_key = \"core_eia923__monthly_generation\"\n",
     "df = defs.load_asset_value(AssetKey(asset_key))"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc08c9a2-a4ef-4e37-8a6b-f08e280af7a0",
+   "id": "6ebbf799-c2e8-46a6-97a7-29ad39d4752f",
    "metadata": {},
    "outputs": [],
    "source": [
     "df"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "4f41ab9c-6177-4be3-ad00-02762d73d6f0",
-   "metadata": {},
-   "source": [
-    "## Inspect an asset that uses the `pudl_sqlite_io_manager`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2d284fa5-6ac0-4807-b958-9954c7871bfe",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from dagster import AssetKey\n",
-    "\n",
-    "from pudl.definitions import defs\n",
-    "\n",
-    "asset_key = \"core_eia923__monthly_generation\"\n",
-    "df = defs.load_asset_value(AssetKey(asset_key))"
    ]
   }
  ],

--- a/devtools/pudl_id_mapping_help.ipynb
+++ b/devtools/pudl_id_mapping_help.ipynb
@@ -20,7 +20,8 @@
     "import pandas as pd\n",
     "import pudl\n",
     "import pudl.logging_helpers\n",
-    "from pudl.definitions import defs\n",
+    "from pudl.dagster.build import build_interactive_defs\n",
+    "defs = build_interactive_defs()\n",
     "\n",
     "logger = pudl.logging_helpers.get_logger(__name__)"
    ]


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://docs.catalyst.coop/pudl/en/nightly/CONTRIBUTING.html
* code of conduct: https://docs.catalyst.coop/pudl/en/nightly/code_of_conduct.html
-->

## What did you change?

`from pudl.definitions import defs` no longer works. Replace with: 

```
from pudl.dagster.build import build_interactive_defs
defs = build_interactive_defs()
```