### PR TITLE
Sanitize batch IDs for deploy/build jobs

### DIFF
--- a/.github/workflows/build-pudl.yml
+++ b/.github/workflows/build-pudl.yml
@@ -49,18 +49,23 @@ jobs:
         # Nightly builds and builds triggered by stable tag pushes trigger production
         # deployments. Branch builds trigger staging deployments
         run: |
-          BUILD_ID="$(date +%Y-%m-%d-%H%M)-$(git rev-parse --short=9 HEAD)"
+          BUILD_ID_SUFFIX="$(date +%Y-%m-%d-%H%M)-$(git rev-parse --short=9 HEAD)-${{ github.ref_name }}"
           echo "BUILD_ID=$BUILD_ID" >> "$GITHUB_ENV"
           if [[ ${{ github.event_name }} == "schedule" ]]; then
               echo "GIT_TAG=nightly-$(date +%Y-%m-%d)" >> "$GITHUB_ENV"
               echo "DEPLOYMENT_ENVIRONMENT=production" >> "$GITHUB_ENV"
+              BUILD_ID_RAW="nightly-$BUILD_ID_SUFFIX"
           elif [[ ${{ github.event_name }} == "workflow_dispatch" ]]; then
-              echo "GIT_TAG=branch-$BUILD_ID" >> "$GITHUB_ENV"
               echo "DEPLOYMENT_ENVIRONMENT=staging" >> "$GITHUB_ENV"
+              BUILD_ID_RAW="branch-$BUILD_ID_SUFFIX"
+              echo "GIT_TAG=$BUILD_ID_RAW" >> "$GITHUB_ENV"
           elif [[ ${{ github.event_name }} == "push" ]]; then
               echo "GIT_TAG=${{ github.ref_name }}" >>  "$GITHUB_ENV"
               echo "DEPLOYMENT_ENVIRONMENT=production" >> "$GITHUB_ENV"
+              BUILD_ID_RAW="stable-$BUILD_ID_SUFFIX"
           fi
+          BUILD_ID_SANITIZED="$(echo $BUILD_ID_RAW | sed 's/[^[:alnum:]-]/-/g')"
+          echo "BUILD_ID=${BUILD_ID_SANITIZED:0:63}" >> "$GITHUB_ENV"
 
       - name: Show freshly set envvars
         if: ${{ env.SKIP_BUILD != 'true' }}
@@ -180,7 +185,7 @@ jobs:
       # Start the batch job
       - name: Kick off batch job
         if: ${{ env.SKIP_BUILD != 'true' }}
-        run: gcloud batch jobs submit build-pudl-${{ env.BUILD_ID }} --config ${{ env.BATCH_JOB_JSON }} --location us-west1
+        run: gcloud batch jobs submit ${{ env.BUILD_ID }} --config ${{ env.BATCH_JOB_JSON }} --location us-west1
 
       - name: Status emoji
         if: ${{ env.SKIP_BUILD != 'true' }}

--- a/.github/workflows/deploy-pudl.yml
+++ b/.github/workflows/deploy-pudl.yml
@@ -28,9 +28,6 @@ jobs:
       # (either by a human via the UI, or by pudl_batch.sh's automated dispatch).
       GIT_TAG: ${{ inputs.git_tag }}
       DEPLOYMENT_ENVIRONMENT: ${{ inputs.deployment_environment }}
-      # Computed once and reused for both the container-env (so pudl_deploy can
-      # link to this job's own logs) and the actual job submission below.
-      BATCH_JOB_NAME: deploy-pudl-${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -96,6 +93,13 @@ jobs:
             echo "* [View this deploy-pudl.yml run]($RUN_URL)"
             echo "EOF"
           } >> "$GITHUB_ENV"
+
+      - name: Set batch ID
+        if: ${{ always() }}
+        run: |
+          BUILD_ID_RAW="deploy-${{ env.DEPLOYMENT_ENVIRONMENT }}-$(date +%Y-%m-%d-%H%M)-${{ env.GIT_TAG }}"
+          BUILD_ID_SANITIZED="$(echo $BUILD_ID_RAW | sed 's/[^[:alnum:]-]/-/g')"
+          echo "BUILD_ID=${BUILD_ID_SANITIZED:0:63}" >> "$GITHUB_ENV"
 
       - name: Notify Zulip of deployment start
         if: ${{ always() }}
@@ -168,14 +172,14 @@ jobs:
             --container-env AWS_DEFAULT_REGION=${{ secrets.AWS_DEFAULT_REGION }} \
             --container-env AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }} \
             --container-env ZULIP_API_KEY=${{ secrets.ZULIP_API_KEY }} \
-            --container-env BATCH_JOB_NAME=${{ env.BATCH_JOB_NAME }} \
+            --container-env BATCH_JOB_NAME=${{ env.BUILD_ID }} \
             --vcpu=8 \
             --mem-gb=31 \
             --disk-gb=100 \
             --output batch_job.json
 
       - name: Kick off batch job
-        run: gcloud batch jobs submit ${{ env.BATCH_JOB_NAME }} --config batch_job.json --location us-east1
+        run: gcloud batch jobs submit ${{ env.BUILD_ID }} --config batch_job.json --location us-east1
 
       - name: Status emoji
         if: ${{ always() }}

--- a/src/pudl/deploy/pudl.py
+++ b/src/pudl/deploy/pudl.py
@@ -605,9 +605,11 @@ def get_build_from_tag(tag: str) -> UPath:
     # Loop through all builds associated with git ref and find most recent one
     most_recent_build_dt = datetime.min
     most_recent_build_path = None
-    build_path_pattern = re.compile(r"(\d{4}-\d{2}-\d{2}-\d{4})-([a-f|0-9]{9})")
+    build_path_pattern = re.compile(
+        r"(nightly|branch|stable)-(\d{4}-\d{2}-\d{2}-\d{4})-([a-f|0-9]{9})-.+"
+    )
     checked = []
-    for build_path in build_bucket.glob(f"*-{git_ref}"):
+    for build_path in build_bucket.glob(f"*-{git_ref}-*"):
         checked.append(str(build_path))
         if (match := build_path_pattern.search(str(build_path))) is None:
             raise RuntimeError(
@@ -615,7 +617,7 @@ def get_build_from_tag(tag: str) -> UPath:
             )
 
         if (
-            next_dt := datetime.strptime(match.group(1), "%Y-%m-%d-%H%M")
+            next_dt := datetime.strptime(match.group(2), "%Y-%m-%d-%H%M")
         ) > most_recent_build_dt:
             most_recent_build_dt = next_dt
             most_recent_build_path = build_path

--- a/tests/unit/deploy/deploy_pudl_test.py
+++ b/tests/unit/deploy/deploy_pudl_test.py
@@ -567,9 +567,14 @@ def test_update_pudl_viewer_selects_workflow_by_environment(
 @pytest.mark.parametrize(
     "create_builds,build_successful,build_type,git_ref_name",
     [
-        (True, True, "nightly", "main"),
-        (True, False, "stable", "v2026-01-01"),
-        (False, True, "branch", "my-branch-name"),
+        (create_builds, build_successful, *build_type_info)
+        for create_builds in [True, False]
+        for build_successful in [True, False]
+        for build_type_info in [
+            ("nightly", "main"),
+            ("stable", "v2026-01-01"),
+            ("branch", "my-branch-name"),
+        ]
     ],
 )
 def test_get_build_from_tag(

--- a/tests/unit/deploy/deploy_pudl_test.py
+++ b/tests/unit/deploy/deploy_pudl_test.py
@@ -565,15 +565,19 @@ def test_update_pudl_viewer_selects_workflow_by_environment(
 
 
 @pytest.mark.parametrize(
-    "create_builds,build_successful",
+    "create_builds,build_successful,build_type,git_ref_name",
     [
-        (True, True),
-        (True, False),
-        (False, True),
+        (True, True, "nightly", "main"),
+        (True, False, "stable", "v2026-01-01"),
+        (False, True, "branch", "my-branch-name"),
     ],
 )
 def test_get_build_from_tag(
-    tmp_path: Path, create_builds: bool, build_successful: bool
+    tmp_path: Path,
+    create_builds: bool,
+    build_successful: bool,
+    build_type: str,
+    git_ref_name: str,
 ):
     """Test getting build path from git tag."""
     example_tag = "example_tag"
@@ -583,11 +587,11 @@ def test_get_build_from_tag(
     # Create build directories in tmp_path
     if create_builds:
         for build_name, most_recent_build in [
-            (f"2026-02-04-1230-{expected_hash}", True),
-            (f"2026-02-04-0530-{expected_hash}", False),
-            (f"2026-01-01-0000-{expected_hash}", False),
-            (f"2026-01-01-1200-{other_hash}", True),
-            (f"2025-12-31-1200-{other_hash}", False),
+            (f"{build_type}-2026-02-04-1230-{expected_hash}-{git_ref_name}", True),
+            (f"{build_type}-2026-02-04-0530-{expected_hash}-{git_ref_name}", False),
+            (f"{build_type}-2026-01-01-0000-{expected_hash}-{git_ref_name}", False),
+            (f"{build_type}-2026-01-01-1200-{other_hash}-{git_ref_name}", True),
+            (f"{build_type}-2025-12-31-1200-{other_hash}-{git_ref_name}", False),
         ]:
             build_path = tmp_path / build_name
             build_path.mkdir()


### PR DESCRIPTION
# Overview

Closes #5411.

## What problem does this address?
Google enforces strict requirements for batch job IDs. This caused issues during our last release that we had to work around by making the IDs more generic. This PR improves the IDs to make them compatible with Google's requirements while still containing useful information.

## What did you change?
Updated the `deploy`/`build` workflows to sanitize IDs.