### PR TITLE
Switch com-dev-notify to run on pr target

### DIFF
--- a/.github/workflows/com-dev-notify.yml
+++ b/.github/workflows/com-dev-notify.yml
@@ -17,7 +17,7 @@ env:
   username: ""
   url: ""
   org: catalyst-cooperative
-  ignored_users: '["e-belfer", "krivard"]'     
+  ignored_users: '["e-belfer", "krivard"]'
 jobs:
   com-dev-notify:
     name: Notify Catalyst of community activity

--- a/.github/workflows/com-dev-notify.yml
+++ b/.github/workflows/com-dev-notify.yml
@@ -10,7 +10,7 @@ on:
     types: [created]
   issue_comment:
     types: [created]
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 env:
@@ -48,7 +48,7 @@ jobs:
           echo "url=${{ github.event.comment.html_url }}" >> "${GITHUB_ENV}"
 
       - name: Get username if a pull request was opened
-        if: ${{ github.event_name == 'pull_request' }}
+        if: ${{ github.event_name == 'pull_request_target' }}
         run: |
           echo "username=${{ github.event.pull_request.user.login }}" >> "${GITHUB_ENV}"
           echo "url=${{ github.event.pull_request.html_url }}" >> "${GITHUB_ENV}"

--- a/.github/workflows/com-dev-notify.yml
+++ b/.github/workflows/com-dev-notify.yml
@@ -17,7 +17,7 @@ env:
   username: ""
   url: ""
   org: catalyst-cooperative
-  ignored_users: '["e-belfer", "krivard"]'
+  ignored_users: '["e-belfer", "krivard"]'     
 jobs:
   com-dev-notify:
     name: Notify Catalyst of community activity


### PR DESCRIPTION
# Overview

- The `com-dev-notify.yml` workflow fails when it's run on a PR from a fork because permissions.
- Changed run on from `pull_request` to `pull_request_target` which should fix this.
- ✅ 🤖 I will also check whether our other bot PR bugbear is fixed on this little guy...