### PR TITLE
Propagate hashtag comments into human-editable schema files

### DIFF
--- a/dbt/schema_inputs/eia860/out_eia860__yearly_ownership/schema.human.yml
+++ b/dbt/schema_inputs/eia860/out_eia860__yearly_ownership/schema.human.yml
@@ -14,6 +14,9 @@ sources:
                 multiplier: 1
                 date_column: report_date
           - expect_complete_valid_ownership:
+              # Known failures as of June 2025:
+              # 341 CT5 has 1.5 total ownership fraction for 2021, 2022, 2023, 2024
+              # 56032 generator 1 has a 2.0 total ownership fraction in 2024
               arguments:
                 n_acceptable_failures: 5
           - expect_unique_utility_id_eia

--- a/dbt/schema_inputs/eia861/core_eia861__yearly_operational_data_revenue/schema.human.yml
+++ b/dbt/schema_inputs/eia861/core_eia861__yearly_operational_data_revenue/schema.human.yml
@@ -15,4 +15,4 @@ sources:
                   arguments:
                     min_value: 0.0
                     row_condition: revenue_class != 'credits_or_adjustments'
-                    error_if: ">764"
+                    error_if: ">764" # Relatively high, worth investigating

--- a/dbt/schema_inputs/eia861/core_eia861__yearly_sales/schema.human.yml
+++ b/dbt/schema_inputs/eia861/core_eia861__yearly_sales/schema.human.yml
@@ -28,4 +28,4 @@ sources:
                   arguments:
                     min_value: 0.0
                     row_condition: utility_id_eia != 99999
-                    error_if: ">300"
+                    error_if: ">300" # Relatively large, worth investigating

--- a/dbt/schema_inputs/eia923/_core_eia923__yearly_emissions_control/schema.human.yml
+++ b/dbt/schema_inputs/eia923/_core_eia923__yearly_emissions_control/schema.human.yml
@@ -69,7 +69,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                     warn_if: ">0"
-                    error_if: ">66"
+                    error_if: ">66" # A few records have efficiencies between 1 and 10.
           - name: particulate_test_date
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/schema_inputs/rus12/core_rus12__yearly_loans/schema.human.yml
+++ b/dbt/schema_inputs/rus12/core_rus12__yearly_loans/schema.human.yml
@@ -10,7 +10,7 @@ sources:
                 column_B: loan_balance
                 or_equal: true
               config:
-                error_if: ">1"
+                error_if: ">1" #TODO: Investigate 1 case where loan balance exceeds original amount.
               description:
                 The original amount of the loan should be greater than or equal
                 to the current balance of the loan.

--- a/dbt/schema_inputs/rus12/core_rus12__yearly_plant_costs/schema.human.yml
+++ b/dbt/schema_inputs/rus12/core_rus12__yearly_plant_costs/schema.human.yml
@@ -14,7 +14,8 @@ sources:
                 denominator_column: cost_per_mmbtu
                 min_ratio: 3.412142
               config:
-                error_if: ">96"
+                error_if: ">96" # ~6% of the data
+          # CALCULATE FUEL COST SUBTOTALS BY PLANT TYPE
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -127,7 +128,7 @@ sources:
               row_condition: plant_type IN ('steam', 'internal_combustion', 'combined_cycle')
               description: Check that steam, IC and CC operation subcomponents sum to total.
               config:
-                error_if: ">2300"
+                error_if: ">2300" # This is almost all of them, INVESTIGATE!
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -172,7 +173,7 @@ sources:
               row_condition: plant_type == 'nuclear'
               description: Check that nuclear operation subcomponents sum to total.
               config:
-                error_if: ">129"
+                error_if: ">129" # This is almost all of them, INVESTIGATE!
         columns:
           - name: cost
             data_tests:
@@ -180,14 +181,14 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">213"
+                    error_if: ">213" # 0.4% of the data
           - name: cost_per_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">381"
+                    error_if: ">381" # 0.7% of the data
           - name: cost_per_mmbtu
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/schema_inputs/rus12/core_rus12__yearly_plant_factors_and_maximum_demand/schema.human.yml
+++ b/dbt/schema_inputs/rus12/core_rus12__yearly_plant_factors_and_maximum_demand/schema.human.yml
@@ -15,7 +15,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">13"
+                    error_if: ">13" # Investigate 13 instances of cap fac > 1 for nuclear plants
           - name: capacity_factor_running
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -23,7 +23,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">121"
+                    error_if: ">121" # Investigate 121 instances of cap fac running > 1
           - name: load_factor
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -31,7 +31,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">2"
+                    error_if: ">2" # Investigate 2 instances of load fac > 1
           - name: peak_gross_demand_mw
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/schema_inputs/rus12/core_rus12__yearly_statement_of_operations/schema.human.yml
+++ b/dbt/schema_inputs/rus12/core_rus12__yearly_statement_of_operations/schema.human.yml
@@ -11,7 +11,7 @@ sources:
                 min_ratio: 0.05
                 max_ratio: 0.2
               config:
-                error_if: ">4300"
+                error_if: ">4300" # ~20% of records
               description:
                 Monthly spending should roughly equal 1/12 of the YTD budget
                 (5-20% range).
@@ -22,7 +22,7 @@ sources:
                 min_ratio: 0.75
                 max_ratio: 1.25
               config:
-                error_if: ">3667"
+                error_if: ">3667" # ~15% of records
               description: Budgeted spending and YTD spending should be roughly equivalent.
           - check_row_counts_per_partition:
               arguments:
@@ -49,7 +49,7 @@ sources:
                 tolerance: 10
               row_condition: opex_group == 'operation_revenue_and_patronage_capital'
               config:
-                error_if: ">201"
+                error_if: ">201" # About 25% of data
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -61,7 +61,7 @@ sources:
                 tolerance: 10
               row_condition: opex_group == 'operation_revenue_and_patronage_capital'
               config:
-                error_if: ">184"
+                error_if: ">184" # About 25% of data
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -167,7 +167,7 @@ sources:
                 total_label: total_cost_of_electric_service
                 tolerance: 10
               config:
-                error_if: ">202"
+                error_if: ">202" #~25% of records
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -188,7 +188,7 @@ sources:
                 total_label: total_cost_of_electric_service
                 tolerance: 10
               config:
-                error_if: ">160"
+                error_if: ">160" #~20% of records
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -216,7 +216,7 @@ sources:
                 total_label: operating_margins
                 tolerance: 10
               config:
-                error_if: ">204"
+                error_if: ">204" # ~26% of records
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -231,7 +231,7 @@ sources:
                 total_label: operating_margins
                 tolerance: 10
               config:
-                error_if: ">155"
+                error_if: ">155" # ~20% of records
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:

--- a/dbt/schema_inputs/rus12/out_rus12__yearly_loans/schema.human.yml
+++ b/dbt/schema_inputs/rus12/out_rus12__yearly_loans/schema.human.yml
@@ -10,7 +10,7 @@ sources:
                 column_B: loan_balance
                 or_equal: true
               config:
-                error_if: ">1"
+                error_if: ">1" #TODO: Investigate 1 case where loan balance exceeds original amount.
               description:
                 The original amount of the loan should be greater than or equal
                 to the current balance of the loan.

--- a/dbt/schema_inputs/rus12/out_rus12__yearly_plant_costs/schema.human.yml
+++ b/dbt/schema_inputs/rus12/out_rus12__yearly_plant_costs/schema.human.yml
@@ -14,7 +14,8 @@ sources:
                 denominator_column: cost_per_mmbtu
                 min_ratio: 3.412142
               config:
-                error_if: ">96"
+                error_if: ">96" # ~6% of the data
+          # CALCULATE FUEL COST SUBTOTALS BY PLANT TYPE
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -127,7 +128,7 @@ sources:
               row_condition: plant_type IN ('steam', 'internal_combustion', 'combined_cycle')
               description: Check that steam, IC and CC operation subcomponents sum to total.
               config:
-                error_if: ">2300"
+                error_if: ">2300" # This is almost all of them, INVESTIGATE!
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -172,7 +173,7 @@ sources:
               row_condition: plant_type == 'nuclear'
               description: Check that nuclear operation subcomponents sum to total.
               config:
-                error_if: ">129"
+                error_if: ">129" # This is almost all of them, INVESTIGATE!
         columns:
           - name: cost
             data_tests:
@@ -180,14 +181,14 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">213"
+                    error_if: ">213" # 0.4% of the data
           - name: cost_per_mwh
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">381"
+                    error_if: ">381" # 0.7% of the data
           - name: cost_per_mmbtu
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:

--- a/dbt/schema_inputs/rus12/out_rus12__yearly_plant_factors_and_maximum_demand/schema.human.yml
+++ b/dbt/schema_inputs/rus12/out_rus12__yearly_plant_factors_and_maximum_demand/schema.human.yml
@@ -15,7 +15,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">13"
+                    error_if: ">13" # Investigate 13 instances of cap fac > 1 for nuclear plants
           - name: capacity_factor_running
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -23,7 +23,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">121"
+                    error_if: ">121" # Investigate 121 instances of cap fac running > 1
           - name: load_factor
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
@@ -31,7 +31,7 @@ sources:
                     min_value: 0.0
                     max_value: 1.0
                   config:
-                    error_if: ">2"
+                    error_if: ">2" # Investigate 2 instances of load fac > 1
           - name: peak_gross_demand_mw
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/schema_inputs/rus12/out_rus12__yearly_statement_of_operations/schema.human.yml
+++ b/dbt/schema_inputs/rus12/out_rus12__yearly_statement_of_operations/schema.human.yml
@@ -49,7 +49,7 @@ sources:
                 tolerance: 10
               row_condition: opex_group == 'operation_revenue_and_patronage_capital'
               config:
-                error_if: ">201"
+                error_if: ">201" # About 25% of data
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -61,7 +61,7 @@ sources:
                 tolerance: 10
               row_condition: opex_group == 'operation_revenue_and_patronage_capital'
               config:
-                error_if: ">184"
+                error_if: ">184" # About 25% of data
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -167,7 +167,7 @@ sources:
                 total_label: total_cost_of_electric_service
                 tolerance: 10
               config:
-                error_if: ">202"
+                error_if: ">202" #~25% of records
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -188,7 +188,7 @@ sources:
                 total_label: total_cost_of_electric_service
                 tolerance: 10
               config:
-                error_if: ">160"
+                error_if: ">160" #~20% of records
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -216,7 +216,7 @@ sources:
                 total_label: operating_margins
                 tolerance: 10
               config:
-                error_if: ">204"
+                error_if: ">204" # ~26% of records
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:
@@ -231,7 +231,7 @@ sources:
                 total_label: operating_margins
                 tolerance: 10
               config:
-                error_if: ">155"
+                error_if: ">155" # ~20% of records
           - subcomponents_sum_to_total:
               arguments:
                 group_by_columns:

--- a/dbt/schema_inputs/rus7/core_rus7__yearly_distribution_services/schema.human.yml
+++ b/dbt/schema_inputs/rus7/core_rus7__yearly_distribution_services/schema.human.yml
@@ -8,6 +8,7 @@ sources:
               arguments:
                 table_name: core_rus7__yearly_distribution_services
                 partition_expr: EXTRACT(YEAR FROM report_date)
+        # TODO: VALIDATE STATUSES SUM TO TOTAL
         columns:
           - name: services
             data_tests:

--- a/dbt/schema_inputs/rus7/core_rus7__yearly_external_financial_risk_ratio/schema.human.yml
+++ b/dbt/schema_inputs/rus7/core_rus7__yearly_external_financial_risk_ratio/schema.human.yml
@@ -15,4 +15,4 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">18"
+                    error_if: ">18" # TODO: Investigate negative original loan amount values

--- a/dbt/schema_inputs/rus7/core_rus7__yearly_loans/schema.human.yml
+++ b/dbt/schema_inputs/rus7/core_rus7__yearly_loans/schema.human.yml
@@ -10,7 +10,7 @@ sources:
                 column_B: loan_balance
                 or_equal: true
               config:
-                error_if: ">38"
+                error_if: ">38" # TODO: Investigate cases where loan balance exceeds original amount.
               description:
                 The original amount of the loan guarantee should be greater than
                 or equal to the current balance of the loan.
@@ -33,11 +33,11 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">4"
+                    error_if: ">4" # TODO: Investigate negative loan balance values
           - name: loan_original_amount
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
+                    error_if: ">1" # TODO: Investigate negative original loan amount values

--- a/dbt/schema_inputs/rus7/core_rus7__yearly_transmission_and_distribution_mileage/schema.human.yml
+++ b/dbt/schema_inputs/rus7/core_rus7__yearly_transmission_and_distribution_mileage/schema.human.yml
@@ -8,6 +8,7 @@ sources:
               arguments:
                 table_name: core_rus7__yearly_transmission_and_distribution_mileage
                 partition_expr: EXTRACT(YEAR FROM report_date)
+        # TODO: CHECK SUBCOMPONENTS SUM TO TOTAL
         columns:
           - name: miles
             data_tests:

--- a/dbt/schema_inputs/rus7/out_rus7__yearly_distribution_services/schema.human.yml
+++ b/dbt/schema_inputs/rus7/out_rus7__yearly_distribution_services/schema.human.yml
@@ -8,6 +8,7 @@ sources:
               arguments:
                 table_name: out_rus7__yearly_distribution_services
                 partition_expr: EXTRACT(YEAR FROM report_date)
+        # TODO: VALIDATE STATUSES SUM TO TOTAL
         columns:
           - name: services
             data_tests:

--- a/dbt/schema_inputs/rus7/out_rus7__yearly_external_financial_risk_ratio/schema.human.yml
+++ b/dbt/schema_inputs/rus7/out_rus7__yearly_external_financial_risk_ratio/schema.human.yml
@@ -15,4 +15,4 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">18"
+                    error_if: ">18" # TODO: Investigate negative original loan amount values

--- a/dbt/schema_inputs/rus7/out_rus7__yearly_loans/schema.human.yml
+++ b/dbt/schema_inputs/rus7/out_rus7__yearly_loans/schema.human.yml
@@ -10,7 +10,7 @@ sources:
                 column_B: loan_balance
                 or_equal: true
               config:
-                error_if: ">38"
+                error_if: ">38" # TODO: Investigate cases where loan balance exceeds original amount.
               description:
                 The original amount of the loan guarantee should be greater than
                 or equal to the current balance of the loan.
@@ -33,11 +33,11 @@ sources:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">4"
+                    error_if: ">4" # TODO: Investigate negative loan balance values
           - name: loan_original_amount
             data_tests:
               - dbt_expectations.expect_column_min_to_be_between:
                   arguments:
                     min_value: 0.0
                   config:
-                    error_if: ">1"
+                    error_if: ">1" # TODO: Investigate negative original loan amount values

--- a/dbt/schema_inputs/rus7/out_rus7__yearly_transmission_and_distribution_mileage/schema.human.yml
+++ b/dbt/schema_inputs/rus7/out_rus7__yearly_transmission_and_distribution_mileage/schema.human.yml
@@ -8,6 +8,7 @@ sources:
               arguments:
                 table_name: out_rus7__yearly_transmission_and_distribution_mileage
                 partition_expr: EXTRACT(YEAR FROM report_date)
+        # TODO: CHECK SUBCOMPONENTS SUM TO TOTAL
         columns:
           - name: miles
             data_tests:


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://docs.catalyst.coop/pudl/en/nightly/CONTRIBUTING.html
* code of conduct: https://docs.catalyst.coop/pudl/en/nightly/code_of_conduct.html
-->

# Overview

* Ensure all hashtag comments are present in schema.human.yml
* Prerequisite for #5269 

## What problem does this address?

Some of our dbt model files (dbt/models/**/schema.yml) have hashtag comments in them, which are not preserved by the YAML readers & writers that will regenerate these files as part of the movement away from sqlite & alembic.

Like this:
```
          - expect_complete_valid_ownership:
              # Known failures as of June 2025:
              # 341 CT5 has 1.5 total ownership fraction for 2021, 2022, 2023, 2024
              # 56032 generator 1 has a 2.0 total ownership fraction in 2024
              arguments:
                n_acceptable_failures: 5
```

We don't want to lose the information in those comments, so they need to be relocated to their schema.human.yml counterparts under dbt/schema_inputs/.

We need to do this before we add "regenerate dbt schema.yml files" to the commit hooks in #5279, because once that is merged, schema.yml files will start getting overwritten more frequently.

## What did you change?

Used a script to identify all comments in dbt/models that weren't in dbt/schema_inputs, and copied each comment into its forever home.

<details><summary>Script follows:</summary>

```bash
# get the table name of every schema.yml that contains hashtag comments
find dbt/models/ -name schema.yml -exec grep -l "#" {} + |sed 's_dbt/models/__;s_/schema.yml__;s_^[^/]*/__' |sort >tables_with_comments.txt

# get the table name of every available schema.human.yml file
find dbt/schema_inputs/ -name "*.yml" |sed 's_dbt/schema.inputs/__;s_/schema.human.yml__;s_^[^/]*/__' |sort >tables_with_human.txt

# ensure every schema.yml with comments in it already has a corresponding schema.human.yml 
# (which was not guaranteed)
# expect zero here ✅ 
comm -23 tables_with_comments.txt tables_with_human.txt

# collect the number of comment lines in the two schema files for each table
for t in `cat tables_with_comments.txt`; do echo $t; find dbt/models -path "*$t*" -name schema.yml -exec grep -c "#" {} +; find dbt/schema_inputs -path "*$t*" -name schema.human.yml -exec grep -c "#" {} +; echo "--"; done >comment_stats.txt

# whenever the number of comment lines in schema.yml exceeds the number of comment lines
# in schema.human.yml, add it to the fixlist
awk 'BEGIN{RS="--"} $2>$3 {print $1}' comment_stats.txt >comment_fixlist.txt

# for each table in the fixlist, bring up schema.yml and schema.human.yml side-by-side for editing
for t in `cat comment_fixlist.txt`; do echo $t; emacs `find dbt/schema_inputs -path "*$t*" -name schema.human.yml` `find dbt/models -path "*$t*" -name schema.yml`; done
```
</details>

# Testing

How did you make sure this worked? How can a reviewer verify this?

* Run the above script in main and see output
* Run it here and get no output = no remaining schema.yml files with more comment lines than in their schema.human.yml counterparts
* Run `awk 'BEGIN{RS="--"} $2!=$3 {print $1}' comment_stats.txt` and get no output = number of comment lines exactly matches (so no extra comments in schema.human.yml either)

## To-do list

- [x] Run `pixi run prek-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
