### PR TITLE
Fix batch job IDs to comply with google regex

### DIFF
--- a/.github/workflows/build-pudl.yml
+++ b/.github/workflows/build-pudl.yml
@@ -49,7 +49,7 @@ jobs:
         # Nightly builds and builds triggered by stable tag pushes trigger production
         # deployments. Branch builds trigger staging deployments
         run: |
-          BUILD_ID="$(date +%Y-%m-%d-%H%M)-$(git rev-parse --short=9 HEAD)-${{ github.ref_name }}"
+          BUILD_ID="$(date +%Y-%m-%d-%H%M)-$(git rev-parse --short=9 HEAD)"
           echo "BUILD_ID=$BUILD_ID" >> "$GITHUB_ENV"
           if [[ ${{ github.event_name }} == "schedule" ]]; then
               echo "GIT_TAG=nightly-$(date +%Y-%m-%d)" >> "$GITHUB_ENV"
@@ -82,7 +82,7 @@ jobs:
           if [[ "${{ env.SKIP_BUILD }}" == 'true' ]]; then
             echo "notification_content=:ghost: Skipping nightly build for $(date +%Y-%m-%d)" >> "$GITHUB_ENV"
           else
-            echo "notification_content=:rocket: Launching PUDL Build: ${{ env.BUILD_ID }}" >> "$GITHUB_ENV"
+            echo "notification_content=:rocket: Launching PUDL Build: ${{ env.BUILD_ID }} (${{ env.GIT_TAG }})" >> "$GITHUB_ENV"
           fi
 
       - name: Notify Zulip of build start or skip
@@ -149,7 +149,7 @@ jobs:
       - name: Make GCP Batch config file
         if: ${{ env.SKIP_BUILD != 'true' }}
         env:
-          PUDL_GCS_OUTPUT: ${{ env.GCS_OUTPUT_BUCKET }}/${{ env.BUILD_ID }}
+          PUDL_GCS_OUTPUT: ${{ env.GCS_OUTPUT_BUCKET }}/${{ env.BUILD_ID }}-${{ env.GIT_TAG }}
         run: |-
           ./devtools/generate_batch_config.py \
             --container-image "docker.io/catalystcoop/pudl-etl@${{ steps.docker-build.outputs.digest }}" \
@@ -203,4 +203,4 @@ jobs:
           to: "pudl-deployments"
           topic: "build-deploy-pudl"
           content: >
-            ${{ env.emoji }} Google Batch job for ${{ env.BUILD_ID }} launched with status: ${{ job.status }}.
+            ${{ env.emoji }} Google Batch job for ${{ env.BUILD_ID }} (${{ env.GIT_TAG }}) launched with status: ${{ job.status }}.

--- a/.github/workflows/build-pudl.yml
+++ b/.github/workflows/build-pudl.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Make GCP Batch config file
         if: ${{ env.SKIP_BUILD != 'true' }}
         env:
-          PUDL_GCS_OUTPUT: ${{ env.GCS_OUTPUT_BUCKET }}/${{ env.BUILD_ID }}-${{ env.GIT_TAG }}
+          PUDL_GCS_OUTPUT: ${{ env.GCS_OUTPUT_BUCKET }}/${{ env.BUILD_ID }}
         run: |-
           ./devtools/generate_batch_config.py \
             --container-image "docker.io/catalystcoop/pudl-etl@${{ steps.docker-build.outputs.digest }}" \


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://docs.catalyst.coop/pudl/en/nightly/CONTRIBUTING.html
* code of conduct: https://docs.catalyst.coop/pudl/en/nightly/code_of_conduct.html
-->

# Overview

## What problem does this address?

build fails on release tags, which contain the "." character

## What did you change?

Drop gitref from job ids, and annotate only human-readable texts as needed

## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://docs.catalyst.coop/pudl/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run prek-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://docs.catalyst.coop/pudl/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
