### PR TITLE
Warm gha caches

### DIFF
--- a/.github/workflows/build-deploy-ferceqr.yml
+++ b/.github/workflows/build-deploy-ferceqr.yml
@@ -112,8 +112,8 @@ jobs:
           push: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=catalystcoop/pudl-etl:buildcache
+          cache-to: type=registry,ref=catalystcoop/pudl-etl:buildcache,mode=max
 
       - name: Authenticate with Google Cloud
         id: "gcloud-auth"

--- a/.github/workflows/build-deploy-ferceqr.yml
+++ b/.github/workflows/build-deploy-ferceqr.yml
@@ -112,7 +112,7 @@ jobs:
           push: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
-          # Docker caching temporarily disabled -- see docker-build-test.yml.
+          # Docker caching disabled -- see docker-build-test.yml.
 
       - name: Authenticate with Google Cloud
         id: "gcloud-auth"

--- a/.github/workflows/build-deploy-ferceqr.yml
+++ b/.github/workflows/build-deploy-ferceqr.yml
@@ -112,8 +112,7 @@ jobs:
           push: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
-          cache-from: type=registry,ref=catalystcoop/pudl-etl:buildcache
-          cache-to: type=registry,ref=catalystcoop/pudl-etl:buildcache,mode=max
+          # Docker caching temporarily disabled -- see docker-build-test.yml.
 
       - name: Authenticate with Google Cloud
         id: "gcloud-auth"

--- a/.github/workflows/build-pudl.yml
+++ b/.github/workflows/build-pudl.yml
@@ -130,8 +130,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
-          cache-from: type=registry,ref=catalystcoop/pudl-etl:buildcache
-          cache-to: type=registry,ref=catalystcoop/pudl-etl:buildcache,mode=max
+          # Docker caching temporarily disabled -- see docker-build-test.yml.
 
       - id: "auth"
         if: ${{ env.SKIP_BUILD != 'true' }}

--- a/.github/workflows/build-pudl.yml
+++ b/.github/workflows/build-pudl.yml
@@ -130,7 +130,7 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
-          # Docker caching temporarily disabled -- see docker-build-test.yml.
+          # Docker caching disabled -- see docker-build-test.yml.
 
       - id: "auth"
         if: ${{ env.SKIP_BUILD != 'true' }}

--- a/.github/workflows/build-pudl.yml
+++ b/.github/workflows/build-pudl.yml
@@ -130,8 +130,8 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=catalystcoop/pudl-etl:buildcache
+          cache-to: type=registry,ref=catalystcoop/pudl-etl:buildcache,mode=max
 
       - id: "auth"
         if: ${{ env.SKIP_BUILD != 'true' }}

--- a/.github/workflows/deploy-pudl.yml
+++ b/.github/workflows/deploy-pudl.yml
@@ -138,8 +138,7 @@ jobs:
           push: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
-          cache-from: type=registry,ref=catalystcoop/pudl-etl:buildcache
-          cache-to: type=registry,ref=catalystcoop/pudl-etl:buildcache,mode=max
+          # Docker caching temporarily disabled -- see docker-build-test.yml.
 
       - name: Determine container image to use
         id: container-image

--- a/.github/workflows/deploy-pudl.yml
+++ b/.github/workflows/deploy-pudl.yml
@@ -138,8 +138,8 @@ jobs:
           push: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=catalystcoop/pudl-etl:buildcache
+          cache-to: type=registry,ref=catalystcoop/pudl-etl:buildcache,mode=max
 
       - name: Determine container image to use
         id: container-image

--- a/.github/workflows/deploy-pudl.yml
+++ b/.github/workflows/deploy-pudl.yml
@@ -138,7 +138,7 @@ jobs:
           push: true
           tags: ${{ steps.docker_metadata.outputs.tags }}
           labels: ${{ steps.docker_metadata.outputs.labels }}
-          # Docker caching temporarily disabled -- see docker-build-test.yml.
+          # Docker temporarily disabled -- see docker-build-test.yml.
 
       - name: Determine container image to use
         id: container-image

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -35,11 +35,11 @@ jobs:
           context: .
           file: builds/Dockerfile
           push: false
-          # Docker caching temporarily disabled entirely (all cache-from/
-          # cache-to removed across build-pudl.yml, deploy-pudl.yml,
-          # build-deploy-ferceqr.yml, and here) to verify the Zenodo/FERC
-          # caches work correctly once they aren't competing for the shared
-          # 10GB Actions cache quota. Re-add type=registry caching afterward.
+          # Docker caching disabled entirely (all cache-from/ cache-to removed across
+          # build-pudl.yml, deploy-pudl.yml, build-deploy-ferceqr.yml, and here) to
+          # avoid it taking up all available GitHub Actions cache quota and evicting the
+          # Zenodo/FERC caches. Because of the way we are installing pixi dependencies
+          # in the Dockerfile, this does not significantly increase build time.
 
   pudl_devcontainer_smoke_test:
     name: Test building and running the PUDL devcontainer

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -35,8 +35,11 @@ jobs:
           context: .
           file: builds/Dockerfile
           push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Read-only: this job never logs in to Docker Hub (it runs on
+          # pull_request, including from forks, which don't get secrets), so it
+          # can't write to the registry cache -- but pulling the public
+          # catalystcoop/pudl-etl cache manifest works fine anonymously.
+          cache-from: type=registry,ref=catalystcoop/pudl-etl:buildcache
 
   pudl_devcontainer_smoke_test:
     name: Test building and running the PUDL devcontainer

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -35,11 +35,11 @@ jobs:
           context: .
           file: builds/Dockerfile
           push: false
-          # Read-only: this job never logs in to Docker Hub (it runs on
-          # pull_request, including from forks, which don't get secrets), so it
-          # can't write to the registry cache -- but pulling the public
-          # catalystcoop/pudl-etl cache manifest works fine anonymously.
-          cache-from: type=registry,ref=catalystcoop/pudl-etl:buildcache
+          # Docker caching temporarily disabled entirely (all cache-from/
+          # cache-to removed across build-pudl.yml, deploy-pudl.yml,
+          # build-deploy-ferceqr.yml, and here) to verify the Zenodo/FERC
+          # caches work correctly once they aren't competing for the shared
+          # 10GB Actions cache quota. Re-add type=registry caching afterward.
 
   pudl_devcontainer_smoke_test:
     name: Test building and running the PUDL devcontainer
@@ -73,3 +73,10 @@ jobs:
           # build identifier in CI and is never pushed to GHCR.
           imageName: ghcr.io/catalyst-cooperative/pudl-devcontainer
           runCmd: pixi run --frozen pytest-unit
+          # This action writes its BuildKit cache to the GitHub Actions cache
+          # backend by default. It runs on every PR push and was consuming the
+          # majority of the repo's shared 10GB cache quota (8.2 of 12.8GB
+          # measured on 2026-07-07), evicting the Zenodo/FERC caches
+          # ci-integration depends on. This is a correctness smoke test, not
+          # a performance-sensitive build, so disable caching entirely.
+          noCache: true

--- a/.github/workflows/docs-linkcheck.yml
+++ b/.github/workflows/docs-linkcheck.yml
@@ -28,6 +28,10 @@ jobs:
         with:
           locked: true
           cache: true
+          # Manual-dispatch-only workflow: writing here would create a
+          # branch-scoped cache that's never reused. build-deploy-docs.yml
+          # and warm-gha-caches.yml keep the main-branch copy fresh.
+          cache-write: false
 
       - name: Make input, output and dagster dirs
         run: mkdir -p ${{ env.PUDL_OUTPUT }} ${{ env.PUDL_INPUT }} ${{ env.DAGSTER_HOME }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -235,7 +235,7 @@ jobs:
           cache-write: false
 
       - name: Restore Zenodo datastore from cache if possible
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: cache-zenodo-datastore
         with:
           path: ${{ env.PUDL_INPUT }}
@@ -252,7 +252,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Restore ferc1 XBRL outputs from cache if possible
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: cache-ferc1-xbrl
         with:
           path: |
@@ -263,7 +263,7 @@ jobs:
           key: ferc1-xbrl-${{ env.FERC1_XBRL_HASH }}
 
       - name: Restore ferc1 DBF from cache if possible
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: cache-ferc1-dbf
         with:
           path: |
@@ -272,7 +272,7 @@ jobs:
           key: ferc1-dbf-${{ env.FERC1_DBF_HASH }}
 
       - name: Restore ferc714 XBRL from cache if possible
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: cache-ferc714-xbrl
         with:
           path: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -56,6 +56,7 @@ jobs:
               - '!.github/workflows/q-update-issue-scheduler.yml'
               - '!.github/workflows/release.yml'
               - '!.github/workflows/update-lockfiles.yml'
+              - '!.github/workflows/warm-gha-caches.yml'
               - '!.github/workflows/zenodo-cache-sync.yml'
               - '!.github/workflows/zenodo-data-release.yml'
               - '!.github/skills/**'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -104,7 +104,13 @@ jobs:
         with:
           locked: true
           cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          # This workflow never writes the pixi env cache: it runs on every
+          # PR/merge_group push, so writing here would refill the shared 10GB
+          # Actions cache quota with branch-scoped copies that mostly never
+          # get reused. build-deploy-docs.yml (push to main) and
+          # warm-gha-caches.yml are responsible for keeping the main-branch
+          # copy fresh.
+          cache-write: false
 
       - name: Make input, output and dagster dirs
         run: mkdir -p ${{ env.PUDL_OUTPUT }} ${{ env.PUDL_INPUT}} ${{ env.DAGSTER_HOME }}
@@ -141,7 +147,8 @@ jobs:
         with:
           locked: true
           cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          # See ci-docs above for why this is always false.
+          cache-write: false
 
       - name: Make input, output and dagster dirs
         run: mkdir -p ${{ env.PUDL_OUTPUT }} ${{ env.PUDL_INPUT}} ${{ env.DAGSTER_HOME }}
@@ -178,7 +185,8 @@ jobs:
         with:
           locked: true
           cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          # See ci-docs above for why this is always false.
+          cache-write: false
 
       - name: Make input, output and dagster dirs
         run: |
@@ -223,7 +231,8 @@ jobs:
         with:
           locked: true
           cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          # See ci-docs above for why this is always false.
+          cache-write: false
 
       - name: Restore Zenodo datastore from cache if possible
         uses: actions/cache@v5
@@ -320,6 +329,8 @@ jobs:
         with:
           locked: true
           cache: true
+          # See ci-docs above for why this is always false.
+          cache-write: false
       - name: Combine coverage data, output XML, and report
         run: |
           pixi run coverage combine coverage/*/.coverage

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -226,7 +226,7 @@ jobs:
           cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
       - name: Restore Zenodo datastore from cache if possible
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         id: cache-zenodo-datastore
         with:
           path: ${{ env.PUDL_INPUT }}
@@ -243,7 +243,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Restore ferc1 XBRL outputs from cache if possible
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         id: cache-ferc1-xbrl
         with:
           path: |
@@ -254,7 +254,7 @@ jobs:
           key: ferc1-xbrl-${{ env.FERC1_XBRL_HASH }}
 
       - name: Restore ferc1 DBF from cache if possible
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         id: cache-ferc1-dbf
         with:
           path: |
@@ -263,7 +263,7 @@ jobs:
           key: ferc1-dbf-${{ env.FERC1_DBF_HASH }}
 
       - name: Restore ferc714 XBRL from cache if possible
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         id: cache-ferc714-xbrl
         with:
           path: |

--- a/.github/workflows/update-dois.yml
+++ b/.github/workflows/update-dois.yml
@@ -29,7 +29,10 @@ jobs:
         with:
           locked: true
           cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          # This workflow only triggers on schedule/workflow_dispatch, never
+          # push, so it never writes. warm-gha-caches.yml and
+          # build-deploy-docs.yml keep the main-branch copy fresh.
+          cache-write: false
 
       - name: Run Zenodo DOI updater
         id: update

--- a/.github/workflows/warm-gha-caches.yml
+++ b/.github/workflows/warm-gha-caches.yml
@@ -56,7 +56,7 @@ jobs:
       # they must use identical cache keys and paths so the entries this job
       # writes are usable by (and reused from) that job.
       - name: Restore Zenodo datastore from cache if possible
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: cache-zenodo-datastore
         with:
           path: ${{ env.PUDL_INPUT }}
@@ -73,7 +73,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Restore ferc1 XBRL outputs from cache if possible
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: cache-ferc1-xbrl
         with:
           path: |
@@ -84,7 +84,7 @@ jobs:
           key: ferc1-xbrl-${{ env.FERC1_XBRL_HASH }}
 
       - name: Restore ferc1 DBF from cache if possible
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: cache-ferc1-dbf
         with:
           path: |
@@ -93,7 +93,7 @@ jobs:
           key: ferc1-dbf-${{ env.FERC1_DBF_HASH }}
 
       - name: Restore ferc714 XBRL from cache if possible
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         id: cache-ferc714-xbrl
         with:
           path: |

--- a/.github/workflows/warm-gha-caches.yml
+++ b/.github/workflows/warm-gha-caches.yml
@@ -52,7 +52,7 @@ jobs:
       # they must use identical cache keys and paths so the entries this job
       # writes are usable by (and reused from) that job.
       - name: Restore Zenodo datastore from cache if possible
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         id: cache-zenodo-datastore
         with:
           path: ${{ env.PUDL_INPUT }}
@@ -69,7 +69,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Restore ferc1 XBRL outputs from cache if possible
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         id: cache-ferc1-xbrl
         with:
           path: |
@@ -80,7 +80,7 @@ jobs:
           key: ferc1-xbrl-${{ env.FERC1_XBRL_HASH }}
 
       - name: Restore ferc1 DBF from cache if possible
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         id: cache-ferc1-dbf
         with:
           path: |
@@ -89,7 +89,7 @@ jobs:
           key: ferc1-dbf-${{ env.FERC1_DBF_HASH }}
 
       - name: Restore ferc714 XBRL from cache if possible
-        uses: actions/cache@v6
+        uses: actions/cache@v5
         id: cache-ferc714-xbrl
         with:
           path: |

--- a/.github/workflows/warm-gha-caches.yml
+++ b/.github/workflows/warm-gha-caches.yml
@@ -1,0 +1,110 @@
+---
+name: warm-gha-caches
+
+# Cache entries written by pytest.yml's ci-integration job (the raw Zenodo
+# datastore archives, and the generated ferc1/ferc714 databases) are scoped to
+# the branch that created them, with a fallback to the repository's default
+# branch. But pytest.yml never runs directly on main -- only on
+# pull_request/merge_group/workflow_dispatch -- so no cache entry it writes ever
+# becomes reachable from that default-branch fallback: pull_request runs are
+# scoped to their own head branch, and merge_group runs are scoped to GitHub's
+# ephemeral gh-readonly-queue ref, which is unique per merge attempt.
+#
+# This workflow plugs that gap: once a day, it restores the same four caches
+# ci-integration relies on (the Zenodo datastore, and the ferc1 dbf/xbrl and
+# ferc714 xbrl databases), and only runs the full integration test suite --
+# which downloads and regenerates all of them -- if at least one actually
+# missed.
+on:
+  schedule:
+    - cron: "0 5 * * *" # 5am UTC daily, ahead of the 6am nightly ETL build
+  workflow_dispatch:
+
+env:
+  PUDL_OUTPUT: /home/runner/pudl-work/output/
+  PUDL_INPUT: /home/runner/pudl-work/input/
+  DAGSTER_HOME: /home/runner/pudl-work/dagster_home/
+  ZENODO_SANDBOX_TOKEN_PUBLISH: ${{ secrets.ZENODO_SANDBOX_TOKEN_PUBLISH }}
+
+jobs:
+  warm-pytest-integration-caches:
+    # Same runner as pytest.yml's ci-integration job -- see the comment there.
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        shell: bash {0}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - name: Install pudl environment using pixi
+        uses: prefix-dev/setup-pixi@v0.10.0
+        with:
+          locked: true
+          cache: true
+          cache-write: true
+
+      # The steps below intentionally mirror pytest.yml's ci-integration job:
+      # they must use identical cache keys and paths so the entries this job
+      # writes are usable by (and reused from) that job.
+      - name: Restore Zenodo datastore from cache if possible
+        uses: actions/cache@v6
+        id: cache-zenodo-datastore
+        with:
+          path: ${{ env.PUDL_INPUT }}
+          key: zenodo-datastore-${{ hashFiles('src/pudl/package_data/settings/zenodo_dois.yml') }}
+          restore-keys: |
+            zenodo-datastore-
+
+      - name: Generate FERC Provenance Hashes
+        run: |
+          {
+            echo "FERC1_XBRL_HASH=$(pixi run generate_ferc_provenance ferc1 xbrl | sha256sum | cut -d' ' -f1)"
+            echo "FERC1_DBF_HASH=$(pixi run generate_ferc_provenance ferc1 dbf | sha256sum | cut -d' ' -f1)"
+            echo "FERC714_XBRL_HASH=$(pixi run generate_ferc_provenance ferc714 xbrl | sha256sum | cut -d' ' -f1)"
+          } >> "$GITHUB_ENV"
+
+      - name: Restore ferc1 XBRL outputs from cache if possible
+        uses: actions/cache@v6
+        id: cache-ferc1-xbrl
+        with:
+          path: |
+            ${{ env.PUDL_OUTPUT }}/ferc1_xbrl.sqlite
+            ${{ env.PUDL_OUTPUT }}/ferc1_xbrl.duckdb
+            ${{ env.PUDL_OUTPUT }}/ferc1_xbrl_datapackage.json
+            ${{ env.PUDL_OUTPUT }}/ferc1_xbrl_taxonomy_metadata.json
+          key: ferc1-xbrl-${{ env.FERC1_XBRL_HASH }}
+
+      - name: Restore ferc1 DBF from cache if possible
+        uses: actions/cache@v6
+        id: cache-ferc1-dbf
+        with:
+          path: |
+            ${{ env.PUDL_OUTPUT }}/ferc1_dbf.sqlite
+            ${{ env.PUDL_OUTPUT }}/ferc1_dbf_datapackage.json
+          key: ferc1-dbf-${{ env.FERC1_DBF_HASH }}
+
+      - name: Restore ferc714 XBRL from cache if possible
+        uses: actions/cache@v6
+        id: cache-ferc714-xbrl
+        with:
+          path: |
+            ${{ env.PUDL_OUTPUT }}/ferc714_xbrl.sqlite
+            ${{ env.PUDL_OUTPUT }}/ferc714_xbrl.duckdb
+            ${{ env.PUDL_OUTPUT }}/ferc714_xbrl_datapackage.json
+            ${{ env.PUDL_OUTPUT }}/ferc714_xbrl_taxonomy_metadata.json
+          key: ferc714-xbrl-${{ env.FERC714_XBRL_HASH }}
+
+      - name: Run the integration tests if any cache was missed
+        if: |
+          steps.cache-zenodo-datastore.outputs.cache-hit != 'true' ||
+          steps.cache-ferc1-xbrl.outputs.cache-hit != 'true' ||
+          steps.cache-ferc1-dbf.outputs.cache-hit != 'true' ||
+          steps.cache-ferc714-xbrl.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p ${{ env.PUDL_OUTPUT }} ${{ env.PUDL_INPUT }} ${{ env.DAGSTER_HOME }}
+          pixi run pytest-integration

--- a/.github/workflows/warm-gha-caches.yml
+++ b/.github/workflows/warm-gha-caches.yml
@@ -46,7 +46,11 @@ jobs:
         with:
           locked: true
           cache: true
-          cache-write: true
+          # Only write when this is reachable as the main-branch fallback for
+          # other branches. The daily schedule always runs on main, so this
+          # doesn't affect that path -- it only stops a manual test dispatch
+          # on a feature branch from writing a dead-end branch-scoped copy.
+          cache-write: ${{ github.ref_name == 'main' }}
 
       # The steps below intentionally mirror pytest.yml's ci-integration job:
       # they must use identical cache keys and paths so the entries this job

--- a/.github/workflows/zenodo-cache-sync.yml
+++ b/.github/workflows/zenodo-cache-sync.yml
@@ -35,7 +35,10 @@ jobs:
         with:
           locked: true
           cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          # This workflow triggers on schedule/workflow_dispatch/pull_request,
+          # never push, so it never writes. warm-gha-caches.yml and
+          # build-deploy-docs.yml keep the main-branch copy fresh.
+          cache-write: false
 
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@v6

--- a/.github/workflows/zenodo-data-release.yml
+++ b/.github/workflows/zenodo-data-release.yml
@@ -60,7 +60,10 @@ jobs:
         with:
           locked: true
           cache: true
-          cache-write: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+          # This workflow only triggers on workflow_dispatch, never push, so
+          # it never writes. warm-gha-caches.yml and build-deploy-docs.yml
+          # keep the main-branch copy fresh.
+          cache-write: false
 
       - name: Do a Zenodo data release
         env:


### PR DESCRIPTION
# Overview

- Trying to make sure that our work to cache Zenodo archives& FERC DBs is actually being used.

Closes #XXXX.

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://docs.catalyst.coop/pudl/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run prek-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://docs.catalyst.coop/pudl/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
