### PR TITLE
Add list of ignored users to com-dev-notify

### DIFF
--- a/.github/workflows/com-dev-notify.yml
+++ b/.github/workflows/com-dev-notify.yml
@@ -6,6 +6,8 @@ on:
     types: [opened]
   discussion:
     types: [created]
+  discussion_comment:
+    types: [created]
   issue_comment:
     types: [created]
   pull_request:
@@ -15,6 +17,7 @@ env:
   username: ""
   url: ""
   org: catalyst-cooperative
+  ignored_users: '["pre-commit-ci[bot]", "krivard", "dependabot[bot]", "github-actions[bot]"]'
 
 jobs:
   com-dev-notify:
@@ -32,6 +35,12 @@ jobs:
         run: |
           echo "username=${{ github.event.discussion.user.login }}" >> "${GITHUB_ENV}"
           echo "url=${{ github.event.discussion.html_url }}" >> "${GITHUB_ENV}"
+
+      - name: Get username if a discussion comment was created
+        if: ${{ github.event_name == 'discussion_comment' }}
+        run: |
+          echo "username=${{ github.event.comment.user.login }}" >> "${GITHUB_ENV}"
+          echo "url=${{ github.event.comment.html_url }}" >> "${GITHUB_ENV}"
 
       - name: Get username if a comment was created
         if: ${{ github.event_name == 'issue_comment' }}
@@ -54,7 +63,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Send message to ComDev Zulip channel
-        if: ${{ steps.is_organization_member.outputs.result == 'false' }}
+        if: >-
+          ${{ steps.is_organization_member.outputs.result == 'false' && !contains(fromJSON(env.ignored_users), env.username) }}
         uses: zulip/github-actions-zulip/send-message@v2
         with:
           api-key: ${{ secrets.ZULIP_API_KEY }}


### PR DESCRIPTION
# Overview

- Add a list of ignored users (especially bots) so we don't get Zulip notifications from them.
- Also watch for `discussion_comment` events.