### PR TITLE
Validate RUS 7 mileage totals

### DIFF
--- a/dbt/models/rus7/core_rus7__yearly_transmission_and_distribution_mileage/schema.yml
+++ b/dbt/models/rus7/core_rus7__yearly_transmission_and_distribution_mileage/schema.yml
@@ -8,8 +8,18 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: core_rus7__yearly_transmission_and_distribution_mileage
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
-          # TODO: CHECK SUBCOMPONENTS SUM TO TOTAL
+                partition_expr: EXTRACT(YEAR FROM report_date)
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: line_type
+                value_column: miles
+                total_label: total
+                tolerance: 1
+              config:
+                error_if: ">4"
         columns:
           - name: report_date
           - name: borrower_id_rus

--- a/dbt/models/rus7/out_rus7__yearly_transmission_and_distribution_mileage/schema.yml
+++ b/dbt/models/rus7/out_rus7__yearly_transmission_and_distribution_mileage/schema.yml
@@ -8,13 +8,23 @@ sources:
           - check_row_counts_per_partition:
               arguments:
                 table_name: out_rus7__yearly_transmission_and_distribution_mileage
-                partition_expr: "EXTRACT(YEAR FROM report_date)"
-          # TODO: CHECK SUBCOMPONENTS SUM TO TOTAL
+                partition_expr: EXTRACT(YEAR FROM report_date)
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: line_type
+                value_column: miles
+                total_label: total
+                tolerance: 1
+              config:
+                error_if: ">4"
         columns:
-          - name: borrower_name_rus
-          - name: state
           - name: report_date
           - name: borrower_id_rus
+          - name: borrower_name_rus
+          - name: state
           - name: line_type
           - name: miles
             data_tests:

--- a/dbt/schema_inputs/rus7/core_rus7__yearly_transmission_and_distribution_mileage/schema.human.yml
+++ b/dbt/schema_inputs/rus7/core_rus7__yearly_transmission_and_distribution_mileage/schema.human.yml
@@ -8,7 +8,17 @@ sources:
               arguments:
                 table_name: core_rus7__yearly_transmission_and_distribution_mileage
                 partition_expr: EXTRACT(YEAR FROM report_date)
-        # TODO: CHECK SUBCOMPONENTS SUM TO TOTAL
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: line_type
+                value_column: miles
+                total_label: total
+                tolerance: 1
+              config:
+                error_if: ">4"
         columns:
           - name: miles
             data_tests:

--- a/dbt/schema_inputs/rus7/out_rus7__yearly_transmission_and_distribution_mileage/schema.human.yml
+++ b/dbt/schema_inputs/rus7/out_rus7__yearly_transmission_and_distribution_mileage/schema.human.yml
@@ -8,7 +8,17 @@ sources:
               arguments:
                 table_name: out_rus7__yearly_transmission_and_distribution_mileage
                 partition_expr: EXTRACT(YEAR FROM report_date)
-        # TODO: CHECK SUBCOMPONENTS SUM TO TOTAL
+          - subcomponents_sum_to_total:
+              arguments:
+                group_by_columns:
+                  - borrower_id_rus
+                  - report_date
+                categorical_column: line_type
+                value_column: miles
+                total_label: total
+                tolerance: 1
+              config:
+                error_if: ">4"
         columns:
           - name: miles
             data_tests:

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,6 +2,20 @@
 PUDL Release Notes
 =======================================================================================
 
+.. _release-v2026.7.0:
+
+---------------------------------------------------------------------------------------
+v2026.7.0 (2026-07-XX)
+---------------------------------------------------------------------------------------
+
+New Data Tests & Validations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* Validate that sub-components in
+  :ref:`core_rus7__yearly_transmission_and_distribution_mileage` and
+  :ref:`out_rus7__yearly_transmission_and_distribution_mileage` sum to their reported
+  totals. See issue :issue:`5314` and PR :pr:`5341`.
+
 .. _release-v2026.6.0:
 
 ---------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `subcomponents_sum_to_total` dbt validations for `core_rus7__yearly_transmission_and_distribution_mileage`.
- Adds the same validation for `out_rus7__yearly_transmission_and_distribution_mileage`.
- Configures both tests with `error_if: ">4"` based on the four known 2006 mismatches in current nightly data.

Closes #5314.

## Context

The RUS 7 form reports `Total Miles Energized` as the sum of miles transmission, miles distribution overhead, and miles distribution underground. The transformed `line_type` values mirror those subcomponents plus `total`, so these tests group by `borrower_id_rus` and `report_date` and compare the summed subcomponents to the reported total with a tolerance of 1 mile.

Current nightly data has four known mismatches in both the core and output tables: `AL0035`, `AR0011`, `MS0050`, and `SD0042`, all for `2006-12-01`.

## Testing

- Refreshed the two target nightly parquet files from `s3://pudl.catalyst.coop/nightly/`.
- Confirmed both tables still have 4 current total-check mismatches using DuckDB.
- `dbt parse --profiles-dir . --project-dir .`
- `dbt_helper validate --asset-select "key:core_rus7__yearly_transmission_and_distribution_mileage"`
  - `PASS=3 WARN=1 ERROR=0`
- `dbt_helper validate --asset-select "key:out_rus7__yearly_transmission_and_distribution_mileage"`
  - `PASS=3 WARN=1 ERROR=0`
- `prek run check-yaml prettier trailing-whitespace end-of-file-fixer --files ...`
