### PR TITLE
Document newer EIA-930 renewable energy sources.

### DIFF
--- a/docs/templates/eia930_child.rst.jinja
+++ b/docs/templates/eia930_child.rst.jinja
@@ -68,6 +68,11 @@ source used, if known, and under the generator's primary energy source, if not k
 To maintain generator confidentiality, generation may sometimes be reported in the Other
 category if too few generators are reported for a particular energy source category.
 
+In 2024Q3 EIA started using different and more granular energy source categories,
+particularly for renewable energy sources. The new categories differentiate between wind
+and solar plants that do and don't have energy storage, and split out pumped hydro from
+hydro without storage. They also added new battery storage and geothermal categories.
+
 In some of our electricity publications, we report generation from all utility-scale
 generating units in the United States. BAs only meter generating units that are from a
 subset of all utility-scale generating units. As a result, when hourly generation from

--- a/src/pudl/metadata/resources/eia930.py
+++ b/src/pudl/metadata/resources/eia930.py
@@ -58,7 +58,12 @@ multiple-fuel (using multiple fuels simultaneously) generators under the actual 
 To maintain generator confidentiality, generation may sometimes be reported in the Other category if too few generators are reported for a particular energy source category.
 
 In theory, the sum of net generation across all energy sources should equal the total net generation reported in the balancing authority operations table. In practice,
-there are many cases in which these values diverge significantly, which require further investigation.""",
+there are many cases in which these values diverge significantly, which require further investigation.
+
+In 2024Q3 EIA started using different and more granular energy source categories, particularly for renewable energy sources.
+The new categories differentiate between wind and solar plants that do and don't have energy storage, and split out pumped hydro from hydro without storage.
+They also added new battery storage and geothermal categories.
+""",
         },
         "schema": {
             "fields": [


### PR DESCRIPTION
# Overview

The introduction of more granular energy source categories into the EIA-930 net generation by energy source table has caused some confusing among users.  This PR updates the table and data source documentation to note the change explicitly.

Closes #5335 

## Documentation

- [x] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [x] Update relevant table or source description metadata (see `src/metadata`).
- [x] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

Built the docs locally and inspected the table and data source pages.

