### PR TITLE
Check who OPENED the PR, not the last actor on it.

### DIFF
--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -40,4 +40,4 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto "$PR_URL"
+          gh pr merge --auto "$PR_URL"    

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -15,9 +15,12 @@ jobs:
   bot-auto-merge:
     name: Auto-merge passing bot PRs
     runs-on: ubuntu-latest
+    # Gate on who *opened* the PR, not github.actor -- for a `synchronize` event,
+    # github.actor is whoever pushed the latest commit (e.g. pre-commit-ci fixing up
+    # a human-authored PR), which must not by itself trigger auto-merge.
     if: >-
-      github.actor == 'dependabot[bot]' ||
-      github.actor == 'pre-commit-ci[bot]'
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'pre-commit-ci[bot]'
     steps:
       - name: Impersonate auto merge PR bot
         uses: actions/create-github-app-token@v3

--- a/.github/workflows/bot-auto-merge.yml
+++ b/.github/workflows/bot-auto-merge.yml
@@ -40,4 +40,4 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto "$PR_URL"    
+          gh pr merge --auto "$PR_URL"


### PR DESCRIPTION
# Overview

- Previously the `bot-auto-merge.yml` action decided whether to merge based on the identity of the most recent *actor* on the PR, rather than the user who *opened* the PR.
- This led to the surprising and unintended outcome of #5395 auto-merging immediately after the @pre-commit-ci bot fixed some formatting.
- I've changed it to look at the PR opener, not the last actor.
- In general, the `gh pr merge --auto` call defers to whatever the branch protection rules are, rather than encoding the merge criteria in the action, so if we want to change when things can be merged, that can be a repo-level configuration.

# Testing

- Hard to test whether it works how we want without getting a real pre-commit or dependabot PR
- But maybe I can try to reproduce the oopsie on this PR and see if it merges when pre-commit bot fixes something...

## To-do list

- [x] Introduce a minor formatting issue that the pre-commit hooks will fix, and see if the PR auto-merges.