### PR TITLE
Warm up C-NEMS Zenodo cache

### DIFF
--- a/src/pudl/package_data/settings/zenodo_dois.yml
+++ b/src/pudl/package_data/settings/zenodo_dois.yml
@@ -10,6 +10,7 @@ eia923: 10.5281/zenodo.21108616
 eia930: 10.5281/zenodo.21204532
 eiaaeo: 10.5281/zenodo.19535635
 eiaapi: 10.5281/zenodo.21204533
+eianems: 10.5281/zenodo.20380636
 epacamd_eia: 10.5281/zenodo.17582121
 epacems: 10.5281/zenodo.21204540
 ferc1: 10.5281/zenodo.20474290

--- a/src/pudl/workspace/datastore.py
+++ b/src/pudl/workspace/datastore.py
@@ -195,6 +195,7 @@ class ZenodoDoiSettings(BaseSettings):
     eia930: ZenodoDoi
     eiaaeo: ZenodoDoi
     eiaapi: ZenodoDoi
+    eianems: ZenodoDoi
     epacamd_eia: ZenodoDoi
     epacems: ZenodoDoi
     ferc1: ZenodoDoi


### PR DESCRIPTION
# Do not merge this PR

- Add the new C-NEMS archive DOIs to `zenodo_dois.yml` on this branch.
- Add the new dataset ID to the list of known datasets un the `datastore.py` module.
- Push to the branch and `zenodo-cache-sync.yml` will be triggered, warming the cache in S3
- Update the DOI if need be later and re-push and the new version will get uploaded to S3.