### PR TITLE
Only checkout 2 revisions for CI filter

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 2
       - uses: dorny/paths-filter@v4
         id: filter
         with:


### PR DESCRIPTION
# Overview

- I noticed that the `change_filter` job was taking like 4 minutes to complete and can actually end up being the longest running job on PRs that don't touch any files that need the integration tests to be run.
- It looks like this was due to the fact that we were doing a complete checkout of the repository's very long commit history.
- I updated the job to only checkout only the last 2 revisions, as we do for the other CI test jobs.
- Now it takes less than 10 seconds to resolve.