### PR TITLE
Add target override option to dbt_helper for extreme cases

### DIFF
--- a/src/pudl/scripts/dbt_helper.py
+++ b/src/pudl/scripts/dbt_helper.py
@@ -347,11 +347,20 @@ def update_tables(
     help="If dry, will print out the parameters we would pass to dbt, but not "
     "actually run the validation tests. Defaults to not-dry.",
 )
+@click.option(
+    "--override-target",
+    help=(
+        "Name of the target to use instead of etl-full. "
+        "Not used for normal development and updates; generally only needed "
+        "for local debugging of remote CI failures."
+    ),
+)
 def validate(
     select: str | None = None,
     asset_select: str | None = None,
     exclude: str | None = None,
     dry_run: bool = False,
+    override_target: str | None = None,
 ) -> None:
     """Validate a selection of dbt nodes.
 
@@ -400,7 +409,7 @@ def validate(
     build_params = {
         "node_selection": node_selection,
         "node_exclusion": exclude,
-        "dbt_target": "etl-full",
+        "dbt_target": override_target if override_target else "etl-full",
     }
 
     if dry_run:


### PR DESCRIPTION
# Overview

Add `--override-target` option to `dbt_helper validate`

## What problem does this address?

We haven't had good luck getting local etl-fast runs to exactly match the remote runs that happen in CI, so almost always you want to be running `dbt_helper` with the etl-full target.

HOWEVER.

When debugging a failure that only occurs in CI etl-fast, it would be handy to be able to at least _try_ to replicate the behavior locally. Thus, a new option to `dbt_helper validate` to override the target option that is passed to dbt.

## What did you change?

- Add an option to dbt_helper validate which, by default, does nothing, but when specified, sets the `--target` option passed to dbt to a value of the user's choice.

## Documentation

**Leaving this as a semi-stealth option for now: it will show up in the help text for `dbt_helper validate`, but not in any other dev guide** bc we really don't want anyone trying to use it as part of their normal data update integration workflow.

- [x] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

```
Esker:pudl 10:59:37$ pixi run dbt_helper validate --override-target etl-fast --dry-run
[...]
Dry run - would build with these params: {"node_selection": "*", "node_exclusion": null, "dbt_target": "etl-fast"}
Esker:pudl 11:00:13$ pixi run dbt_helper validate --dry-run
[...]
Dry run - would build with these params: {"node_selection": "*", "node_exclusion": null, "dbt_target": "etl-full"}
```

## To-do list

- [x] Run `pixi run prek-run` to run linters and static code analysis checks.