### PR TITLE
Fix boolean check in com-dev-notify

### DIFF
--- a/.github/workflows/com-dev-notify.yml
+++ b/.github/workflows/com-dev-notify.yml
@@ -1,3 +1,4 @@
+---
 name: com-dev-notify
 
 on:
@@ -53,7 +54,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Send message to ComDev Zulip channel
-        if: ${{ !steps.is_organization_member.outputs.result }}
+        if: ${{ steps.is_organization_member.outputs.result == 'false' }}
         uses: zulip/github-actions-zulip/send-message@v2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,15 +67,6 @@ jobs:
     needs:
       - create-github-release
     steps:
-      - name: Status emoji
-        run: |
-          if [[ "${{ needs.create-github-release.result }}" == "success" ]]; then
-            echo "emoji=:check:" >> "$GITHUB_ENV"
-          elif [[ "${{ needs.create-github-release.result }}" == "failure" ]]; then
-            echo "emoji=:x:" >> "$GITHUB_ENV"
-          else
-            echo "emoji=:warning:" >> "$GITHUB_ENV"
-          fi
       - name: Notify Zulip of release status
         uses: zulip/github-actions-zulip/send-message@v2
         continue-on-error: true
@@ -87,7 +78,7 @@ jobs:
           to: "pudl-deployments"
           topic: "pudl-release"
           content: >
-            ${{ env.emoji }}
+            ${{ needs.create-github-release.result  == 'success' && ':check:' || needs.create-github-release.result == 'failure' && ':x:' || ':warning:' }}
             ${{ github.repository }} release (`${{ github.ref_name }}`)
             finished with status: ${{ needs.create-github-release.result }}.
             [See the logs here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/.github/workflows/zenodo-data-release.yml
+++ b/.github/workflows/zenodo-data-release.yml
@@ -73,17 +73,7 @@ jobs:
             ${{ inputs.ignore_regex && format('--ignore "{0}"', inputs.ignore_regex) || '' }} \
             --${{ inputs.publish }}
 
-      - name: Status emoji
-        run: |
-          if [[ "${{ job.status }}" == "success" ]]; then
-            echo "emoji=:check:" >> "$GITHUB_ENV"
-          elif [[ "${{ job.status }}" == "failure" ]]; then
-            echo "emoji=:x:" >> "$GITHUB_ENV"
-          else
-            echo "emoji=:warning:" >> "$GITHUB_ENV"
-          fi
-
-      - name: Post status to pudl-deployments channel
+      - name: Notify Zulip of Zenodo data release status
         if: always()
         uses: zulip/github-actions-zulip/send-message@v2
         with:
@@ -94,7 +84,6 @@ jobs:
           to: "pudl-deployments"
           topic: "build-deploy-pudl"
           content: >
-            ${{ env.emoji }} zenodo-data-release
-            on `${{ github.ref_name }}`
-            finished with status: ${{ job.status }}.
+            ${{ job.status == 'success' && ':check:' || job.status == 'failure' && ':x:' || ':warning:' }}
+            `zenodo-data-release` finished with status `${{ job.status }}` on `${{ github.ref_name }}`
             [See the logs here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).


### PR DESCRIPTION
# Overview

- We were treating the output of the "is_organization_member` action as a boolean, but actually it's a string "false"
- Check for string equality instead of a boolean value.
- Also try and fix apparently broken slackmoji in release notifications ❌  ✅ ⚠️ 