### PR TITLE
Enable content validation for LazyFrame checks

### DIFF
--- a/.pyrefly-baseline.json
+++ b/.pyrefly-baseline.json
@@ -3541,9 +3541,9 @@
       "severity": "error"
     },
     {
-      "line": 619,
+      "line": 622,
       "column": 26,
-      "stop_line": 619,
+      "stop_line": 622,
       "stop_column": 30,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3553,9 +3553,9 @@
       "severity": "error"
     },
     {
-      "line": 769,
+      "line": 772,
       "column": 25,
-      "stop_line": 769,
+      "stop_line": 772,
       "stop_column": 52,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3565,9 +3565,9 @@
       "severity": "error"
     },
     {
-      "line": 780,
+      "line": 783,
       "column": 25,
-      "stop_line": 780,
+      "stop_line": 783,
       "stop_column": 52,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3577,9 +3577,9 @@
       "severity": "error"
     },
     {
-      "line": 781,
+      "line": 784,
       "column": 26,
-      "stop_line": 781,
+      "stop_line": 784,
       "stop_column": 54,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3589,9 +3589,9 @@
       "severity": "error"
     },
     {
-      "line": 912,
+      "line": 915,
       "column": 31,
-      "stop_line": 912,
+      "stop_line": 915,
       "stop_column": 41,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3601,9 +3601,9 @@
       "severity": "error"
     },
     {
-      "line": 1474,
+      "line": 1477,
       "column": 12,
-      "stop_line": 1474,
+      "stop_line": 1477,
       "stop_column": 18,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3613,9 +3613,9 @@
       "severity": "error"
     },
     {
-      "line": 1700,
+      "line": 1703,
       "column": 22,
-      "stop_line": 1700,
+      "stop_line": 1703,
       "stop_column": 49,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3625,9 +3625,9 @@
       "severity": "error"
     },
     {
-      "line": 1701,
+      "line": 1704,
       "column": 17,
-      "stop_line": 1701,
+      "stop_line": 1704,
       "stop_column": 44,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3637,9 +3637,9 @@
       "severity": "error"
     },
     {
-      "line": 1703,
+      "line": 1706,
       "column": 21,
-      "stop_line": 1703,
+      "stop_line": 1706,
       "stop_column": 26,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3649,9 +3649,9 @@
       "severity": "error"
     },
     {
-      "line": 1848,
+      "line": 1851,
       "column": 9,
-      "stop_line": 1849,
+      "stop_line": 1852,
       "stop_column": 41,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3661,9 +3661,9 @@
       "severity": "error"
     },
     {
-      "line": 1906,
+      "line": 1909,
       "column": 47,
-      "stop_line": 1906,
+      "stop_line": 1909,
       "stop_column": 56,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3673,9 +3673,9 @@
       "severity": "error"
     },
     {
-      "line": 2074,
+      "line": 2077,
       "column": 22,
-      "stop_line": 2074,
+      "stop_line": 2077,
       "stop_column": 30,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3685,39 +3685,15 @@
       "severity": "error"
     },
     {
-      "line": 2119,
+      "line": 2122,
       "column": 10,
-      "stop_line": 2123,
+      "stop_line": 2126,
       "stop_column": 17,
       "path": "src/pudl/helpers.py",
       "code": -2,
       "name": "missing-attribute",
       "description": "Object of class `ndarray` has no attribute `filled`",
       "concise_description": "Object of class `ndarray` has no attribute `filled`",
-      "severity": "error"
-    },
-    {
-      "line": 2155,
-      "column": 35,
-      "stop_line": 2155,
-      "stop_column": 46,
-      "path": "src/pudl/helpers.py",
-      "code": -2,
-      "name": "bad-argument-type",
-      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "severity": "error"
-    },
-    {
-      "line": 2156,
-      "column": 9,
-      "stop_line": 2156,
-      "stop_column": 32,
-      "path": "src/pudl/helpers.py",
-      "code": -2,
-      "name": "unsupported-operation",
-      "description": "`+` is not supported between `Iterable[str]` and `list[str]`\n  Cannot find `__radd__` or `__add__`",
-      "concise_description": "`+` is not supported between `Iterable[str]` and `list[str]`",
       "severity": "error"
     },
     {
@@ -3745,9 +3721,33 @@
       "severity": "error"
     },
     {
-      "line": 2371,
+      "line": 2161,
+      "column": 35,
+      "stop_line": 2161,
+      "stop_column": 46,
+      "path": "src/pudl/helpers.py",
+      "code": -2,
+      "name": "bad-argument-type",
+      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
+      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
+      "severity": "error"
+    },
+    {
+      "line": 2162,
+      "column": 9,
+      "stop_line": 2162,
+      "stop_column": 32,
+      "path": "src/pudl/helpers.py",
+      "code": -2,
+      "name": "unsupported-operation",
+      "description": "`+` is not supported between `Iterable[str]` and `list[str]`\n  Cannot find `__radd__` or `__add__`",
+      "concise_description": "`+` is not supported between `Iterable[str]` and `list[str]`",
+      "severity": "error"
+    },
+    {
+      "line": 2406,
       "column": 57,
-      "stop_line": 2371,
+      "stop_line": 2406,
       "stop_column": 73,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3757,9 +3757,9 @@
       "severity": "error"
     },
     {
-      "line": 2492,
+      "line": 2527,
       "column": 1,
-      "stop_line": 2492,
+      "stop_line": 2527,
       "stop_column": 16,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3769,9 +3769,9 @@
       "severity": "error"
     },
     {
-      "line": 2495,
+      "line": 2530,
       "column": 6,
-      "stop_line": 2495,
+      "stop_line": 2530,
       "stop_column": 63,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3781,9 +3781,9 @@
       "severity": "error"
     },
     {
-      "line": 2521,
+      "line": 2556,
       "column": 6,
-      "stop_line": 2521,
+      "stop_line": 2556,
       "stop_column": 29,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3793,9 +3793,9 @@
       "severity": "error"
     },
     {
-      "line": 2669,
+      "line": 2704,
       "column": 27,
-      "stop_line": 2669,
+      "stop_line": 2704,
       "stop_column": 55,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3805,9 +3805,9 @@
       "severity": "error"
     },
     {
-      "line": 2697,
+      "line": 2732,
       "column": 12,
-      "stop_line": 2697,
+      "stop_line": 2732,
       "stop_column": 40,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3817,9 +3817,9 @@
       "severity": "error"
     },
     {
-      "line": 173,
+      "line": 176,
       "column": 58,
-      "stop_line": 173,
+      "stop_line": 176,
       "stop_column": 62,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3829,21 +3829,9 @@
       "severity": "error"
     },
     {
-      "line": 288,
-      "column": 33,
-      "stop_line": 288,
-      "stop_column": 37,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "bad-function-definition",
-      "description": "Default `None` is not assignable to parameter `value` with type `list[Unknown]`\n  The declared type does not allow `None`. Consider changing the declared type to `list[Unknown] | None`.",
-      "concise_description": "Default `None` is not assignable to parameter `value` with type `list[Unknown]`",
-      "severity": "error"
-    },
-    {
-      "line": 610,
+      "line": 611,
       "column": 51,
-      "stop_line": 610,
+      "stop_line": 611,
       "stop_column": 60,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3853,9 +3841,9 @@
       "severity": "error"
     },
     {
-      "line": 739,
+      "line": 740,
       "column": 16,
-      "stop_line": 739,
+      "stop_line": 740,
       "stop_column": 46,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3865,9 +3853,9 @@
       "severity": "error"
     },
     {
-      "line": 750,
+      "line": 751,
       "column": 20,
-      "stop_line": 750,
+      "stop_line": 751,
       "stop_column": 51,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3877,21 +3865,9 @@
       "severity": "error"
     },
     {
-      "line": 750,
-      "column": 27,
-      "stop_line": 750,
-      "stop_column": 51,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "no-matching-overload",
-      "description": "No matching overload found for function `sqlalchemy.sql.sqltypes.Enum.__init__` called with arguments: (*list[bool | date | datetime | float | int | str])\n  Possible overloads:\n    (enums: type[Enum], **kw: Any) -> None [closest match]\n    (*enums: str, **kw: Any) -> None\n  Argument `bool | date | datetime | float | int | str` is not assignable to parameter `enums` with type `type[Enum]` in function `sqlalchemy.sql.sqltypes.Enum.__init__`",
-      "concise_description": "No matching overload found for function `sqlalchemy.sql.sqltypes.Enum.__init__` called with arguments: (*list[bool | date | datetime | float | int | str])",
-      "severity": "error"
-    },
-    {
-      "line": 751,
+      "line": 752,
       "column": 16,
-      "stop_line": 751,
+      "stop_line": 752,
       "stop_column": 46,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3901,21 +3877,9 @@
       "severity": "error"
     },
     {
-      "line": 929,
-      "column": 16,
-      "stop_line": 934,
-      "stop_column": 10,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "bad-return",
-      "description": "Returned type `pandera.api.pandas.components.Column | pandera.api.polars.components.Column` is not assignable to declared return type `pandera.api.polars.components.Column`",
-      "concise_description": "Returned type `pandera.api.pandas.components.Column | pandera.api.polars.components.Column` is not assignable to declared return type `pandera.api.polars.components.Column`",
-      "severity": "error"
-    },
-    {
-      "line": 930,
+      "line": 933,
       "column": 13,
-      "stop_line": 930,
+      "stop_line": 933,
       "stop_column": 24,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3925,9 +3889,9 @@
       "severity": "error"
     },
     {
-      "line": 930,
+      "line": 933,
       "column": 13,
-      "stop_line": 930,
+      "stop_line": 933,
       "stop_column": 24,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3937,9 +3901,9 @@
       "severity": "error"
     },
     {
-      "line": 1183,
+      "line": 1207,
       "column": 56,
-      "stop_line": 1183,
+      "stop_line": 1207,
       "stop_column": 60,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3949,9 +3913,9 @@
       "severity": "error"
     },
     {
-      "line": 1212,
+      "line": 1236,
       "column": 40,
-      "stop_line": 1212,
+      "stop_line": 1236,
       "stop_column": 69,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3961,9 +3925,9 @@
       "severity": "error"
     },
     {
-      "line": 1682,
+      "line": 1707,
       "column": 5,
-      "stop_line": 1682,
+      "stop_line": 1707,
       "stop_column": 11,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3973,9 +3937,9 @@
       "severity": "error"
     },
     {
-      "line": 1766,
+      "line": 1791,
       "column": 59,
-      "stop_line": 1766,
+      "stop_line": 1791,
       "stop_column": 74,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3985,9 +3949,9 @@
       "severity": "error"
     },
     {
-      "line": 1767,
+      "line": 1792,
       "column": 69,
-      "stop_line": 1767,
+      "stop_line": 1792,
       "stop_column": 78,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3997,9 +3961,9 @@
       "severity": "error"
     },
     {
-      "line": 1881,
+      "line": 1906,
       "column": 33,
-      "stop_line": 1881,
+      "stop_line": 1906,
       "stop_column": 37,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4009,9 +3973,9 @@
       "severity": "error"
     },
     {
-      "line": 1899,
+      "line": 1924,
       "column": 32,
-      "stop_line": 1899,
+      "stop_line": 1924,
       "stop_column": 44,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4021,9 +3985,9 @@
       "severity": "error"
     },
     {
-      "line": 1920,
+      "line": 1947,
       "column": 24,
-      "stop_line": 1920,
+      "stop_line": 1947,
       "stop_column": 39,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4033,9 +3997,9 @@
       "severity": "error"
     },
     {
-      "line": 1997,
+      "line": 2024,
       "column": 16,
-      "stop_line": 1997,
+      "stop_line": 2024,
       "stop_column": 21,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4045,9 +4009,9 @@
       "severity": "error"
     },
     {
-      "line": 2077,
+      "line": 2104,
       "column": 32,
-      "stop_line": 2077,
+      "stop_line": 2104,
       "stop_column": 45,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4057,21 +4021,9 @@
       "severity": "error"
     },
     {
-      "line": 2130,
-      "column": 73,
-      "stop_line": 2130,
-      "stop_column": 77,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "bad-function-definition",
-      "description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`\n  The declared type does not allow `None`. Consider changing the declared type to `(...) -> Unknown | None`.",
-      "concise_description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`",
-      "severity": "error"
-    },
-    {
-      "line": 2237,
+      "line": 2514,
       "column": 27,
-      "stop_line": 2237,
+      "stop_line": 2514,
       "stop_column": 31,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4081,9 +4033,9 @@
       "severity": "error"
     },
     {
-      "line": 2303,
+      "line": 2580,
       "column": 47,
-      "stop_line": 2303,
+      "stop_line": 2580,
       "stop_column": 70,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4093,9 +4045,9 @@
       "severity": "error"
     },
     {
-      "line": 2409,
+      "line": 2686,
       "column": 36,
-      "stop_line": 2409,
+      "stop_line": 2686,
       "stop_column": 68,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4105,9 +4057,9 @@
       "severity": "error"
     },
     {
-      "line": 2411,
+      "line": 2688,
       "column": 43,
-      "stop_line": 2411,
+      "stop_line": 2688,
       "stop_column": 45,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4117,9 +4069,9 @@
       "severity": "error"
     },
     {
-      "line": 2487,
+      "line": 2764,
       "column": 16,
-      "stop_line": 2487,
+      "stop_line": 2764,
       "stop_column": 28,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4129,9 +4081,9 @@
       "severity": "error"
     },
     {
-      "line": 2573,
+      "line": 2850,
       "column": 40,
-      "stop_line": 2573,
+      "stop_line": 2850,
       "stop_column": 53,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4141,9 +4093,9 @@
       "severity": "error"
     },
     {
-      "line": 2577,
+      "line": 2854,
       "column": 72,
-      "stop_line": 2577,
+      "stop_line": 2854,
       "stop_column": 88,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4153,9 +4105,9 @@
       "severity": "error"
     },
     {
-      "line": 2578,
+      "line": 2855,
       "column": 59,
-      "stop_line": 2578,
+      "stop_line": 2855,
       "stop_column": 83,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4165,9 +4117,9 @@
       "severity": "error"
     },
     {
-      "line": 2579,
+      "line": 2856,
       "column": 62,
-      "stop_line": 2579,
+      "stop_line": 2856,
       "stop_column": 89,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4177,9 +4129,9 @@
       "severity": "error"
     },
     {
-      "line": 2600,
+      "line": 2877,
       "column": 44,
-      "stop_line": 2600,
+      "stop_line": 2877,
       "stop_column": 80,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -10093,9 +10045,9 @@
       "severity": "error"
     },
     {
-      "line": 139,
+      "line": 142,
       "column": 27,
-      "stop_line": 139,
+      "stop_line": 142,
       "stop_column": 55,
       "path": "tests/unit/dagster/asset_checks_test.py",
       "code": -2,
@@ -10753,9 +10705,9 @@
       "severity": "error"
     },
     {
-      "line": 455,
+      "line": 812,
       "column": 13,
-      "stop_line": 455,
+      "stop_line": 812,
       "stop_column": 38,
       "path": "tests/unit/metadata/metadata_test.py",
       "code": -2,

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -13,12 +13,6 @@
       "skillPath": "skills/datapackage/SKILL.md",
       "computedHash": "ee9b9e47d0fb9fc00c8dfd4086262a42dc4039fc5ed137a12dc3aceebc0dfd79"
     },
-    "dignified-python": {
-      "source": "dagster-io/skills",
-      "sourceType": "github",
-      "skillPath": "skills/dignified-python/skills/dignified-python/SKILL.md",
-      "computedHash": "af77280f19bc321a9456d4695f13e6b9d9822766a0faeff2e198acea375fd5b3"
-    },
     "pudl": {
       "source": "catalyst-cooperative/agent-skills",
       "sourceType": "github",

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -227,41 +227,42 @@ def _collect_primary_key_metadata(
     }
 
 
-_MAX_FAILURE_CASE_SAMPLE = 20
-"""Cap on how many failure-case rows to embed per error in check metadata.
-
-``failure_case_count`` always reflects the true total; this just bounds how
-much actual data gets rendered inline, so a violation affecting millions of
-rows doesn't balloon the check's metadata payload.
-"""
-
-
-def _failure_cases_sample(failure_cases: Any) -> tuple[int | None, Any]:
+def _failure_cases_sample(
+    failure_cases: Any, max_failure_samples: int = 20
+) -> tuple[int | None, Any]:
     """Return ``(total_count, bounded_json_safe_sample)`` for an error's failure cases.
 
-    Structured (list of records) rather than a stringified table dump: the
-    latter embeds Polars' box-drawing-character table rendering as a giant
-    escaped-newline blob, unreadable once JSON-encoded for Dagster's UI. Falls
-    back to a plain string only for failure-case types we don't specifically
-    recognize.
+    Structured (list of records) rather than a stringified table dump: the latter embeds
+    Polars' box-drawing-character table rendering as a giant escaped-newline blob,
+    unreadable once JSON-encoded for Dagster's UI. Falls back to a plain string only for
+    failure-case types we don't specifically recognize.
+
+    ``total_count`` always reflects the true total; max_failure_samples just bounds how
+    much actual data gets rendered inline, so a violation affecting millions of rows
+    doesn't balloon the check's metadata payload.
+
+    Args:
+        failure_cases: The ``failure_cases`` attribute of a Pandera ``SchemaError``.
+            Can be a Polars or Pandas dataframe, a Pandas series, a list, or None.
+        max_failure_samples: Maximum number of rows to include in the returned sample.
     """
     if isinstance(failure_cases, pl.DataFrame):
         return (
             failure_cases.height,
-            failure_cases.head(_MAX_FAILURE_CASE_SAMPLE).to_dicts(),
+            failure_cases.head(max_failure_samples).to_dicts(),
         )
     if isinstance(failure_cases, pd.DataFrame):
         return (
             len(failure_cases),
-            failure_cases.head(_MAX_FAILURE_CASE_SAMPLE).to_dict(orient="records"),
+            failure_cases.head(max_failure_samples).to_dict(orient="records"),
         )
     if isinstance(failure_cases, pd.Series):
         return (
             len(failure_cases),
-            failure_cases.head(_MAX_FAILURE_CASE_SAMPLE).tolist(),
+            failure_cases.head(max_failure_samples).tolist(),
         )
     if isinstance(failure_cases, list):
-        return len(failure_cases), failure_cases[:_MAX_FAILURE_CASE_SAMPLE]
+        return len(failure_cases), failure_cases[:max_failure_samples]
     if failure_cases is None:
         return None, None
     return None, str(failure_cases)

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -22,6 +22,7 @@ should go in dbt.
 
 import itertools
 import json
+import time
 from typing import Any
 
 import dagster as dg
@@ -38,7 +39,13 @@ from pandera.errors import SchemaError, SchemaErrors
 from pudl.dagster.assets import all_asset_modules, asset_keys
 from pudl.dagster.partitions import ferceqr_year_quarters
 from pudl.helpers import ParquetData, get_parquet_table_polars
-from pudl.metadata.classes import PUDL_PACKAGE, Field, Package, Resource
+from pudl.metadata.classes import (
+    _CHUNKED_PK_CHECK_TABLES,
+    PUDL_PACKAGE,
+    Field,
+    Package,
+    Resource,
+)
 
 
 def _collect_asset_metadata(asset_value) -> dict[str, Any]:
@@ -84,6 +91,52 @@ def _extract_actual_columns_and_dtypes(
     )
 
 
+def _field_has_content_constraints(field: Field) -> bool:
+    """Whether a field's constraints require reading its actual values to check."""
+    c = field.constraints
+    return any(
+        [
+            c.required,
+            c.unique,
+            c.minimum is not None,
+            c.maximum is not None,
+            c.min_length is not None,
+            c.max_length is not None,
+            c.pattern is not None,
+            bool(c.enum),
+        ]
+    )
+
+
+def _field_constraints_metadata(field: Field) -> dict[str, Any]:
+    """Build a JSON-safe summary of a field's declared constraints, if any.
+
+    Only constraints actually set (non-default) are included, so a caller can
+    tell at a glance what's being enforced on a column without cross-referencing
+    the PUDL metadata source. ``minimum``/``maximum`` can be dates, and
+    ``pattern`` is a compiled regex -- both are stringified for JSON safety.
+    """
+    c = field.constraints
+    constraints: dict[str, Any] = {}
+    if c.required:
+        constraints["required"] = True
+    if c.unique:
+        constraints["unique"] = True
+    if c.minimum is not None:
+        constraints["minimum"] = str(c.minimum)
+    if c.maximum is not None:
+        constraints["maximum"] = str(c.maximum)
+    if c.min_length is not None:
+        constraints["min_length"] = c.min_length
+    if c.max_length is not None:
+        constraints["max_length"] = c.max_length
+    if c.pattern is not None:
+        constraints["pattern"] = c.pattern.pattern
+    if c.enum:
+        constraints["enum"] = list(c.enum)
+    return constraints
+
+
 def _collect_dtype_metadata(
     asset_value: pl.LazyFrame | pd.DataFrame,
     resource: Resource,
@@ -98,7 +151,9 @@ def _collect_dtype_metadata(
 
     Returns:
         A metadata dictionary with:
-        - ``field_details``: per-column expected and actual dtype details.
+        - ``field_details``: per-column expected/actual dtype details, declared
+          constraints, and whether the column is content-checked (see
+          :func:`_field_has_content_constraints`).
         - ``column_comparison``: expected/actual column counts and optional missing
           or extra column lists.
         - ``type_mismatches``: only present when common columns have differing dtype
@@ -135,6 +190,8 @@ def _collect_dtype_metadata(
             "pudl_field_dtype": field.type,
             "expected_pandera_dtype": pandera_dtypes.get(field.name, "Unknown"),
             "actual_dtype": actual_dtypes.get(field.name, "Column not present"),
+            "content_checked": _field_has_content_constraints(field),
+            "constraints": _field_constraints_metadata(field),
         }
         for field in resource.schema.fields
     }
@@ -192,26 +249,103 @@ def _collect_geometry_metadata(asset_value) -> dict[str, Any]:
     return metadata
 
 
+def _collect_primary_key_metadata(
+    resource: Resource, actual_columns: list[str]
+) -> dict[str, Any]:
+    """Describe the primary-key check that will run for this resource, if any.
+
+    Whether a composite-uniqueness check is chunked (see
+    ``_CHUNKED_PK_CHECK_TABLES``) is a cheap name lookup, not a re-run of the
+    (potentially expensive, for our largest tables) chunking logic itself.
+    """
+    primary_key = resource.schema.primary_key
+    if not primary_key:
+        return {"primary_key": {"declared": False}}
+
+    missing_columns = sorted(set(primary_key) - set(actual_columns))
+    return {
+        "primary_key": {
+            "declared": True,
+            "columns": primary_key,
+            "chunked": resource.name in _CHUNKED_PK_CHECK_TABLES,
+            "checked": not missing_columns,
+            "missing_columns": missing_columns or None,
+        }
+    }
+
+
+_MAX_FAILURE_CASE_SAMPLE = 20
+"""Cap on how many failure-case rows to embed per error in check metadata.
+
+``failure_case_count`` always reflects the true total; this just bounds how
+much actual data gets rendered inline, so a violation affecting millions of
+rows doesn't balloon the check's metadata payload.
+"""
+
+
+def _failure_cases_sample(failure_cases: Any) -> tuple[int | None, Any]:
+    """Return ``(total_count, bounded_json_safe_sample)`` for an error's failure cases.
+
+    Structured (list of records) rather than a stringified table dump: the
+    latter embeds Polars' box-drawing-character table rendering as a giant
+    escaped-newline blob, unreadable once JSON-encoded for Dagster's UI. Falls
+    back to a plain string only for failure-case types we don't specifically
+    recognize.
+    """
+    if isinstance(failure_cases, pl.DataFrame):
+        return (
+            failure_cases.height,
+            failure_cases.head(_MAX_FAILURE_CASE_SAMPLE).to_dicts(),
+        )
+    if isinstance(failure_cases, pd.DataFrame):
+        return (
+            len(failure_cases),
+            failure_cases.head(_MAX_FAILURE_CASE_SAMPLE).to_dict(orient="records"),
+        )
+    if isinstance(failure_cases, pd.Series):
+        return (
+            len(failure_cases),
+            failure_cases.head(_MAX_FAILURE_CASE_SAMPLE).tolist(),
+        )
+    if isinstance(failure_cases, list):
+        return len(failure_cases), failure_cases[:_MAX_FAILURE_CASE_SAMPLE]
+    if failure_cases is None:
+        return None, None
+    return None, str(failure_cases)
+
+
 def _process_schema_errors(schema_errors: SchemaErrors) -> dict[str, Any]:
-    """Process Pandera schema errors into structured metadata."""
+    """Process Pandera schema errors into compact, structured metadata.
+
+    Each error is reduced to its essentials -- a one-line message, the reason
+    and check that triggered it, which column/table it came from, and a
+    bounded sample of the actual offending rows -- rather than several
+    overlapping stringified dumps of the same underlying data (as ``args``,
+    ``data``, and a table-formatted ``failure_cases`` all tend to be).
+    """
     detailed_errors = []
 
     for err in schema_errors.schema_errors:
-        error_info = {
-            "error_type": type(err).__name__,
-            "error_message": str(err),
-            "failure_cases": str(err.failure_cases)
-            if hasattr(err, "failure_cases")
-            else "No failure_cases",
-            "data": str(err.data) if hasattr(err, "data") else "No data",
-        }
+        failure_case_count, failure_cases_sample = _failure_cases_sample(
+            getattr(err, "failure_cases", None)
+        )
+        schema_obj = getattr(err, "schema", None)
 
-        # Add optional error attributes
-        for attr in ["schema", "check", "args"]:
-            if hasattr(err, attr):
-                error_info[f"{attr}_info"] = str(getattr(err, attr))
-
-        detailed_errors.append(error_info)
+        detailed_errors.append(
+            {
+                "error_type": type(err).__name__,
+                "reason_code": str(err.reason_code)
+                if getattr(err, "reason_code", None) is not None
+                else None,
+                "error_message": str(err),
+                "check": str(err.check)
+                if getattr(err, "check", None) is not None
+                else None,
+                "schema_name": getattr(schema_obj, "name", None),
+                "failure_case_count": failure_case_count,
+                "failure_cases_sample": failure_cases_sample,
+            }
+        )
 
     return {
         "detailed_errors": detailed_errors,
@@ -262,27 +396,14 @@ def group_mean_continuity_check(
     return dg.AssetCheckResult(passed=True, metadata=metadata)
 
 
-def _field_has_content_constraints(field: Field) -> bool:
-    """Whether a field's constraints require reading its actual values to check."""
-    c = field.constraints
-    return any(
-        [
-            c.required,
-            c.unique,
-            c.minimum is not None,
-            c.maximum is not None,
-            c.min_length is not None,
-            c.max_length is not None,
-            c.pattern is not None,
-            bool(c.enum),
-        ]
-    )
-
-
 def _validate_polars_content(
     asset_value: pl.LazyFrame, resource: Resource
-) -> list[SchemaError]:
+) -> tuple[list[SchemaError], dict[str, float]]:
     """Validate per-column value constraints and primary-key uniqueness.
+
+    Returns the combined error list alongside a ``{"content_check_seconds": ...,
+    "pk_check_seconds": ...}`` timing breakdown, so slow phases are visible in
+    asset-check metadata without needing to reproduce the check locally.
 
     Pandera's Polars backend only runs Check/nullable/unique validation
     (as opposed to just column presence and dtype validation) when the
@@ -311,8 +432,10 @@ def _validate_polars_content(
     :meth:`Resource.check_primary_key`.
     """
     errors: list[SchemaError] = []
+    timings: dict[str, float] = {}
     present_columns = set(asset_value.collect_schema().names())
 
+    content_start = time.perf_counter()
     with config_context(validation_depth=ValidationDepth.SCHEMA_AND_DATA):
         for field in resource.schema.fields:
             if field.name not in present_columns:
@@ -326,16 +449,19 @@ def _validate_polars_content(
                 column_schema.validate(asset_value.select(field.name), lazy=True)
             except SchemaErrors as schema_errors:
                 errors.extend(schema_errors.schema_errors)
+    timings["content_check_seconds"] = time.perf_counter() - content_start
 
-        primary_key = resource.schema.primary_key
-        if primary_key and all(col in present_columns for col in primary_key):
-            # asset_value is unambiguously a LazyFrame here, so call the
-            # precisely-typed polars implementation directly rather than the
-            # public check_primary_key dispatcher, whose return type is
-            # broadened to accommodate its pandas branch (which returns None).
-            errors.extend(resource._check_primary_key_polars(asset_value))
+    pk_start = time.perf_counter()
+    primary_key = resource.schema.primary_key
+    if primary_key and all(col in present_columns for col in primary_key):
+        # asset_value is unambiguously a LazyFrame here, so call the
+        # precisely-typed polars implementation directly rather than the
+        # public check_primary_key dispatcher, whose return type is
+        # broadened to accommodate its pandas branch (which returns None).
+        errors.extend(resource._check_primary_key_polars(asset_value))
+    timings["pk_check_seconds"] = time.perf_counter() - pk_start
 
-    return errors
+    return errors, timings
 
 
 def asset_check_from_schema(  # noqa: C901
@@ -381,18 +507,30 @@ def asset_check_from_schema(  # noqa: C901
     def pandera_schema_check(
         asset_value: asset_type,  # type: ignore[valid-type]
     ) -> dg.AssetCheckResult:
+        source_partitions = (
+            asset_value.partitions if isinstance(asset_value, ParquetData) else None
+        )
         if isinstance(asset_value, ParquetData):
             asset_value = get_parquet_table_polars(
                 table_name=resource_id,
                 partitions=asset_value.partitions,
             )
 
-        # Collect all metadata
-        metadata = (
+        actual_columns, _, _ = _extract_actual_columns_and_dtypes(asset_value)
+
+        # Collect all metadata that's cheap and available regardless of outcome,
+        # up front -- so it's present on every return path below, including one
+        # that hits an entirely unexpected exception rather than a SchemaErrors.
+        metadata: dict[str, Any] = (
             _collect_asset_metadata(asset_value)
             | _collect_dtype_metadata(asset_value, resource)
             | _collect_geometry_metadata(asset_value)
+            | _collect_primary_key_metadata(resource, actual_columns)
         )
+        metadata["is_duckdb_asset"] = duckdb_asset
+        if source_partitions is not None:
+            metadata["partitions"] = source_partitions
+        timings: dict[str, float] = {}
 
         try:
             if isinstance(asset_value, pl.LazyFrame):
@@ -407,12 +545,21 @@ def asset_check_from_schema(  # noqa: C901
                 # to re-run the check to discover the other.
                 assert isinstance(pandera_schema, pr_polars.DataFrameSchema)
                 errors: list[SchemaError] = []
+                schema_check_start = time.perf_counter()
                 try:
                     pandera_schema.validate(asset_value, lazy=True)
                 except SchemaErrors as schema_errors:
                     errors.extend(schema_errors.schema_errors)
+                finally:
+                    timings["schema_check_seconds"] = (
+                        time.perf_counter() - schema_check_start
+                    )
 
-                errors.extend(_validate_polars_content(asset_value, resource))
+                content_errors, content_timings = _validate_polars_content(
+                    asset_value, resource
+                )
+                errors.extend(content_errors)
+                timings.update(content_timings)
 
                 if errors:
                     raise SchemaErrors(
@@ -422,14 +569,23 @@ def asset_check_from_schema(  # noqa: C901
                     )
             else:
                 assert isinstance(pandera_schema, pr_pandas.DataFrameSchema)
-                pandera_schema.validate(asset_value, lazy=True)
+                schema_check_start = time.perf_counter()
+                try:
+                    pandera_schema.validate(asset_value, lazy=True)
+                finally:
+                    timings["schema_check_seconds"] = (
+                        time.perf_counter() - schema_check_start
+                    )
+            metadata["timing"] = timings
             return dg.AssetCheckResult(passed=True, metadata=metadata)
 
         except SchemaErrors as schema_errors:
+            metadata["timing"] = timings
             metadata.update(_process_schema_errors(schema_errors))
             return dg.AssetCheckResult(passed=False, metadata=metadata)
 
         except Exception as exc:
+            metadata["timing"] = timings
             metadata["unexpected_error"] = {
                 "error_type": type(exc).__name__,
                 "error_message": str(exc),

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -20,7 +20,6 @@ to SQL/dbt data tests are also defined here, but in general all data validation 
 should go in dbt.
 """
 
-import datetime
 import itertools
 import json
 from typing import Any
@@ -34,7 +33,7 @@ import pandera.polars as pr_polars
 import pint
 import polars as pl
 from pandera.config import ValidationDepth, config_context
-from pandera.errors import SchemaError, SchemaErrorReason, SchemaErrors
+from pandera.errors import SchemaError, SchemaErrors
 
 from pudl.dagster.assets import all_asset_modules, asset_keys
 from pudl.dagster.partitions import ferceqr_year_quarters
@@ -280,165 +279,6 @@ def _field_has_content_constraints(field: Field) -> bool:
     )
 
 
-# Tables large enough that checking composite primary-key uniqueness in a
-# single pass is worth chunking (see NOTE in `_validate_primary_key_uniqueness`
-# and polars-comment.md for the memory measurements that motivated this). Maps
-# resource name to a primary-key field to chunk by: a date/datetime field
-# chunks by year; anything else chunks by each of its distinct values. Either
-# way, the column must be part of the primary key -- see
-# `_chunk_filters` for why that's what makes chunking exact rather than
-# approximate.
-#
-# `core_ferceqr__transactions` is deliberately NOT listed here: its metadata
-# currently declares no primary key at all (see `additional_primary_key_text`
-# in `pudl.metadata.resources.ferceqr`), since real duplicate records were
-# found for the columns that would otherwise form one -- see
-# polars-comment.md and the PUDL issue tracking that investigation. Once that
-# investigation lands on a real, enforceable primary key, add it back here if
-# the table still needs chunking at that point.
-_CHUNKED_PK_CHECK_TABLES: dict[str, str] = {
-    "core_epacems__hourly_emissions": "operating_datetime_utc",
-    "out_vcerare__hourly_available_capacity_factor": "datetime_utc",
-}
-
-
-def _find_duplicate_primary_keys(
-    lf: pl.LazyFrame, primary_key: list[str]
-) -> pl.DataFrame:
-    """Return the primary-key combinations that appear more than once in ``lf``.
-
-    Uses a single group-by/count/filter reduction, run with
-    ``engine="streaming"``, rather than pandera's built-in composite-uniqueness
-    check (`DataFrameSchema(unique=...)`), which collects the same LazyFrame
-    up to three times and calls the eager, non-lazy `.is_duplicated()`. On our
-    largest table's largest quarterly partition (228M rows) this measured at
-    ~33GB / 3.4s, versus ~109GB / 152s for pandera's built-in check on the
-    exact same data -- see polars-comment.md.
-    """
-    return (
-        lf.group_by(primary_key)
-        .agg(pl.len().alias("_pk_count"))
-        .filter(pl.col("_pk_count") > 1)
-        .collect(engine="streaming")
-    )
-
-
-def _duplicate_primary_key_error(
-    resource: Resource, primary_key: list[str], duplicates: pl.DataFrame
-) -> SchemaError:
-    """Build a SchemaError describing duplicate primary-key combinations."""
-    return SchemaError(
-        schema=None,
-        data=duplicates,
-        message=f"columns {tuple(primary_key)!r} not unique:\n{duplicates}",
-        check="multiple_fields_uniqueness",
-        reason_code=SchemaErrorReason.DUPLICATES,
-        failure_cases=duplicates,
-        column_name=resource.name,
-    )
-
-
-def _chunk_filters(lf: pl.LazyFrame, chunk_field: str) -> list[pl.Expr]:
-    """Build filter expressions that partition ``lf`` by ``chunk_field``.
-
-    Every filter is a literal comparison directly against ``chunk_field``'s
-    own stored values -- a year-range comparison for date/datetime columns,
-    an equality comparison against each distinct value otherwise -- never a
-    derived expression. This matters for two reasons:
-
-    1. Correctness: since ``chunk_field`` is required to be part of the
-       primary key, two rows sharing a composite key necessarily share the
-       same value of it, so a boundary drawn directly on that column's own
-       value can never split a duplicate pair across chunks. Deriving the
-       boundary from some other, only approximately-correlated column would
-       not have this guarantee -- e.g. EPACEMS' separately stored `year`
-       field reflects reporting period, not the UTC timestamp, and disagrees
-       with `operating_datetime_utc.dt.year()` for hundreds of rows a year
-       near timezone-shifted boundaries.
-    2. Efficiency: a literal comparison against a stored column stays
-       eligible for Parquet row-group pruning, since Polars can compare it
-       directly to each row group's min/max statistics without decoding any
-       data. A filter on a *derived* expression (e.g. `.dt.year() == y`)
-       cannot be pushed down the same way, so Polars must read and decode
-       every row group on every chunk iteration regardless of whether that
-       chunk's rows are actually present. Measured on our billion-row table:
-       ~0.02s to select one year's rows via a literal range filter, vs ~0.56s
-       via a `.dt.year()` filter for the same result.
-
-    PUDL's long time-series tables are written and physically stored in
-    temporal (or, for `core_ferceqr__transactions`, filer) order, so this
-    pruning is not theoretical: EPACEMS' row groups are each confined to a
-    single calendar year, and most of `core_ferceqr__transactions`' row
-    groups are confined to a single seller.
-    """
-    dtype = lf.select(chunk_field).collect_schema()[chunk_field]
-
-    if dtype in (pl.Date, pl.Datetime) or isinstance(dtype, pl.Datetime):
-        bounds = lf.select(
-            pl.col(chunk_field).min().alias("_min"),
-            pl.col(chunk_field).max().alias("_max"),
-        ).collect(engine="streaming")
-        min_year = bounds["_min"][0].year
-        max_year = bounds["_max"][0].year
-        boundary = datetime.date if dtype == pl.Date else datetime.datetime
-        return [
-            pl.col(chunk_field).is_between(
-                boundary(year, 1, 1), boundary(year + 1, 1, 1), closed="left"
-            )
-            for year in range(min_year, max_year + 1)
-        ]
-
-    values = (
-        lf.select(chunk_field)
-        .unique()
-        .collect(engine="streaming")
-        .get_column(chunk_field)
-        .to_list()
-    )
-    return [pl.col(chunk_field) == value for value in values]
-
-
-def _validate_primary_key_uniqueness(
-    asset_value: pl.LazyFrame, resource: Resource
-) -> list[SchemaError]:
-    """Validate composite primary-key uniqueness, chunked for oversized tables.
-
-    Never uses pandera's built-in composite-uniqueness check (see
-    `_find_duplicate_primary_keys` for why). For the handful of tables large
-    enough to matter (`_CHUNKED_PK_CHECK_TABLES`), this checks uniqueness one
-    chunk at a time instead of all at once, which is exact -- not an
-    approximation -- as long as the chunking column is part of the primary
-    key (see `_chunk_filters`). Every other table just runs the check once
-    on the whole (already narrow, primary-key-only) LazyFrame, which is fine
-    at their scale.
-    """
-    primary_key = resource.schema.primary_key
-    if not primary_key:
-        return []
-
-    narrow = asset_value.select(primary_key)
-    chunk_field = _CHUNKED_PK_CHECK_TABLES.get(resource.name)
-    if chunk_field:
-        assert chunk_field in primary_key, (
-            f"_CHUNKED_PK_CHECK_TABLES lists {chunk_field!r} as the chunk column "
-            f"for {resource.name!r}, but it isn't part of that resource's "
-            f"primary key ({primary_key!r}). Chunking is only exact when the "
-            "chunk column is part of the primary key -- see _chunk_filters."
-        )
-        chunks = [narrow.filter(f) for f in _chunk_filters(narrow, chunk_field)]
-    else:
-        chunks = [narrow]
-
-    errors: list[SchemaError] = []
-    for chunk in chunks:
-        duplicates = _find_duplicate_primary_keys(chunk, primary_key)
-        if duplicates.height > 0:
-            errors.append(
-                _duplicate_primary_key_error(resource, primary_key, duplicates)
-            )
-    return errors
-
-
 def _validate_polars_content(
     asset_value: pl.LazyFrame, resource: Resource
 ) -> list[SchemaError]:
@@ -466,6 +306,9 @@ def _validate_polars_content(
     immediately (a raw ``pl.exceptions.ColumnNotFoundError``, not a pandera
     ``SchemaError``), and a missing column is already reported separately by
     the schema-level check in ``pandera_schema_check``.
+
+    Composite primary-key uniqueness is handled separately -- see
+    :meth:`Resource.check_primary_key`.
     """
     errors: list[SchemaError] = []
     present_columns = set(asset_value.collect_schema().names())
@@ -486,7 +329,11 @@ def _validate_polars_content(
 
         primary_key = resource.schema.primary_key
         if primary_key and all(col in present_columns for col in primary_key):
-            errors.extend(_validate_primary_key_uniqueness(asset_value, resource))
+            # asset_value is unambiguously a LazyFrame here, so call the
+            # precisely-typed polars implementation directly rather than the
+            # public check_primary_key dispatcher, whose return type is
+            # broadened to accommodate its pandas branch (which returns None).
+            errors.extend(resource._check_primary_key_polars(asset_value))
 
     return errors
 

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -143,7 +143,7 @@ def _collect_dtype_metadata(
             "expected_pandera_dtype": pandera_dtypes.get(field.name, "Unknown"),
             "actual_dtype": actual_dtypes.get(field.name, "Column not present"),
             "content_checked": field.has_content_constraints(),
-            "constraints": field.constraints.to_metadata_dict(),
+            "constraints": field.constraints.model_dump_json(exclude_defaults=True),
         }
         for field in resource.schema.fields
     }

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -105,7 +105,7 @@ def _collect_dtype_metadata(
         A metadata dictionary with:
         - ``field_details``: per-column expected/actual dtype details, declared
           constraints, and whether the column is content-checked (see
-          :meth:`~pudl.metadata.classes.Field.has_content_constraints`).
+          :meth:`~pudl.metadata.classes.FieldConstraints.requires_content_validation`).
         - ``column_comparison``: expected/actual column counts and optional missing
           or extra column lists.
         - ``type_mismatches``: only present when common columns have differing dtype
@@ -142,7 +142,7 @@ def _collect_dtype_metadata(
             "pudl_field_dtype": field.type,
             "expected_pandera_dtype": pandera_dtypes.get(field.name, "Unknown"),
             "actual_dtype": actual_dtypes.get(field.name, "Column not present"),
-            "content_checked": field.has_content_constraints(),
+            "content_checked": field.constraints.requires_content_validation(),
             "constraints": field.constraints.model_dump_json(exclude_defaults=True),
         }
         for field in resource.schema.fields
@@ -207,7 +207,7 @@ def _collect_primary_key_metadata(
     """Describe the primary-key check that will run for this resource, if any.
 
     Whether a composite-uniqueness check is chunked (see
-    :attr:`~pudl.metadata.classes.Schema.chunk_field`) is a cheap attribute lookup,
+    :attr:`~pudl.metadata.classes.Schema.pk_check_chunk_field`) is a cheap attribute lookup,
     not a re-run of the (potentially expensive, for our largest tables) chunking
     logic itself.
     """
@@ -220,7 +220,7 @@ def _collect_primary_key_metadata(
         "primary_key": {
             "declared": True,
             "columns": primary_key,
-            "chunked": resource.schema.chunk_field is not None,
+            "chunked": resource.schema.pk_check_chunk_field is not None,
             "checked": not missing_columns,
             "missing_columns": missing_columns or None,
         }
@@ -394,7 +394,7 @@ def _validate_polars_content(
         for field in resource.schema.fields:
             if field.name not in present_columns:
                 continue
-            if not field.has_content_constraints():
+            if not field.constraints.requires_content_validation():
                 continue
             column_schema = pr_polars.DataFrameSchema(
                 {field.name: field.to_pandera_column(use_pandas_backend=False)}

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -20,6 +20,7 @@ to SQL/dbt data tests are also defined here, but in general all data validation 
 should go in dbt.
 """
 
+import datetime
 import itertools
 import json
 from typing import Any
@@ -32,12 +33,13 @@ import pandera.pandas as pr_pandas
 import pandera.polars as pr_polars
 import pint
 import polars as pl
-from pandera.errors import SchemaErrors
+from pandera.config import ValidationDepth, config_context
+from pandera.errors import SchemaError, SchemaErrorReason, SchemaErrors
 
 from pudl.dagster.assets import all_asset_modules, asset_keys
 from pudl.dagster.partitions import ferceqr_year_quarters
 from pudl.helpers import ParquetData, get_parquet_table_polars
-from pudl.metadata.classes import PUDL_PACKAGE, Package, Resource
+from pudl.metadata.classes import PUDL_PACKAGE, Field, Package, Resource
 
 
 def _collect_asset_metadata(asset_value) -> dict[str, Any]:
@@ -261,6 +263,234 @@ def group_mean_continuity_check(
     return dg.AssetCheckResult(passed=True, metadata=metadata)
 
 
+def _field_has_content_constraints(field: Field) -> bool:
+    """Whether a field's constraints require reading its actual values to check."""
+    c = field.constraints
+    return any(
+        [
+            c.required,
+            c.unique,
+            c.minimum is not None,
+            c.maximum is not None,
+            c.min_length is not None,
+            c.max_length is not None,
+            c.pattern is not None,
+            bool(c.enum),
+        ]
+    )
+
+
+# Tables large enough that checking composite primary-key uniqueness in a
+# single pass is worth chunking (see NOTE in `_validate_primary_key_uniqueness`
+# and polars-comment.md for the memory measurements that motivated this). Maps
+# resource name to a primary-key field to chunk by: a date/datetime field
+# chunks by year; anything else chunks by each of its distinct values. Either
+# way, the column must be part of the primary key -- see
+# `_chunk_filters` for why that's what makes chunking exact rather than
+# approximate.
+#
+# `core_ferceqr__transactions` is deliberately NOT listed here: its metadata
+# currently declares no primary key at all (see `additional_primary_key_text`
+# in `pudl.metadata.resources.ferceqr`), since real duplicate records were
+# found for the columns that would otherwise form one -- see
+# polars-comment.md and the PUDL issue tracking that investigation. Once that
+# investigation lands on a real, enforceable primary key, add it back here if
+# the table still needs chunking at that point.
+_CHUNKED_PK_CHECK_TABLES: dict[str, str] = {
+    "core_epacems__hourly_emissions": "operating_datetime_utc",
+    "out_vcerare__hourly_available_capacity_factor": "datetime_utc",
+}
+
+
+def _find_duplicate_primary_keys(
+    lf: pl.LazyFrame, primary_key: list[str]
+) -> pl.DataFrame:
+    """Return the primary-key combinations that appear more than once in ``lf``.
+
+    Uses a single group-by/count/filter reduction, run with
+    ``engine="streaming"``, rather than pandera's built-in composite-uniqueness
+    check (`DataFrameSchema(unique=...)`), which collects the same LazyFrame
+    up to three times and calls the eager, non-lazy `.is_duplicated()`. On our
+    largest table's largest quarterly partition (228M rows) this measured at
+    ~33GB / 3.4s, versus ~109GB / 152s for pandera's built-in check on the
+    exact same data -- see polars-comment.md.
+    """
+    return (
+        lf.group_by(primary_key)
+        .agg(pl.len().alias("_pk_count"))
+        .filter(pl.col("_pk_count") > 1)
+        .collect(engine="streaming")
+    )
+
+
+def _duplicate_primary_key_error(
+    resource: Resource, primary_key: list[str], duplicates: pl.DataFrame
+) -> SchemaError:
+    """Build a SchemaError describing duplicate primary-key combinations."""
+    return SchemaError(
+        schema=None,
+        data=duplicates,
+        message=f"columns {tuple(primary_key)!r} not unique:\n{duplicates}",
+        check="multiple_fields_uniqueness",
+        reason_code=SchemaErrorReason.DUPLICATES,
+        failure_cases=duplicates,
+        column_name=resource.name,
+    )
+
+
+def _chunk_filters(lf: pl.LazyFrame, chunk_field: str) -> list[pl.Expr]:
+    """Build filter expressions that partition ``lf`` by ``chunk_field``.
+
+    Every filter is a literal comparison directly against ``chunk_field``'s
+    own stored values -- a year-range comparison for date/datetime columns,
+    an equality comparison against each distinct value otherwise -- never a
+    derived expression. This matters for two reasons:
+
+    1. Correctness: since ``chunk_field`` is required to be part of the
+       primary key, two rows sharing a composite key necessarily share the
+       same value of it, so a boundary drawn directly on that column's own
+       value can never split a duplicate pair across chunks. Deriving the
+       boundary from some other, only approximately-correlated column would
+       not have this guarantee -- e.g. EPACEMS' separately stored `year`
+       field reflects reporting period, not the UTC timestamp, and disagrees
+       with `operating_datetime_utc.dt.year()` for hundreds of rows a year
+       near timezone-shifted boundaries.
+    2. Efficiency: a literal comparison against a stored column stays
+       eligible for Parquet row-group pruning, since Polars can compare it
+       directly to each row group's min/max statistics without decoding any
+       data. A filter on a *derived* expression (e.g. `.dt.year() == y`)
+       cannot be pushed down the same way, so Polars must read and decode
+       every row group on every chunk iteration regardless of whether that
+       chunk's rows are actually present. Measured on our billion-row table:
+       ~0.02s to select one year's rows via a literal range filter, vs ~0.56s
+       via a `.dt.year()` filter for the same result.
+
+    PUDL's long time-series tables are written and physically stored in
+    temporal (or, for `core_ferceqr__transactions`, filer) order, so this
+    pruning is not theoretical: EPACEMS' row groups are each confined to a
+    single calendar year, and most of `core_ferceqr__transactions`' row
+    groups are confined to a single seller.
+    """
+    dtype = lf.select(chunk_field).collect_schema()[chunk_field]
+
+    if dtype in (pl.Date, pl.Datetime) or isinstance(dtype, pl.Datetime):
+        bounds = lf.select(
+            pl.col(chunk_field).min().alias("_min"),
+            pl.col(chunk_field).max().alias("_max"),
+        ).collect(engine="streaming")
+        min_year = bounds["_min"][0].year
+        max_year = bounds["_max"][0].year
+        boundary = datetime.date if dtype == pl.Date else datetime.datetime
+        return [
+            pl.col(chunk_field).is_between(
+                boundary(year, 1, 1), boundary(year + 1, 1, 1), closed="left"
+            )
+            for year in range(min_year, max_year + 1)
+        ]
+
+    values = (
+        lf.select(chunk_field)
+        .unique()
+        .collect(engine="streaming")
+        .get_column(chunk_field)
+        .to_list()
+    )
+    return [pl.col(chunk_field) == value for value in values]
+
+
+def _validate_primary_key_uniqueness(
+    asset_value: pl.LazyFrame, resource: Resource
+) -> list[SchemaError]:
+    """Validate composite primary-key uniqueness, chunked for oversized tables.
+
+    Never uses pandera's built-in composite-uniqueness check (see
+    `_find_duplicate_primary_keys` for why). For the handful of tables large
+    enough to matter (`_CHUNKED_PK_CHECK_TABLES`), this checks uniqueness one
+    chunk at a time instead of all at once, which is exact -- not an
+    approximation -- as long as the chunking column is part of the primary
+    key (see `_chunk_filters`). Every other table just runs the check once
+    on the whole (already narrow, primary-key-only) LazyFrame, which is fine
+    at their scale.
+    """
+    primary_key = resource.schema.primary_key
+    if not primary_key:
+        return []
+
+    narrow = asset_value.select(primary_key)
+    chunk_field = _CHUNKED_PK_CHECK_TABLES.get(resource.name)
+    if chunk_field:
+        assert chunk_field in primary_key, (
+            f"_CHUNKED_PK_CHECK_TABLES lists {chunk_field!r} as the chunk column "
+            f"for {resource.name!r}, but it isn't part of that resource's "
+            f"primary key ({primary_key!r}). Chunking is only exact when the "
+            "chunk column is part of the primary key -- see _chunk_filters."
+        )
+        chunks = [narrow.filter(f) for f in _chunk_filters(narrow, chunk_field)]
+    else:
+        chunks = [narrow]
+
+    errors: list[SchemaError] = []
+    for chunk in chunks:
+        duplicates = _find_duplicate_primary_keys(chunk, primary_key)
+        if duplicates.height > 0:
+            errors.append(
+                _duplicate_primary_key_error(resource, primary_key, duplicates)
+            )
+    return errors
+
+
+def _validate_polars_content(
+    asset_value: pl.LazyFrame, resource: Resource
+) -> list[SchemaError]:
+    """Validate per-column value constraints and primary-key uniqueness.
+
+    Pandera's Polars backend only runs Check/nullable/unique validation
+    (as opposed to just column presence and dtype validation) when the
+    validation depth is explicitly forced to ``SCHEMA_AND_DATA``, and even
+    then it does so by repeatedly collecting the *entire* dataframe passed to
+    it -- once per check. For PUDL's largest tables (hundreds of millions to
+    billions of rows) collecting the full table is not tractable, even though
+    only a handful of columns actually carry constraints worth checking.
+
+    Instead, this validates one narrow slice at a time: for each field with an
+    actual constraint, ``.select()`` just that column before collecting.
+    Columns with no constraints at all are never read. This scales uniformly
+    regardless of table size, since a single narrow column is always small
+    enough to collect, even when the full table is not -- measured at ~1.2GB
+    peak memory total for all four checked columns on our billion-row table.
+    Composite primary-key uniqueness is handled separately -- see
+    `_validate_primary_key_uniqueness`.
+
+    Columns that are entirely missing from ``asset_value`` are skipped here
+    rather than selected: ``.select()`` on a genuinely absent column raises
+    immediately (a raw ``pl.exceptions.ColumnNotFoundError``, not a pandera
+    ``SchemaError``), and a missing column is already reported separately by
+    the schema-level check in ``pandera_schema_check``.
+    """
+    errors: list[SchemaError] = []
+    present_columns = set(asset_value.collect_schema().names())
+
+    with config_context(validation_depth=ValidationDepth.SCHEMA_AND_DATA):
+        for field in resource.schema.fields:
+            if field.name not in present_columns:
+                continue
+            if not _field_has_content_constraints(field):
+                continue
+            column_schema = pr_polars.DataFrameSchema(
+                {field.name: field.to_pandera_column(use_pandas_backend=False)}
+            )
+            try:
+                column_schema.validate(asset_value.select(field.name), lazy=True)
+            except SchemaErrors as schema_errors:
+                errors.extend(schema_errors.schema_errors)
+
+        primary_key = resource.schema.primary_key
+        if primary_key and all(col in present_columns for col in primary_key):
+            errors.extend(_validate_primary_key_uniqueness(asset_value, resource))
+
+    return errors
+
+
 def asset_check_from_schema(  # noqa: C901
     asset_key: dg.AssetKey,
     package: Package,
@@ -319,16 +549,30 @@ def asset_check_from_schema(  # noqa: C901
 
         try:
             if isinstance(asset_value, pl.LazyFrame):
-                # NOTE: Pandera's polars backend only performs schema-level
-                # validation (column presence + dtype) for a `pl.LazyFrame`,
-                # via `collect_schema()` -- it does not run Check/unique/
-                # non-nullable content validation unless the validation depth
-                # is explicitly forced to `SCHEMA_AND_DATA`, which we do not
-                # currently do here. Content constraints declared in PUDL's
-                # metadata (enum values, ranges, uniqueness, etc.) are
-                # therefore NOT enforced for Polars LazyFrame assets today.
+                # Column presence and dtypes are checked here, using only the
+                # cheap `collect_schema()` metadata -- no data is read. Value
+                # constraints (ranges, enums, uniqueness, etc.) are checked
+                # separately below, one narrow column at a time, so that even
+                # PUDL's largest tables remain tractable to validate. Errors
+                # from both passes are collected and reported together,
+                # rather than stopping at whichever one fails first, since
+                # they're independent and a caller fixing one shouldn't have
+                # to re-run the check to discover the other.
                 assert isinstance(pandera_schema, pr_polars.DataFrameSchema)
-                pandera_schema.validate(asset_value, lazy=True)
+                errors: list[SchemaError] = []
+                try:
+                    pandera_schema.validate(asset_value, lazy=True)
+                except SchemaErrors as schema_errors:
+                    errors.extend(schema_errors.schema_errors)
+
+                errors.extend(_validate_polars_content(asset_value, resource))
+
+                if errors:
+                    raise SchemaErrors(
+                        schema=pandera_schema,
+                        schema_errors=errors,
+                        data=asset_value,
+                    )
             else:
                 assert isinstance(pandera_schema, pr_pandas.DataFrameSchema)
                 pandera_schema.validate(asset_value, lazy=True)

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -41,7 +41,6 @@ from pudl.dagster.partitions import ferceqr_year_quarters
 from pudl.helpers import ParquetData, get_parquet_table_polars
 from pudl.metadata.classes import (
     PUDL_PACKAGE,
-    Field,
     Package,
     Resource,
 )
@@ -90,23 +89,6 @@ def _extract_actual_columns_and_dtypes(
     )
 
 
-def _field_has_content_constraints(field: Field) -> bool:
-    """Whether a field's constraints require reading its actual values to check."""
-    c = field.constraints
-    return any(
-        [
-            c.required,
-            c.unique,
-            c.minimum is not None,
-            c.maximum is not None,
-            c.min_length is not None,
-            c.max_length is not None,
-            c.pattern is not None,
-            bool(c.enum),
-        ]
-    )
-
-
 def _collect_dtype_metadata(
     asset_value: pl.LazyFrame | pd.DataFrame,
     resource: Resource,
@@ -123,7 +105,7 @@ def _collect_dtype_metadata(
         A metadata dictionary with:
         - ``field_details``: per-column expected/actual dtype details, declared
           constraints, and whether the column is content-checked (see
-          :func:`_field_has_content_constraints`).
+          :meth:`~pudl.metadata.classes.Field.has_content_constraints`).
         - ``column_comparison``: expected/actual column counts and optional missing
           or extra column lists.
         - ``type_mismatches``: only present when common columns have differing dtype
@@ -160,7 +142,7 @@ def _collect_dtype_metadata(
             "pudl_field_dtype": field.type,
             "expected_pandera_dtype": pandera_dtypes.get(field.name, "Unknown"),
             "actual_dtype": actual_dtypes.get(field.name, "Column not present"),
-            "content_checked": _field_has_content_constraints(field),
+            "content_checked": field.has_content_constraints(),
             "constraints": field.constraints.to_metadata_dict(),
         }
         for field in resource.schema.fields
@@ -411,7 +393,7 @@ def _validate_polars_content(
         for field in resource.schema.fields:
             if field.name not in present_columns:
                 continue
-            if not _field_has_content_constraints(field):
+            if not field.has_content_constraints():
                 continue
             column_schema = pr_polars.DataFrameSchema(
                 {field.name: field.to_pandera_column(use_pandas_backend=False)}

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -46,25 +46,6 @@ from pudl.metadata.classes import (
     Resource,
 )
 
-_CHUNKED_PK_CHECK_TABLES: dict[str, str] = {
-    "core_epacems__hourly_emissions": "operating_datetime_utc",
-    "out_vcerare__hourly_available_capacity_factor": "datetime_utc",
-}
-"""Tables large enough that their primary-key check needs to run in chunks.
-
-Keys are table names; values are the primary-key column to chunk by (see
-``Resource._chunk_filters`` for what makes a column a valid choice). This is an
-orchestration decision -- which of PUDL's tables are large enough that checking
-uniqueness in one pass isn't practical -- so it lives here rather than as a
-property of :class:`~pudl.metadata.classes.Resource` itself; ``check_primary_key``
-takes ``chunk_field`` as a plain parameter and doesn't know or care which tables
-are large.
-
-Note that `core_ferceqr__transactions` is deliberately NOT listed here because it
-does not currently have a primary key (2026-07-30). If we establish one, it should
-be added.
-"""
-
 
 def _collect_asset_metadata(asset_value) -> dict[str, Any]:
     """Collect basic metadata about the asset."""
@@ -126,35 +107,6 @@ def _field_has_content_constraints(field: Field) -> bool:
     )
 
 
-def _field_constraints_metadata(field: Field) -> dict[str, Any]:
-    """Build a JSON-safe summary of a field's declared constraints, if any.
-
-    Only constraints actually set (non-default) are included, so a caller can
-    tell at a glance what's being enforced on a column without cross-referencing
-    the PUDL metadata source. ``minimum``/``maximum`` can be dates, and
-    ``pattern`` is a compiled regex -- both are stringified for JSON safety.
-    """
-    c = field.constraints
-    constraints: dict[str, Any] = {}
-    if c.required:
-        constraints["required"] = True
-    if c.unique:
-        constraints["unique"] = True
-    if c.minimum is not None:
-        constraints["minimum"] = str(c.minimum)
-    if c.maximum is not None:
-        constraints["maximum"] = str(c.maximum)
-    if c.min_length is not None:
-        constraints["min_length"] = c.min_length
-    if c.max_length is not None:
-        constraints["max_length"] = c.max_length
-    if c.pattern is not None:
-        constraints["pattern"] = c.pattern.pattern
-    if c.enum:
-        constraints["enum"] = list(c.enum)
-    return constraints
-
-
 def _collect_dtype_metadata(
     asset_value: pl.LazyFrame | pd.DataFrame,
     resource: Resource,
@@ -209,7 +161,7 @@ def _collect_dtype_metadata(
             "expected_pandera_dtype": pandera_dtypes.get(field.name, "Unknown"),
             "actual_dtype": actual_dtypes.get(field.name, "Column not present"),
             "content_checked": _field_has_content_constraints(field),
-            "constraints": _field_constraints_metadata(field),
+            "constraints": field.constraints.to_metadata_dict(),
         }
         for field in resource.schema.fields
     }
@@ -273,8 +225,9 @@ def _collect_primary_key_metadata(
     """Describe the primary-key check that will run for this resource, if any.
 
     Whether a composite-uniqueness check is chunked (see
-    ``_CHUNKED_PK_CHECK_TABLES``) is a cheap name lookup, not a re-run of the
-    (potentially expensive, for our largest tables) chunking logic itself.
+    :attr:`~pudl.metadata.classes.Schema.chunk_field`) is a cheap attribute lookup,
+    not a re-run of the (potentially expensive, for our largest tables) chunking
+    logic itself.
     """
     primary_key = resource.schema.primary_key
     if not primary_key:
@@ -285,7 +238,7 @@ def _collect_primary_key_metadata(
         "primary_key": {
             "declared": True,
             "columns": primary_key,
-            "chunked": resource.name in _CHUNKED_PK_CHECK_TABLES,
+            "chunked": resource.schema.chunk_field is not None,
             "checked": not missing_columns,
             "missing_columns": missing_columns or None,
         }
@@ -472,8 +425,7 @@ def _validate_polars_content(
     pk_start = time.perf_counter()
     primary_key = resource.schema.primary_key
     if primary_key and all(col in present_columns for col in primary_key):
-        chunk_field = _CHUNKED_PK_CHECK_TABLES.get(resource.name)
-        errors.extend(resource.check_primary_key(asset_value, chunk_field=chunk_field))
+        errors.extend(resource.check_primary_key(asset_value))
     timings["pk_check_seconds"] = time.perf_counter() - pk_start
 
     return errors, timings

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -40,12 +40,30 @@ from pudl.dagster.assets import all_asset_modules, asset_keys
 from pudl.dagster.partitions import ferceqr_year_quarters
 from pudl.helpers import ParquetData, get_parquet_table_polars
 from pudl.metadata.classes import (
-    _CHUNKED_PK_CHECK_TABLES,
     PUDL_PACKAGE,
     Field,
     Package,
     Resource,
 )
+
+_CHUNKED_PK_CHECK_TABLES: dict[str, str] = {
+    "core_epacems__hourly_emissions": "operating_datetime_utc",
+    "out_vcerare__hourly_available_capacity_factor": "datetime_utc",
+}
+"""Tables large enough that their primary-key check needs to run in chunks.
+
+Keys are table names; values are the primary-key column to chunk by (see
+``Resource._chunk_filters`` for what makes a column a valid choice). This is an
+orchestration decision -- which of PUDL's tables are large enough that checking
+uniqueness in one pass isn't practical -- so it lives here rather than as a
+property of :class:`~pudl.metadata.classes.Resource` itself; ``check_primary_key``
+takes ``chunk_field`` as a plain parameter and doesn't know or care which tables
+are large.
+
+Note that `core_ferceqr__transactions` is deliberately NOT listed here because it
+does not currently have a primary key (2026-07-30). If we establish one, it should
+be added.
+"""
 
 
 def _collect_asset_metadata(asset_value) -> dict[str, Any]:
@@ -454,11 +472,8 @@ def _validate_polars_content(
     pk_start = time.perf_counter()
     primary_key = resource.schema.primary_key
     if primary_key and all(col in present_columns for col in primary_key):
-        # asset_value is unambiguously a LazyFrame here, so call the
-        # precisely-typed polars implementation directly rather than the
-        # public check_primary_key dispatcher, whose return type is
-        # broadened to accommodate its pandas branch (which returns None).
-        errors.extend(resource._check_primary_key_polars(asset_value))
+        chunk_field = _CHUNKED_PK_CHECK_TABLES.get(resource.name)
+        errors.extend(resource.check_primary_key(asset_value, chunk_field=chunk_field))
     timings["pk_check_seconds"] = time.perf_counter() - pk_start
 
     return errors, timings

--- a/src/pudl/dagster/io_managers.py
+++ b/src/pudl/dagster/io_managers.py
@@ -19,7 +19,7 @@ from sqlite3 import sqlite_version
 from typing import Any, ClassVar
 
 import dagster as dg
-import geopandas as gpd  # noqa: ICN002
+import geopandas
 import pandas as pd
 import polars as pl
 import pyarrow.parquet as pq
@@ -144,7 +144,7 @@ class PudlMixedFormatIOManager(ConfigurableIOManager):
 
     def load_input(
         self, context: dg.InputContext
-    ) -> pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame:
+    ) -> pd.DataFrame | geopandas.GeoDataFrame | pl.LazyFrame:
         """Reads input from the appropriate IO manager instance."""
         if self.read_from_parquet:
             return self._parquet_io_manager.load_input(context)
@@ -379,7 +379,7 @@ class PudlParquetIOManager(dg.ConfigurableIOManager):
     def handle_output(
         self,
         context: dg.OutputContext,
-        obj: pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame,
+        obj: pd.DataFrame | geopandas.GeoDataFrame | pl.LazyFrame,
     ) -> None:
         """Writes a pudl dataframe to a Parquet file.
 
@@ -393,7 +393,7 @@ class PudlParquetIOManager(dg.ConfigurableIOManager):
         parquet_path = self.pudl_paths.parquet_path(table_name)
         parquet_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if isinstance(obj, gpd.GeoDataFrame):
+        if isinstance(obj, geopandas.GeoDataFrame):
             gdf = res.enforce_schema(obj)
             gdf.to_parquet(parquet_path, index=False)
         elif isinstance(obj, pd.DataFrame):
@@ -419,7 +419,7 @@ class PudlParquetIOManager(dg.ConfigurableIOManager):
 
     def load_input(
         self, context: dg.InputContext
-    ) -> pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame:
+    ) -> pd.DataFrame | geopandas.GeoDataFrame | pl.LazyFrame:
         """Loads pudl table from parquet file."""
         table_name = get_table_name_from_context(context)
         if context.dagster_type.typing_type == pl.LazyFrame:

--- a/src/pudl/dagster/io_managers.py
+++ b/src/pudl/dagster/io_managers.py
@@ -19,7 +19,7 @@ from sqlite3 import sqlite_version
 from typing import Any, ClassVar
 
 import dagster as dg
-import geopandas as gpd  # noqa: ICN002
+import geopandas
 import pandas as pd
 import polars as pl
 import pyarrow.parquet as pq
@@ -132,7 +132,7 @@ class PudlMixedFormatIOManager(ConfigurableIOManager):
 
     def load_input(
         self, context: dg.InputContext
-    ) -> pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame:
+    ) -> pd.DataFrame | geopandas.GeoDataFrame | pl.LazyFrame:
         """Reads input from the appropriate IO manager instance."""
         if self.read_from_parquet:
             return self._parquet_io_manager.load_input(context)
@@ -367,7 +367,7 @@ class PudlParquetIOManager(dg.ConfigurableIOManager):
     def handle_output(
         self,
         context: dg.OutputContext,
-        obj: pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame,
+        obj: pd.DataFrame | geopandas.GeoDataFrame | pl.LazyFrame,
     ) -> None:
         """Writes a pudl dataframe to a Parquet file.
 
@@ -381,7 +381,7 @@ class PudlParquetIOManager(dg.ConfigurableIOManager):
         parquet_path = self.pudl_paths.parquet_path(table_name)
         parquet_path.parent.mkdir(parents=True, exist_ok=True)
 
-        if isinstance(obj, gpd.GeoDataFrame):
+        if isinstance(obj, geopandas.GeoDataFrame):
             gdf = res.enforce_schema(obj)
             gdf.to_parquet(parquet_path, index=False)
         elif isinstance(obj, pd.DataFrame):
@@ -407,7 +407,7 @@ class PudlParquetIOManager(dg.ConfigurableIOManager):
 
     def load_input(
         self, context: dg.InputContext
-    ) -> pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame:
+    ) -> pd.DataFrame | geopandas.GeoDataFrame | pl.LazyFrame:
         """Loads pudl table from parquet file."""
         table_name = get_table_name_from_context(context)
         if context.dagster_type.typing_type == pl.LazyFrame:

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import duckdb
 import geopandas as gpd  # noqa: ICN002
@@ -38,6 +38,9 @@ from pydantic import BaseModel, Field
 import pudl.logging_helpers
 from pudl.metadata.dtypes import apply_pudl_dtypes, get_pudl_dtypes
 from pudl.workspace.setup import PudlPaths
+
+if TYPE_CHECKING:
+    from pudl.metadata.classes import Resource
 
 sum_na = partial(pd.Series.sum, skipna=False)
 """A sum function that returns NA if the Series includes any NA values.
@@ -2260,6 +2263,32 @@ def get_parquet_table_polars(
     )
 
 
+def _fix_residual_read_dtypes(df: pd.DataFrame, resource: "Resource") -> pd.DataFrame:
+    """Fix the handful of dtypes ``dtype_backend="numpy_nullable"`` can't get right.
+
+    Three gaps remain after a ``dtype_backend="numpy_nullable"`` read, none of them
+    fixable by that argument alone:
+
+    * integer/number columns are narrower on disk (e.g. 32-bit) than PUDL's pandas
+      targets (see ``FIELD_DTYPES_PYARROW``/``FIELD_DTYPES_PANDAS``);
+    * "date" columns (Arrow ``date32``) always come back as plain ``object`` --
+      pandas has no native nullable date-only dtype -- rather than PUDL's
+      ``datetime64[s]`` target;
+    * "datetime" columns come back at whatever timestamp resolution is stored on
+      disk (e.g. ``datetime64[ms]``), not PUDL's ``datetime64[s]`` target.
+
+    Every other field type -- including enum-constrained strings -- is already
+    correct after that read and needs no further casting.
+    """
+    fixes = {
+        field.name: field.to_pandas_dtype()
+        for field in resource.schema.fields
+        if field.type in ("integer", "number", "date", "datetime")
+        and field.name in df.columns
+    }
+    return df.astype(fixes) if fixes else df
+
+
 def get_parquet_table(
     table_name: str,
     columns: list[str] | None = None,
@@ -2303,6 +2332,8 @@ def get_parquet_table(
 
     is_geospatial = any(resource.get_field(col).type == "geometry" for col in columns)
 
+    full_read = set(columns) == set(resource.get_field_names())
+
     if is_geospatial:
         df = gpd.read_parquet(
             path=parquet_path,
@@ -2312,7 +2343,14 @@ def get_parquet_table(
             use_threads=True,
             memory_map=True,
         )
-    else:
+        # geopandas' reader has no equivalent to pandas' dtype_backend, so this
+        # branch still needs enforce_schema's full re-cast.
+        df = (
+            resource.enforce_schema(df)
+            if full_read
+            else apply_pudl_dtypes(df, resource=resource.name)
+        )
+    else:  # not geospatial -- the normal case
         df = pd.read_parquet(
             path=parquet_path,
             columns=columns,
@@ -2320,13 +2358,24 @@ def get_parquet_table(
             schema=pyarrow_schema,
             use_threads=True,
             memory_map=True,
+            dtype_backend="numpy_nullable",
         )
 
-    # Only enforce schema if we're reading all columns
-    if set(columns) == set(resource.get_field_names()):
-        return resource.enforce_schema(df)
-    # For specific columns, apply PUDL dtypes including resource-level overrides
-    return apply_pudl_dtypes(df, resource=resource.name)
+    if not full_read:
+        # For specific columns, apply PUDL dtypes including resource-level overrides
+        df = apply_pudl_dtypes(df, resource=resource.name)
+    else:
+        # dtype_backend="numpy_nullable" already gets every column to PUDL's target
+        # dtype except for the few gaps _fix_residual_read_dtypes covers -- enforce_schema's
+        # full re-cast of every column, including enum fields, is redundant here: pandas'
+        # Categorical reconstructs a constrained dtype's full category list (even unused
+        # ones) straight from the Parquet dictionary page, with no PUDL-metadata-driven
+        # re-derivation needed. See tests/unit/helpers_test.py's
+        # test_constrained_categorical_cross_backend_parquet_roundtrip.
+        df = _fix_residual_read_dtypes(df, resource)
+        resource.check_primary_key(df)
+
+    return df
 
 
 def standardize_phone_column(df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2361,7 +2361,8 @@ def get_parquet_table(
             memory_map=True,
         )
         # geopandas' reader has no equivalent to pandas' dtype_backend, so this
-        # branch still needs enforce_schema's full re-cast.
+        # branch still needs enforce_schema's full re-cast (which also runs the
+        # primary-key check for a full read).
         df = (
             resource.enforce_schema(df)
             if full_read
@@ -2377,20 +2378,19 @@ def get_parquet_table(
             memory_map=True,
             dtype_backend="numpy_nullable",
         )
-
-    if not full_read:
-        # For specific columns, apply PUDL dtypes including resource-level overrides
-        df = apply_pudl_dtypes(df, resource=resource.name)
-    else:
-        # dtype_backend="numpy_nullable" already gets every column to PUDL's target
-        # dtype except for the few gaps _fix_residual_read_dtypes covers -- enforce_schema's
-        # full re-cast of every column, including enum fields, is redundant here: pandas'
-        # Categorical reconstructs a constrained dtype's full category list (even unused
-        # ones) straight from the Parquet dictionary page, with no PUDL-metadata-driven
-        # re-derivation needed. See tests/unit/helpers_test.py's
-        # test_constrained_categorical_cross_backend_parquet_roundtrip.
-        df = _fix_residual_read_dtypes(df, resource)
-        resource.check_primary_key(df)
+        if not full_read:
+            # For specific columns, apply PUDL dtypes including resource-level overrides
+            df = apply_pudl_dtypes(df, resource=resource.name)
+        else:
+            # dtype_backend="numpy_nullable" already gets every column to PUDL's target
+            # dtype except for the few gaps _fix_residual_read_dtypes covers -- enforce_schema's
+            # full re-cast of every column, including enum fields, is redundant here: pandas'
+            # Categorical reconstructs a constrained dtype's full category list (even unused
+            # ones) straight from the Parquet dictionary page, with no PUDL-metadata-driven
+            # re-derivation needed. See tests/unit/helpers_test.py's
+            # test_constrained_categorical_cross_backend_parquet_roundtrip.
+            df = _fix_residual_read_dtypes(df, resource)
+            resource.check_primary_key(df)
 
     return df
 

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2249,16 +2249,39 @@ def get_parquet_table_polars(
     from pudl.metadata.classes import Resource
 
     resource = Resource.from_id(table_name)
-    # Pass the expected schema in directly rather than scanning then casting: casting
-    # a LazyFrame containing Enum-typed columns forces materialization, which is very
-    # slow for our largest hourly tables. Enum-constrained fields are stored as plain
-    # Categorical (see Field.to_polars_dtype), so no such cast is needed here anyway.
+
+    # Scan without an explicit schema first to discover each column's actual
+    # on-disk dtype -- this is metadata-only (collect_schema()), no data is read.
+    # Enum-constrained string fields are stored as unconstrained Categorical (see
+    # Field.to_polars_dtype), but the physical on-disk type can still vary: DuckDB-
+    # produced files store these columns as plain String rather than Categorical
+    # (verified against real core_ferceqr__contracts output). Requesting a fixed
+    # schema up front fails outright for those columns the moment it doesn't match
+    # the on-disk type exactly, so this deliberately scans without one and only
+    # overrides the specific columns that actually need it below.
+    natural_schema = pl.scan_parquet(parquet_path).collect_schema()
+
     # Parquet files still store integer/float columns as 32-bit (FIELD_DTYPES_PYARROW),
-    # narrower than the 64-bit Polars schema we're requesting here, so allow scan-time
-    # upcasting rather than the strict match scan_parquet defaults to.
+    # narrower than the 64-bit Polars schema we're requesting here, so override just
+    # those columns to allow scan-time upcasting rather than the strict match
+    # scan_parquet defaults to. Every other column -- including Categorical/string
+    # ones -- passes through with its natural, on-disk dtype.
+    def _needs_numeric_upcast(on_disk: pl.DataType, target: pl.DataType) -> bool:
+        same_numeric_kind = (on_disk.is_integer() and target.is_integer()) or (
+            on_disk.is_float() and target.is_float()
+        )
+        return same_numeric_kind and on_disk != target
+
+    target_dtypes = resource.to_polars_dtypes()
+    schema = {
+        name: target_dtypes[name]
+        if name in target_dtypes and _needs_numeric_upcast(dtype, target_dtypes[name])
+        else dtype
+        for name, dtype in natural_schema.items()
+    }
     return pl.scan_parquet(
         parquet_path,
-        schema=resource.to_polars_dtypes(),
+        schema=schema,
         cast_options=pl.ScanCastOptions(integer_cast="upcast", float_cast="upcast"),
     )
 

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2245,69 +2245,29 @@ def get_parquet_table_polars(
         # Points to a directory of parquet files when there partitions is non None
         parquet_path = parquet_data.parquet_path
 
-    # Import here to avoid circular imports
-    from pudl.metadata.classes import Resource
-
-    resource = Resource.from_id(table_name)
-
-    # Scan without an explicit schema first to discover each column's actual
-    # on-disk dtype -- this is metadata-only (collect_schema()), no data is read.
-    # Enum-constrained string fields are stored as unconstrained Categorical (see
-    # Field.to_polars_dtype), but the physical on-disk type can still vary: DuckDB-
-    # produced files store these columns as plain String rather than Categorical
-    # (verified against real core_ferceqr__contracts output). Requesting a fixed
-    # schema up front fails outright for those columns the moment it doesn't match
-    # the on-disk type exactly, so this deliberately scans without one and only
-    # overrides the specific columns that actually need it below.
-    natural_schema = pl.scan_parquet(parquet_path).collect_schema()
-
-    # Parquet files still store integer/float columns as 32-bit (FIELD_DTYPES_PYARROW),
-    # narrower than the 64-bit Polars schema we're requesting here, so override just
-    # those columns to allow scan-time upcasting rather than the strict match
-    # scan_parquet defaults to. Every other column -- including Categorical/string
-    # ones -- passes through with its natural, on-disk dtype.
-    def _needs_numeric_upcast(on_disk: pl.DataType, target: pl.DataType) -> bool:
-        same_numeric_kind = (on_disk.is_integer() and target.is_integer()) or (
-            on_disk.is_float() and target.is_float()
-        )
-        return same_numeric_kind and on_disk != target
-
-    target_dtypes = resource.to_polars_dtypes()
-    schema = {
-        name: target_dtypes[name]
-        if name in target_dtypes and _needs_numeric_upcast(dtype, target_dtypes[name])
-        else dtype
-        for name, dtype in natural_schema.items()
-    }
-    return pl.scan_parquet(
-        parquet_path,
-        schema=schema,
-        cast_options=pl.ScanCastOptions(integer_cast="upcast", float_cast="upcast"),
-    )
+    return pl.scan_parquet(parquet_path)
 
 
-def _fix_residual_read_dtypes(df: pd.DataFrame, resource: "Resource") -> pd.DataFrame:
-    """Fix the handful of dtypes ``dtype_backend="numpy_nullable"`` can't get right.
+def _fix_residual_dtypes(df: pd.DataFrame, resource: "Resource") -> pd.DataFrame:
+    """Fix the two dtype gaps ``dtype_backend="numpy_nullable"`` can't get right.
 
-    Three gaps remain after a ``dtype_backend="numpy_nullable"`` read, none of them
-    fixable by that argument alone:
+    Integer and datetime columns already come back from a
+    ``dtype_backend="numpy_nullable"`` read matching their pandas targets (see
+    ``FIELD_DTYPES_PANDAS``) directly. Two gaps remain, neither fixable by
+    ``dtype_backend`` alone:
 
-    * integer/number columns are narrower on disk (e.g. 32-bit) than PUDL's pandas
-      targets (see ``FIELD_DTYPES_PYARROW``/``FIELD_DTYPES_PANDAS``);
-    * "date" columns (Arrow ``date32``) always come back as plain ``object`` --
-      pandas has no native nullable date-only dtype -- rather than PUDL's
-      ``datetime64[s]`` target;
-    * "datetime" columns come back at whatever timestamp resolution is stored on
-      disk (e.g. ``datetime64[ms]``), not PUDL's ``datetime64[s]`` target.
-
-    Every other field type -- including enum-constrained strings -- is already
-    correct after that read and needs no further casting.
+    * "number" columns come back as pandas' nullable ``Float64``, but PUDL's target
+      is plain (non-nullable) ``float64`` -- unlike integers, floats can already
+      represent missing values natively via ``NaN``, so PUDL doesn't use the
+      nullable dtype for them.
+    * "date" columns (Arrow ``date32``) always come back as plain ``object`` holding
+      Python ``datetime.date`` scalars, since pandas has no native nullable
+      date-only dtype.
     """
     fixes = {
         field.name: field.to_pandas_dtype()
         for field in resource.schema.fields
-        if field.type in ("integer", "number", "date", "datetime")
-        and field.name in df.columns
+        if field.type in ("number", "date") and field.name in df.columns
     }
     return df.astype(fixes) if fixes else df
 
@@ -2389,13 +2349,13 @@ def get_parquet_table(
             df = apply_pudl_dtypes(df, resource=resource.name)
         else:
             # dtype_backend="numpy_nullable" already gets every column to PUDL's target
-            # dtype except for the few gaps _fix_residual_read_dtypes covers -- enforce_schema's
+            # dtype except for the few gaps _fix_residual_dtypes covers -- enforce_schema's
             # full re-cast of every column, including enum fields, is redundant here: pandas'
             # Categorical reconstructs a constrained dtype's full category list (even unused
             # ones) straight from the Parquet dictionary page, with no PUDL-metadata-driven
             # re-derivation needed. See tests/unit/helpers_test.py's
             # test_constrained_categorical_cross_backend_parquet_roundtrip.
-            df = _fix_residual_read_dtypes(df, resource)
+            df = _fix_residual_dtypes(df, resource)
             resource.check_primary_key(df)
 
     return df

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2367,7 +2367,8 @@ def get_parquet_table(
             memory_map=True,
         )
         # geopandas' reader has no equivalent to pandas' dtype_backend, so this
-        # branch still needs enforce_schema's full re-cast.
+        # branch still needs enforce_schema's full re-cast (which also runs the
+        # primary-key check for a full read).
         df = (
             resource.enforce_schema(df)
             if full_read
@@ -2383,20 +2384,19 @@ def get_parquet_table(
             memory_map=True,
             dtype_backend="numpy_nullable",
         )
-
-    if not full_read:
-        # For specific columns, apply PUDL dtypes including resource-level overrides
-        df = apply_pudl_dtypes(df, resource=resource.name)
-    else:
-        # dtype_backend="numpy_nullable" already gets every column to PUDL's target
-        # dtype except for the few gaps _fix_residual_read_dtypes covers -- enforce_schema's
-        # full re-cast of every column, including enum fields, is redundant here: pandas'
-        # Categorical reconstructs a constrained dtype's full category list (even unused
-        # ones) straight from the Parquet dictionary page, with no PUDL-metadata-driven
-        # re-derivation needed. See tests/unit/helpers_test.py's
-        # test_constrained_categorical_cross_backend_parquet_roundtrip.
-        df = _fix_residual_read_dtypes(df, resource)
-        resource.check_primary_key(df)
+        if not full_read:
+            # For specific columns, apply PUDL dtypes including resource-level overrides
+            df = apply_pudl_dtypes(df, resource=resource.name)
+        else:
+            # dtype_backend="numpy_nullable" already gets every column to PUDL's target
+            # dtype except for the few gaps _fix_residual_read_dtypes covers -- enforce_schema's
+            # full re-cast of every column, including enum fields, is redundant here: pandas'
+            # Categorical reconstructs a constrained dtype's full category list (even unused
+            # ones) straight from the Parquet dictionary page, with no PUDL-metadata-driven
+            # re-derivation needed. See tests/unit/helpers_test.py's
+            # test_constrained_categorical_cross_backend_parquet_roundtrip.
+            df = _fix_residual_read_dtypes(df, resource)
+            resource.check_primary_key(df)
 
     return df
 

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2239,69 +2239,29 @@ def get_parquet_table_polars(
         # Points to a directory of parquet files when there partitions is non None
         parquet_path = parquet_data.parquet_path
 
-    # Import here to avoid circular imports
-    from pudl.metadata.classes import Resource
-
-    resource = Resource.from_id(table_name)
-
-    # Scan without an explicit schema first to discover each column's actual
-    # on-disk dtype -- this is metadata-only (collect_schema()), no data is read.
-    # Enum-constrained string fields are stored as unconstrained Categorical (see
-    # Field.to_polars_dtype), but the physical on-disk type can still vary: DuckDB-
-    # produced files store these columns as plain String rather than Categorical
-    # (verified against real core_ferceqr__contracts output). Requesting a fixed
-    # schema up front fails outright for those columns the moment it doesn't match
-    # the on-disk type exactly, so this deliberately scans without one and only
-    # overrides the specific columns that actually need it below.
-    natural_schema = pl.scan_parquet(parquet_path).collect_schema()
-
-    # Parquet files still store integer/float columns as 32-bit (FIELD_DTYPES_PYARROW),
-    # narrower than the 64-bit Polars schema we're requesting here, so override just
-    # those columns to allow scan-time upcasting rather than the strict match
-    # scan_parquet defaults to. Every other column -- including Categorical/string
-    # ones -- passes through with its natural, on-disk dtype.
-    def _needs_numeric_upcast(on_disk: pl.DataType, target: pl.DataType) -> bool:
-        same_numeric_kind = (on_disk.is_integer() and target.is_integer()) or (
-            on_disk.is_float() and target.is_float()
-        )
-        return same_numeric_kind and on_disk != target
-
-    target_dtypes = resource.to_polars_dtypes()
-    schema = {
-        name: target_dtypes[name]
-        if name in target_dtypes and _needs_numeric_upcast(dtype, target_dtypes[name])
-        else dtype
-        for name, dtype in natural_schema.items()
-    }
-    return pl.scan_parquet(
-        parquet_path,
-        schema=schema,
-        cast_options=pl.ScanCastOptions(integer_cast="upcast", float_cast="upcast"),
-    )
+    return pl.scan_parquet(parquet_path)
 
 
-def _fix_residual_read_dtypes(df: pd.DataFrame, resource: "Resource") -> pd.DataFrame:
-    """Fix the handful of dtypes ``dtype_backend="numpy_nullable"`` can't get right.
+def _fix_residual_dtypes(df: pd.DataFrame, resource: "Resource") -> pd.DataFrame:
+    """Fix the two dtype gaps ``dtype_backend="numpy_nullable"`` can't get right.
 
-    Three gaps remain after a ``dtype_backend="numpy_nullable"`` read, none of them
-    fixable by that argument alone:
+    Integer and datetime columns already come back from a
+    ``dtype_backend="numpy_nullable"`` read matching their pandas targets (see
+    ``FIELD_DTYPES_PANDAS``) directly. Two gaps remain, neither fixable by
+    ``dtype_backend`` alone:
 
-    * integer/number columns are narrower on disk (e.g. 32-bit) than PUDL's pandas
-      targets (see ``FIELD_DTYPES_PYARROW``/``FIELD_DTYPES_PANDAS``);
-    * "date" columns (Arrow ``date32``) always come back as plain ``object`` --
-      pandas has no native nullable date-only dtype -- rather than PUDL's
-      ``datetime64[s]`` target;
-    * "datetime" columns come back at whatever timestamp resolution is stored on
-      disk (e.g. ``datetime64[ms]``), not PUDL's ``datetime64[s]`` target.
-
-    Every other field type -- including enum-constrained strings -- is already
-    correct after that read and needs no further casting.
+    * "number" columns come back as pandas' nullable ``Float64``, but PUDL's target
+      is plain (non-nullable) ``float64`` -- unlike integers, floats can already
+      represent missing values natively via ``NaN``, so PUDL doesn't use the
+      nullable dtype for them.
+    * "date" columns (Arrow ``date32``) always come back as plain ``object`` holding
+      Python ``datetime.date`` scalars, since pandas has no native nullable
+      date-only dtype.
     """
     fixes = {
         field.name: field.to_pandas_dtype()
         for field in resource.schema.fields
-        if field.type in ("integer", "number", "date", "datetime")
-        and field.name in df.columns
+        if field.type in ("number", "date") and field.name in df.columns
     }
     return df.astype(fixes) if fixes else df
 
@@ -2383,13 +2343,13 @@ def get_parquet_table(
             df = apply_pudl_dtypes(df, resource=resource.name)
         else:
             # dtype_backend="numpy_nullable" already gets every column to PUDL's target
-            # dtype except for the few gaps _fix_residual_read_dtypes covers -- enforce_schema's
+            # dtype except for the few gaps _fix_residual_dtypes covers -- enforce_schema's
             # full re-cast of every column, including enum fields, is redundant here: pandas'
             # Categorical reconstructs a constrained dtype's full category list (even unused
             # ones) straight from the Parquet dictionary page, with no PUDL-metadata-driven
             # re-derivation needed. See tests/unit/helpers_test.py's
             # test_constrained_categorical_cross_backend_parquet_roundtrip.
-            df = _fix_residual_read_dtypes(df, resource)
+            df = _fix_residual_dtypes(df, resource)
             resource.check_primary_key(df)
 
     return df

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2350,7 +2350,10 @@ def get_parquet_table(
             # re-derivation needed. See tests/unit/helpers_test.py's
             # test_constrained_categorical_cross_backend_parquet_roundtrip.
             df = _fix_residual_dtypes(df, resource)
-            resource.check_primary_key(df)
+            if errors := resource.check_primary_key(df):
+                raise ValueError(
+                    f"{resource.name}: " + "\n".join(str(error) for error in errors)
+                )
 
     return df
 

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2356,7 +2356,10 @@ def get_parquet_table(
             # re-derivation needed. See tests/unit/helpers_test.py's
             # test_constrained_categorical_cross_backend_parquet_roundtrip.
             df = _fix_residual_dtypes(df, resource)
-            resource.check_primary_key(df)
+            if errors := resource.check_primary_key(df):
+                raise ValueError(
+                    f"{resource.name}: " + "\n".join(str(error) for error in errors)
+                )
 
     return df
 

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2243,16 +2243,39 @@ def get_parquet_table_polars(
     from pudl.metadata.classes import Resource
 
     resource = Resource.from_id(table_name)
-    # Pass the expected schema in directly rather than scanning then casting: casting
-    # a LazyFrame containing Enum-typed columns forces materialization, which is very
-    # slow for our largest hourly tables. Enum-constrained fields are stored as plain
-    # Categorical (see Field.to_polars_dtype), so no such cast is needed here anyway.
+
+    # Scan without an explicit schema first to discover each column's actual
+    # on-disk dtype -- this is metadata-only (collect_schema()), no data is read.
+    # Enum-constrained string fields are stored as unconstrained Categorical (see
+    # Field.to_polars_dtype), but the physical on-disk type can still vary: DuckDB-
+    # produced files store these columns as plain String rather than Categorical
+    # (verified against real core_ferceqr__contracts output). Requesting a fixed
+    # schema up front fails outright for those columns the moment it doesn't match
+    # the on-disk type exactly, so this deliberately scans without one and only
+    # overrides the specific columns that actually need it below.
+    natural_schema = pl.scan_parquet(parquet_path).collect_schema()
+
     # Parquet files still store integer/float columns as 32-bit (FIELD_DTYPES_PYARROW),
-    # narrower than the 64-bit Polars schema we're requesting here, so allow scan-time
-    # upcasting rather than the strict match scan_parquet defaults to.
+    # narrower than the 64-bit Polars schema we're requesting here, so override just
+    # those columns to allow scan-time upcasting rather than the strict match
+    # scan_parquet defaults to. Every other column -- including Categorical/string
+    # ones -- passes through with its natural, on-disk dtype.
+    def _needs_numeric_upcast(on_disk: pl.DataType, target: pl.DataType) -> bool:
+        same_numeric_kind = (on_disk.is_integer() and target.is_integer()) or (
+            on_disk.is_float() and target.is_float()
+        )
+        return same_numeric_kind and on_disk != target
+
+    target_dtypes = resource.to_polars_dtypes()
+    schema = {
+        name: target_dtypes[name]
+        if name in target_dtypes and _needs_numeric_upcast(dtype, target_dtypes[name])
+        else dtype
+        for name, dtype in natural_schema.items()
+    }
     return pl.scan_parquet(
         parquet_path,
-        schema=resource.to_polars_dtypes(),
+        schema=schema,
         cast_options=pl.ScanCastOptions(integer_cast="upcast", float_cast="upcast"),
     )
 

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2283,8 +2283,8 @@ def get_parquet_table(
     """Read a table from Parquet files with optional column selection and filtering.
 
     This function provides a general-purpose interface for reading PUDL tables from
-    Parquet files. It supports selective column reading for performance, optional
-    filters for data subsetting, and automatic schema validation.
+    Parquet files. It supports selective column reading for performance and optional
+    filters for data subsetting.
 
     Args:
         table_name: Name of the table to read.

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -21,7 +21,7 @@ from contextlib import contextmanager
 from functools import partial
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Literal, NamedTuple
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple
 
 import duckdb
 import geopandas as gpd  # noqa: ICN002
@@ -38,6 +38,9 @@ from pydantic import BaseModel, Field
 import pudl.logging_helpers
 from pudl.metadata.dtypes import apply_pudl_dtypes, get_pudl_dtypes
 from pudl.workspace.setup import PudlPaths
+
+if TYPE_CHECKING:
+    from pudl.metadata.classes import Resource
 
 sum_na = partial(pd.Series.sum, skipna=False)
 """A sum function that returns NA if the Series includes any NA values.
@@ -2254,6 +2257,32 @@ def get_parquet_table_polars(
     )
 
 
+def _fix_residual_read_dtypes(df: pd.DataFrame, resource: "Resource") -> pd.DataFrame:
+    """Fix the handful of dtypes ``dtype_backend="numpy_nullable"`` can't get right.
+
+    Three gaps remain after a ``dtype_backend="numpy_nullable"`` read, none of them
+    fixable by that argument alone:
+
+    * integer/number columns are narrower on disk (e.g. 32-bit) than PUDL's pandas
+      targets (see ``FIELD_DTYPES_PYARROW``/``FIELD_DTYPES_PANDAS``);
+    * "date" columns (Arrow ``date32``) always come back as plain ``object`` --
+      pandas has no native nullable date-only dtype -- rather than PUDL's
+      ``datetime64[s]`` target;
+    * "datetime" columns come back at whatever timestamp resolution is stored on
+      disk (e.g. ``datetime64[ms]``), not PUDL's ``datetime64[s]`` target.
+
+    Every other field type -- including enum-constrained strings -- is already
+    correct after that read and needs no further casting.
+    """
+    fixes = {
+        field.name: field.to_pandas_dtype()
+        for field in resource.schema.fields
+        if field.type in ("integer", "number", "date", "datetime")
+        and field.name in df.columns
+    }
+    return df.astype(fixes) if fixes else df
+
+
 def get_parquet_table(
     table_name: str,
     columns: list[str] | None = None,
@@ -2297,6 +2326,8 @@ def get_parquet_table(
 
     is_geospatial = any(resource.get_field(col).type == "geometry" for col in columns)
 
+    full_read = set(columns) == set(resource.get_field_names())
+
     if is_geospatial:
         df = gpd.read_parquet(
             path=parquet_path,
@@ -2306,7 +2337,14 @@ def get_parquet_table(
             use_threads=True,
             memory_map=True,
         )
-    else:
+        # geopandas' reader has no equivalent to pandas' dtype_backend, so this
+        # branch still needs enforce_schema's full re-cast.
+        df = (
+            resource.enforce_schema(df)
+            if full_read
+            else apply_pudl_dtypes(df, resource=resource.name)
+        )
+    else:  # not geospatial -- the normal case
         df = pd.read_parquet(
             path=parquet_path,
             columns=columns,
@@ -2314,13 +2352,24 @@ def get_parquet_table(
             schema=pyarrow_schema,
             use_threads=True,
             memory_map=True,
+            dtype_backend="numpy_nullable",
         )
 
-    # Only enforce schema if we're reading all columns
-    if set(columns) == set(resource.get_field_names()):
-        return resource.enforce_schema(df)
-    # For specific columns, apply PUDL dtypes including resource-level overrides
-    return apply_pudl_dtypes(df, resource=resource.name)
+    if not full_read:
+        # For specific columns, apply PUDL dtypes including resource-level overrides
+        df = apply_pudl_dtypes(df, resource=resource.name)
+    else:
+        # dtype_backend="numpy_nullable" already gets every column to PUDL's target
+        # dtype except for the few gaps _fix_residual_read_dtypes covers -- enforce_schema's
+        # full re-cast of every column, including enum fields, is redundant here: pandas'
+        # Categorical reconstructs a constrained dtype's full category list (even unused
+        # ones) straight from the Parquet dictionary page, with no PUDL-metadata-driven
+        # re-derivation needed. See tests/unit/helpers_test.py's
+        # test_constrained_categorical_cross_backend_parquet_roundtrip.
+        df = _fix_residual_read_dtypes(df, resource)
+        resource.check_primary_key(df)
+
+    return df
 
 
 def standardize_phone_column(df: pd.DataFrame, columns: list[str]) -> pd.DataFrame:

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -380,15 +380,6 @@ class FieldConstraints(PudlMeta):
 
         return checks
 
-    def to_metadata_dict(self) -> dict[str, Any]:
-        """Build a JSON-safe summary of only the constraints actually set.
-
-        Used by callers (e.g. Dagster asset-check metadata) that want to show what's
-        being enforced on a column without cross-referencing the PUDL metadata source
-        or wading through every unset default.
-        """
-        return self.model_dump(exclude_defaults=True, mode="json")
-
 
 class FieldHarvest(PudlMeta):
     """Field harvest parameters (`resource.schema.fields[...].harvest`)."""

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -944,6 +944,22 @@ class Field(PudlMeta):
             unique=constraints.unique,
         )
 
+    def has_content_constraints(self) -> bool:
+        """Whether this field's constraints require reading its actual values to check."""
+        c = self.constraints
+        return any(
+            [
+                c.required,
+                c.unique,
+                c.minimum is not None,
+                c.maximum is not None,
+                c.min_length is not None,
+                c.max_length is not None,
+                c.pattern is not None,
+                bool(c.enum),
+            ]
+        )
+
 
 # ---- Classes: Resource ---- #
 

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -339,6 +339,20 @@ class FieldConstraints(PudlMeta):
         | None
     ) = None
 
+    def has_content_constraints(self) -> bool:
+        """Whether checking these constraints requires reading actual field values.
+
+        Every constraint field is assumed to require a content read (true of all
+        constraint types to date), so this checks all of ``model_fields`` rather
+        than a hand-maintained list — a newly added constraint field is covered
+        automatically instead of being silently skipped.
+        """
+        cls = type(self)
+        defaults = cls()
+        return any(
+            getattr(self, name) != getattr(defaults, name) for name in cls.model_fields
+        )
+
     @field_validator("max_length")
     @classmethod
     def _check_max_length(cls, value, info: ValidationInfo):
@@ -924,19 +938,7 @@ class Field(PudlMeta):
 
     def has_content_constraints(self) -> bool:
         """Whether this field's constraints require reading its actual values to check."""
-        c = self.constraints
-        return any(
-            [
-                c.required,
-                c.unique,
-                c.minimum is not None,
-                c.maximum is not None,
-                c.min_length is not None,
-                c.max_length is not None,
-                c.pattern is not None,
-                bool(c.enum),
-            ]
-        )
+        return self.constraints.has_content_constraints()
 
 
 # ---- Classes: Resource ---- #

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -27,6 +27,7 @@ import pyarrow as pa
 import pydantic
 import sqlalchemy as sa
 from pandas._libs.missing import NAType
+from pandera.constants import CHECK_OUTPUT_KEY
 from pandera.errors import SchemaError, SchemaErrorReason
 from pydantic import (
     AnyHttpUrl,
@@ -2311,12 +2312,31 @@ class Resource(PudlMeta):
         """Build a SchemaError describing duplicate primary-key combinations."""
         primary_key = self.schema.primary_key
         return SchemaError(
-            schema=None,
-            data=duplicates,
-            message=f"columns {tuple(primary_key)!r} not unique:\n{duplicates}",
+            # pandera's polars backend unconditionally reads schema.name and
+            # check_output (see failure_cases_metadata in
+            # pandera/backends/polars/base.py) whenever failure_cases is a
+            # pl.DataFrame, crashing with an unhelpful AttributeError on the
+            # defaults (`schema=None`/`check_output=None`) this error would
+            # otherwise have. A minimal, columnless DataFrameSchema satisfies
+            # the `.name` access without needing this resource's real schema.
+            schema=pr_polars.DataFrameSchema(name=self.name),
+            # None, not duplicates again: identical to failure_cases below, and
+            # pandera's own per-column errors leave data=None too -- callers
+            # that want the offending rows should look at failure_cases.
+            data=None,
+            # A short summary, not the full table -- callers that want the
+            # actual offending rows should use failure_cases/failure_case_count
+            # (see asset_checks._process_schema_errors), not this string.
+            message=(
+                f"columns {tuple(primary_key)!r} not unique: "
+                f"{duplicates.height} duplicate combinations"
+            ),
             check="multiple_fields_uniqueness",
             reason_code=SchemaErrorReason.DUPLICATES,
             failure_cases=duplicates,
+            # Every row here already *is* a failure, so this is a same-length,
+            # all-False stand-in for a real per-row check_output.
+            check_output=pl.DataFrame({CHECK_OUTPUT_KEY: [False] * duplicates.height}),
             column_name=self.name,
         )
 

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -734,25 +734,25 @@ class Field(PudlMeta):
         that file with a different schema or even slightly different ``Enum`` fails
         instead of being coerced. ``Categorical`` round-trips through Parquet fine.
         """
-        if self.constraints.enum and self.type == "string":
+        if self.constraints.enum:
             return pl.Categorical()
         return FIELD_DTYPES_POLARS[self.type]
 
     def to_pandas_dtype(self) -> str | pd.CategoricalDtype:
         """Return Pandas data type."""
-        if self.constraints.enum and self.type == "string":
+        if self.constraints.enum:
             return pd.CategoricalDtype(self.constraints.enum)
         return FIELD_DTYPES_PANDAS[self.type]
 
     def to_sqlite_dtype(self) -> type:  # noqa: A003
         """Return SQLAlchemy data type."""
-        if self.constraints.enum and self.type == "string":
+        if self.constraints.enum:
             return sa.Enum(*self.constraints.enum)
         return FIELD_DTYPES_SQLITE[self.type]
 
     def to_pyarrow_dtype(self) -> pa.DataType:
         """Return PyArrow data type."""
-        if self.constraints.enum and self.type == "string":
+        if self.constraints.enum:
             return pa.dictionary(pa.int32(), pa.string(), ordered=False)
         return FIELD_DTYPES_PYARROW[self.type]
 
@@ -912,7 +912,7 @@ class Field(PudlMeta):
         """Encode this field def as a Pandera column."""
         constraints = self.constraints
         checks = constraints.to_pandera_checks(use_pandas_backend)
-        if constraints.enum and self.type == "string":
+        if constraints.enum:
             # The physical dtype is unconstrained Categorical/"category" (see
             # Field.to_polars_dtype / Field.to_pandas_dtype); the enum value
             # constraint itself is enforced by the `checks` (Check.isin) above,
@@ -1553,27 +1553,6 @@ class PudlResourceDescriptor(PudlMeta):
     extrapaths: list[str] | None = None
 
 
-# Tables large enough that checking composite primary-key uniqueness in a single
-# pass is worth chunking (see NOTE in `Resource.check_primary_key_polars` for the
-# memory measurements that motivated this). Maps resource name to a primary-key
-# field to chunk by: a date/datetime field chunks by year; anything else chunks by
-# each of its distinct values. Either way, the column must be part of the primary
-# key -- see `_chunk_filters` for why that's what makes chunking exact rather than
-# approximate.
-#
-# `core_ferceqr__transactions` is deliberately NOT listed here: its metadata
-# currently declares no primary key at all (see `additional_primary_key_text`
-# in `pudl.metadata.resources.ferceqr`), since real duplicate records were
-# found for the columns that would otherwise form one -- see
-# polars-comment.md and the PUDL issue tracking that investigation. Once that
-# investigation lands on a real, enforceable primary key, add it back here if
-# the table still needs chunking at that point.
-_CHUNKED_PK_CHECK_TABLES: dict[str, str] = {
-    "core_epacems__hourly_emissions": "operating_datetime_utc",
-    "out_vcerare__hourly_available_capacity_factor": "datetime_utc",
-}
-
-
 class Resource(PudlMeta):
     """Tabular data resource (`package.resources[...]`).
 
@@ -2131,101 +2110,155 @@ class Resource(PudlMeta):
             )
 
         df = self.format_df(df)
-        self.check_primary_key(df)
+        if errors := self.check_primary_key(df):
+            raise ValueError(
+                f"{self.name}: " + "\n".join(str(error) for error in errors)
+            )
         return df
 
     def check_primary_key(
-        self, data: pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame
-    ) -> list[SchemaError] | None:
-        """Validate this resource's primary key, dispatching on ``data``'s type.
+        self,
+        data: pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame,
+        chunk_field: str | None = None,
+    ) -> list[SchemaError]:
+        """Validate this resource's primary key for uniqueness and non-nullness.
 
-        A single entry point for both backends, so callers don't need to know
-        which backend-specific method to pick. The two backends differ in more
-        than just implementation, though -- their error-reporting contracts are
-        intentionally different, matching what each caller actually needs:
+        Primary keys are validated to be unique and non-null. Returns every violation
+        found as a list of :class:`pandera.errors.SchemaError` (empty list if none).
+        Callers that want a hard failure (e.g. :meth:`enforce_schema` and
+        :func:`pudl.helpers.get_parquet_table`) should check the returned list and raise
+        themselves; a Dagster asset check instead combines it with other schema/content
+        errors into one report rather than stopping at whichever is found first.
 
-        * For a pandas/geopandas ``data``, this raises a single ``ValueError``
-          immediately, combining every violation found (both duplicates and
-          nulls) into one message -- what :meth:`enforce_schema` and
-          :func:`pudl.helpers.get_parquet_table` want for a standalone check.
-        * For a Polars ``data``, this returns a list of
-          :class:`pandera.errors.SchemaError` instead of raising, so a Dagster
-          asset check can combine it with other schema/content errors into one
-          report rather than stopping at whichever is found first.
+        Args:
+            data: DataFrame, GeoDataFrame, or LazyFrame to check against the primary key
+                defined in this resource's schema.
+            chunk_field: Optional primary-key column to chunk the check by, for tables
+                large enough that checking uniqueness in a single pass is impractical
+                (see ``_chunk_filters``). Only meaningful for a Polars ``data``; ignored
+                for pandas/geopandas, which are already fully loaded into memory. Which
+                tables need this, if any, is an orchestration decision for the caller to
+                make -- this method doesn't know or care which tables are large.
+
+        Returns:
+            List of :class:`pandera.errors.SchemaError` for each primary key violation
+            found (empty if none).
         """
+        if not self.schema.primary_key:
+            return []
+
         if isinstance(data, pl.LazyFrame):
-            return self._check_primary_key_polars(data)
-        self._check_primary_key_pandas(data)
-        return None
+            return self._check_primary_key_polars(data, chunk_field=chunk_field)
+        return self._check_primary_key_pandas(data)
 
-    def _check_primary_key_pandas(self, df: pd.DataFrame | gpd.GeoDataFrame) -> None:
-        """Raise if this resource's primary key columns contain duplicates or nulls.
+    def _check_primary_key_pandas(
+        self, df: pd.DataFrame | gpd.GeoDataFrame
+    ) -> list[SchemaError]:
+        """Check a pandas DataFrame for primary key uniqueness and non-nullness.
 
-        Checks both conditions before raising, so a single run reports every
-        violation found instead of stopping at whichever is discovered first.
+        Does not do any chunking, since pandas DataFrames are already fully loaded into
+        memory.
 
-        Split out of :meth:`enforce_schema` so callers that skip the rest of that
-        method's full dtype re-casting (e.g. a Parquet read that already trusts the
-        dtypes it got) can still get this check.
+        Args:
+            df: DataFrame to check.
+
+        Returns:
+            List of :class:`pandera.errors.SchemaError` for each primary key violation
+            found (empty if none).
         """
         pk = self.schema.primary_key
-        if not pk:
-            return
+        schema = pr_pandas.DataFrameSchema(name=self.name)
+        errors: list[SchemaError] = []
 
-        errors = []
         dupes = df[df.duplicated(subset=pk, keep=False)].sort_values(pk)
         if not dupes.empty:
             errors.append(
-                f"{len(dupes)}/{len(df)} duplicate primary keys ({pk=}):\n"
-                f"{dupes.head()}{'\n...' if len(dupes) > 5 else ''}"
+                SchemaError(
+                    schema=schema,
+                    data=None,
+                    message=(
+                        f"{len(dupes)}/{len(df)} duplicate primary keys ({pk=}):\n"
+                        f"{dupes.head()}{'\n...' if len(dupes) > 5 else ''}"
+                    ),
+                    check="multiple_fields_uniqueness",
+                    reason_code=SchemaErrorReason.DUPLICATES,
+                    column_name=self.name,
+                )
             )
 
         nulls = df[df[pk].isna().any(axis=1)]
         if not nulls.empty:
-            errors.append(f"Null values found in primary key columns:\n{nulls}")
-
-        if errors:
-            raise ValueError(f"{self.name}: " + "\n".join(errors))
-
-    def _check_primary_key_polars(self, lf: pl.LazyFrame) -> list[SchemaError]:
-        """Validate composite primary-key uniqueness on a LazyFrame.
-
-        Never uses pandera's built-in composite-uniqueness check
-        (`DataFrameSchema(unique=...)`), which collects the same LazyFrame up to
-        three times and calls the eager, non-lazy `.is_duplicated()` -- see
-        `_find_duplicate_primary_keys` for the memory measurements that ruled
-        that out. For the handful of tables large enough to matter
-        (`_CHUNKED_PK_CHECK_TABLES`), this checks uniqueness one chunk at a time
-        instead of all at once, which is exact -- not an approximation -- as long
-        as the chunking column is part of the primary key (see `_chunk_filters`).
-        Every other table just runs the check once on the whole (already narrow,
-        primary-key-only) LazyFrame, which is fine at their scale.
-        """
-        primary_key = self.schema.primary_key
-        if not primary_key:
-            return []
-
-        narrow = lf.select(primary_key)
-        chunk_field = _CHUNKED_PK_CHECK_TABLES.get(self.name)
-        if chunk_field:
-            assert chunk_field in primary_key, (
-                f"_CHUNKED_PK_CHECK_TABLES lists {chunk_field!r} as the chunk column "
-                f"for {self.name!r}, but it isn't part of that resource's "
-                f"primary key ({primary_key!r}). Chunking is only exact when the "
-                "chunk column is part of the primary key -- see _chunk_filters."
+            errors.append(
+                SchemaError(
+                    schema=schema,
+                    data=None,
+                    message=f"Null values found in primary key columns:\n{nulls}",
+                    check="not_nullable",
+                    reason_code=SchemaErrorReason.SERIES_CONTAINS_NULLS,
+                    column_name=self.name,
+                )
             )
+
+        return errors
+
+    def _check_primary_key_polars(
+        self, lf: pl.LazyFrame, chunk_field: str | None = None
+    ) -> list[SchemaError]:
+        """Validate LazyFrame primary-key is unique and non-null.
+
+        Uses a single group-by/count/filter reduction, run with ``engine="streaming"``,
+        to minimize memory usage.
+
+        Args:
+            lf: LazyFrame to check.
+            chunk_field: Optional primary-key column to chunk the check by, for
+                tables large enough that checking uniqueness in a single pass is
+                impractical.
+
+        Returns:
+            List of :class:`pandera.errors.SchemaError` for each primary key violation
+            found (empty if none).
+
+        Raises:
+            ValueError: If ``chunk_field`` is given but isn't part of the primary key.
+        """
+        pk = self.schema.primary_key
+        narrow = lf.select(pk)
+
+        errors: list[SchemaError] = []
+
+        nulls = self._find_null_primary_keys(narrow, pk)
+        if nulls.height > 0:
+            errors.append(self._null_primary_key_error(nulls))
+
+        if chunk_field:
+            if chunk_field not in pk:
+                raise ValueError(
+                    f"{chunk_field!r} was given as the chunk column for "
+                    f"{self.name!r}, but it isn't part of that resource's "
+                    f"primary key ({pk!r}). Chunking is only exact when the "
+                    "chunk column is part of the primary key -- see _chunk_filters."
+                )
             chunks = [
                 narrow.filter(f) for f in self._chunk_filters(narrow, chunk_field)
             ]
         else:
             chunks = [narrow]
 
-        errors: list[SchemaError] = []
         for chunk in chunks:
-            duplicates = self._find_duplicate_primary_keys(chunk, primary_key)
+            duplicates = self._find_duplicate_primary_keys(chunk, pk)
             if duplicates.height > 0:
                 errors.append(self._duplicate_primary_key_error(duplicates))
         return errors
+
+    @staticmethod
+    def _find_null_primary_keys(
+        lf: pl.LazyFrame, primary_key: list[str]
+    ) -> pl.DataFrame:
+        """Return rows where any primary-key column is null."""
+        return lf.filter(
+            pl.any_horizontal(pl.col(c).is_null() for c in primary_key)
+        ).collect(engine="streaming")
 
     @staticmethod
     def _find_duplicate_primary_keys(
@@ -2233,17 +2266,21 @@ class Resource(PudlMeta):
     ) -> pl.DataFrame:
         """Return the primary-key combinations that appear more than once in ``lf``.
 
-        Uses a single group-by/count/filter reduction, run with
-        ``engine="streaming"``, rather than pandera's built-in composite-uniqueness
-        check (`DataFrameSchema(unique=...)`), which collects the same LazyFrame
-        up to three times and calls the eager, non-lazy `.is_duplicated()`. On our
-        largest table's largest quarterly partition (228M rows) this measured at
-        ~33GB / 3.4s, versus ~109GB / 152s for pandera's built-in check on the
-        exact same data -- see polars-comment.md.
+        Uses a single group-by/count/filter reduction, run with ``engine="streaming"``
+        to minimize memory usage. For comparison, on the largest quarter of EQR
+        transaction data (228M rows) this method uses ~33GB of memory and takes ~3.4s,
+        versus ~109GB and 152s for pandera's built-in check on the same data.
+
+        Args:
+            lf: LazyFrame to check.
+            primary_key: List of column names to check for uniqueness.
+
+        Returns:
+            DataFrame of primary-key combinations that appear more than once in ``lf``.
         """
         return (
             lf.group_by(primary_key)
-            .agg(pl.len().alias("_pk_count"))
+            .agg(_pk_count=pl.len())
             .filter(pl.col("_pk_count") > 1)
             .collect(engine="streaming")
         )
@@ -2286,8 +2323,8 @@ class Resource(PudlMeta):
 
         if dtype in (pl.Date, pl.Datetime) or isinstance(dtype, pl.Datetime):
             bounds = lf.select(
-                pl.col(chunk_field).min().alias("_min"),
-                pl.col(chunk_field).max().alias("_max"),
+                _min=pl.col(chunk_field).min(),
+                _max=pl.col(chunk_field).max(),
             ).collect(engine="streaming")
             min_year = bounds["_min"][0].year
             max_year = bounds["_max"][0].year
@@ -2312,17 +2349,7 @@ class Resource(PudlMeta):
         """Build a SchemaError describing duplicate primary-key combinations."""
         primary_key = self.schema.primary_key
         return SchemaError(
-            # pandera's polars backend unconditionally reads schema.name and
-            # check_output (see failure_cases_metadata in
-            # pandera/backends/polars/base.py) whenever failure_cases is a
-            # pl.DataFrame, crashing with an unhelpful AttributeError on the
-            # defaults (`schema=None`/`check_output=None`) this error would
-            # otherwise have. A minimal, columnless DataFrameSchema satisfies
-            # the `.name` access without needing this resource's real schema.
             schema=pr_polars.DataFrameSchema(name=self.name),
-            # None, not duplicates again: identical to failure_cases below, and
-            # pandera's own per-column errors leave data=None too -- callers
-            # that want the offending rows should look at failure_cases.
             data=None,
             # A short summary, not the full table -- callers that want the
             # actual offending rows should use failure_cases/failure_case_count
@@ -2340,8 +2367,30 @@ class Resource(PudlMeta):
             column_name=self.name,
         )
 
+    def _null_primary_key_error(self, nulls: pl.DataFrame) -> SchemaError:
+        """Build a SchemaError describing null primary-key values."""
+        primary_key = self.schema.primary_key
+        return SchemaError(
+            schema=pr_polars.DataFrameSchema(name=self.name),
+            data=None,
+            # A short summary, not the full table -- callers that want the
+            # actual offending rows should use failure_cases/failure_case_count
+            # (see asset_checks._process_schema_errors), not this string.
+            message=(
+                f"columns {tuple(primary_key)!r}: {nulls.height} rows with a "
+                "null primary-key value"
+            ),
+            check="not_nullable",
+            reason_code=SchemaErrorReason.SERIES_CONTAINS_NULLS,
+            failure_cases=nulls,
+            # Every row here already *is* a failure, so this is a same-length,
+            # all-False stand-in for a real per-row check_output.
+            check_output=pl.DataFrame({CHECK_OUTPUT_KEY: [False] * nulls.height}),
+            column_name=self.name,
+        )
+
     def aggregate_df(
-        self, df: pd.DataFrame, raised: bool = False, error: Callable = None
+        self, df: pd.DataFrame, raised: bool = False, error: Callable | None = None
     ) -> tuple[pd.DataFrame, dict]:
         """Aggregate dataframe by primary key.
 

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -905,11 +905,13 @@ class Field(PudlMeta):
             descriptor["constraints"] = constraints
         return frictionless.Field.from_descriptor(descriptor)
 
-    def to_pandera_column(self, use_pandas_backend: bool) -> pr_polars.Column:
+    def to_pandera_column(
+        self, use_pandas_backend: bool
+    ) -> pr_polars.Column | pr_pandas.Column:
         """Encode this field def as a Pandera column."""
         constraints = self.constraints
         checks = constraints.to_pandera_checks(use_pandas_backend)
-        if constraints.enum:
+        if constraints.enum and self.type == "string":
             # The physical dtype is unconstrained Categorical/"category" (see
             # Field.to_polars_dtype / Field.to_pandas_dtype); the enum value
             # constraint itself is enforced by the `checks` (Check.isin) above,

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -734,25 +734,25 @@ class Field(PudlMeta):
         that file with a different schema or even slightly different ``Enum`` fails
         instead of being coerced. ``Categorical`` round-trips through Parquet fine.
         """
-        if self.constraints.enum and self.type == "string":
+        if self.constraints.enum:
             return pl.Categorical
         return FIELD_DTYPES_POLARS[self.type]
 
     def to_pandas_dtype(self) -> str | pd.CategoricalDtype:
         """Return Pandas data type."""
-        if self.constraints.enum and self.type == "string":
+        if self.constraints.enum:
             return pd.CategoricalDtype(self.constraints.enum)
         return FIELD_DTYPES_PANDAS[self.type]
 
     def to_sqlite_dtype(self) -> type:  # noqa: A003
         """Return SQLAlchemy data type."""
-        if self.constraints.enum and self.type == "string":
+        if self.constraints.enum:
             return sa.Enum(*self.constraints.enum)
         return FIELD_DTYPES_SQLITE[self.type]
 
     def to_pyarrow_dtype(self) -> pa.DataType:
         """Return PyArrow data type."""
-        if self.constraints.enum and self.type == "string":
+        if self.constraints.enum:
             return pa.dictionary(pa.int32(), pa.string(), ordered=False)
         return FIELD_DTYPES_PYARROW[self.type]
 
@@ -912,7 +912,7 @@ class Field(PudlMeta):
         """Encode this field def as a Pandera column."""
         constraints = self.constraints
         checks = constraints.to_pandera_checks(use_pandas_backend)
-        if constraints.enum and self.type == "string":
+        if constraints.enum:
             # The physical dtype is unconstrained Categorical/"category" (see
             # Field.to_polars_dtype / Field.to_pandas_dtype); the enum value
             # constraint itself is enforced by the `checks` (Check.isin) above,
@@ -1553,27 +1553,6 @@ class PudlResourceDescriptor(PudlMeta):
     extrapaths: list[str] | None = None
 
 
-# Tables large enough that checking composite primary-key uniqueness in a single
-# pass is worth chunking (see NOTE in `Resource.check_primary_key_polars` for the
-# memory measurements that motivated this). Maps resource name to a primary-key
-# field to chunk by: a date/datetime field chunks by year; anything else chunks by
-# each of its distinct values. Either way, the column must be part of the primary
-# key -- see `_chunk_filters` for why that's what makes chunking exact rather than
-# approximate.
-#
-# `core_ferceqr__transactions` is deliberately NOT listed here: its metadata
-# currently declares no primary key at all (see `additional_primary_key_text`
-# in `pudl.metadata.resources.ferceqr`), since real duplicate records were
-# found for the columns that would otherwise form one -- see
-# polars-comment.md and the PUDL issue tracking that investigation. Once that
-# investigation lands on a real, enforceable primary key, add it back here if
-# the table still needs chunking at that point.
-_CHUNKED_PK_CHECK_TABLES: dict[str, str] = {
-    "core_epacems__hourly_emissions": "operating_datetime_utc",
-    "out_vcerare__hourly_available_capacity_factor": "datetime_utc",
-}
-
-
 class Resource(PudlMeta):
     """Tabular data resource (`package.resources[...]`).
 
@@ -2131,101 +2110,155 @@ class Resource(PudlMeta):
             )
 
         df = self.format_df(df)
-        self.check_primary_key(df)
+        if errors := self.check_primary_key(df):
+            raise ValueError(
+                f"{self.name}: " + "\n".join(str(error) for error in errors)
+            )
         return df
 
     def check_primary_key(
-        self, data: pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame
-    ) -> list[SchemaError] | None:
-        """Validate this resource's primary key, dispatching on ``data``'s type.
+        self,
+        data: pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame,
+        chunk_field: str | None = None,
+    ) -> list[SchemaError]:
+        """Validate this resource's primary key for uniqueness and non-nullness.
 
-        A single entry point for both backends, so callers don't need to know
-        which backend-specific method to pick. The two backends differ in more
-        than just implementation, though -- their error-reporting contracts are
-        intentionally different, matching what each caller actually needs:
+        Primary keys are validated to be unique and non-null. Returns every violation
+        found as a list of :class:`pandera.errors.SchemaError` (empty list if none).
+        Callers that want a hard failure (e.g. :meth:`enforce_schema` and
+        :func:`pudl.helpers.get_parquet_table`) should check the returned list and raise
+        themselves; a Dagster asset check instead combines it with other schema/content
+        errors into one report rather than stopping at whichever is found first.
 
-        * For a pandas/geopandas ``data``, this raises a single ``ValueError``
-          immediately, combining every violation found (both duplicates and
-          nulls) into one message -- what :meth:`enforce_schema` and
-          :func:`pudl.helpers.get_parquet_table` want for a standalone check.
-        * For a Polars ``data``, this returns a list of
-          :class:`pandera.errors.SchemaError` instead of raising, so a Dagster
-          asset check can combine it with other schema/content errors into one
-          report rather than stopping at whichever is found first.
+        Args:
+            data: DataFrame, GeoDataFrame, or LazyFrame to check against the primary key
+                defined in this resource's schema.
+            chunk_field: Optional primary-key column to chunk the check by, for tables
+                large enough that checking uniqueness in a single pass is impractical
+                (see ``_chunk_filters``). Only meaningful for a Polars ``data``; ignored
+                for pandas/geopandas, which are already fully loaded into memory. Which
+                tables need this, if any, is an orchestration decision for the caller to
+                make -- this method doesn't know or care which tables are large.
+
+        Returns:
+            List of :class:`pandera.errors.SchemaError` for each primary key violation
+            found (empty if none).
         """
+        if not self.schema.primary_key:
+            return []
+
         if isinstance(data, pl.LazyFrame):
-            return self._check_primary_key_polars(data)
-        self._check_primary_key_pandas(data)
-        return None
+            return self._check_primary_key_polars(data, chunk_field=chunk_field)
+        return self._check_primary_key_pandas(data)
 
-    def _check_primary_key_pandas(self, df: pd.DataFrame | gpd.GeoDataFrame) -> None:
-        """Raise if this resource's primary key columns contain duplicates or nulls.
+    def _check_primary_key_pandas(
+        self, df: pd.DataFrame | gpd.GeoDataFrame
+    ) -> list[SchemaError]:
+        """Check a pandas DataFrame for primary key uniqueness and non-nullness.
 
-        Checks both conditions before raising, so a single run reports every
-        violation found instead of stopping at whichever is discovered first.
+        Does not do any chunking, since pandas DataFrames are already fully loaded into
+        memory.
 
-        Split out of :meth:`enforce_schema` so callers that skip the rest of that
-        method's full dtype re-casting (e.g. a Parquet read that already trusts the
-        dtypes it got) can still get this check.
+        Args:
+            df: DataFrame to check.
+
+        Returns:
+            List of :class:`pandera.errors.SchemaError` for each primary key violation
+            found (empty if none).
         """
         pk = self.schema.primary_key
-        if not pk:
-            return
+        schema = pr_pandas.DataFrameSchema(name=self.name)
+        errors: list[SchemaError] = []
 
-        errors = []
         dupes = df[df.duplicated(subset=pk, keep=False)].sort_values(pk)
         if not dupes.empty:
             errors.append(
-                f"{len(dupes)}/{len(df)} duplicate primary keys ({pk=}):\n"
-                f"{dupes.head()}{'\n...' if len(dupes) > 5 else ''}"
+                SchemaError(
+                    schema=schema,
+                    data=None,
+                    message=(
+                        f"{len(dupes)}/{len(df)} duplicate primary keys ({pk=}):\n"
+                        f"{dupes.head()}{'\n...' if len(dupes) > 5 else ''}"
+                    ),
+                    check="multiple_fields_uniqueness",
+                    reason_code=SchemaErrorReason.DUPLICATES,
+                    column_name=self.name,
+                )
             )
 
         nulls = df[df[pk].isna().any(axis=1)]
         if not nulls.empty:
-            errors.append(f"Null values found in primary key columns:\n{nulls}")
-
-        if errors:
-            raise ValueError(f"{self.name}: " + "\n".join(errors))
-
-    def _check_primary_key_polars(self, lf: pl.LazyFrame) -> list[SchemaError]:
-        """Validate composite primary-key uniqueness on a LazyFrame.
-
-        Never uses pandera's built-in composite-uniqueness check
-        (`DataFrameSchema(unique=...)`), which collects the same LazyFrame up to
-        three times and calls the eager, non-lazy `.is_duplicated()` -- see
-        `_find_duplicate_primary_keys` for the memory measurements that ruled
-        that out. For the handful of tables large enough to matter
-        (`_CHUNKED_PK_CHECK_TABLES`), this checks uniqueness one chunk at a time
-        instead of all at once, which is exact -- not an approximation -- as long
-        as the chunking column is part of the primary key (see `_chunk_filters`).
-        Every other table just runs the check once on the whole (already narrow,
-        primary-key-only) LazyFrame, which is fine at their scale.
-        """
-        primary_key = self.schema.primary_key
-        if not primary_key:
-            return []
-
-        narrow = lf.select(primary_key)
-        chunk_field = _CHUNKED_PK_CHECK_TABLES.get(self.name)
-        if chunk_field:
-            assert chunk_field in primary_key, (
-                f"_CHUNKED_PK_CHECK_TABLES lists {chunk_field!r} as the chunk column "
-                f"for {self.name!r}, but it isn't part of that resource's "
-                f"primary key ({primary_key!r}). Chunking is only exact when the "
-                "chunk column is part of the primary key -- see _chunk_filters."
+            errors.append(
+                SchemaError(
+                    schema=schema,
+                    data=None,
+                    message=f"Null values found in primary key columns:\n{nulls}",
+                    check="not_nullable",
+                    reason_code=SchemaErrorReason.SERIES_CONTAINS_NULLS,
+                    column_name=self.name,
+                )
             )
+
+        return errors
+
+    def _check_primary_key_polars(
+        self, lf: pl.LazyFrame, chunk_field: str | None = None
+    ) -> list[SchemaError]:
+        """Validate LazyFrame primary-key is unique and non-null.
+
+        Uses a single group-by/count/filter reduction, run with ``engine="streaming"``,
+        to minimize memory usage.
+
+        Args:
+            lf: LazyFrame to check.
+            chunk_field: Optional primary-key column to chunk the check by, for
+                tables large enough that checking uniqueness in a single pass is
+                impractical.
+
+        Returns:
+            List of :class:`pandera.errors.SchemaError` for each primary key violation
+            found (empty if none).
+
+        Raises:
+            ValueError: If ``chunk_field`` is given but isn't part of the primary key.
+        """
+        pk = self.schema.primary_key
+        narrow = lf.select(pk)
+
+        errors: list[SchemaError] = []
+
+        nulls = self._find_null_primary_keys(narrow, pk)
+        if nulls.height > 0:
+            errors.append(self._null_primary_key_error(nulls))
+
+        if chunk_field:
+            if chunk_field not in pk:
+                raise ValueError(
+                    f"{chunk_field!r} was given as the chunk column for "
+                    f"{self.name!r}, but it isn't part of that resource's "
+                    f"primary key ({pk!r}). Chunking is only exact when the "
+                    "chunk column is part of the primary key -- see _chunk_filters."
+                )
             chunks = [
                 narrow.filter(f) for f in self._chunk_filters(narrow, chunk_field)
             ]
         else:
             chunks = [narrow]
 
-        errors: list[SchemaError] = []
         for chunk in chunks:
-            duplicates = self._find_duplicate_primary_keys(chunk, primary_key)
+            duplicates = self._find_duplicate_primary_keys(chunk, pk)
             if duplicates.height > 0:
                 errors.append(self._duplicate_primary_key_error(duplicates))
         return errors
+
+    @staticmethod
+    def _find_null_primary_keys(
+        lf: pl.LazyFrame, primary_key: list[str]
+    ) -> pl.DataFrame:
+        """Return rows where any primary-key column is null."""
+        return lf.filter(
+            pl.any_horizontal(pl.col(c).is_null() for c in primary_key)
+        ).collect(engine="streaming")
 
     @staticmethod
     def _find_duplicate_primary_keys(
@@ -2233,17 +2266,21 @@ class Resource(PudlMeta):
     ) -> pl.DataFrame:
         """Return the primary-key combinations that appear more than once in ``lf``.
 
-        Uses a single group-by/count/filter reduction, run with
-        ``engine="streaming"``, rather than pandera's built-in composite-uniqueness
-        check (`DataFrameSchema(unique=...)`), which collects the same LazyFrame
-        up to three times and calls the eager, non-lazy `.is_duplicated()`. On our
-        largest table's largest quarterly partition (228M rows) this measured at
-        ~33GB / 3.4s, versus ~109GB / 152s for pandera's built-in check on the
-        exact same data -- see polars-comment.md.
+        Uses a single group-by/count/filter reduction, run with ``engine="streaming"``
+        to minimize memory usage. For comparison, on the largest quarter of EQR
+        transaction data (228M rows) this method uses ~33GB of memory and takes ~3.4s,
+        versus ~109GB and 152s for pandera's built-in check on the same data.
+
+        Args:
+            lf: LazyFrame to check.
+            primary_key: List of column names to check for uniqueness.
+
+        Returns:
+            DataFrame of primary-key combinations that appear more than once in ``lf``.
         """
         return (
             lf.group_by(primary_key)
-            .agg(pl.len().alias("_pk_count"))
+            .agg(_pk_count=pl.len())
             .filter(pl.col("_pk_count") > 1)
             .collect(engine="streaming")
         )
@@ -2286,8 +2323,8 @@ class Resource(PudlMeta):
 
         if dtype in (pl.Date, pl.Datetime) or isinstance(dtype, pl.Datetime):
             bounds = lf.select(
-                pl.col(chunk_field).min().alias("_min"),
-                pl.col(chunk_field).max().alias("_max"),
+                _min=pl.col(chunk_field).min(),
+                _max=pl.col(chunk_field).max(),
             ).collect(engine="streaming")
             min_year = bounds["_min"][0].year
             max_year = bounds["_max"][0].year
@@ -2312,17 +2349,7 @@ class Resource(PudlMeta):
         """Build a SchemaError describing duplicate primary-key combinations."""
         primary_key = self.schema.primary_key
         return SchemaError(
-            # pandera's polars backend unconditionally reads schema.name and
-            # check_output (see failure_cases_metadata in
-            # pandera/backends/polars/base.py) whenever failure_cases is a
-            # pl.DataFrame, crashing with an unhelpful AttributeError on the
-            # defaults (`schema=None`/`check_output=None`) this error would
-            # otherwise have. A minimal, columnless DataFrameSchema satisfies
-            # the `.name` access without needing this resource's real schema.
             schema=pr_polars.DataFrameSchema(name=self.name),
-            # None, not duplicates again: identical to failure_cases below, and
-            # pandera's own per-column errors leave data=None too -- callers
-            # that want the offending rows should look at failure_cases.
             data=None,
             # A short summary, not the full table -- callers that want the
             # actual offending rows should use failure_cases/failure_case_count
@@ -2340,8 +2367,30 @@ class Resource(PudlMeta):
             column_name=self.name,
         )
 
+    def _null_primary_key_error(self, nulls: pl.DataFrame) -> SchemaError:
+        """Build a SchemaError describing null primary-key values."""
+        primary_key = self.schema.primary_key
+        return SchemaError(
+            schema=pr_polars.DataFrameSchema(name=self.name),
+            data=None,
+            # A short summary, not the full table -- callers that want the
+            # actual offending rows should use failure_cases/failure_case_count
+            # (see asset_checks._process_schema_errors), not this string.
+            message=(
+                f"columns {tuple(primary_key)!r}: {nulls.height} rows with a "
+                "null primary-key value"
+            ),
+            check="not_nullable",
+            reason_code=SchemaErrorReason.SERIES_CONTAINS_NULLS,
+            failure_cases=nulls,
+            # Every row here already *is* a failure, so this is a same-length,
+            # all-False stand-in for a real per-row check_output.
+            check_output=pl.DataFrame({CHECK_OUTPUT_KEY: [False] * nulls.height}),
+            column_name=self.name,
+        )
+
     def aggregate_df(
-        self, df: pd.DataFrame, raised: bool = False, error: Callable = None
+        self, df: pd.DataFrame, raised: bool = False, error: Callable | None = None
     ) -> tuple[pd.DataFrame, dict]:
         """Aggregate dataframe by primary key.
 

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -393,6 +393,15 @@ class FieldConstraints(PudlMeta):
 
         return checks
 
+    def to_metadata_dict(self) -> dict[str, Any]:
+        """Build a JSON-safe summary of only the constraints actually set.
+
+        Used by callers (e.g. Dagster asset-check metadata) that want to show what's
+        being enforced on a column without cross-referencing the PUDL metadata source
+        or wading through every unset default.
+        """
+        return self.model_dump(exclude_defaults=True, mode="json")
+
 
 class FieldHarvest(PudlMeta):
     """Field harvest parameters (`resource.schema.fields[...].harvest`)."""
@@ -1001,6 +1010,8 @@ class Schema(PudlMeta):
     missing_values: list[StrictStr] = [""]
     primary_key: list[SnakeCase] = []
     foreign_keys: list[ForeignKey] = []
+    chunk_field: SnakeCase | None = None
+    """Primary-key column to use when chunking this table for processing, if any."""
 
     _check_unique = _validator(
         "missing_values", "primary_key", "foreign_keys", fn=_check_unique
@@ -1011,6 +1022,19 @@ class Schema(PudlMeta):
     def _check_field_names_unique(cls, fields: list[Field]):
         _check_unique([f.name for f in fields])
         return fields
+
+    @field_validator("chunk_field")
+    @classmethod
+    def _check_chunk_field_in_primary_key(cls, chunk_field, info: ValidationInfo):
+        """Verify that chunk_field, if set, is part of the primary key."""
+        pk = info.data.get("primary_key")
+        if chunk_field is not None and pk is not None and chunk_field not in pk:
+            raise ValueError(
+                f"{chunk_field!r} was given as the chunk_field, but it isn't part "
+                f"of this schema's primary key ({pk!r}). Chunking is only exact "
+                "when the chunk column is part of the primary key."
+            )
+        return chunk_field
 
     @field_validator("primary_key")
     @classmethod
@@ -1343,6 +1367,7 @@ class PudlResourceDescriptor(PudlMeta):
         field_ids: list[str] = pydantic.Field(alias="fields", default=[])
         primary_key_ids: list[str] = pydantic.Field(alias="primary_key", default=[])
         foreign_key_rules: PudlForeignKeyRules = PudlForeignKeyRules()
+        chunk_field: SnakeCase | None = None
 
     class PudlCodeMetadata(PudlMeta):
         """Describes a bunch of codes."""
@@ -1908,6 +1933,8 @@ class Resource(PudlMeta):
             primary_key=self.schema.primary_key,
             foreign_keys=[fk.to_frictionless() for fk in self.schema.foreign_keys],
         )
+        if self.schema.chunk_field:
+            schema.custom["chunk_field"] = self.schema.chunk_field
 
         resource = frictionless.Resource(
             name=self.name,
@@ -2119,7 +2146,6 @@ class Resource(PudlMeta):
     def check_primary_key(
         self,
         data: pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame,
-        chunk_field: str | None = None,
     ) -> list[SchemaError]:
         """Validate this resource's primary key for uniqueness and non-nullness.
 
@@ -2130,15 +2156,14 @@ class Resource(PudlMeta):
         themselves; a Dagster asset check instead combines it with other schema/content
         errors into one report rather than stopping at whichever is found first.
 
+        For tables large enough that checking uniqueness in a single pass is
+        impractical, the check is chunked by ``self.schema.chunk_field`` (see
+        ``_chunk_filters``) when set. Only meaningful for a Polars ``data``; ignored
+        for pandas/geopandas, which are already fully loaded into memory.
+
         Args:
             data: DataFrame, GeoDataFrame, or LazyFrame to check against the primary key
                 defined in this resource's schema.
-            chunk_field: Optional primary-key column to chunk the check by, for tables
-                large enough that checking uniqueness in a single pass is impractical
-                (see ``_chunk_filters``). Only meaningful for a Polars ``data``; ignored
-                for pandas/geopandas, which are already fully loaded into memory. Which
-                tables need this, if any, is an orchestration decision for the caller to
-                make -- this method doesn't know or care which tables are large.
 
         Returns:
             List of :class:`pandera.errors.SchemaError` for each primary key violation
@@ -2148,7 +2173,7 @@ class Resource(PudlMeta):
             return []
 
         if isinstance(data, pl.LazyFrame):
-            return self._check_primary_key_polars(data, chunk_field=chunk_field)
+            return self._check_primary_key_polars(data)
         return self._check_primary_key_pandas(data)
 
     def _check_primary_key_pandas(
@@ -2201,26 +2226,20 @@ class Resource(PudlMeta):
 
         return errors
 
-    def _check_primary_key_polars(
-        self, lf: pl.LazyFrame, chunk_field: str | None = None
-    ) -> list[SchemaError]:
+    def _check_primary_key_polars(self, lf: pl.LazyFrame) -> list[SchemaError]:
         """Validate LazyFrame primary-key is unique and non-null.
 
         Uses a single group-by/count/filter reduction, run with ``engine="streaming"``,
-        to minimize memory usage.
+        to minimize memory usage. For tables large enough that checking uniqueness in
+        a single pass is impractical, the check is chunked by ``self.schema.chunk_field``
+        when set.
 
         Args:
             lf: LazyFrame to check.
-            chunk_field: Optional primary-key column to chunk the check by, for
-                tables large enough that checking uniqueness in a single pass is
-                impractical.
 
         Returns:
             List of :class:`pandera.errors.SchemaError` for each primary key violation
             found (empty if none).
-
-        Raises:
-            ValueError: If ``chunk_field`` is given but isn't part of the primary key.
         """
         pk = self.schema.primary_key
         narrow = lf.select(pk)
@@ -2231,14 +2250,7 @@ class Resource(PudlMeta):
         if nulls.height > 0:
             errors.append(self._null_primary_key_error(nulls))
 
-        if chunk_field:
-            if chunk_field not in pk:
-                raise ValueError(
-                    f"{chunk_field!r} was given as the chunk column for "
-                    f"{self.name!r}, but it isn't part of that resource's "
-                    f"primary key ({pk!r}). Chunking is only exact when the "
-                    "chunk column is part of the primary key -- see _chunk_filters."
-                )
+        if chunk_field := self.schema.chunk_field:
             chunks = [
                 narrow.filter(f) for f in self._chunk_filters(narrow, chunk_field)
             ]
@@ -2321,7 +2333,7 @@ class Resource(PudlMeta):
         """
         dtype = lf.select(chunk_field).collect_schema()[chunk_field]
 
-        if dtype in (pl.Date, pl.Datetime) or isinstance(dtype, pl.Datetime):
+        if dtype in (pl.Date, pl.Datetime):
             bounds = lf.select(
                 _min=pl.col(chunk_field).min(),
                 _max=pl.col(chunk_field).max(),

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -2148,8 +2148,8 @@ class Resource(PudlMeta):
 
         For tables large enough that checking uniqueness in a single pass is
         impractical, the check is chunked by ``self.schema.chunk_field`` (see
-        ``_chunk_filters``) when set. Only meaningful for a Polars ``data``; ignored
-        for pandas/geopandas, which are already fully loaded into memory.
+        ``_chunk_filters``) when set. Only meaningful for a Polars ``LazyFrame``;
+        ignored for pandas/geopandas, which are already fully loaded into memory.
 
         Args:
             data: DataFrame, GeoDataFrame, or LazyFrame to check against the primary key

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -27,6 +27,7 @@ import pyarrow as pa
 import pydantic
 import sqlalchemy as sa
 from pandas._libs.missing import NAType
+from pandera.errors import SchemaError, SchemaErrorReason
 from pydantic import (
     AnyHttpUrl,
     BaseModel,
@@ -1549,6 +1550,27 @@ class PudlResourceDescriptor(PudlMeta):
     extrapaths: list[str] | None = None
 
 
+# Tables large enough that checking composite primary-key uniqueness in a single
+# pass is worth chunking (see NOTE in `Resource.check_primary_key_polars` for the
+# memory measurements that motivated this). Maps resource name to a primary-key
+# field to chunk by: a date/datetime field chunks by year; anything else chunks by
+# each of its distinct values. Either way, the column must be part of the primary
+# key -- see `_chunk_filters` for why that's what makes chunking exact rather than
+# approximate.
+#
+# `core_ferceqr__transactions` is deliberately NOT listed here: its metadata
+# currently declares no primary key at all (see `additional_primary_key_text`
+# in `pudl.metadata.resources.ferceqr`), since real duplicate records were
+# found for the columns that would otherwise form one -- see
+# polars-comment.md and the PUDL issue tracking that investigation. Once that
+# investigation lands on a real, enforceable primary key, add it back here if
+# the table still needs chunking at that point.
+_CHUNKED_PK_CHECK_TABLES: dict[str, str] = {
+    "core_epacems__hourly_emissions": "operating_datetime_utc",
+    "out_vcerare__hourly_available_capacity_factor": "datetime_utc",
+}
+
+
 class Resource(PudlMeta):
     """Tabular data resource (`package.resources[...]`).
 
@@ -2106,23 +2128,195 @@ class Resource(PudlMeta):
             )
 
         df = self.format_df(df)
+        self.check_primary_key(df)
+        return df
+
+    def check_primary_key(
+        self, data: pd.DataFrame | gpd.GeoDataFrame | pl.LazyFrame
+    ) -> list[SchemaError] | None:
+        """Validate this resource's primary key, dispatching on ``data``'s type.
+
+        A single entry point for both backends, so callers don't need to know
+        which backend-specific method to pick. The two backends differ in more
+        than just implementation, though -- their error-reporting contracts are
+        intentionally different, matching what each caller actually needs:
+
+        * For a pandas/geopandas ``data``, this raises a single ``ValueError``
+          immediately, combining every violation found (both duplicates and
+          nulls) into one message -- what :meth:`enforce_schema` and
+          :func:`pudl.helpers.get_parquet_table` want for a standalone check.
+        * For a Polars ``data``, this returns a list of
+          :class:`pandera.errors.SchemaError` instead of raising, so a Dagster
+          asset check can combine it with other schema/content errors into one
+          report rather than stopping at whichever is found first.
+        """
+        if isinstance(data, pl.LazyFrame):
+            return self._check_primary_key_polars(data)
+        self._check_primary_key_pandas(data)
+        return None
+
+    def _check_primary_key_pandas(self, df: pd.DataFrame | gpd.GeoDataFrame) -> None:
+        """Raise if this resource's primary key columns contain duplicates or nulls.
+
+        Checks both conditions before raising, so a single run reports every
+        violation found instead of stopping at whichever is discovered first.
+
+        Split out of :meth:`enforce_schema` so callers that skip the rest of that
+        method's full dtype re-casting (e.g. a Parquet read that already trusts the
+        dtypes it got) can still get this check.
+        """
         pk = self.schema.primary_key
-        if (
-            pk
-            and not (
-                dupes := df[df.duplicated(subset=pk, keep=False)].sort_values(pk)
-            ).empty
-        ):
-            raise ValueError(
-                f"{self.name} {len(dupes)}/{len(df)} duplicate primary keys ({pk=}) "
-                "when enforcing schema:\n"
+        if not pk:
+            return
+
+        errors = []
+        dupes = df[df.duplicated(subset=pk, keep=False)].sort_values(pk)
+        if not dupes.empty:
+            errors.append(
+                f"{len(dupes)}/{len(df)} duplicate primary keys ({pk=}):\n"
                 f"{dupes.head()}{'\n...' if len(dupes) > 5 else ''}"
             )
-        if pk and not (nulls := df[df[pk].isna().any(axis=1)]).empty:
-            raise ValueError(
-                f"{self.name} Null values found in primary key columns.\n{nulls}"
+
+        nulls = df[df[pk].isna().any(axis=1)]
+        if not nulls.empty:
+            errors.append(f"Null values found in primary key columns:\n{nulls}")
+
+        if errors:
+            raise ValueError(f"{self.name}: " + "\n".join(errors))
+
+    def _check_primary_key_polars(self, lf: pl.LazyFrame) -> list[SchemaError]:
+        """Validate composite primary-key uniqueness on a LazyFrame.
+
+        Never uses pandera's built-in composite-uniqueness check
+        (`DataFrameSchema(unique=...)`), which collects the same LazyFrame up to
+        three times and calls the eager, non-lazy `.is_duplicated()` -- see
+        `_find_duplicate_primary_keys` for the memory measurements that ruled
+        that out. For the handful of tables large enough to matter
+        (`_CHUNKED_PK_CHECK_TABLES`), this checks uniqueness one chunk at a time
+        instead of all at once, which is exact -- not an approximation -- as long
+        as the chunking column is part of the primary key (see `_chunk_filters`).
+        Every other table just runs the check once on the whole (already narrow,
+        primary-key-only) LazyFrame, which is fine at their scale.
+        """
+        primary_key = self.schema.primary_key
+        if not primary_key:
+            return []
+
+        narrow = lf.select(primary_key)
+        chunk_field = _CHUNKED_PK_CHECK_TABLES.get(self.name)
+        if chunk_field:
+            assert chunk_field in primary_key, (
+                f"_CHUNKED_PK_CHECK_TABLES lists {chunk_field!r} as the chunk column "
+                f"for {self.name!r}, but it isn't part of that resource's "
+                f"primary key ({primary_key!r}). Chunking is only exact when the "
+                "chunk column is part of the primary key -- see _chunk_filters."
             )
-        return df
+            chunks = [
+                narrow.filter(f) for f in self._chunk_filters(narrow, chunk_field)
+            ]
+        else:
+            chunks = [narrow]
+
+        errors: list[SchemaError] = []
+        for chunk in chunks:
+            duplicates = self._find_duplicate_primary_keys(chunk, primary_key)
+            if duplicates.height > 0:
+                errors.append(self._duplicate_primary_key_error(duplicates))
+        return errors
+
+    @staticmethod
+    def _find_duplicate_primary_keys(
+        lf: pl.LazyFrame, primary_key: list[str]
+    ) -> pl.DataFrame:
+        """Return the primary-key combinations that appear more than once in ``lf``.
+
+        Uses a single group-by/count/filter reduction, run with
+        ``engine="streaming"``, rather than pandera's built-in composite-uniqueness
+        check (`DataFrameSchema(unique=...)`), which collects the same LazyFrame
+        up to three times and calls the eager, non-lazy `.is_duplicated()`. On our
+        largest table's largest quarterly partition (228M rows) this measured at
+        ~33GB / 3.4s, versus ~109GB / 152s for pandera's built-in check on the
+        exact same data -- see polars-comment.md.
+        """
+        return (
+            lf.group_by(primary_key)
+            .agg(pl.len().alias("_pk_count"))
+            .filter(pl.col("_pk_count") > 1)
+            .collect(engine="streaming")
+        )
+
+    @staticmethod
+    def _chunk_filters(lf: pl.LazyFrame, chunk_field: str) -> list[pl.Expr]:
+        """Build filter expressions that partition ``lf`` by ``chunk_field``.
+
+        Every filter is a literal comparison directly against ``chunk_field``'s
+        own stored values -- a year-range comparison for date/datetime columns,
+        an equality comparison against each distinct value otherwise -- never a
+        derived expression. This matters for two reasons:
+
+        1. Correctness: since ``chunk_field`` is required to be part of the
+           primary key, two rows sharing a composite key necessarily share the
+           same value of it, so a boundary drawn directly on that column's own
+           value can never split a duplicate pair across chunks. Deriving the
+           boundary from some other, only approximately-correlated column would
+           not have this guarantee -- e.g. EPACEMS' separately stored `year`
+           field reflects reporting period, not the UTC timestamp, and disagrees
+           with `operating_datetime_utc.dt.year()` for hundreds of rows a year
+           near timezone-shifted boundaries.
+        2. Efficiency: a literal comparison against a stored column stays
+           eligible for Parquet row-group pruning, since Polars can compare it
+           directly to each row group's min/max statistics without decoding any
+           data. A filter on a *derived* expression (e.g. `.dt.year() == y`)
+           cannot be pushed down the same way, so Polars must read and decode
+           every row group on every chunk iteration regardless of whether that
+           chunk's rows are actually present. Measured on our billion-row table:
+           ~0.02s to select one year's rows via a literal range filter, vs ~0.56s
+           via a `.dt.year()` filter for the same result.
+
+        PUDL's long time-series tables are written and physically stored in
+        temporal (or, for `core_ferceqr__transactions`, filer) order, so this
+        pruning is not theoretical: EPACEMS' row groups are each confined to a
+        single calendar year, and most of `core_ferceqr__transactions`' row
+        groups are confined to a single seller.
+        """
+        dtype = lf.select(chunk_field).collect_schema()[chunk_field]
+
+        if dtype in (pl.Date, pl.Datetime) or isinstance(dtype, pl.Datetime):
+            bounds = lf.select(
+                pl.col(chunk_field).min().alias("_min"),
+                pl.col(chunk_field).max().alias("_max"),
+            ).collect(engine="streaming")
+            min_year = bounds["_min"][0].year
+            max_year = bounds["_max"][0].year
+            boundary = datetime.date if dtype == pl.Date else datetime.datetime
+            return [
+                pl.col(chunk_field).is_between(
+                    boundary(year, 1, 1), boundary(year + 1, 1, 1), closed="left"
+                )
+                for year in range(min_year, max_year + 1)
+            ]
+
+        values = (
+            lf.select(chunk_field)
+            .unique()
+            .collect(engine="streaming")
+            .get_column(chunk_field)
+            .to_list()
+        )
+        return [pl.col(chunk_field) == value for value in values]
+
+    def _duplicate_primary_key_error(self, duplicates: pl.DataFrame) -> SchemaError:
+        """Build a SchemaError describing duplicate primary-key combinations."""
+        primary_key = self.schema.primary_key
+        return SchemaError(
+            schema=None,
+            data=duplicates,
+            message=f"columns {tuple(primary_key)!r} not unique:\n{duplicates}",
+            check="multiple_fields_uniqueness",
+            reason_code=SchemaErrorReason.DUPLICATES,
+            failure_cases=duplicates,
+            column_name=self.name,
+        )
 
     def aggregate_df(
         self, df: pd.DataFrame, raised: bool = False, error: Callable = None

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -339,7 +339,7 @@ class FieldConstraints(PudlMeta):
         | None
     ) = None
 
-    def has_content_constraints(self) -> bool:
+    def requires_content_validation(self) -> bool:
         """Whether checking these constraints requires reading actual field values.
 
         Every constraint field is assumed to require a content read (true of all
@@ -936,10 +936,6 @@ class Field(PudlMeta):
             unique=constraints.unique,
         )
 
-    def has_content_constraints(self) -> bool:
-        """Whether this field's constraints require reading its actual values to check."""
-        return self.constraints.has_content_constraints()
-
 
 # ---- Classes: Resource ---- #
 
@@ -1002,8 +998,12 @@ class Schema(PudlMeta):
     missing_values: list[StrictStr] = [""]
     primary_key: list[SnakeCase] = []
     foreign_keys: list[ForeignKey] = []
-    chunk_field: SnakeCase | None = None
-    """Primary-key column to use when chunking this table for processing, if any."""
+    pk_check_chunk_field: SnakeCase | None = None
+    """Primary-key column to chunk primary-key uniqueness checks by, if any.
+
+    A date/datetime column is always chunked by calendar year; any other column is
+    chunked by exact distinct value. See ``Resource._chunk_filters``.
+    """
 
     _check_unique = field_validator("missing_values", "primary_key", "foreign_keys")(
         _check_unique
@@ -1015,18 +1015,24 @@ class Schema(PudlMeta):
         _check_unique([f.name for f in fields])
         return fields
 
-    @field_validator("chunk_field")
+    @field_validator("pk_check_chunk_field")
     @classmethod
-    def _check_chunk_field_in_primary_key(cls, chunk_field, info: ValidationInfo):
-        """Verify that chunk_field, if set, is part of the primary key."""
+    def _check_pk_check_chunk_field_in_primary_key(
+        cls, pk_check_chunk_field, info: ValidationInfo
+    ):
+        """Verify that pk_check_chunk_field, if set, is part of the primary key."""
         pk = info.data.get("primary_key")
-        if chunk_field is not None and pk is not None and chunk_field not in pk:
+        if (
+            pk_check_chunk_field is not None
+            and pk is not None
+            and pk_check_chunk_field not in pk
+        ):
             raise ValueError(
-                f"{chunk_field!r} was given as the chunk_field, but it isn't part "
-                f"of this schema's primary key ({pk!r}). Chunking is only exact "
-                "when the chunk column is part of the primary key."
+                f"{pk_check_chunk_field!r} was given as the pk_check_chunk_field, but "
+                f"it isn't part of this schema's primary key ({pk!r}). Chunking is "
+                "only exact when the chunk column is part of the primary key."
             )
-        return chunk_field
+        return pk_check_chunk_field
 
     @field_validator("primary_key")
     @classmethod
@@ -1359,7 +1365,7 @@ class PudlResourceDescriptor(PudlMeta):
         field_ids: list[str] = pydantic.Field(alias="fields", default=[])
         primary_key_ids: list[str] = pydantic.Field(alias="primary_key", default=[])
         foreign_key_rules: PudlForeignKeyRules = PudlForeignKeyRules()
-        chunk_field: SnakeCase | None = None
+        pk_check_chunk_field: SnakeCase | None = None
 
     class PudlCodeMetadata(PudlMeta):
         """Describes a bunch of codes."""
@@ -1925,8 +1931,8 @@ class Resource(PudlMeta):
             primary_key=self.schema.primary_key,
             foreign_keys=[fk.to_frictionless() for fk in self.schema.foreign_keys],
         )
-        if self.schema.chunk_field:
-            schema.custom["chunk_field"] = self.schema.chunk_field
+        if self.schema.pk_check_chunk_field:
+            schema.custom["pk_check_chunk_field"] = self.schema.pk_check_chunk_field
 
         resource = frictionless.Resource(
             name=self.name,
@@ -2149,8 +2155,9 @@ class Resource(PudlMeta):
         errors into one report rather than stopping at whichever is found first.
 
         For tables large enough that checking uniqueness in a single pass is
-        impractical, the check is chunked by ``self.schema.chunk_field`` (see
-        ``_chunk_filters``) when set. Only meaningful for a Polars ``LazyFrame``;
+        impractical, the check is chunked by ``self.schema.pk_check_chunk_field`` when
+        set -- by calendar year if it's a date/datetime column, by exact distinct value
+        otherwise (see ``_chunk_filters``). Only meaningful for a Polars ``LazyFrame``;
         ignored for pandas/geopandas, which are already fully loaded into memory.
 
         Args:
@@ -2223,8 +2230,9 @@ class Resource(PudlMeta):
 
         Uses a single group-by/count/filter reduction, run with ``engine="streaming"``,
         to minimize memory usage. For tables large enough that checking uniqueness in
-        a single pass is impractical, the check is chunked by ``self.schema.chunk_field``
-        when set.
+        a single pass is impractical, the check is chunked by
+        ``self.schema.pk_check_chunk_field`` when set -- by calendar year if it's a
+        date/datetime column, by exact distinct value otherwise.
 
         Args:
             lf: LazyFrame to check.
@@ -2242,9 +2250,10 @@ class Resource(PudlMeta):
         if nulls.height > 0:
             errors.append(self._null_primary_key_error(nulls))
 
-        if chunk_field := self.schema.chunk_field:
+        if pk_check_chunk_field := self.schema.pk_check_chunk_field:
             chunks = [
-                narrow.filter(f) for f in self._chunk_filters(narrow, chunk_field)
+                narrow.filter(f)
+                for f in self._chunk_filters(narrow, pk_check_chunk_field)
             ]
         else:
             chunks = [narrow]
@@ -2290,15 +2299,16 @@ class Resource(PudlMeta):
         )
 
     @staticmethod
-    def _chunk_filters(lf: pl.LazyFrame, chunk_field: str) -> list[pl.Expr]:
-        """Build filter expressions that partition ``lf`` by ``chunk_field``.
+    def _chunk_filters(lf: pl.LazyFrame, pk_check_chunk_field: str) -> list[pl.Expr]:
+        """Build filter expressions that partition ``lf`` by ``pk_check_chunk_field``.
 
-        Every filter is a literal comparison directly against ``chunk_field``'s
-        own stored values -- a year-range comparison for date/datetime columns,
-        an equality comparison against each distinct value otherwise -- never a
-        derived expression. This matters for two reasons:
+        Every filter is a literal comparison directly against ``pk_check_chunk_field``'s
+        own stored values -- always a one-calendar-year range for date/datetime
+        columns (chunking is annual only; no other granularity is supported), an
+        equality comparison against each distinct value otherwise -- never a derived
+        expression. This matters for two reasons:
 
-        1. Correctness: since ``chunk_field`` is required to be part of the
+        1. Correctness: since ``pk_check_chunk_field`` is required to be part of the
            primary key, two rows sharing a composite key necessarily share the
            same value of it, so a boundary drawn directly on that column's own
            value can never split a duplicate pair across chunks. Deriving the
@@ -2323,31 +2333,31 @@ class Resource(PudlMeta):
         single calendar year, and most of `core_ferceqr__transactions`' row
         groups are confined to a single seller.
         """
-        dtype = lf.select(chunk_field).collect_schema()[chunk_field]
+        dtype = lf.select(pk_check_chunk_field).collect_schema()[pk_check_chunk_field]
 
         if dtype in (pl.Date, pl.Datetime):
             bounds = lf.select(
-                _min=pl.col(chunk_field).min(),
-                _max=pl.col(chunk_field).max(),
+                _min=pl.col(pk_check_chunk_field).min(),
+                _max=pl.col(pk_check_chunk_field).max(),
             ).collect(engine="streaming")
             min_year = bounds["_min"][0].year
             max_year = bounds["_max"][0].year
             boundary = datetime.date if dtype == pl.Date else datetime.datetime
             return [
-                pl.col(chunk_field).is_between(
+                pl.col(pk_check_chunk_field).is_between(
                     boundary(year, 1, 1), boundary(year + 1, 1, 1), closed="left"
                 )
                 for year in range(min_year, max_year + 1)
             ]
 
         values = (
-            lf.select(chunk_field)
+            lf.select(pk_check_chunk_field)
             .unique()
             .collect(engine="streaming")
-            .get_column(chunk_field)
+            .get_column(pk_check_chunk_field)
             .to_list()
         )
-        return [pl.col(chunk_field) == value for value in values]
+        return [pl.col(pk_check_chunk_field) == value for value in values]
 
     def _duplicate_primary_key_error(self, duplicates: pl.DataFrame) -> SchemaError:
         """Build a SchemaError describing duplicate primary-key combinations."""

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -30,6 +30,7 @@ from pandas._libs.missing import NAType
 from pandera.constants import CHECK_OUTPUT_KEY
 from pandera.errors import SchemaError, SchemaErrorReason
 from pydantic import (
+    AfterValidator,
     AnyHttpUrl,
     BaseModel,
     ConfigDict,
@@ -303,24 +304,6 @@ def _sort_deterministically(value: list | None = None) -> list | None:
     return value
 
 
-def _validator(*names, fn: Callable) -> Callable:
-    """Construct reusable Pydantic validator.
-
-    Args:
-        names: Names of attributes to validate.
-        fn: Validation function (see :meth:`pydantic.field_validator`).
-
-    Examples:
-        >>> class Class(BaseModel):
-        ...     x: list = None
-        ...     _check_unique = _validator("x", fn=_check_unique)
-        >>> Class(x=[0, 0])
-        Traceback (most recent call last):
-        ValidationError: ...
-    """
-    return field_validator(*names)(fn)
-
-
 ########################################################################################
 # PUDL Metadata Classes
 ########################################################################################
@@ -347,10 +330,14 @@ class FieldConstraints(PudlMeta):
     minimum: StrictInt | StrictFloat | datetime.date | datetime.datetime | None = None
     maximum: StrictInt | StrictFloat | datetime.date | datetime.datetime | None = None
     pattern: re.Pattern | None = None
-    enum: StrictList[String] | None = None
-
-    _check_unique = _validator("enum", fn=_check_unique)
-    _sort_enum = _validator("enum", fn=_sort_deterministically)
+    enum: (
+        Annotated[
+            StrictList[String],
+            AfterValidator(_check_unique),
+            AfterValidator(_sort_deterministically),
+        ]
+        | None
+    ) = None
 
     @field_validator("max_length")
     @classmethod
@@ -971,9 +958,7 @@ class ForeignKeyReference(PudlMeta):
     """
 
     resource: SnakeCase
-    fields: StrictList[SnakeCase]
-
-    _check_unique = _validator("fields", fn=_check_unique)
+    fields: Annotated[StrictList[SnakeCase], AfterValidator(_check_unique)]
 
 
 class ForeignKey(PudlMeta):
@@ -982,10 +967,8 @@ class ForeignKey(PudlMeta):
     See https://specs.frictionlessdata.io/table-schema/#foreign-keys.
     """
 
-    fields: StrictList[SnakeCase]
+    fields: Annotated[StrictList[SnakeCase], AfterValidator(_check_unique)]
     reference: ForeignKeyReference
-
-    _check_unique = _validator("fields", fn=_check_unique)
 
     @field_validator("reference")
     @classmethod
@@ -1029,8 +1012,8 @@ class Schema(PudlMeta):
     chunk_field: SnakeCase | None = None
     """Primary-key column to use when chunking this table for processing, if any."""
 
-    _check_unique = _validator(
-        "missing_values", "primary_key", "foreign_keys", fn=_check_unique
+    _check_unique = field_validator("missing_values", "primary_key", "foreign_keys")(
+        _check_unique
     )
 
     @field_validator("fields")
@@ -1738,8 +1721,8 @@ class Resource(PudlMeta):
     etl_group: EtlGroup | None = None
     create_database_schema: bool = True
 
-    _check_unique = _validator(
-        "contributors", "keywords", "licenses", "sources", fn=_check_unique
+    _check_unique = field_validator("contributors", "keywords", "licenses", "sources")(
+        _check_unique
     )
 
     @property

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -285,12 +285,19 @@ ETL_GROUPS: tuple[EtlGroup, ...] = get_args(EtlGroup)
 # ---- Class attribute validators ---- #
 
 
-def _check_unique(value: list = None) -> list | None:
+def _check_unique(value: list | None = None) -> list | None:
     """Check that input list has unique values."""
     if value:
         for i in range(len(value)):
             if value[i] in value[:i]:
                 raise ValueError(f"contains duplicate {value[i]}")
+    return value
+
+
+def _sort_deterministically(value: list | None = None) -> list | None:
+    """Sort an enum constraint's values into a deterministic order."""
+    if value:
+        return sorted(value)
     return value
 
 
@@ -338,19 +345,10 @@ class FieldConstraints(PudlMeta):
     minimum: StrictInt | StrictFloat | datetime.date | datetime.datetime | None = None
     maximum: StrictInt | StrictFloat | datetime.date | datetime.datetime | None = None
     pattern: re.Pattern | None = None
-    enum: (
-        StrictList[
-            String
-            | StrictInt
-            | StrictFloat
-            | StrictBool
-            | datetime.date
-            | datetime.datetime
-        ]
-        | None
-    ) = None
+    enum: StrictList[String] | None = None
 
     _check_unique = _validator("enum", fn=_check_unique)
+    _sort_enum = _validator("enum", fn=_sort_deterministically)
 
     @field_validator("max_length")
     @classmethod

--- a/src/pudl/metadata/dtypes.py
+++ b/src/pudl/metadata/dtypes.py
@@ -29,7 +29,7 @@ from copy import deepcopy
 from typing import Any, Literal
 
 import duckdb.sqltypes
-import geoarrow.pyarrow as ga
+import geoarrow.pyarrow as geoarrow
 import geopandas
 import pandas as pd
 import polars as pl
@@ -79,7 +79,7 @@ FIELD_DTYPES_PYARROW: dict[str, pa.DataType] = {
     "boolean": pa.bool_(),
     "date": pa.date32(),
     "datetime": pa.timestamp("us"),
-    "geometry": ga.wkb(),
+    "geometry": geoarrow.wkb(),
     "integer": pa.int64(),
     "number": pa.float64(),
     "string": pa.string(),

--- a/src/pudl/metadata/resources/epacems.py
+++ b/src/pudl/metadata/resources/epacems.py
@@ -46,6 +46,7 @@ CEMS data.
                 "emissions_unit_id_epa",
                 "operating_datetime_utc",
             ],
+            "chunk_field": "operating_datetime_utc",
         },
         "sources": ["eia860", "epacems"],
         "field_namespace": "epacems",

--- a/src/pudl/metadata/resources/epacems.py
+++ b/src/pudl/metadata/resources/epacems.py
@@ -46,7 +46,7 @@ CEMS data.
                 "emissions_unit_id_epa",
                 "operating_datetime_utc",
             ],
-            "chunk_field": "operating_datetime_utc",
+            "pk_check_chunk_field": "operating_datetime_utc",
         },
         "sources": ["eia860", "epacems"],
         "field_namespace": "epacems",

--- a/src/pudl/metadata/resources/ferceqr.py
+++ b/src/pudl/metadata/resources/ferceqr.py
@@ -33,6 +33,17 @@ TABLE_DESCRIPTIONS = {
             "Contains information about individual electricity market transactions that took place"
             " during a given reporting quarter. Reported by the seller."
         ),
+        "additional_primary_key_text": (
+            "The primary key ought to be ['year_quarter', 'seller_company_id_ferc', "
+            "'transaction_unique_id']. However, many reporting quarters contain a "
+            "substantial number of records that duplicate this combination of "
+            "columns, in some cases repeated many times over, and the number of "
+            "duplicates appears to grow in more recent quarters. It isn't yet clear "
+            "whether this reflects a data quality issue in the underlying FERC EQR "
+            "submissions or a bug in PUDL's extraction or transformation of this "
+            "table. Further investigation is required, so this table currently has "
+            "no enforced primary key."
+        ),
         "usage_warnings": ["experimental_wip"],
     },
     "index_pub": {
@@ -154,11 +165,6 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "standardized_price",
                 "total_transmission_charge",
                 "total_transaction_charge",
-            ],
-            "primary_key": [
-                "year_quarter",
-                "seller_company_id_ferc",
-                "transaction_unique_id",
             ],
         },
         "create_database_schema": False,

--- a/src/pudl/metadata/resources/vcerare.py
+++ b/src/pudl/metadata/resources/vcerare.py
@@ -80,6 +80,7 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "capacity_factor_offshore_wind",
             ],
             "primary_key": ["state", "place_name", "datetime_utc"],
+            "chunk_field": "datetime_utc",
         },
         "sources": ["vcerare"],
         "field_namespace": "vcerare",

--- a/src/pudl/metadata/resources/vcerare.py
+++ b/src/pudl/metadata/resources/vcerare.py
@@ -80,7 +80,7 @@ RESOURCE_METADATA: dict[str, dict[str, Any]] = {
                 "capacity_factor_offshore_wind",
             ],
             "primary_key": ["state", "place_name", "datetime_utc"],
-            "chunk_field": "datetime_utc",
+            "pk_check_chunk_field": "datetime_utc",
         },
         "sources": ["vcerare"],
         "field_namespace": "vcerare",

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -29,8 +29,10 @@ on each generated check is the *exact* expected type object (using ``is``, not `
 """
 
 import io
+from datetime import date
 
 import dagster as dg
+import geopandas as gpd  # noqa: ICN002
 import pandas as pd
 import pint
 import polars as pl
@@ -39,15 +41,20 @@ from dagster._core.definitions.asset_checks.asset_checks_definition import (
     AssetChecksDefinition,
 )
 from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
+from shapely.geometry import Point
 
 from pudl.dagster.asset_checks import (
+    _CHUNKED_PK_CHECK_TABLES,
     _build_registry_from_descriptor,
+    _chunk_filters,
+    _find_duplicate_primary_keys,
     _validate_datapackage_unit_strings,
+    _validate_primary_key_uniqueness,
     asset_check_from_schema,
     group_mean_continuity_check,
 )
 from pudl.helpers import ParquetData
-from pudl.metadata.classes import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE, Package, Resource
 from pudl.metadata.units import PUDL_UNIT_DEFINITIONS
 
 
@@ -209,4 +216,499 @@ def test_validate_datapackage_unit_strings_missing_registry() -> None:
     assert len(errors) == 1
     assert "Could not build unit registry" in errors[0], (
         f"Unexpected error message: {errors[0]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for content-level (not just schema-level) validation
+# ---------------------------------------------------------------------------
+#
+# Pandera's Polars backend forces SCHEMA_ONLY validation depth for LazyFrame
+# inputs unless validation depth is explicitly configured (see
+# pandera.api.polars.utils.get_validation_depth). PUDL never configures it, so
+# pandera_schema_check currently verifies column presence and dtypes for every
+# Polars LazyFrame asset (the vast majority of PUDL tables), but silently skips
+# every Check.ge/Check.le/Check.isin/uniqueness constraint declared in PUDL's
+# metadata. The pandas/geopandas backend has no such override and already
+# enforces those checks. These tests use synthetic, minimal resources (rather
+# than real PUDL tables) so the fixtures stay small and independent of
+# unrelated metadata changes.
+
+
+def _content_check_fields(*, with_geometry: bool) -> list[dict]:
+    """Shared field set for the polars and geopandas content-check fixtures."""
+    fields = [
+        {"name": "id", "type": "integer", "description": "Primary key."},
+        {
+            "name": "value",
+            "type": "integer",
+            "description": "Value bounded to [0, 100].",
+            "constraints": {"minimum": 0, "maximum": 100},
+        },
+        {
+            "name": "code",
+            "type": "string",
+            "description": "Enum-constrained code.",
+            "constraints": {"enum": ["a", "b", "c"]},
+        },
+    ]
+    if with_geometry:
+        fields.append(
+            {"name": "geometry", "type": "geometry", "description": "Geometry."}
+        )
+    return fields
+
+
+def _content_check_fn(*, with_geometry: bool):
+    """Build the generated ``pandera_schema_check`` function for a synthetic resource."""
+    resource = Resource(
+        name="_test__geopandas_content_checks"
+        if with_geometry
+        else "_test__polars_content_checks",
+        description="Synthetic resource for asset-check content-validation tests.",
+        schema={
+            "fields": _content_check_fields(with_geometry=with_geometry),
+            "primary_key": ["id"],
+        },
+    )
+    package = Package(name="_test_package", resources=[resource])
+    check = asset_check_from_schema(
+        dg.AssetKey([resource.name]), package, duckdb_asset=False
+    )
+    assert check is not None
+    return check.node_def.compute_fn.decorated_fn
+
+
+@pytest.mark.parametrize(
+    ("value", "code", "expected_pass"),
+    [
+        (30, "a", True),
+        (150, "a", False),  # violates maximum=100
+        (30, "z", False),  # violates enum=["a", "b", "c"]
+    ],
+    ids=["valid", "value_out_of_range", "code_not_in_enum"],
+)
+def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
+    """Content (not just schema) violations should fail the generated asset check.
+
+    As of this writing, pandera's Polars backend does not enforce content-level
+    checks (Check.ge/le/isin/etc.) on ``pl.LazyFrame`` inputs by default, so the
+    two violation cases here are expected to incorrectly report ``passed=True``
+    until that is fixed.
+    """
+    fn = _content_check_fn(with_geometry=False)
+    lf = pl.LazyFrame(
+        {"id": [1, 2, 3], "value": [10, 20, value], "code": ["a", "b", code]}
+    )
+    lf = lf.with_columns(pl.col("code").cast(pl.Categorical))
+    result = fn(lf)
+    assert result.passed == expected_pass
+
+
+@pytest.mark.parametrize(
+    ("value", "code", "expected_pass"),
+    [
+        (30, "a", True),
+        (150, "a", False),  # violates maximum=100
+        (30, "z", False),  # violates enum=["a", "b", "c"]
+    ],
+    ids=["valid", "value_out_of_range", "code_not_in_enum"],
+)
+def test_geopandas_content_checks(value, code, expected_pass) -> None:
+    """Content violations are already correctly caught on the geopandas/pandas path.
+
+    Geometry-bearing tables use pandera's pandas backend
+    (:func:`pudl.metadata.classes.Schema.to_pandera`), which has no
+    LazyFrame-specific validation-depth override, so these checks already run
+    today and all three cases are expected to pass as written.
+    """
+    fn = _content_check_fn(with_geometry=True)
+    gdf = gpd.GeoDataFrame(
+        {
+            "id": pd.array([1, 2, 3], dtype="Int64"),
+            "value": pd.array([10, 20, value], dtype="Int64"),
+            "code": pd.Categorical(["a", "b", code]),
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        }
+    )
+    result = fn(gdf)
+    assert result.passed == expected_pass
+
+
+# ---------------------------------------------------------------------------
+# Tests for nullable/uniqueness validation
+# ---------------------------------------------------------------------------
+#
+# These constraints are structurally different from the Check-based value/enum
+# constraints above: `required` maps to `Column(nullable=...)`, single-column
+# `unique` maps to `Column(unique=...)`, and the primary key maps to a
+# DataFrame-level `unique=[...]` composite check
+# (see Field.to_pandera_column and Schema.to_pandera). They go through
+# different pandera code than Check.ge/le/isin, so they're tested separately
+# rather than assumed to be fixed by the same code path.
+
+
+def _uniqueness_check_fields(*, with_geometry: bool) -> list[dict]:
+    """Shared field set for the polars and geopandas uniqueness-check fixtures."""
+    fields = [
+        {"name": "id", "type": "integer", "description": "Primary key, part 1."},
+        {"name": "id2", "type": "integer", "description": "Primary key, part 2."},
+        {
+            "name": "required_field",
+            "type": "integer",
+            "description": "Non-nullable, non-key field.",
+            "constraints": {"required": True},
+        },
+        {
+            "name": "unique_field",
+            "type": "integer",
+            "description": "Single-column uniqueness constraint.",
+            "constraints": {"unique": True},
+        },
+    ]
+    if with_geometry:
+        fields.append(
+            {"name": "geometry", "type": "geometry", "description": "Geometry."}
+        )
+    return fields
+
+
+def _uniqueness_check_fn(*, with_geometry: bool):
+    """Build the generated ``pandera_schema_check`` function for a synthetic resource."""
+    resource = Resource(
+        name="_test__geopandas_uniqueness_checks"
+        if with_geometry
+        else "_test__polars_uniqueness_checks",
+        description="Synthetic resource for asset-check uniqueness-validation tests.",
+        schema={
+            "fields": _uniqueness_check_fields(with_geometry=with_geometry),
+            "primary_key": ["id", "id2"],
+        },
+    )
+    package = Package(name="_test_package", resources=[resource])
+    check = asset_check_from_schema(
+        dg.AssetKey([resource.name]), package, duckdb_asset=False
+    )
+    assert check is not None
+    return check.node_def.compute_fn.decorated_fn
+
+
+_UNIQUENESS_CASES = [
+    ([1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3], True),
+    ([1, 2, 3], [1, 2, 3], [1, None, 3], [1, 2, 3], False),  # null required_field
+    ([1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 1, 3], False),  # duplicate unique_field
+    ([1, 1, 3], [1, 1, 3], [1, 2, 3], [1, 2, 3], False),  # duplicate composite PK
+]
+_UNIQUENESS_IDS = [
+    "valid",
+    "null_in_required_field",
+    "duplicate_unique_field",
+    "duplicate_primary_key",
+]
+
+
+@pytest.mark.parametrize(
+    ("id_", "id2", "required_field", "unique_field", "expected_pass"),
+    _UNIQUENESS_CASES,
+    ids=_UNIQUENESS_IDS,
+)
+def test_polars_lazyframe_uniqueness_checks(
+    id_, id2, required_field, unique_field, expected_pass
+) -> None:
+    """Nullable and uniqueness violations should fail the generated asset check.
+
+    This resource isn't in ``_CHUNKED_PK_CHECK_TABLES``, so composite
+    primary-key uniqueness goes through pandera's normal, unchunked check
+    (see ``test_validate_primary_key_by_temporal_chunk*`` for the chunked
+    path used by PUDL's few oversized tables).
+    """
+    fn = _uniqueness_check_fn(with_geometry=False)
+    lf = pl.LazyFrame(
+        {
+            "id": id_,
+            "id2": id2,
+            "required_field": required_field,
+            "unique_field": unique_field,
+        }
+    )
+    result = fn(lf)
+    assert result.passed == expected_pass
+
+
+@pytest.mark.parametrize(
+    ("id_", "id2", "required_field", "unique_field", "expected_pass"),
+    _UNIQUENESS_CASES,
+    ids=_UNIQUENESS_IDS,
+)
+def test_geopandas_uniqueness_checks(
+    id_, id2, required_field, unique_field, expected_pass
+) -> None:
+    """Nullable and uniqueness violations are already correctly caught on the
+    geopandas/pandas path.
+    """
+    fn = _uniqueness_check_fn(with_geometry=True)
+    gdf = gpd.GeoDataFrame(
+        {
+            "id": pd.array(id_, dtype="Int64"),
+            "id2": pd.array(id2, dtype="Int64"),
+            "required_field": pd.array(required_field, dtype="Int64"),
+            "unique_field": pd.array(unique_field, dtype="Int64"),
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        }
+    )
+    result = fn(gdf)
+    assert result.passed == expected_pass
+
+
+# ---------------------------------------------------------------------------
+# Tests for chunked primary-key uniqueness checking
+# ---------------------------------------------------------------------------
+#
+# `_validate_primary_key_uniqueness` never uses pandera's built-in composite-
+# uniqueness check (too memory-hungry, see polars-comment.md); it always uses
+# its own group-by/count-based `_find_duplicate_primary_keys`, optionally run
+# once per chunk instead of once on the whole table for PUDL's few oversized
+# tables (`_CHUNKED_PK_CHECK_TABLES`). Chunking is only correct because the
+# chunking column is itself part of the primary key -- two rows with an
+# identical composite key necessarily share the same value of it, so
+# duplicates can never span chunk boundaries, whether the column is
+# date/datetime (chunked by year) or anything else (chunked by distinct
+# value). These tests exercise the machinery directly with synthetic
+# resources, independent of which real tables are currently enumerated.
+
+
+def _temporal_pk_resource() -> Resource:
+    return Resource(
+        name="_test__temporal_pk_chunking",
+        description="Synthetic resource with a temporal primary key.",
+        schema={
+            "fields": [
+                {"name": "event_date", "type": "date", "description": "Event date."},
+                {"name": "unit_id", "type": "integer", "description": "Unit ID."},
+            ],
+            "primary_key": ["event_date", "unit_id"],
+        },
+    )
+
+
+def _categorical_pk_resource() -> Resource:
+    return Resource(
+        name="_test__categorical_pk_chunking",
+        description="Synthetic resource with a string primary-key column.",
+        schema={
+            "fields": [
+                {"name": "filer_id", "type": "string", "description": "Filer ID."},
+                {
+                    "name": "record_id",
+                    "type": "integer",
+                    "description": "Record ID.",
+                },
+            ],
+            "primary_key": ["filer_id", "record_id"],
+        },
+    )
+
+
+def test_validate_primary_key_uniqueness_temporal_valid() -> None:
+    """Repeated non-key values across different years are not false positives.
+
+    ``_temporal_pk_resource`` isn't in ``_CHUNKED_PK_CHECK_TABLES``, so this
+    exercises ``_validate_primary_key_uniqueness``'s default, unchunked
+    dispatch path; ``test_chunk_filters_temporal_*`` below separately verify
+    the chunking mechanism itself preserves the same correctness.
+    """
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [
+                date(2020, 1, 1),
+                date(2020, 1, 2),
+                date(2021, 1, 1),
+                date(2021, 1, 2),
+            ],
+            # unit_id repeats across years -- fine, since event_date differs.
+            "unit_id": [1, 2, 1, 2],
+        }
+    )
+    errors = _validate_primary_key_uniqueness(lf, resource)
+    assert errors == []
+
+
+def test_validate_primary_key_uniqueness_temporal_catches_duplicate() -> None:
+    """A true duplicate composite key within one year is still caught."""
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
+            "unit_id": [1, 1, 1],
+        }
+    )
+    errors = _validate_primary_key_uniqueness(lf, resource)
+    assert len(errors) > 0
+
+
+def test_validate_primary_key_uniqueness_categorical_valid() -> None:
+    """Repeated non-key values across different filers are not false positives."""
+    resource = _categorical_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "filer_id": ["A", "A", "B", "B"],
+            # record_id repeats across filers -- fine, since filer_id differs.
+            "record_id": [1, 2, 1, 2],
+        }
+    )
+    errors = _validate_primary_key_uniqueness(lf, resource)
+    assert errors == []
+
+
+def test_validate_primary_key_uniqueness_categorical_catches_duplicate() -> None:
+    """A true duplicate composite key within one filer is still caught."""
+    resource = _categorical_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "filer_id": ["A", "A", "B"],
+            "record_id": [1, 1, 1],
+        }
+    )
+    errors = _validate_primary_key_uniqueness(lf, resource)
+    assert len(errors) > 0
+
+
+def test_chunk_filters_temporal_partitions_by_year() -> None:
+    """Temporal chunk filters split rows into non-overlapping, year-aligned sets."""
+    lf = pl.LazyFrame(
+        {"event_date": [date(2020, 1, 1), date(2020, 6, 1), date(2021, 3, 1)]}
+    )
+    filters = _chunk_filters(lf, "event_date")
+    assert len(filters) == 2  # 2020 and 2021
+    row_counts = sorted(lf.filter(f).select(pl.len()).collect().item() for f in filters)
+    assert row_counts == [1, 2]
+
+
+def test_chunk_filters_categorical_partitions_by_value() -> None:
+    """Categorical chunk filters split rows by each distinct value, exactly."""
+    lf = pl.LazyFrame({"filer_id": ["A", "A", "B"]})
+    filters = _chunk_filters(lf, "filer_id")
+    assert len(filters) == 2  # "A" and "B"
+    counts_by_value = {}
+    for f in filters:
+        chunk = lf.filter(f).collect()
+        counts_by_value[chunk["filer_id"][0]] = chunk.height
+    assert counts_by_value == {"A": 2, "B": 1}
+
+
+def test_validate_primary_key_uniqueness_no_primary_key() -> None:
+    """Resources without a primary key are trivially valid."""
+    resource = Resource(
+        name="_test__no_pk",
+        description="Synthetic resource without a primary key.",
+        schema={"fields": [{"name": "x", "type": "integer", "description": "X."}]},
+    )
+    lf = pl.LazyFrame({"x": [1, 1, 1]})
+    assert _validate_primary_key_uniqueness(lf, resource) == []
+
+
+def test_validate_primary_key_uniqueness_rejects_bad_chunk_field(mocker) -> None:
+    """A chunk field that isn't part of the primary key is a config error.
+
+    Chunking is only exact (see `_chunk_filters`) when the chunk column is
+    part of the primary key -- if `_CHUNKED_PK_CHECK_TABLES` is ever
+    misconfigured with a column that isn't, that has to fail loudly rather
+    than silently produce an incomplete uniqueness check.
+    """
+    resource = Resource(
+        name="_test__bad_chunk_field",
+        description="Synthetic resource for testing chunk-field misconfiguration.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."},
+                {"name": "other", "type": "integer", "description": "Not in the PK."},
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    mocker.patch.dict(_CHUNKED_PK_CHECK_TABLES, {resource.name: "other"})
+    lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
+    with pytest.raises(AssertionError, match="isn't part of"):
+        _validate_primary_key_uniqueness(lf, resource)
+
+
+def test_find_duplicate_primary_keys() -> None:
+    """The underlying group-by/count reduction correctly identifies duplicates."""
+    lf = pl.LazyFrame({"a": [1, 1, 2], "b": ["x", "x", "y"]})
+    duplicates = _find_duplicate_primary_keys(lf, ["a", "b"])
+    assert duplicates.height == 1
+    assert duplicates["a"][0] == 1
+    assert duplicates["b"][0] == "x"
+    assert duplicates["_pk_count"][0] == 2
+
+
+def test_chunked_pk_check_tables_are_valid() -> None:
+    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
+
+    Guards against the mapping silently going stale if a listed resource's
+    primary key changes -- the chunking column must remain part of the
+    primary key, since that's what makes chunking by it exact rather than
+    approximate.
+    """
+    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
+        resource = PUDL_PACKAGE.get_resource(resource_name)
+        assert field_name in resource.schema.primary_key, (
+            f"{field_name} is not part of {resource_name}'s primary key"
+        )
+
+
+def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
+    """Schema-level and content-level errors are reported together, not either/or.
+
+    Regression test: a naive implementation runs pandera's schema-only pass
+    first and lets a `SchemaErrors` from it propagate immediately, which
+    skips the content checks entirely -- so a caller only ever sees whichever
+    kind of error happened to be found first, and has to fix-and-rerun to
+    discover the other. The two are independent, so both should show up in
+    one report.
+    """
+    resource = Resource(
+        name="_test__combined_errors",
+        description="Synthetic resource with both a missing column and a "
+        "content-constraint violation.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."},
+                {
+                    "name": "value",
+                    "type": "integer",
+                    "description": "Bounded value.",
+                    "constraints": {"minimum": 0, "maximum": 100},
+                },
+                {
+                    "name": "missing_field",
+                    "type": "string",
+                    "description": "A required field absent from the data.",
+                    "constraints": {"required": True},
+                },
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    package = Package(name="_test_package", resources=[resource])
+    check = asset_check_from_schema(
+        dg.AssetKey([resource.name]), package, duckdb_asset=False
+    )
+    assert check is not None
+    fn = check.node_def.compute_fn.decorated_fn
+
+    # `missing_field` is omitted entirely (schema error: column not present),
+    # and `value=150` violates its maximum=100 constraint (content error).
+    lf = pl.LazyFrame({"id": [1, 2], "value": [10, 150]})
+    result = fn(lf)
+
+    assert result.passed is False
+    detailed_errors = result.metadata["detailed_errors"].data
+    messages = [e["error_message"] for e in detailed_errors]
+    assert any("missing_field" in m for m in messages), (
+        f"Expected a missing-column schema error, got: {messages}"
+    )
+    assert any("value" in m and "100" in m for m in messages), (
+        f"Expected a value-constraint content error, got: {messages}"
     )

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -248,7 +248,12 @@ def _build_check_fn(name: str, fields: list[dict], primary_key: list[str]):
         dg.AssetKey([resource.name]), package, duckdb_asset=False
     )
     assert check is not None
-    return check.node_def.compute_fn.decorated_fn
+    node_def = check.node_def
+    assert isinstance(node_def, dg.OpDefinition)
+    # compute_fn is typed as Callable | DecoratedOpFunction; the @asset_check
+    # decorator always produces the latter, but DecoratedOpFunction is a
+    # private dagster type we can't import to narrow against.
+    return node_def.compute_fn.decorated_fn  # type: ignore[missing-attribute]
 
 
 def _content_check_fields(*, with_geometry: bool) -> list[dict]:

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -42,7 +42,6 @@ from dagster._core.definitions.asset_checks.asset_checks_definition import (
 from shapely.geometry import Point
 
 from pudl.dagster.asset_checks import (
-    _CHUNKED_PK_CHECK_TABLES,
     _build_registry_from_descriptor,
     _validate_datapackage_unit_strings,
     asset_check_from_schema,
@@ -416,7 +415,7 @@ def test_polars_lazyframe_uniqueness_checks(
 ) -> None:
     """Nullable and uniqueness violations should fail the generated asset check.
 
-    This resource isn't in ``_CHUNKED_PK_CHECK_TABLES``, so composite
+    This resource's schema doesn't set ``chunk_field``, so composite
     primary-key uniqueness goes through
     :meth:`Resource.check_primary_key_polars`'s normal, unchunked path (see
     ``tests/unit/metadata/metadata_test.py`` for the chunked path used by
@@ -520,18 +519,3 @@ def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
     assert any("value" in m and "100" in m for m in messages), (
         f"Expected a value-constraint content error, got: {messages}"
     )
-
-
-def test_chunked_pk_check_tables_are_valid() -> None:
-    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
-
-    Guards against the mapping silently going stale if a listed resource's
-    primary key changes -- the chunking column must remain part of the
-    primary key, since that's what makes chunking by it exact rather than
-    approximate (see ``Resource._chunk_filters``).
-    """
-    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
-        resource = PUDL_PACKAGE.get_resource(resource_name)
-        assert field_name in resource.schema.primary_key, (
-            f"{field_name} is not part of {resource_name}'s primary key"
-        )

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -58,6 +58,7 @@ from pudl.metadata.units import PUDL_UNIT_DEFINITIONS
     [
         ("core_pudl__codes_subdivisions", False, pl.LazyFrame),
         ("core_ferceqr__contracts", True, ParquetData),
+        ("out_censusdp1tract__counties", False, gpd.GeoDataFrame),
     ],
 )
 def test_asset_checks_preserve_runtime_input_types(
@@ -230,6 +231,26 @@ def test_validate_datapackage_unit_strings_missing_registry() -> None:
 # unrelated metadata changes.
 
 
+def _build_check_fn(name: str, fields: list[dict], primary_key: list[str]):
+    """Build the generated ``pandera_schema_check`` function for a synthetic resource.
+
+    Shared by every synthetic-resource asset-check test below, so each one only
+    has to supply what actually varies: the resource name, its fields, and its
+    primary key.
+    """
+    resource = Resource(
+        name=name,
+        description="Synthetic resource for asset-check tests.",
+        schema={"fields": fields, "primary_key": primary_key},
+    )
+    package = Package(name="_test_package", resources=[resource])
+    check = asset_check_from_schema(
+        dg.AssetKey([resource.name]), package, duckdb_asset=False
+    )
+    assert check is not None
+    return check.node_def.compute_fn.decorated_fn
+
+
 def _content_check_fields(*, with_geometry: bool) -> list[dict]:
     """Shared field set for the polars and geopandas content-check fixtures."""
     fields = [
@@ -254,44 +275,27 @@ def _content_check_fields(*, with_geometry: bool) -> list[dict]:
     return fields
 
 
-def _content_check_fn(*, with_geometry: bool):
-    """Build the generated ``pandera_schema_check`` function for a synthetic resource."""
-    resource = Resource(
-        name="_test__geopandas_content_checks"
-        if with_geometry
-        else "_test__polars_content_checks",
-        description="Synthetic resource for asset-check content-validation tests.",
-        schema={
-            "fields": _content_check_fields(with_geometry=with_geometry),
-            "primary_key": ["id"],
-        },
-    )
-    package = Package(name="_test_package", resources=[resource])
-    check = asset_check_from_schema(
-        dg.AssetKey([resource.name]), package, duckdb_asset=False
-    )
-    assert check is not None
-    return check.node_def.compute_fn.decorated_fn
+_CONTENT_CHECK_CASES = [
+    (30, "a", True),
+    (150, "a", False),  # violates maximum=100
+    (30, "z", False),  # violates enum=["a", "b", "c"]
+]
+_CONTENT_CHECK_IDS = ["valid", "value_out_of_range", "code_not_in_enum"]
 
 
 @pytest.mark.parametrize(
-    ("value", "code", "expected_pass"),
-    [
-        (30, "a", True),
-        (150, "a", False),  # violates maximum=100
-        (30, "z", False),  # violates enum=["a", "b", "c"]
-    ],
-    ids=["valid", "value_out_of_range", "code_not_in_enum"],
+    ("value", "code", "expected_pass"), _CONTENT_CHECK_CASES, ids=_CONTENT_CHECK_IDS
 )
 def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
     """Content (not just schema) violations should fail the generated asset check.
 
-    As of this writing, pandera's Polars backend does not enforce content-level
-    checks (Check.ge/le/isin/etc.) on ``pl.LazyFrame`` inputs by default, so the
-    two violation cases here are expected to incorrectly report ``passed=True``
-    until that is fixed.
+    All errors must produce SchemaErrors, not generic exceptions.
     """
-    fn = _content_check_fn(with_geometry=False)
+    fn = _build_check_fn(
+        "_test__polars_content_checks",
+        _content_check_fields(with_geometry=False),
+        ["id"],
+    )
     lf = pl.LazyFrame(
         {"id": [1, 2, 3], "value": [10, 20, value], "code": ["a", "b", code]}
     )
@@ -305,23 +309,18 @@ def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
 
 
 @pytest.mark.parametrize(
-    ("value", "code", "expected_pass"),
-    [
-        (30, "a", True),
-        (150, "a", False),  # violates maximum=100
-        (30, "z", False),  # violates enum=["a", "b", "c"]
-    ],
-    ids=["valid", "value_out_of_range", "code_not_in_enum"],
+    ("value", "code", "expected_pass"), _CONTENT_CHECK_CASES, ids=_CONTENT_CHECK_IDS
 )
 def test_geopandas_content_checks(value, code, expected_pass) -> None:
     """Content violations are already correctly caught on the geopandas/pandas path.
 
-    Geometry-bearing tables use pandera's pandas backend
-    (:func:`pudl.metadata.classes.Schema.to_pandera`), which has no
-    LazyFrame-specific validation-depth override, so these checks already run
-    today and all three cases are expected to pass as written.
+    All errors must produce SchemaErrors, not generic exceptions.
     """
-    fn = _content_check_fn(with_geometry=True)
+    fn = _build_check_fn(
+        "_test__geopandas_content_checks",
+        _content_check_fields(with_geometry=True),
+        ["id"],
+    )
     gdf = gpd.GeoDataFrame(
         {
             "id": pd.array([1, 2, 3], dtype="Int64"),
@@ -373,26 +372,6 @@ def _uniqueness_check_fields(*, with_geometry: bool) -> list[dict]:
     return fields
 
 
-def _uniqueness_check_fn(*, with_geometry: bool):
-    """Build the generated ``pandera_schema_check`` function for a synthetic resource."""
-    resource = Resource(
-        name="_test__geopandas_uniqueness_checks"
-        if with_geometry
-        else "_test__polars_uniqueness_checks",
-        description="Synthetic resource for asset-check uniqueness-validation tests.",
-        schema={
-            "fields": _uniqueness_check_fields(with_geometry=with_geometry),
-            "primary_key": ["id", "id2"],
-        },
-    )
-    package = Package(name="_test_package", resources=[resource])
-    check = asset_check_from_schema(
-        dg.AssetKey([resource.name]), package, duckdb_asset=False
-    )
-    assert check is not None
-    return check.node_def.compute_fn.decorated_fn
-
-
 _UNIQUENESS_CASES = [
     ([1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3], True),
     ([1, 2, 3], [1, 2, 3], [1, None, 3], [1, 2, 3], False),  # null required_field
@@ -417,13 +396,16 @@ def test_polars_lazyframe_uniqueness_checks(
 ) -> None:
     """Nullable and uniqueness violations should fail the generated asset check.
 
-    This resource's schema doesn't set ``chunk_field``, so composite
-    primary-key uniqueness goes through
-    :meth:`Resource.check_primary_key_polars`'s normal, unchunked path (see
-    ``tests/unit/metadata/metadata_test.py`` for the chunked path used by
-    PUDL's few oversized tables).
+    This resource's schema doesn't set ``chunk_field``, so composite primary-key
+    uniqueness goes through :meth:`Resource.check_primary_key_polars`'s normal,
+    unchunked path (see ``tests/unit/metadata/metadata_test.py`` for the chunked path
+    used by PUDL's few oversized tables).
     """
-    fn = _uniqueness_check_fn(with_geometry=False)
+    fn = _build_check_fn(
+        "_test__polars_uniqueness_checks",
+        _uniqueness_check_fields(with_geometry=False),
+        ["id", "id2"],
+    )
     lf = pl.LazyFrame(
         {
             "id": id_,
@@ -451,7 +433,11 @@ def test_geopandas_uniqueness_checks(
     """Nullable and uniqueness violations are already correctly caught on the
     geopandas/pandas path.
     """
-    fn = _uniqueness_check_fn(with_geometry=True)
+    fn = _build_check_fn(
+        "_test__geopandas_uniqueness_checks",
+        _uniqueness_check_fields(with_geometry=True),
+        ["id", "id2"],
+    )
     gdf = gpd.GeoDataFrame(
         {
             "id": pd.array(id_, dtype="Int64"),
@@ -469,42 +455,31 @@ def test_geopandas_uniqueness_checks(
 def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
     """Schema-level and content-level errors are reported together, not either/or.
 
-    Regression test: a naive implementation runs pandera's schema-only pass
-    first and lets a `SchemaErrors` from it propagate immediately, which
-    skips the content checks entirely -- so a caller only ever sees whichever
-    kind of error happened to be found first, and has to fix-and-rerun to
-    discover the other. The two are independent, so both should show up in
-    one report.
+    Check that we don't let `SchemaErrors` from schema-only checks propagate
+    immediately, skipping the content checks entirely, meaning the caller only ever sees
+    whichever kind of error happened first, requiring them to to fix-and-rerun to
+    discover the other family of errors. The two are independent, so both should show up
+    in one error report.
     """
-    resource = Resource(
-        name="_test__combined_errors",
-        description="Synthetic resource with both a missing column and a "
-        "content-constraint violation.",
-        schema={
-            "fields": [
-                {"name": "id", "type": "integer", "description": "Primary key."},
-                {
-                    "name": "value",
-                    "type": "integer",
-                    "description": "Bounded value.",
-                    "constraints": {"minimum": 0, "maximum": 100},
-                },
-                {
-                    "name": "missing_field",
-                    "type": "string",
-                    "description": "A required field absent from the data.",
-                    "constraints": {"required": True},
-                },
-            ],
-            "primary_key": ["id"],
-        },
+    fn = _build_check_fn(
+        "_test__combined_errors",
+        [
+            {"name": "id", "type": "integer", "description": "Primary key."},
+            {
+                "name": "value",
+                "type": "integer",
+                "description": "Bounded value.",
+                "constraints": {"minimum": 0, "maximum": 100},
+            },
+            {
+                "name": "missing_field",
+                "type": "string",
+                "description": "A required field absent from the data.",
+                "constraints": {"required": True},
+            },
+        ],
+        ["id"],
     )
-    package = Package(name="_test_package", resources=[resource])
-    check = asset_check_from_schema(
-        dg.AssetKey([resource.name]), package, duckdb_asset=False
-    )
-    assert check is not None
-    fn = check.node_def.compute_fn.decorated_fn
 
     # `missing_field` is omitted entirely (schema error: column not present),
     # and `value=150` violates its maximum=100 constraint (content error).

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -43,6 +43,7 @@ from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunctio
 from shapely.geometry import Point
 
 from pudl.dagster.asset_checks import (
+    _CHUNKED_PK_CHECK_TABLES,
     _build_registry_from_descriptor,
     _validate_datapackage_unit_strings,
     asset_check_from_schema,
@@ -521,3 +522,18 @@ def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
     assert any("value" in m and "100" in m for m in messages), (
         f"Expected a value-constraint content error, got: {messages}"
     )
+
+
+def test_chunked_pk_check_tables_are_valid() -> None:
+    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
+
+    Guards against the mapping silently going stale if a listed resource's
+    primary key changes -- the chunking column must remain part of the
+    primary key, since that's what makes chunking by it exact rather than
+    approximate (see ``Resource._chunk_filters``).
+    """
+    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
+        resource = PUDL_PACKAGE.get_resource(resource_name)
+        assert field_name in resource.schema.primary_key, (
+            f"{field_name} is not part of {resource_name}'s primary key"
+        )

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -275,21 +275,41 @@ def _content_check_fields(*, with_geometry: bool) -> list[dict]:
     return fields
 
 
-_CONTENT_CHECK_CASES = [
-    (30, "a", True),
-    (150, "a", False),  # violates maximum=100
-    (30, "z", False),  # violates enum=["a", "b", "c"]
-]
-_CONTENT_CHECK_IDS = ["valid", "value_out_of_range", "code_not_in_enum"]
+def test_polars_lazyframe_content_checks_valid() -> None:
+    """Content-valid data should pass the generated asset check."""
+    fn = _build_check_fn(
+        "_test__polars_content_checks",
+        _content_check_fields(with_geometry=False),
+        ["id"],
+    )
+    lf = pl.LazyFrame({"id": [1, 2, 3], "value": [10, 20, 30], "code": ["a", "b", "a"]})
+    lf = lf.with_columns(pl.col("code").cast(pl.Categorical))
+    result = fn(lf)
+    assert result.passed is True
+    assert "unexpected_error" not in result.metadata
 
 
 @pytest.mark.parametrize(
-    ("value", "code", "expected_pass"), _CONTENT_CHECK_CASES, ids=_CONTENT_CHECK_IDS
+    ("value", "code", "expected_metadata_error"),
+    [
+        (150, "a", "'value': 150"),  # violates maximum=100
+        (30, "z", "'code': 'z'"),  # violates enum=["a", "b", "c"]
+    ],
+    ids=["value_out_of_range", "code_not_in_enum"],
 )
-def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
-    """Content (not just schema) violations should fail the generated asset check.
+def test_polars_lazyframe_content_checks_errors(
+    value, code, expected_metadata_error
+) -> None:
+    """Content (not just schema) violations should fail with informative detail.
 
-    All errors must produce SchemaErrors, not generic exceptions.
+    Checks the actual failure-case content in ``detailed_errors``, not just
+    ``passed=False`` -- that's what would catch a regression where the check
+    fails for the right row but reports the wrong column, or a generic/empty
+    error in place of the real failure case.
+
+    Regression guard: a failure must also go through the clean SchemaErrors path
+    (populating ``detailed_errors``), not fall through to the generic exception
+    handler -- see ``Resource._duplicate_primary_key_error``'s history.
     """
     fn = _build_check_fn(
         "_test__polars_content_checks",
@@ -301,15 +321,23 @@ def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
     )
     lf = lf.with_columns(pl.col("code").cast(pl.Categorical))
     result = fn(lf)
-    assert result.passed == expected_pass
-    # Regression guard: a failure must go through the clean SchemaErrors path
-    # (populating detailed_errors), not fall through to the generic exception
-    # handler -- see Resource._duplicate_primary_key_error's history.
+
+    assert result.passed is False
     assert "unexpected_error" not in result.metadata
+    messages = [e["error_message"] for e in result.metadata["detailed_errors"].data]
+    assert any(expected_metadata_error in m for m in messages), (
+        f"Expected {expected_metadata_error!r} in one of: {messages}"
+    )
 
 
 @pytest.mark.parametrize(
-    ("value", "code", "expected_pass"), _CONTENT_CHECK_CASES, ids=_CONTENT_CHECK_IDS
+    ("value", "code", "expected_pass"),
+    [
+        (30, "a", True),
+        (150, "a", False),  # violates maximum=100
+        (30, "z", False),  # violates enum=["a", "b", "c"]
+    ],
+    ids=["valid", "value_out_of_range", "code_not_in_enum"],
 )
 def test_geopandas_content_checks(value, code, expected_pass) -> None:
     """Content violations are already correctly caught on the geopandas/pandas path.
@@ -372,14 +400,48 @@ def _uniqueness_check_fields(*, with_geometry: bool) -> list[dict]:
     return fields
 
 
-_UNIQUENESS_CASES = [
-    ([1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3], True),
-    ([1, 2, 3], [1, 2, 3], [1, None, 3], [1, 2, 3], False),  # null required_field
-    ([1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 1, 3], False),  # duplicate unique_field
-    ([1, 1, 3], [1, 1, 3], [1, 2, 3], [1, 2, 3], False),  # duplicate composite PK
+_UNIQUENESS_BASE_DATA = {
+    "id": [1, 2, 3],
+    "id2": [1, 2, 3],
+    "required_field": [1, 2, 3],
+    "unique_field": [1, 2, 3],
+}
+"""Happy-path column data for the uniqueness-check fixtures below.
+
+Every error case is built from this via :func:`_uniqueness_data`, overriding only
+the column(s) it actually violates.
+"""
+
+
+def _uniqueness_data(**overrides: list) -> dict[str, list]:
+    """Override columns of :data:`_UNIQUENESS_BASE_DATA` to build a test case."""
+    return {**_UNIQUENESS_BASE_DATA, **overrides}
+
+
+def test_polars_lazyframe_uniqueness_checks_valid() -> None:
+    """Nullable- and uniqueness-valid data should pass the generated asset check."""
+    fn = _build_check_fn(
+        "_test__polars_uniqueness_checks",
+        _uniqueness_check_fields(with_geometry=False),
+        ["id", "id2"],
+    )
+    result = fn(pl.LazyFrame(_UNIQUENESS_BASE_DATA))
+    assert result.passed is True
+    assert "unexpected_error" not in result.metadata
+
+
+_UNIQUENESS_ERROR_CASES = [
+    (
+        _uniqueness_data(required_field=[1, None, 3]),
+        "non-nullable column 'required_field'",
+    ),
+    (_uniqueness_data(unique_field=[1, 1, 3]), "column 'unique_field' not unique"),
+    (
+        _uniqueness_data(id=[1, 1, 3], id2=[1, 1, 3]),
+        "('id', 'id2') not unique",
+    ),
 ]
-_UNIQUENESS_IDS = [
-    "valid",
+_UNIQUENESS_ERROR_IDS = [
     "null_in_required_field",
     "duplicate_unique_field",
     "duplicate_primary_key",
@@ -387,69 +449,110 @@ _UNIQUENESS_IDS = [
 
 
 @pytest.mark.parametrize(
-    ("id_", "id2", "required_field", "unique_field", "expected_pass"),
-    _UNIQUENESS_CASES,
-    ids=_UNIQUENESS_IDS,
+    ("data", "expected_metadata_error"),
+    _UNIQUENESS_ERROR_CASES,
+    ids=_UNIQUENESS_ERROR_IDS,
 )
-def test_polars_lazyframe_uniqueness_checks(
-    id_, id2, required_field, unique_field, expected_pass
+def test_polars_lazyframe_uniqueness_checks_errors(
+    data, expected_metadata_error
 ) -> None:
-    """Nullable and uniqueness violations should fail the generated asset check.
+    """Nullable and uniqueness violations should fail with informative detail.
 
     This resource's schema doesn't set ``chunk_field``, so composite primary-key
     uniqueness goes through :meth:`Resource.check_primary_key_polars`'s normal,
     unchunked path (see ``tests/unit/metadata/metadata_test.py`` for the chunked path
     used by PUDL's few oversized tables).
+
+    Checks the actual failure content in ``detailed_errors``, not just
+    ``passed=False`` -- that's what would catch a regression where the check fails
+    for the right row but reports the wrong column or constraint.
+
+    Regression guard: in particular, the "duplicate_primary_key" case must fail via
+    the clean SchemaErrors path, not the generic exception handler -- see
+    ``Resource._duplicate_primary_key_error``'s history.
     """
     fn = _build_check_fn(
         "_test__polars_uniqueness_checks",
         _uniqueness_check_fields(with_geometry=False),
         ["id", "id2"],
     )
-    lf = pl.LazyFrame(
+    result = fn(pl.LazyFrame(data))
+
+    assert result.passed is False
+    assert "unexpected_error" not in result.metadata
+    messages = [e["error_message"] for e in result.metadata["detailed_errors"].data]
+    assert any(expected_metadata_error in m for m in messages), (
+        f"Expected {expected_metadata_error!r} in one of: {messages}"
+    )
+
+
+def _uniqueness_geodataframe(data: dict[str, list]) -> gpd.GeoDataFrame:
+    """Build the GeoDataFrame counterpart of a :func:`_uniqueness_data` case."""
+    return gpd.GeoDataFrame(
         {
-            "id": id_,
-            "id2": id2,
-            "required_field": required_field,
-            "unique_field": unique_field,
+            "id": pd.array(data["id"], dtype="Int64"),
+            "id2": pd.array(data["id2"], dtype="Int64"),
+            "required_field": pd.array(data["required_field"], dtype="Int64"),
+            "unique_field": pd.array(data["unique_field"], dtype="Int64"),
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
         }
     )
-    result = fn(lf)
-    assert result.passed == expected_pass
-    # Regression guard: in particular, the "duplicate_primary_key" case must
-    # fail via the clean SchemaErrors path, not the generic exception handler
-    # -- see Resource._duplicate_primary_key_error's history.
+
+
+def test_geopandas_uniqueness_checks_valid() -> None:
+    """Nullable- and uniqueness-valid data should pass the generated asset check."""
+    fn = _build_check_fn(
+        "_test__geopandas_uniqueness_checks",
+        _uniqueness_check_fields(with_geometry=True),
+        ["id", "id2"],
+    )
+    result = fn(_uniqueness_geodataframe(_UNIQUENESS_BASE_DATA))
+    assert result.passed is True
     assert "unexpected_error" not in result.metadata
 
 
+_GEOPANDAS_UNIQUENESS_ERROR_CASES = [
+    (
+        _uniqueness_data(required_field=[1, None, 3]),
+        "'required_field' contains null values",
+    ),
+    (_uniqueness_data(unique_field=[1, 1, 3]), "'unique_field' contains duplicate"),
+    (
+        _uniqueness_data(id=[1, 1, 3], id2=[1, 1, 3]),
+        "('id', 'id2')' not unique",
+    ),
+]
+
+
 @pytest.mark.parametrize(
-    ("id_", "id2", "required_field", "unique_field", "expected_pass"),
-    _UNIQUENESS_CASES,
-    ids=_UNIQUENESS_IDS,
+    ("data", "expected_metadata_error"),
+    _GEOPANDAS_UNIQUENESS_ERROR_CASES,
+    ids=_UNIQUENESS_ERROR_IDS,
 )
-def test_geopandas_uniqueness_checks(
-    id_, id2, required_field, unique_field, expected_pass
-) -> None:
+def test_geopandas_uniqueness_checks_errors(data, expected_metadata_error) -> None:
     """Nullable and uniqueness violations are already correctly caught on the
-    geopandas/pandas path.
+    geopandas/pandas path, with informative detail.
+
+    Checks the actual failure content in ``detailed_errors``, not just
+    ``passed=False`` -- see the equivalent polars test for why. The pandas
+    backend's error phrasing ("series ... contains duplicate values") differs
+    from the polars backend's ("column ... not unique"), so these expected
+    substrings are backend-specific even though the underlying cases are the
+    same as :func:`test_polars_lazyframe_uniqueness_checks_errors`.
     """
     fn = _build_check_fn(
         "_test__geopandas_uniqueness_checks",
         _uniqueness_check_fields(with_geometry=True),
         ["id", "id2"],
     )
-    gdf = gpd.GeoDataFrame(
-        {
-            "id": pd.array(id_, dtype="Int64"),
-            "id2": pd.array(id2, dtype="Int64"),
-            "required_field": pd.array(required_field, dtype="Int64"),
-            "unique_field": pd.array(unique_field, dtype="Int64"),
-            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
-        }
-    )
-    result = fn(gdf)
-    assert result.passed == expected_pass
+    result = fn(_uniqueness_geodataframe(data))
+
+    assert result.passed is False
     assert "unexpected_error" not in result.metadata
+    messages = [e["error_message"] for e in result.metadata["detailed_errors"].data]
+    assert any(expected_metadata_error in m for m in messages), (
+        f"Expected {expected_metadata_error!r} in one of: {messages}"
+    )
 
 
 def test_pandera_schema_check_combines_schema_and_content_errors() -> None:

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -29,7 +29,6 @@ on each generated check is the *exact* expected type object (using ``is``, not `
 """
 
 import io
-from datetime import date
 
 import dagster as dg
 import geopandas as gpd  # noqa: ICN002
@@ -43,12 +42,8 @@ from dagster._core.definitions.asset_checks.asset_checks_definition import (
 from shapely.geometry import Point
 
 from pudl.dagster.asset_checks import (
-    _CHUNKED_PK_CHECK_TABLES,
     _build_registry_from_descriptor,
-    _chunk_filters,
-    _find_duplicate_primary_keys,
     _validate_datapackage_unit_strings,
-    _validate_primary_key_uniqueness,
     asset_check_from_schema,
     group_mean_continuity_check,
 )
@@ -416,9 +411,10 @@ def test_polars_lazyframe_uniqueness_checks(
     """Nullable and uniqueness violations should fail the generated asset check.
 
     This resource isn't in ``_CHUNKED_PK_CHECK_TABLES``, so composite
-    primary-key uniqueness goes through pandera's normal, unchunked check
-    (see ``test_validate_primary_key_by_temporal_chunk*`` for the chunked
-    path used by PUDL's few oversized tables).
+    primary-key uniqueness goes through
+    :meth:`Resource.check_primary_key_polars`'s normal, unchunked path (see
+    ``tests/unit/metadata/metadata_test.py`` for the chunked path used by
+    PUDL's few oversized tables).
     """
     fn = _uniqueness_check_fn(with_geometry=False)
     lf = pl.LazyFrame(
@@ -456,204 +452,6 @@ def test_geopandas_uniqueness_checks(
     )
     result = fn(gdf)
     assert result.passed == expected_pass
-
-
-# ---------------------------------------------------------------------------
-# Tests for chunked primary-key uniqueness checking
-# ---------------------------------------------------------------------------
-#
-# `_validate_primary_key_uniqueness` never uses pandera's built-in composite-
-# uniqueness check (too memory-hungry, see polars-comment.md); it always uses
-# its own group-by/count-based `_find_duplicate_primary_keys`, optionally run
-# once per chunk instead of once on the whole table for PUDL's few oversized
-# tables (`_CHUNKED_PK_CHECK_TABLES`). Chunking is only correct because the
-# chunking column is itself part of the primary key -- two rows with an
-# identical composite key necessarily share the same value of it, so
-# duplicates can never span chunk boundaries, whether the column is
-# date/datetime (chunked by year) or anything else (chunked by distinct
-# value). These tests exercise the machinery directly with synthetic
-# resources, independent of which real tables are currently enumerated.
-
-
-def _temporal_pk_resource() -> Resource:
-    return Resource(
-        name="_test__temporal_pk_chunking",
-        description="Synthetic resource with a temporal primary key.",
-        schema={
-            "fields": [
-                {"name": "event_date", "type": "date", "description": "Event date."},
-                {"name": "unit_id", "type": "integer", "description": "Unit ID."},
-            ],
-            "primary_key": ["event_date", "unit_id"],
-        },
-    )
-
-
-def _categorical_pk_resource() -> Resource:
-    return Resource(
-        name="_test__categorical_pk_chunking",
-        description="Synthetic resource with a string primary-key column.",
-        schema={
-            "fields": [
-                {"name": "filer_id", "type": "string", "description": "Filer ID."},
-                {
-                    "name": "record_id",
-                    "type": "integer",
-                    "description": "Record ID.",
-                },
-            ],
-            "primary_key": ["filer_id", "record_id"],
-        },
-    )
-
-
-def test_validate_primary_key_uniqueness_temporal_valid() -> None:
-    """Repeated non-key values across different years are not false positives.
-
-    ``_temporal_pk_resource`` isn't in ``_CHUNKED_PK_CHECK_TABLES``, so this
-    exercises ``_validate_primary_key_uniqueness``'s default, unchunked
-    dispatch path; ``test_chunk_filters_temporal_*`` below separately verify
-    the chunking mechanism itself preserves the same correctness.
-    """
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [
-                date(2020, 1, 1),
-                date(2020, 1, 2),
-                date(2021, 1, 1),
-                date(2021, 1, 2),
-            ],
-            # unit_id repeats across years -- fine, since event_date differs.
-            "unit_id": [1, 2, 1, 2],
-        }
-    )
-    errors = _validate_primary_key_uniqueness(lf, resource)
-    assert errors == []
-
-
-def test_validate_primary_key_uniqueness_temporal_catches_duplicate() -> None:
-    """A true duplicate composite key within one year is still caught."""
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
-            "unit_id": [1, 1, 1],
-        }
-    )
-    errors = _validate_primary_key_uniqueness(lf, resource)
-    assert len(errors) > 0
-
-
-def test_validate_primary_key_uniqueness_categorical_valid() -> None:
-    """Repeated non-key values across different filers are not false positives."""
-    resource = _categorical_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "filer_id": ["A", "A", "B", "B"],
-            # record_id repeats across filers -- fine, since filer_id differs.
-            "record_id": [1, 2, 1, 2],
-        }
-    )
-    errors = _validate_primary_key_uniqueness(lf, resource)
-    assert errors == []
-
-
-def test_validate_primary_key_uniqueness_categorical_catches_duplicate() -> None:
-    """A true duplicate composite key within one filer is still caught."""
-    resource = _categorical_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "filer_id": ["A", "A", "B"],
-            "record_id": [1, 1, 1],
-        }
-    )
-    errors = _validate_primary_key_uniqueness(lf, resource)
-    assert len(errors) > 0
-
-
-def test_chunk_filters_temporal_partitions_by_year() -> None:
-    """Temporal chunk filters split rows into non-overlapping, year-aligned sets."""
-    lf = pl.LazyFrame(
-        {"event_date": [date(2020, 1, 1), date(2020, 6, 1), date(2021, 3, 1)]}
-    )
-    filters = _chunk_filters(lf, "event_date")
-    assert len(filters) == 2  # 2020 and 2021
-    row_counts = sorted(lf.filter(f).select(pl.len()).collect().item() for f in filters)
-    assert row_counts == [1, 2]
-
-
-def test_chunk_filters_categorical_partitions_by_value() -> None:
-    """Categorical chunk filters split rows by each distinct value, exactly."""
-    lf = pl.LazyFrame({"filer_id": ["A", "A", "B"]})
-    filters = _chunk_filters(lf, "filer_id")
-    assert len(filters) == 2  # "A" and "B"
-    counts_by_value = {}
-    for f in filters:
-        chunk = lf.filter(f).collect()
-        counts_by_value[chunk["filer_id"][0]] = chunk.height
-    assert counts_by_value == {"A": 2, "B": 1}
-
-
-def test_validate_primary_key_uniqueness_no_primary_key() -> None:
-    """Resources without a primary key are trivially valid."""
-    resource = Resource(
-        name="_test__no_pk",
-        description="Synthetic resource without a primary key.",
-        schema={"fields": [{"name": "x", "type": "integer", "description": "X."}]},
-    )
-    lf = pl.LazyFrame({"x": [1, 1, 1]})
-    assert _validate_primary_key_uniqueness(lf, resource) == []
-
-
-def test_validate_primary_key_uniqueness_rejects_bad_chunk_field(mocker) -> None:
-    """A chunk field that isn't part of the primary key is a config error.
-
-    Chunking is only exact (see `_chunk_filters`) when the chunk column is
-    part of the primary key -- if `_CHUNKED_PK_CHECK_TABLES` is ever
-    misconfigured with a column that isn't, that has to fail loudly rather
-    than silently produce an incomplete uniqueness check.
-    """
-    resource = Resource(
-        name="_test__bad_chunk_field",
-        description="Synthetic resource for testing chunk-field misconfiguration.",
-        schema={
-            "fields": [
-                {"name": "id", "type": "integer", "description": "Primary key."},
-                {"name": "other", "type": "integer", "description": "Not in the PK."},
-            ],
-            "primary_key": ["id"],
-        },
-    )
-    mocker.patch.dict(_CHUNKED_PK_CHECK_TABLES, {resource.name: "other"})
-    lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
-    with pytest.raises(AssertionError, match="isn't part of"):
-        _validate_primary_key_uniqueness(lf, resource)
-
-
-def test_find_duplicate_primary_keys() -> None:
-    """The underlying group-by/count reduction correctly identifies duplicates."""
-    lf = pl.LazyFrame({"a": [1, 1, 2], "b": ["x", "x", "y"]})
-    duplicates = _find_duplicate_primary_keys(lf, ["a", "b"])
-    assert duplicates.height == 1
-    assert duplicates["a"][0] == 1
-    assert duplicates["b"][0] == "x"
-    assert duplicates["_pk_count"][0] == 2
-
-
-def test_chunked_pk_check_tables_are_valid() -> None:
-    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
-
-    Guards against the mapping silently going stale if a listed resource's
-    primary key changes -- the chunking column must remain part of the
-    primary key, since that's what makes chunking by it exact rather than
-    approximate.
-    """
-    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
-        resource = PUDL_PACKAGE.get_resource(resource_name)
-        assert field_name in resource.schema.primary_key, (
-            f"{field_name} is not part of {resource_name}'s primary key"
-        )
 
 
 def test_pandera_schema_check_combines_schema_and_content_errors() -> None:

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -298,6 +298,10 @@ def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
     lf = lf.with_columns(pl.col("code").cast(pl.Categorical))
     result = fn(lf)
     assert result.passed == expected_pass
+    # Regression guard: a failure must go through the clean SchemaErrors path
+    # (populating detailed_errors), not fall through to the generic exception
+    # handler -- see Resource._duplicate_primary_key_error's history.
+    assert "unexpected_error" not in result.metadata
 
 
 @pytest.mark.parametrize(
@@ -328,6 +332,7 @@ def test_geopandas_content_checks(value, code, expected_pass) -> None:
     )
     result = fn(gdf)
     assert result.passed == expected_pass
+    assert "unexpected_error" not in result.metadata
 
 
 # ---------------------------------------------------------------------------
@@ -429,6 +434,10 @@ def test_polars_lazyframe_uniqueness_checks(
     )
     result = fn(lf)
     assert result.passed == expected_pass
+    # Regression guard: in particular, the "duplicate_primary_key" case must
+    # fail via the clean SchemaErrors path, not the generic exception handler
+    # -- see Resource._duplicate_primary_key_error's history.
+    assert "unexpected_error" not in result.metadata
 
 
 @pytest.mark.parametrize(
@@ -454,6 +463,7 @@ def test_geopandas_uniqueness_checks(
     )
     result = fn(gdf)
     assert result.passed == expected_pass
+    assert "unexpected_error" not in result.metadata
 
 
 def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
@@ -502,6 +512,7 @@ def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
     result = fn(lf)
 
     assert result.passed is False
+    assert "unexpected_error" not in result.metadata
     detailed_errors = result.metadata["detailed_errors"].data
     messages = [e["error_message"] for e in detailed_errors]
     assert any("missing_field" in m for m in messages), (

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -296,6 +296,10 @@ def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
     lf = lf.with_columns(pl.col("code").cast(pl.Categorical))
     result = fn(lf)
     assert result.passed == expected_pass
+    # Regression guard: a failure must go through the clean SchemaErrors path
+    # (populating detailed_errors), not fall through to the generic exception
+    # handler -- see Resource._duplicate_primary_key_error's history.
+    assert "unexpected_error" not in result.metadata
 
 
 @pytest.mark.parametrize(
@@ -326,6 +330,7 @@ def test_geopandas_content_checks(value, code, expected_pass) -> None:
     )
     result = fn(gdf)
     assert result.passed == expected_pass
+    assert "unexpected_error" not in result.metadata
 
 
 # ---------------------------------------------------------------------------
@@ -427,6 +432,10 @@ def test_polars_lazyframe_uniqueness_checks(
     )
     result = fn(lf)
     assert result.passed == expected_pass
+    # Regression guard: in particular, the "duplicate_primary_key" case must
+    # fail via the clean SchemaErrors path, not the generic exception handler
+    # -- see Resource._duplicate_primary_key_error's history.
+    assert "unexpected_error" not in result.metadata
 
 
 @pytest.mark.parametrize(
@@ -452,6 +461,7 @@ def test_geopandas_uniqueness_checks(
     )
     result = fn(gdf)
     assert result.passed == expected_pass
+    assert "unexpected_error" not in result.metadata
 
 
 def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
@@ -500,6 +510,7 @@ def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
     result = fn(lf)
 
     assert result.passed is False
+    assert "unexpected_error" not in result.metadata
     detailed_errors = result.metadata["detailed_errors"].data
     messages = [e["error_message"] for e in detailed_errors]
     assert any("missing_field" in m for m in messages), (

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -29,8 +29,10 @@ on each generated check is the *exact* expected type object (using ``is``, not `
 """
 
 import io
+from datetime import date
 
 import dagster as dg
+import geopandas as gpd  # noqa: ICN002
 import pandas as pd
 import pint
 import polars as pl
@@ -38,15 +40,20 @@ import pytest
 from dagster._core.definitions.asset_checks.asset_checks_definition import (
     AssetChecksDefinition,
 )
+from shapely.geometry import Point
 
 from pudl.dagster.asset_checks import (
+    _CHUNKED_PK_CHECK_TABLES,
     _build_registry_from_descriptor,
+    _chunk_filters,
+    _find_duplicate_primary_keys,
     _validate_datapackage_unit_strings,
+    _validate_primary_key_uniqueness,
     asset_check_from_schema,
     group_mean_continuity_check,
 )
 from pudl.helpers import ParquetData
-from pudl.metadata.classes import PUDL_PACKAGE
+from pudl.metadata.classes import PUDL_PACKAGE, Package, Resource
 from pudl.metadata.units import PUDL_UNIT_DEFINITIONS
 
 
@@ -207,4 +214,499 @@ def test_validate_datapackage_unit_strings_missing_registry() -> None:
     assert len(errors) == 1
     assert "Could not build unit registry" in errors[0], (
         f"Unexpected error message: {errors[0]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests for content-level (not just schema-level) validation
+# ---------------------------------------------------------------------------
+#
+# Pandera's Polars backend forces SCHEMA_ONLY validation depth for LazyFrame
+# inputs unless validation depth is explicitly configured (see
+# pandera.api.polars.utils.get_validation_depth). PUDL never configures it, so
+# pandera_schema_check currently verifies column presence and dtypes for every
+# Polars LazyFrame asset (the vast majority of PUDL tables), but silently skips
+# every Check.ge/Check.le/Check.isin/uniqueness constraint declared in PUDL's
+# metadata. The pandas/geopandas backend has no such override and already
+# enforces those checks. These tests use synthetic, minimal resources (rather
+# than real PUDL tables) so the fixtures stay small and independent of
+# unrelated metadata changes.
+
+
+def _content_check_fields(*, with_geometry: bool) -> list[dict]:
+    """Shared field set for the polars and geopandas content-check fixtures."""
+    fields = [
+        {"name": "id", "type": "integer", "description": "Primary key."},
+        {
+            "name": "value",
+            "type": "integer",
+            "description": "Value bounded to [0, 100].",
+            "constraints": {"minimum": 0, "maximum": 100},
+        },
+        {
+            "name": "code",
+            "type": "string",
+            "description": "Enum-constrained code.",
+            "constraints": {"enum": ["a", "b", "c"]},
+        },
+    ]
+    if with_geometry:
+        fields.append(
+            {"name": "geometry", "type": "geometry", "description": "Geometry."}
+        )
+    return fields
+
+
+def _content_check_fn(*, with_geometry: bool):
+    """Build the generated ``pandera_schema_check`` function for a synthetic resource."""
+    resource = Resource(
+        name="_test__geopandas_content_checks"
+        if with_geometry
+        else "_test__polars_content_checks",
+        description="Synthetic resource for asset-check content-validation tests.",
+        schema={
+            "fields": _content_check_fields(with_geometry=with_geometry),
+            "primary_key": ["id"],
+        },
+    )
+    package = Package(name="_test_package", resources=[resource])
+    check = asset_check_from_schema(
+        dg.AssetKey([resource.name]), package, duckdb_asset=False
+    )
+    assert check is not None
+    return check.node_def.compute_fn.decorated_fn
+
+
+@pytest.mark.parametrize(
+    ("value", "code", "expected_pass"),
+    [
+        (30, "a", True),
+        (150, "a", False),  # violates maximum=100
+        (30, "z", False),  # violates enum=["a", "b", "c"]
+    ],
+    ids=["valid", "value_out_of_range", "code_not_in_enum"],
+)
+def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
+    """Content (not just schema) violations should fail the generated asset check.
+
+    As of this writing, pandera's Polars backend does not enforce content-level
+    checks (Check.ge/le/isin/etc.) on ``pl.LazyFrame`` inputs by default, so the
+    two violation cases here are expected to incorrectly report ``passed=True``
+    until that is fixed.
+    """
+    fn = _content_check_fn(with_geometry=False)
+    lf = pl.LazyFrame(
+        {"id": [1, 2, 3], "value": [10, 20, value], "code": ["a", "b", code]}
+    )
+    lf = lf.with_columns(pl.col("code").cast(pl.Categorical))
+    result = fn(lf)
+    assert result.passed == expected_pass
+
+
+@pytest.mark.parametrize(
+    ("value", "code", "expected_pass"),
+    [
+        (30, "a", True),
+        (150, "a", False),  # violates maximum=100
+        (30, "z", False),  # violates enum=["a", "b", "c"]
+    ],
+    ids=["valid", "value_out_of_range", "code_not_in_enum"],
+)
+def test_geopandas_content_checks(value, code, expected_pass) -> None:
+    """Content violations are already correctly caught on the geopandas/pandas path.
+
+    Geometry-bearing tables use pandera's pandas backend
+    (:func:`pudl.metadata.classes.Schema.to_pandera`), which has no
+    LazyFrame-specific validation-depth override, so these checks already run
+    today and all three cases are expected to pass as written.
+    """
+    fn = _content_check_fn(with_geometry=True)
+    gdf = gpd.GeoDataFrame(
+        {
+            "id": pd.array([1, 2, 3], dtype="Int64"),
+            "value": pd.array([10, 20, value], dtype="Int64"),
+            "code": pd.Categorical(["a", "b", code]),
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        }
+    )
+    result = fn(gdf)
+    assert result.passed == expected_pass
+
+
+# ---------------------------------------------------------------------------
+# Tests for nullable/uniqueness validation
+# ---------------------------------------------------------------------------
+#
+# These constraints are structurally different from the Check-based value/enum
+# constraints above: `required` maps to `Column(nullable=...)`, single-column
+# `unique` maps to `Column(unique=...)`, and the primary key maps to a
+# DataFrame-level `unique=[...]` composite check
+# (see Field.to_pandera_column and Schema.to_pandera). They go through
+# different pandera code than Check.ge/le/isin, so they're tested separately
+# rather than assumed to be fixed by the same code path.
+
+
+def _uniqueness_check_fields(*, with_geometry: bool) -> list[dict]:
+    """Shared field set for the polars and geopandas uniqueness-check fixtures."""
+    fields = [
+        {"name": "id", "type": "integer", "description": "Primary key, part 1."},
+        {"name": "id2", "type": "integer", "description": "Primary key, part 2."},
+        {
+            "name": "required_field",
+            "type": "integer",
+            "description": "Non-nullable, non-key field.",
+            "constraints": {"required": True},
+        },
+        {
+            "name": "unique_field",
+            "type": "integer",
+            "description": "Single-column uniqueness constraint.",
+            "constraints": {"unique": True},
+        },
+    ]
+    if with_geometry:
+        fields.append(
+            {"name": "geometry", "type": "geometry", "description": "Geometry."}
+        )
+    return fields
+
+
+def _uniqueness_check_fn(*, with_geometry: bool):
+    """Build the generated ``pandera_schema_check`` function for a synthetic resource."""
+    resource = Resource(
+        name="_test__geopandas_uniqueness_checks"
+        if with_geometry
+        else "_test__polars_uniqueness_checks",
+        description="Synthetic resource for asset-check uniqueness-validation tests.",
+        schema={
+            "fields": _uniqueness_check_fields(with_geometry=with_geometry),
+            "primary_key": ["id", "id2"],
+        },
+    )
+    package = Package(name="_test_package", resources=[resource])
+    check = asset_check_from_schema(
+        dg.AssetKey([resource.name]), package, duckdb_asset=False
+    )
+    assert check is not None
+    return check.node_def.compute_fn.decorated_fn
+
+
+_UNIQUENESS_CASES = [
+    ([1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3], True),
+    ([1, 2, 3], [1, 2, 3], [1, None, 3], [1, 2, 3], False),  # null required_field
+    ([1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 1, 3], False),  # duplicate unique_field
+    ([1, 1, 3], [1, 1, 3], [1, 2, 3], [1, 2, 3], False),  # duplicate composite PK
+]
+_UNIQUENESS_IDS = [
+    "valid",
+    "null_in_required_field",
+    "duplicate_unique_field",
+    "duplicate_primary_key",
+]
+
+
+@pytest.mark.parametrize(
+    ("id_", "id2", "required_field", "unique_field", "expected_pass"),
+    _UNIQUENESS_CASES,
+    ids=_UNIQUENESS_IDS,
+)
+def test_polars_lazyframe_uniqueness_checks(
+    id_, id2, required_field, unique_field, expected_pass
+) -> None:
+    """Nullable and uniqueness violations should fail the generated asset check.
+
+    This resource isn't in ``_CHUNKED_PK_CHECK_TABLES``, so composite
+    primary-key uniqueness goes through pandera's normal, unchunked check
+    (see ``test_validate_primary_key_by_temporal_chunk*`` for the chunked
+    path used by PUDL's few oversized tables).
+    """
+    fn = _uniqueness_check_fn(with_geometry=False)
+    lf = pl.LazyFrame(
+        {
+            "id": id_,
+            "id2": id2,
+            "required_field": required_field,
+            "unique_field": unique_field,
+        }
+    )
+    result = fn(lf)
+    assert result.passed == expected_pass
+
+
+@pytest.mark.parametrize(
+    ("id_", "id2", "required_field", "unique_field", "expected_pass"),
+    _UNIQUENESS_CASES,
+    ids=_UNIQUENESS_IDS,
+)
+def test_geopandas_uniqueness_checks(
+    id_, id2, required_field, unique_field, expected_pass
+) -> None:
+    """Nullable and uniqueness violations are already correctly caught on the
+    geopandas/pandas path.
+    """
+    fn = _uniqueness_check_fn(with_geometry=True)
+    gdf = gpd.GeoDataFrame(
+        {
+            "id": pd.array(id_, dtype="Int64"),
+            "id2": pd.array(id2, dtype="Int64"),
+            "required_field": pd.array(required_field, dtype="Int64"),
+            "unique_field": pd.array(unique_field, dtype="Int64"),
+            "geometry": [Point(0, 0), Point(1, 1), Point(2, 2)],
+        }
+    )
+    result = fn(gdf)
+    assert result.passed == expected_pass
+
+
+# ---------------------------------------------------------------------------
+# Tests for chunked primary-key uniqueness checking
+# ---------------------------------------------------------------------------
+#
+# `_validate_primary_key_uniqueness` never uses pandera's built-in composite-
+# uniqueness check (too memory-hungry, see polars-comment.md); it always uses
+# its own group-by/count-based `_find_duplicate_primary_keys`, optionally run
+# once per chunk instead of once on the whole table for PUDL's few oversized
+# tables (`_CHUNKED_PK_CHECK_TABLES`). Chunking is only correct because the
+# chunking column is itself part of the primary key -- two rows with an
+# identical composite key necessarily share the same value of it, so
+# duplicates can never span chunk boundaries, whether the column is
+# date/datetime (chunked by year) or anything else (chunked by distinct
+# value). These tests exercise the machinery directly with synthetic
+# resources, independent of which real tables are currently enumerated.
+
+
+def _temporal_pk_resource() -> Resource:
+    return Resource(
+        name="_test__temporal_pk_chunking",
+        description="Synthetic resource with a temporal primary key.",
+        schema={
+            "fields": [
+                {"name": "event_date", "type": "date", "description": "Event date."},
+                {"name": "unit_id", "type": "integer", "description": "Unit ID."},
+            ],
+            "primary_key": ["event_date", "unit_id"],
+        },
+    )
+
+
+def _categorical_pk_resource() -> Resource:
+    return Resource(
+        name="_test__categorical_pk_chunking",
+        description="Synthetic resource with a string primary-key column.",
+        schema={
+            "fields": [
+                {"name": "filer_id", "type": "string", "description": "Filer ID."},
+                {
+                    "name": "record_id",
+                    "type": "integer",
+                    "description": "Record ID.",
+                },
+            ],
+            "primary_key": ["filer_id", "record_id"],
+        },
+    )
+
+
+def test_validate_primary_key_uniqueness_temporal_valid() -> None:
+    """Repeated non-key values across different years are not false positives.
+
+    ``_temporal_pk_resource`` isn't in ``_CHUNKED_PK_CHECK_TABLES``, so this
+    exercises ``_validate_primary_key_uniqueness``'s default, unchunked
+    dispatch path; ``test_chunk_filters_temporal_*`` below separately verify
+    the chunking mechanism itself preserves the same correctness.
+    """
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [
+                date(2020, 1, 1),
+                date(2020, 1, 2),
+                date(2021, 1, 1),
+                date(2021, 1, 2),
+            ],
+            # unit_id repeats across years -- fine, since event_date differs.
+            "unit_id": [1, 2, 1, 2],
+        }
+    )
+    errors = _validate_primary_key_uniqueness(lf, resource)
+    assert errors == []
+
+
+def test_validate_primary_key_uniqueness_temporal_catches_duplicate() -> None:
+    """A true duplicate composite key within one year is still caught."""
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
+            "unit_id": [1, 1, 1],
+        }
+    )
+    errors = _validate_primary_key_uniqueness(lf, resource)
+    assert len(errors) > 0
+
+
+def test_validate_primary_key_uniqueness_categorical_valid() -> None:
+    """Repeated non-key values across different filers are not false positives."""
+    resource = _categorical_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "filer_id": ["A", "A", "B", "B"],
+            # record_id repeats across filers -- fine, since filer_id differs.
+            "record_id": [1, 2, 1, 2],
+        }
+    )
+    errors = _validate_primary_key_uniqueness(lf, resource)
+    assert errors == []
+
+
+def test_validate_primary_key_uniqueness_categorical_catches_duplicate() -> None:
+    """A true duplicate composite key within one filer is still caught."""
+    resource = _categorical_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "filer_id": ["A", "A", "B"],
+            "record_id": [1, 1, 1],
+        }
+    )
+    errors = _validate_primary_key_uniqueness(lf, resource)
+    assert len(errors) > 0
+
+
+def test_chunk_filters_temporal_partitions_by_year() -> None:
+    """Temporal chunk filters split rows into non-overlapping, year-aligned sets."""
+    lf = pl.LazyFrame(
+        {"event_date": [date(2020, 1, 1), date(2020, 6, 1), date(2021, 3, 1)]}
+    )
+    filters = _chunk_filters(lf, "event_date")
+    assert len(filters) == 2  # 2020 and 2021
+    row_counts = sorted(lf.filter(f).select(pl.len()).collect().item() for f in filters)
+    assert row_counts == [1, 2]
+
+
+def test_chunk_filters_categorical_partitions_by_value() -> None:
+    """Categorical chunk filters split rows by each distinct value, exactly."""
+    lf = pl.LazyFrame({"filer_id": ["A", "A", "B"]})
+    filters = _chunk_filters(lf, "filer_id")
+    assert len(filters) == 2  # "A" and "B"
+    counts_by_value = {}
+    for f in filters:
+        chunk = lf.filter(f).collect()
+        counts_by_value[chunk["filer_id"][0]] = chunk.height
+    assert counts_by_value == {"A": 2, "B": 1}
+
+
+def test_validate_primary_key_uniqueness_no_primary_key() -> None:
+    """Resources without a primary key are trivially valid."""
+    resource = Resource(
+        name="_test__no_pk",
+        description="Synthetic resource without a primary key.",
+        schema={"fields": [{"name": "x", "type": "integer", "description": "X."}]},
+    )
+    lf = pl.LazyFrame({"x": [1, 1, 1]})
+    assert _validate_primary_key_uniqueness(lf, resource) == []
+
+
+def test_validate_primary_key_uniqueness_rejects_bad_chunk_field(mocker) -> None:
+    """A chunk field that isn't part of the primary key is a config error.
+
+    Chunking is only exact (see `_chunk_filters`) when the chunk column is
+    part of the primary key -- if `_CHUNKED_PK_CHECK_TABLES` is ever
+    misconfigured with a column that isn't, that has to fail loudly rather
+    than silently produce an incomplete uniqueness check.
+    """
+    resource = Resource(
+        name="_test__bad_chunk_field",
+        description="Synthetic resource for testing chunk-field misconfiguration.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."},
+                {"name": "other", "type": "integer", "description": "Not in the PK."},
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    mocker.patch.dict(_CHUNKED_PK_CHECK_TABLES, {resource.name: "other"})
+    lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
+    with pytest.raises(AssertionError, match="isn't part of"):
+        _validate_primary_key_uniqueness(lf, resource)
+
+
+def test_find_duplicate_primary_keys() -> None:
+    """The underlying group-by/count reduction correctly identifies duplicates."""
+    lf = pl.LazyFrame({"a": [1, 1, 2], "b": ["x", "x", "y"]})
+    duplicates = _find_duplicate_primary_keys(lf, ["a", "b"])
+    assert duplicates.height == 1
+    assert duplicates["a"][0] == 1
+    assert duplicates["b"][0] == "x"
+    assert duplicates["_pk_count"][0] == 2
+
+
+def test_chunked_pk_check_tables_are_valid() -> None:
+    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
+
+    Guards against the mapping silently going stale if a listed resource's
+    primary key changes -- the chunking column must remain part of the
+    primary key, since that's what makes chunking by it exact rather than
+    approximate.
+    """
+    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
+        resource = PUDL_PACKAGE.get_resource(resource_name)
+        assert field_name in resource.schema.primary_key, (
+            f"{field_name} is not part of {resource_name}'s primary key"
+        )
+
+
+def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
+    """Schema-level and content-level errors are reported together, not either/or.
+
+    Regression test: a naive implementation runs pandera's schema-only pass
+    first and lets a `SchemaErrors` from it propagate immediately, which
+    skips the content checks entirely -- so a caller only ever sees whichever
+    kind of error happened to be found first, and has to fix-and-rerun to
+    discover the other. The two are independent, so both should show up in
+    one report.
+    """
+    resource = Resource(
+        name="_test__combined_errors",
+        description="Synthetic resource with both a missing column and a "
+        "content-constraint violation.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."},
+                {
+                    "name": "value",
+                    "type": "integer",
+                    "description": "Bounded value.",
+                    "constraints": {"minimum": 0, "maximum": 100},
+                },
+                {
+                    "name": "missing_field",
+                    "type": "string",
+                    "description": "A required field absent from the data.",
+                    "constraints": {"required": True},
+                },
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    package = Package(name="_test_package", resources=[resource])
+    check = asset_check_from_schema(
+        dg.AssetKey([resource.name]), package, duckdb_asset=False
+    )
+    assert check is not None
+    fn = check.node_def.compute_fn.decorated_fn
+
+    # `missing_field` is omitted entirely (schema error: column not present),
+    # and `value=150` violates its maximum=100 constraint (content error).
+    lf = pl.LazyFrame({"id": [1, 2], "value": [10, 150]})
+    result = fn(lf)
+
+    assert result.passed is False
+    detailed_errors = result.metadata["detailed_errors"].data
+    messages = [e["error_message"] for e in detailed_errors]
+    assert any("missing_field" in m for m in messages), (
+        f"Expected a missing-column schema error, got: {messages}"
+    )
+    assert any("value" in m and "100" in m for m in messages), (
+        f"Expected a value-constraint content error, got: {messages}"
     )

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -57,6 +57,7 @@ from pudl.metadata.units import PUDL_UNIT_DEFINITIONS
     [
         ("core_pudl__codes_subdivisions", False, pl.LazyFrame),
         ("core_ferceqr__contracts", True, ParquetData),
+        ("out_censusdp1tract__counties", False, gpd.GeoDataFrame),
     ],
 )
 def test_asset_checks_preserve_runtime_input_types(
@@ -228,6 +229,26 @@ def test_validate_datapackage_unit_strings_missing_registry() -> None:
 # unrelated metadata changes.
 
 
+def _build_check_fn(name: str, fields: list[dict], primary_key: list[str]):
+    """Build the generated ``pandera_schema_check`` function for a synthetic resource.
+
+    Shared by every synthetic-resource asset-check test below, so each one only
+    has to supply what actually varies: the resource name, its fields, and its
+    primary key.
+    """
+    resource = Resource(
+        name=name,
+        description="Synthetic resource for asset-check tests.",
+        schema={"fields": fields, "primary_key": primary_key},
+    )
+    package = Package(name="_test_package", resources=[resource])
+    check = asset_check_from_schema(
+        dg.AssetKey([resource.name]), package, duckdb_asset=False
+    )
+    assert check is not None
+    return check.node_def.compute_fn.decorated_fn
+
+
 def _content_check_fields(*, with_geometry: bool) -> list[dict]:
     """Shared field set for the polars and geopandas content-check fixtures."""
     fields = [
@@ -252,44 +273,27 @@ def _content_check_fields(*, with_geometry: bool) -> list[dict]:
     return fields
 
 
-def _content_check_fn(*, with_geometry: bool):
-    """Build the generated ``pandera_schema_check`` function for a synthetic resource."""
-    resource = Resource(
-        name="_test__geopandas_content_checks"
-        if with_geometry
-        else "_test__polars_content_checks",
-        description="Synthetic resource for asset-check content-validation tests.",
-        schema={
-            "fields": _content_check_fields(with_geometry=with_geometry),
-            "primary_key": ["id"],
-        },
-    )
-    package = Package(name="_test_package", resources=[resource])
-    check = asset_check_from_schema(
-        dg.AssetKey([resource.name]), package, duckdb_asset=False
-    )
-    assert check is not None
-    return check.node_def.compute_fn.decorated_fn
+_CONTENT_CHECK_CASES = [
+    (30, "a", True),
+    (150, "a", False),  # violates maximum=100
+    (30, "z", False),  # violates enum=["a", "b", "c"]
+]
+_CONTENT_CHECK_IDS = ["valid", "value_out_of_range", "code_not_in_enum"]
 
 
 @pytest.mark.parametrize(
-    ("value", "code", "expected_pass"),
-    [
-        (30, "a", True),
-        (150, "a", False),  # violates maximum=100
-        (30, "z", False),  # violates enum=["a", "b", "c"]
-    ],
-    ids=["valid", "value_out_of_range", "code_not_in_enum"],
+    ("value", "code", "expected_pass"), _CONTENT_CHECK_CASES, ids=_CONTENT_CHECK_IDS
 )
 def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
     """Content (not just schema) violations should fail the generated asset check.
 
-    As of this writing, pandera's Polars backend does not enforce content-level
-    checks (Check.ge/le/isin/etc.) on ``pl.LazyFrame`` inputs by default, so the
-    two violation cases here are expected to incorrectly report ``passed=True``
-    until that is fixed.
+    All errors must produce SchemaErrors, not generic exceptions.
     """
-    fn = _content_check_fn(with_geometry=False)
+    fn = _build_check_fn(
+        "_test__polars_content_checks",
+        _content_check_fields(with_geometry=False),
+        ["id"],
+    )
     lf = pl.LazyFrame(
         {"id": [1, 2, 3], "value": [10, 20, value], "code": ["a", "b", code]}
     )
@@ -303,23 +307,18 @@ def test_polars_lazyframe_content_checks(value, code, expected_pass) -> None:
 
 
 @pytest.mark.parametrize(
-    ("value", "code", "expected_pass"),
-    [
-        (30, "a", True),
-        (150, "a", False),  # violates maximum=100
-        (30, "z", False),  # violates enum=["a", "b", "c"]
-    ],
-    ids=["valid", "value_out_of_range", "code_not_in_enum"],
+    ("value", "code", "expected_pass"), _CONTENT_CHECK_CASES, ids=_CONTENT_CHECK_IDS
 )
 def test_geopandas_content_checks(value, code, expected_pass) -> None:
     """Content violations are already correctly caught on the geopandas/pandas path.
 
-    Geometry-bearing tables use pandera's pandas backend
-    (:func:`pudl.metadata.classes.Schema.to_pandera`), which has no
-    LazyFrame-specific validation-depth override, so these checks already run
-    today and all three cases are expected to pass as written.
+    All errors must produce SchemaErrors, not generic exceptions.
     """
-    fn = _content_check_fn(with_geometry=True)
+    fn = _build_check_fn(
+        "_test__geopandas_content_checks",
+        _content_check_fields(with_geometry=True),
+        ["id"],
+    )
     gdf = gpd.GeoDataFrame(
         {
             "id": pd.array([1, 2, 3], dtype="Int64"),
@@ -371,26 +370,6 @@ def _uniqueness_check_fields(*, with_geometry: bool) -> list[dict]:
     return fields
 
 
-def _uniqueness_check_fn(*, with_geometry: bool):
-    """Build the generated ``pandera_schema_check`` function for a synthetic resource."""
-    resource = Resource(
-        name="_test__geopandas_uniqueness_checks"
-        if with_geometry
-        else "_test__polars_uniqueness_checks",
-        description="Synthetic resource for asset-check uniqueness-validation tests.",
-        schema={
-            "fields": _uniqueness_check_fields(with_geometry=with_geometry),
-            "primary_key": ["id", "id2"],
-        },
-    )
-    package = Package(name="_test_package", resources=[resource])
-    check = asset_check_from_schema(
-        dg.AssetKey([resource.name]), package, duckdb_asset=False
-    )
-    assert check is not None
-    return check.node_def.compute_fn.decorated_fn
-
-
 _UNIQUENESS_CASES = [
     ([1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3], True),
     ([1, 2, 3], [1, 2, 3], [1, None, 3], [1, 2, 3], False),  # null required_field
@@ -415,13 +394,16 @@ def test_polars_lazyframe_uniqueness_checks(
 ) -> None:
     """Nullable and uniqueness violations should fail the generated asset check.
 
-    This resource's schema doesn't set ``chunk_field``, so composite
-    primary-key uniqueness goes through
-    :meth:`Resource.check_primary_key_polars`'s normal, unchunked path (see
-    ``tests/unit/metadata/metadata_test.py`` for the chunked path used by
-    PUDL's few oversized tables).
+    This resource's schema doesn't set ``chunk_field``, so composite primary-key
+    uniqueness goes through :meth:`Resource.check_primary_key_polars`'s normal,
+    unchunked path (see ``tests/unit/metadata/metadata_test.py`` for the chunked path
+    used by PUDL's few oversized tables).
     """
-    fn = _uniqueness_check_fn(with_geometry=False)
+    fn = _build_check_fn(
+        "_test__polars_uniqueness_checks",
+        _uniqueness_check_fields(with_geometry=False),
+        ["id", "id2"],
+    )
     lf = pl.LazyFrame(
         {
             "id": id_,
@@ -449,7 +431,11 @@ def test_geopandas_uniqueness_checks(
     """Nullable and uniqueness violations are already correctly caught on the
     geopandas/pandas path.
     """
-    fn = _uniqueness_check_fn(with_geometry=True)
+    fn = _build_check_fn(
+        "_test__geopandas_uniqueness_checks",
+        _uniqueness_check_fields(with_geometry=True),
+        ["id", "id2"],
+    )
     gdf = gpd.GeoDataFrame(
         {
             "id": pd.array(id_, dtype="Int64"),
@@ -467,42 +453,31 @@ def test_geopandas_uniqueness_checks(
 def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
     """Schema-level and content-level errors are reported together, not either/or.
 
-    Regression test: a naive implementation runs pandera's schema-only pass
-    first and lets a `SchemaErrors` from it propagate immediately, which
-    skips the content checks entirely -- so a caller only ever sees whichever
-    kind of error happened to be found first, and has to fix-and-rerun to
-    discover the other. The two are independent, so both should show up in
-    one report.
+    Check that we don't let `SchemaErrors` from schema-only checks propagate
+    immediately, skipping the content checks entirely, meaning the caller only ever sees
+    whichever kind of error happened first, requiring them to to fix-and-rerun to
+    discover the other family of errors. The two are independent, so both should show up
+    in one error report.
     """
-    resource = Resource(
-        name="_test__combined_errors",
-        description="Synthetic resource with both a missing column and a "
-        "content-constraint violation.",
-        schema={
-            "fields": [
-                {"name": "id", "type": "integer", "description": "Primary key."},
-                {
-                    "name": "value",
-                    "type": "integer",
-                    "description": "Bounded value.",
-                    "constraints": {"minimum": 0, "maximum": 100},
-                },
-                {
-                    "name": "missing_field",
-                    "type": "string",
-                    "description": "A required field absent from the data.",
-                    "constraints": {"required": True},
-                },
-            ],
-            "primary_key": ["id"],
-        },
+    fn = _build_check_fn(
+        "_test__combined_errors",
+        [
+            {"name": "id", "type": "integer", "description": "Primary key."},
+            {
+                "name": "value",
+                "type": "integer",
+                "description": "Bounded value.",
+                "constraints": {"minimum": 0, "maximum": 100},
+            },
+            {
+                "name": "missing_field",
+                "type": "string",
+                "description": "A required field absent from the data.",
+                "constraints": {"required": True},
+            },
+        ],
+        ["id"],
     )
-    package = Package(name="_test_package", resources=[resource])
-    check = asset_check_from_schema(
-        dg.AssetKey([resource.name]), package, duckdb_asset=False
-    )
-    assert check is not None
-    fn = check.node_def.compute_fn.decorated_fn
 
     # `missing_field` is omitted entirely (schema error: column not present),
     # and `value=150` violates its maximum=100 constraint (content error).

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -29,7 +29,6 @@ on each generated check is the *exact* expected type object (using ``is``, not `
 """
 
 import io
-from datetime import date
 
 import dagster as dg
 import geopandas as gpd  # noqa: ICN002
@@ -44,12 +43,8 @@ from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunctio
 from shapely.geometry import Point
 
 from pudl.dagster.asset_checks import (
-    _CHUNKED_PK_CHECK_TABLES,
     _build_registry_from_descriptor,
-    _chunk_filters,
-    _find_duplicate_primary_keys,
     _validate_datapackage_unit_strings,
-    _validate_primary_key_uniqueness,
     asset_check_from_schema,
     group_mean_continuity_check,
 )
@@ -418,9 +413,10 @@ def test_polars_lazyframe_uniqueness_checks(
     """Nullable and uniqueness violations should fail the generated asset check.
 
     This resource isn't in ``_CHUNKED_PK_CHECK_TABLES``, so composite
-    primary-key uniqueness goes through pandera's normal, unchunked check
-    (see ``test_validate_primary_key_by_temporal_chunk*`` for the chunked
-    path used by PUDL's few oversized tables).
+    primary-key uniqueness goes through
+    :meth:`Resource.check_primary_key_polars`'s normal, unchunked path (see
+    ``tests/unit/metadata/metadata_test.py`` for the chunked path used by
+    PUDL's few oversized tables).
     """
     fn = _uniqueness_check_fn(with_geometry=False)
     lf = pl.LazyFrame(
@@ -458,204 +454,6 @@ def test_geopandas_uniqueness_checks(
     )
     result = fn(gdf)
     assert result.passed == expected_pass
-
-
-# ---------------------------------------------------------------------------
-# Tests for chunked primary-key uniqueness checking
-# ---------------------------------------------------------------------------
-#
-# `_validate_primary_key_uniqueness` never uses pandera's built-in composite-
-# uniqueness check (too memory-hungry, see polars-comment.md); it always uses
-# its own group-by/count-based `_find_duplicate_primary_keys`, optionally run
-# once per chunk instead of once on the whole table for PUDL's few oversized
-# tables (`_CHUNKED_PK_CHECK_TABLES`). Chunking is only correct because the
-# chunking column is itself part of the primary key -- two rows with an
-# identical composite key necessarily share the same value of it, so
-# duplicates can never span chunk boundaries, whether the column is
-# date/datetime (chunked by year) or anything else (chunked by distinct
-# value). These tests exercise the machinery directly with synthetic
-# resources, independent of which real tables are currently enumerated.
-
-
-def _temporal_pk_resource() -> Resource:
-    return Resource(
-        name="_test__temporal_pk_chunking",
-        description="Synthetic resource with a temporal primary key.",
-        schema={
-            "fields": [
-                {"name": "event_date", "type": "date", "description": "Event date."},
-                {"name": "unit_id", "type": "integer", "description": "Unit ID."},
-            ],
-            "primary_key": ["event_date", "unit_id"],
-        },
-    )
-
-
-def _categorical_pk_resource() -> Resource:
-    return Resource(
-        name="_test__categorical_pk_chunking",
-        description="Synthetic resource with a string primary-key column.",
-        schema={
-            "fields": [
-                {"name": "filer_id", "type": "string", "description": "Filer ID."},
-                {
-                    "name": "record_id",
-                    "type": "integer",
-                    "description": "Record ID.",
-                },
-            ],
-            "primary_key": ["filer_id", "record_id"],
-        },
-    )
-
-
-def test_validate_primary_key_uniqueness_temporal_valid() -> None:
-    """Repeated non-key values across different years are not false positives.
-
-    ``_temporal_pk_resource`` isn't in ``_CHUNKED_PK_CHECK_TABLES``, so this
-    exercises ``_validate_primary_key_uniqueness``'s default, unchunked
-    dispatch path; ``test_chunk_filters_temporal_*`` below separately verify
-    the chunking mechanism itself preserves the same correctness.
-    """
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [
-                date(2020, 1, 1),
-                date(2020, 1, 2),
-                date(2021, 1, 1),
-                date(2021, 1, 2),
-            ],
-            # unit_id repeats across years -- fine, since event_date differs.
-            "unit_id": [1, 2, 1, 2],
-        }
-    )
-    errors = _validate_primary_key_uniqueness(lf, resource)
-    assert errors == []
-
-
-def test_validate_primary_key_uniqueness_temporal_catches_duplicate() -> None:
-    """A true duplicate composite key within one year is still caught."""
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
-            "unit_id": [1, 1, 1],
-        }
-    )
-    errors = _validate_primary_key_uniqueness(lf, resource)
-    assert len(errors) > 0
-
-
-def test_validate_primary_key_uniqueness_categorical_valid() -> None:
-    """Repeated non-key values across different filers are not false positives."""
-    resource = _categorical_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "filer_id": ["A", "A", "B", "B"],
-            # record_id repeats across filers -- fine, since filer_id differs.
-            "record_id": [1, 2, 1, 2],
-        }
-    )
-    errors = _validate_primary_key_uniqueness(lf, resource)
-    assert errors == []
-
-
-def test_validate_primary_key_uniqueness_categorical_catches_duplicate() -> None:
-    """A true duplicate composite key within one filer is still caught."""
-    resource = _categorical_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "filer_id": ["A", "A", "B"],
-            "record_id": [1, 1, 1],
-        }
-    )
-    errors = _validate_primary_key_uniqueness(lf, resource)
-    assert len(errors) > 0
-
-
-def test_chunk_filters_temporal_partitions_by_year() -> None:
-    """Temporal chunk filters split rows into non-overlapping, year-aligned sets."""
-    lf = pl.LazyFrame(
-        {"event_date": [date(2020, 1, 1), date(2020, 6, 1), date(2021, 3, 1)]}
-    )
-    filters = _chunk_filters(lf, "event_date")
-    assert len(filters) == 2  # 2020 and 2021
-    row_counts = sorted(lf.filter(f).select(pl.len()).collect().item() for f in filters)
-    assert row_counts == [1, 2]
-
-
-def test_chunk_filters_categorical_partitions_by_value() -> None:
-    """Categorical chunk filters split rows by each distinct value, exactly."""
-    lf = pl.LazyFrame({"filer_id": ["A", "A", "B"]})
-    filters = _chunk_filters(lf, "filer_id")
-    assert len(filters) == 2  # "A" and "B"
-    counts_by_value = {}
-    for f in filters:
-        chunk = lf.filter(f).collect()
-        counts_by_value[chunk["filer_id"][0]] = chunk.height
-    assert counts_by_value == {"A": 2, "B": 1}
-
-
-def test_validate_primary_key_uniqueness_no_primary_key() -> None:
-    """Resources without a primary key are trivially valid."""
-    resource = Resource(
-        name="_test__no_pk",
-        description="Synthetic resource without a primary key.",
-        schema={"fields": [{"name": "x", "type": "integer", "description": "X."}]},
-    )
-    lf = pl.LazyFrame({"x": [1, 1, 1]})
-    assert _validate_primary_key_uniqueness(lf, resource) == []
-
-
-def test_validate_primary_key_uniqueness_rejects_bad_chunk_field(mocker) -> None:
-    """A chunk field that isn't part of the primary key is a config error.
-
-    Chunking is only exact (see `_chunk_filters`) when the chunk column is
-    part of the primary key -- if `_CHUNKED_PK_CHECK_TABLES` is ever
-    misconfigured with a column that isn't, that has to fail loudly rather
-    than silently produce an incomplete uniqueness check.
-    """
-    resource = Resource(
-        name="_test__bad_chunk_field",
-        description="Synthetic resource for testing chunk-field misconfiguration.",
-        schema={
-            "fields": [
-                {"name": "id", "type": "integer", "description": "Primary key."},
-                {"name": "other", "type": "integer", "description": "Not in the PK."},
-            ],
-            "primary_key": ["id"],
-        },
-    )
-    mocker.patch.dict(_CHUNKED_PK_CHECK_TABLES, {resource.name: "other"})
-    lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
-    with pytest.raises(AssertionError, match="isn't part of"):
-        _validate_primary_key_uniqueness(lf, resource)
-
-
-def test_find_duplicate_primary_keys() -> None:
-    """The underlying group-by/count reduction correctly identifies duplicates."""
-    lf = pl.LazyFrame({"a": [1, 1, 2], "b": ["x", "x", "y"]})
-    duplicates = _find_duplicate_primary_keys(lf, ["a", "b"])
-    assert duplicates.height == 1
-    assert duplicates["a"][0] == 1
-    assert duplicates["b"][0] == "x"
-    assert duplicates["_pk_count"][0] == 2
-
-
-def test_chunked_pk_check_tables_are_valid() -> None:
-    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
-
-    Guards against the mapping silently going stale if a listed resource's
-    primary key changes -- the chunking column must remain part of the
-    primary key, since that's what makes chunking by it exact rather than
-    approximate.
-    """
-    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
-        resource = PUDL_PACKAGE.get_resource(resource_name)
-        assert field_name in resource.schema.primary_key, (
-            f"{field_name} is not part of {resource_name}'s primary key"
-        )
 
 
 def test_pandera_schema_check_combines_schema_and_content_errors() -> None:

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -43,7 +43,6 @@ from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunctio
 from shapely.geometry import Point
 
 from pudl.dagster.asset_checks import (
-    _CHUNKED_PK_CHECK_TABLES,
     _build_registry_from_descriptor,
     _validate_datapackage_unit_strings,
     asset_check_from_schema,
@@ -418,7 +417,7 @@ def test_polars_lazyframe_uniqueness_checks(
 ) -> None:
     """Nullable and uniqueness violations should fail the generated asset check.
 
-    This resource isn't in ``_CHUNKED_PK_CHECK_TABLES``, so composite
+    This resource's schema doesn't set ``chunk_field``, so composite
     primary-key uniqueness goes through
     :meth:`Resource.check_primary_key_polars`'s normal, unchunked path (see
     ``tests/unit/metadata/metadata_test.py`` for the chunked path used by
@@ -522,18 +521,3 @@ def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
     assert any("value" in m and "100" in m for m in messages), (
         f"Expected a value-constraint content error, got: {messages}"
     )
-
-
-def test_chunked_pk_check_tables_are_valid() -> None:
-    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
-
-    Guards against the mapping silently going stale if a listed resource's
-    primary key changes -- the chunking column must remain part of the
-    primary key, since that's what makes chunking by it exact rather than
-    approximate (see ``Resource._chunk_filters``).
-    """
-    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
-        resource = PUDL_PACKAGE.get_resource(resource_name)
-        assert field_name in resource.schema.primary_key, (
-            f"{field_name} is not part of {resource_name}'s primary key"
-        )

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -458,7 +458,7 @@ def test_polars_lazyframe_uniqueness_checks_errors(
 ) -> None:
     """Nullable and uniqueness violations should fail with informative detail.
 
-    This resource's schema doesn't set ``chunk_field``, so composite primary-key
+    This resource's schema doesn't set ``pk_check_chunk_field``, so composite primary-key
     uniqueness goes through :meth:`Resource.check_primary_key_polars`'s normal,
     unchunked path (see ``tests/unit/metadata/metadata_test.py`` for the chunked path
     used by PUDL's few oversized tables).

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -42,6 +42,7 @@ from dagster._core.definitions.asset_checks.asset_checks_definition import (
 from shapely.geometry import Point
 
 from pudl.dagster.asset_checks import (
+    _CHUNKED_PK_CHECK_TABLES,
     _build_registry_from_descriptor,
     _validate_datapackage_unit_strings,
     asset_check_from_schema,
@@ -519,3 +520,18 @@ def test_pandera_schema_check_combines_schema_and_content_errors() -> None:
     assert any("value" in m and "100" in m for m in messages), (
         f"Expected a value-constraint content error, got: {messages}"
     )
+
+
+def test_chunked_pk_check_tables_are_valid() -> None:
+    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
+
+    Guards against the mapping silently going stale if a listed resource's
+    primary key changes -- the chunking column must remain part of the
+    primary key, since that's what makes chunking by it exact rather than
+    approximate (see ``Resource._chunk_filters``).
+    """
+    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
+        resource = PUDL_PACKAGE.get_resource(resource_name)
+        assert field_name in resource.schema.primary_key, (
+            f"{field_name} is not part of {resource_name}'s primary key"
+        )

--- a/tests/unit/dbt_schema_test.py
+++ b/tests/unit/dbt_schema_test.py
@@ -361,6 +361,8 @@ def test_description_whitespace_is_normalized(schema_yaml):
     arbitrary ``data_tests`` entry, which pydantic doesn't otherwise model.
     """
     expected = "One flowing line, no wrapping at all."
-    table = _schema_from_yaml(schema_yaml).sources[0].tables[0]
+    # sources/tables/data_tests are Optional in the pydantic model, but the
+    # fixture YAML above always populates them.
+    table = _schema_from_yaml(schema_yaml).sources[0].tables[0]  # type: ignore[unsupported-operation]
     assert table.description == expected
-    assert table.data_tests[0]["some_test"]["description"] == expected
+    assert table.data_tests[0]["some_test"]["description"] == expected  # type: ignore[unsupported-operation]

--- a/tests/unit/helpers_test.py
+++ b/tests/unit/helpers_test.py
@@ -1,12 +1,16 @@
 """Unit tests for the :mod:`pudl.helpers` module."""
 
+from datetime import date, datetime
 from io import StringIO
 
 import numpy as np
 import pandas as pd
+import polars as pl
+import pyarrow as pa
 import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
 from pandas.tseries.offsets import BYearEnd
+from polars.testing import assert_frame_equal as assert_pl_frame_equal
 
 import pudl.helpers
 from pudl.helpers import (
@@ -23,6 +27,7 @@ from pudl.helpers import (
     expand_timeseries,
     flatten_list,
     get_parquet_table,
+    get_parquet_table_polars,
     normalize_year_fragments,
     remove_leading_zeros_from_numeric_strings,
     retry,
@@ -31,6 +36,8 @@ from pudl.helpers import (
     standardize_phone_column,
     zero_pad_numeric_string,
 )
+from pudl.metadata.classes import Resource
+from pudl.workspace.setup import PudlPaths
 
 MONTHLY_GEN_FUEL = pd.DataFrame(
     {
@@ -1162,3 +1169,181 @@ def test_get_parquet_table_subset_applies_resource_override(mocker, tmp_path):
     result = get_parquet_table(resource_name, columns=subset)
     assert str(result["customers"].dtype) == "float64"
     assert result["customers"].tolist() == [1.5]
+
+
+# Shared by the golden-behavior dtype tests below. Covers every PUDL field-type
+# family, each with a null, as plain Python objects so the same dict works for
+# both pd.DataFrame and pl.LazyFrame.
+_MULTI_TYPE_FIELDS = [
+    {"name": "id", "type": "integer", "description": "Primary key."},
+    {"name": "value", "type": "number", "description": "A float value."},
+    {"name": "flag", "type": "boolean", "description": "A boolean flag."},
+    {"name": "name", "type": "string", "description": "A string field."},
+    {"name": "observed_on", "type": "date", "description": "A date."},
+    {"name": "recorded_at", "type": "datetime", "description": "A datetime."},
+    {
+        "name": "code",
+        "type": "string",
+        "description": "Enum-constrained code.",
+        "constraints": {"enum": ["a", "b", "c"]},
+    },
+]
+_MULTI_TYPE_DATA = {
+    "id": [1, 2, 3],
+    "value": [1.5, None, 3.5],
+    "flag": [True, False, None],
+    "name": ["x", None, "z"],
+    "observed_on": [date(2020, 1, 1), date(2020, 2, 1), None],
+    "recorded_at": [datetime(2020, 1, 1), None, datetime(2020, 3, 1, 12, 0, 0)],
+    "code": ["a", "b", None],
+}
+
+
+def _make_multi_type_resource(name: str) -> Resource:
+    """Build a synthetic Resource covering every PUDL field-type family."""
+    return Resource(
+        name=name,
+        description="Synthetic resource covering every PUDL field-type family.",
+        schema={"fields": _MULTI_TYPE_FIELDS, "primary_key": ["id"]},
+    )
+
+
+def _make_test_pudl_paths(tmp_path) -> PudlPaths:
+    """Build a :class:`PudlPaths` rooted at a pytest ``tmp_path``."""
+    return PudlPaths(pudl_input=tmp_path / "input", pudl_output=tmp_path / "output")
+
+
+def test_get_parquet_table_full_read_dtypes(mocker, tmp_path):
+    """Golden-behavior test: a full-column read must reproduce what was written."""
+    resource = _make_multi_type_resource("_test__get_parquet_table_full_read_dtypes")
+    written_df = resource.enforce_schema(pd.DataFrame(_MULTI_TYPE_DATA))
+
+    paths = _make_test_pudl_paths(tmp_path)
+    parquet_path = paths.parquet_path(resource.name)
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    written_df.to_parquet(parquet_path, index=False, schema=resource.to_pyarrow())
+
+    mocker.patch("pudl.metadata.classes.Resource.from_id", return_value=resource)
+
+    result = get_parquet_table(resource.name, paths=paths)
+    assert_frame_equal(result, written_df)
+
+
+def test_get_parquet_table_polars_full_read_dtypes(mocker, tmp_path):
+    """Golden-behavior test: same as above, for the Polars LazyFrame path."""
+    resource = _make_multi_type_resource(
+        "_test__get_parquet_table_polars_full_read_dtypes"
+    )
+    # Pre-existing pyrefly complaint, same as the identical cast() call in
+    # PudlParquetIOManager.handle_output.
+    written_lf = pl.LazyFrame(_MULTI_TYPE_DATA).cast(
+        resource.to_polars_dtypes()  # type: ignore[bad-argument-type]
+    )
+
+    paths = _make_test_pudl_paths(tmp_path)
+    parquet_path = paths.parquet_path(resource.name)
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    written_lf.sink_parquet(parquet_path, engine="streaming")
+
+    mocker.patch("pudl.metadata.classes.Resource.from_id", return_value=resource)
+
+    result = get_parquet_table_polars(resource.name, paths=paths)
+    assert_pl_frame_equal(result.collect(), written_lf.collect())
+
+
+# "c" is declared but never appears in any row, so these check whether an unused
+# category survives -- not just whether observed values round-trip.
+_CATEGORICAL_CATEGORIES = ["a", "b", "c"]
+_CATEGORICAL_VALUES = ["a", "b", None]
+
+
+def _write_pandas_categorical(path):
+    pd.DataFrame(
+        {
+            "code": pd.Categorical(
+                _CATEGORICAL_VALUES, categories=_CATEGORICAL_CATEGORIES
+            )
+        }
+    ).to_parquet(
+        path,
+        schema=pa.schema([pa.field("code", pa.dictionary(pa.int32(), pa.string()))]),
+    )
+
+
+def _write_polars_enum(path):
+    pl.LazyFrame({"code": _CATEGORICAL_VALUES}).cast(
+        {"code": pl.Enum(_CATEGORICAL_CATEGORIES)}
+    ).sink_parquet(path)
+
+
+@pytest.mark.parametrize(
+    ("write", "read_categories", "expected"),
+    [
+        (
+            _write_pandas_categorical,
+            lambda p: set(
+                pd.read_parquet(p)["code"].dtype.categories  # type: ignore[missing-attribute]
+            ),
+            {"a", "b", "c"},
+        ),
+        (
+            _write_polars_enum,
+            # Enum's category list is a fixed, declared dtype-level property.
+            lambda p: set(
+                pl.read_parquet(p)["code"].dtype.categories  # type: ignore[missing-attribute]
+            ),
+            {"a", "b", "c"},
+        ),
+        (
+            _write_polars_enum,
+            lambda p: set(
+                pd.read_parquet(p)["code"].dtype.categories  # type: ignore[missing-attribute]
+            ),
+            {"a", "b", "c"},
+        ),
+        (
+            _write_pandas_categorical,
+            # Categorical has no fixed list -- only whatever's actually present.
+            lambda p: set(pl.read_parquet(p)["code"].drop_nulls().unique().to_list()),
+            {"a", "b"},
+        ),
+    ],
+    ids=[
+        "pandas-write_pandas-read_preserves-unused",
+        "polars-write_polars-read_preserves-unused",
+        "polars-write_pandas-read_preserves-unused",
+        "pandas-write_polars-read_drops-unused",
+    ],
+)
+def test_constrained_categorical_cross_backend_parquet_roundtrip(
+    tmp_path, write, read_categories, expected
+):
+    """Cross-backend behavior for a constrained categorical/enum column's Parquet round trip.
+
+    Not symmetric: Polars' ``Enum`` writer stores its entire declared category
+    list in the physical dictionary page regardless of what's observed, so both
+    pandas and Polars recover it fully. Pandas' plain ``Categorical`` writer only
+    encodes what's actually referenced, and while pandas itself reads that back
+    faithfully, Polars' generic (non-Polars-authored) dictionary decoding compacts
+    away unreferenced entries -- so only that one direction loses the unused
+    category. Locked in here so a future pandas/polars/pyarrow upgrade that
+    changes this is caught rather than discovered downstream.
+    """
+    path = tmp_path / "code.parquet"
+    write(path)
+    assert read_categories(path) == expected
+
+
+def test_polars_enum_parquet_roundtrip_is_order_sensitive(tmp_path):
+    """A pl.Enum's category order is part of its identity, unlike a Categorical's.
+
+    Reading a Polars-written Enum column back with a differently-ordered (but
+    same-membership) Enum schema raises, rather than coercing -- the counterpart
+    to the "preserves order" half of the polars-write/polars-read case above.
+    """
+    path = tmp_path / "code.parquet"
+    pl.LazyFrame({"code": ["a", "b"]}).cast(
+        {"code": pl.Enum(["c", "b", "a"])}
+    ).sink_parquet(path)
+    with pytest.raises(pl.exceptions.SchemaError):
+        pl.scan_parquet(path, schema={"code": pl.Enum(["a", "b", "c"])}).collect()

--- a/tests/unit/helpers_test.py
+++ b/tests/unit/helpers_test.py
@@ -3,14 +3,17 @@
 from datetime import date, datetime
 from io import StringIO
 
+import geopandas as gpd  # noqa: ICN002
 import numpy as np
 import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pytest
+from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_frame_equal, assert_series_equal
 from pandas.tseries.offsets import BYearEnd
 from polars.testing import assert_frame_equal as assert_pl_frame_equal
+from shapely.geometry import Point
 
 import pudl.helpers
 from pudl.helpers import (
@@ -1263,6 +1266,49 @@ def test_get_parquet_table_full_read_dtypes(mocker, tmp_path):
     assert_frame_equal(result, written_df)
 
 
+_GEOSPATIAL_FIELDS = [
+    {"name": "id", "type": "integer", "description": "Primary key."},
+    {"name": "name", "type": "string", "description": "A string field."},
+    {"name": "geometry", "type": "geometry", "description": "A geometry field."},
+]
+_GEOSPATIAL_DATA = {
+    "id": [1, 2, 3],
+    "name": ["x", None, "z"],
+    "geometry": [Point(0, 0), Point(1, 1), None],
+}
+
+
+def test_get_parquet_table_geospatial_full_read_dtypes(mocker, tmp_path):
+    """Golden-behavior test: the geospatial/GeoParquet read path round-trips too.
+
+    ``get_parquet_table`` has a separate ``is_geospatial`` branch (``gpd.read_parquet``
+    plus a full ``enforce_schema`` re-cast, rather than ``pd.read_parquet`` with
+    ``dtype_backend="numpy_nullable"``) that the plain multi-type test above never
+    exercises, since none of its fields are geometry-typed. Writes using
+    ``GeoDataFrame.to_parquet`` directly (not ``resource.to_pyarrow()``-constrained),
+    matching how ``PudlParquetIOManager.handle_output`` actually writes geometry
+    columns as native GeoParquet.
+    """
+    resource = Resource(
+        name="_test__get_parquet_table_geospatial_full_read_dtypes",
+        description="Synthetic resource covering the geospatial read path.",
+        schema={"fields": _GEOSPATIAL_FIELDS, "primary_key": ["id"]},
+    )
+    written_gdf = resource.enforce_schema(gpd.GeoDataFrame(_GEOSPATIAL_DATA))
+    assert isinstance(written_gdf, gpd.GeoDataFrame)
+
+    paths = _make_test_pudl_paths(tmp_path)
+    parquet_path = paths.parquet_path(resource.name)
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    written_gdf.to_parquet(parquet_path, index=False)
+
+    mocker.patch("pudl.metadata.classes.Resource.from_id", return_value=resource)
+
+    result = get_parquet_table(resource.name, paths=paths)
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert_geodataframe_equal(result, written_gdf)
+
+
 def test_get_parquet_table_polars_full_read_dtypes(mocker, tmp_path):
     """Golden-behavior test: same as above, for the Polars LazyFrame path."""
     resource = _make_multi_type_resource(
@@ -1352,32 +1398,18 @@ def _write_polars_enum(path):
 def test_constrained_categorical_cross_backend_parquet_roundtrip(
     tmp_path, write, read_categories, expected
 ):
-    """Cross-backend behavior for a constrained categorical/enum column's Parquet round trip.
+    """Verify cross-backend behavior for constrained categorical/enum columns.
 
-    Not symmetric: Polars' ``Enum`` writer stores its entire declared category
-    list in the physical dictionary page regardless of what's observed, so both
-    pandas and Polars recover it fully. Pandas' plain ``Categorical`` writer only
-    encodes what's actually referenced, and while pandas itself reads that back
-    faithfully, Polars' generic (non-Polars-authored) dictionary decoding compacts
-    away unreferenced entries -- so only that one direction loses the unused
-    category. Locked in here so a future pandas/polars/pyarrow upgrade that
-    changes this is caught rather than discovered downstream.
+    Not symmetric: Polars' ``Enum`` writer stores its entire declared category list in
+    the physical dictionary page regardless of what's observed, so both pandas and
+    Polars recover it fully. Pandas' plain ``Categorical`` writer also encodes all of
+    the defined dictionary keys, whether or not they are referenced in the actual data,
+    and faithfully reconstructs the complete dictionary uplon reading. However, Polars'
+    generic (non-Polars-authored) dictionary decoding compacts away unreferenced entries
+    -- so only that one direction loses any unused categories. Locked in here so a
+    future pandas/polars/pyarrow upgrade that changes this is caught rather than
+    discovered downstream.
     """
     path = tmp_path / "code.parquet"
     write(path)
     assert read_categories(path) == expected
-
-
-def test_polars_enum_parquet_roundtrip_is_order_sensitive(tmp_path):
-    """A pl.Enum's category order is part of its identity, unlike a Categorical's.
-
-    Reading a Polars-written Enum column back with a differently-ordered (but
-    same-membership) Enum schema raises, rather than coercing -- the counterpart
-    to the "preserves order" half of the polars-write/polars-read case above.
-    """
-    path = tmp_path / "code.parquet"
-    pl.LazyFrame({"code": ["a", "b"]}).cast(
-        {"code": pl.Enum(["c", "b", "a"])}
-    ).sink_parquet(path)
-    with pytest.raises(pl.exceptions.SchemaError):
-        pl.scan_parquet(path, schema={"code": pl.Enum(["a", "b", "c"])}).collect()

--- a/tests/unit/helpers_test.py
+++ b/tests/unit/helpers_test.py
@@ -3,14 +3,17 @@
 from datetime import date, datetime
 from io import StringIO
 
+import geopandas as gpd  # noqa: ICN002
 import numpy as np
 import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pytest
+from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_frame_equal, assert_series_equal
 from pandas.tseries.offsets import BYearEnd
 from polars.testing import assert_frame_equal as assert_pl_frame_equal
+from shapely.geometry import Point
 
 import pudl.helpers
 from pudl.helpers import (
@@ -1229,6 +1232,49 @@ def test_get_parquet_table_full_read_dtypes(mocker, tmp_path):
     assert_frame_equal(result, written_df)
 
 
+_GEOSPATIAL_FIELDS = [
+    {"name": "id", "type": "integer", "description": "Primary key."},
+    {"name": "name", "type": "string", "description": "A string field."},
+    {"name": "geometry", "type": "geometry", "description": "A geometry field."},
+]
+_GEOSPATIAL_DATA = {
+    "id": [1, 2, 3],
+    "name": ["x", None, "z"],
+    "geometry": [Point(0, 0), Point(1, 1), None],
+}
+
+
+def test_get_parquet_table_geospatial_full_read_dtypes(mocker, tmp_path):
+    """Golden-behavior test: the geospatial/GeoParquet read path round-trips too.
+
+    ``get_parquet_table`` has a separate ``is_geospatial`` branch (``gpd.read_parquet``
+    plus a full ``enforce_schema`` re-cast, rather than ``pd.read_parquet`` with
+    ``dtype_backend="numpy_nullable"``) that the plain multi-type test above never
+    exercises, since none of its fields are geometry-typed. Writes using
+    ``GeoDataFrame.to_parquet`` directly (not ``resource.to_pyarrow()``-constrained),
+    matching how ``PudlParquetIOManager.handle_output`` actually writes geometry
+    columns as native GeoParquet.
+    """
+    resource = Resource(
+        name="_test__get_parquet_table_geospatial_full_read_dtypes",
+        description="Synthetic resource covering the geospatial read path.",
+        schema={"fields": _GEOSPATIAL_FIELDS, "primary_key": ["id"]},
+    )
+    written_gdf = resource.enforce_schema(gpd.GeoDataFrame(_GEOSPATIAL_DATA))
+    assert isinstance(written_gdf, gpd.GeoDataFrame)
+
+    paths = _make_test_pudl_paths(tmp_path)
+    parquet_path = paths.parquet_path(resource.name)
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    written_gdf.to_parquet(parquet_path, index=False)
+
+    mocker.patch("pudl.metadata.classes.Resource.from_id", return_value=resource)
+
+    result = get_parquet_table(resource.name, paths=paths)
+    assert isinstance(result, gpd.GeoDataFrame)
+    assert_geodataframe_equal(result, written_gdf)
+
+
 def test_get_parquet_table_polars_full_read_dtypes(mocker, tmp_path):
     """Golden-behavior test: same as above, for the Polars LazyFrame path."""
     resource = _make_multi_type_resource(
@@ -1318,32 +1364,18 @@ def _write_polars_enum(path):
 def test_constrained_categorical_cross_backend_parquet_roundtrip(
     tmp_path, write, read_categories, expected
 ):
-    """Cross-backend behavior for a constrained categorical/enum column's Parquet round trip.
+    """Verify cross-backend behavior for constrained categorical/enum columns.
 
-    Not symmetric: Polars' ``Enum`` writer stores its entire declared category
-    list in the physical dictionary page regardless of what's observed, so both
-    pandas and Polars recover it fully. Pandas' plain ``Categorical`` writer only
-    encodes what's actually referenced, and while pandas itself reads that back
-    faithfully, Polars' generic (non-Polars-authored) dictionary decoding compacts
-    away unreferenced entries -- so only that one direction loses the unused
-    category. Locked in here so a future pandas/polars/pyarrow upgrade that
-    changes this is caught rather than discovered downstream.
+    Not symmetric: Polars' ``Enum`` writer stores its entire declared category list in
+    the physical dictionary page regardless of what's observed, so both pandas and
+    Polars recover it fully. Pandas' plain ``Categorical`` writer also encodes all of
+    the defined dictionary keys, whether or not they are referenced in the actual data,
+    and faithfully reconstructs the complete dictionary uplon reading. However, Polars'
+    generic (non-Polars-authored) dictionary decoding compacts away unreferenced entries
+    -- so only that one direction loses any unused categories. Locked in here so a
+    future pandas/polars/pyarrow upgrade that changes this is caught rather than
+    discovered downstream.
     """
     path = tmp_path / "code.parquet"
     write(path)
     assert read_categories(path) == expected
-
-
-def test_polars_enum_parquet_roundtrip_is_order_sensitive(tmp_path):
-    """A pl.Enum's category order is part of its identity, unlike a Categorical's.
-
-    Reading a Polars-written Enum column back with a differently-ordered (but
-    same-membership) Enum schema raises, rather than coercing -- the counterpart
-    to the "preserves order" half of the polars-write/polars-read case above.
-    """
-    path = tmp_path / "code.parquet"
-    pl.LazyFrame({"code": ["a", "b"]}).cast(
-        {"code": pl.Enum(["c", "b", "a"])}
-    ).sink_parquet(path)
-    with pytest.raises(pl.exceptions.SchemaError):
-        pl.scan_parquet(path, schema={"code": pl.Enum(["a", "b", "c"])}).collect()

--- a/tests/unit/helpers_test.py
+++ b/tests/unit/helpers_test.py
@@ -1,12 +1,16 @@
 """Unit tests for the :mod:`pudl.helpers` module."""
 
+from datetime import date, datetime
 from io import StringIO
 
 import numpy as np
 import pandas as pd
+import polars as pl
+import pyarrow as pa
 import pytest
 from pandas.testing import assert_frame_equal, assert_series_equal
 from pandas.tseries.offsets import BYearEnd
+from polars.testing import assert_frame_equal as assert_pl_frame_equal
 
 import pudl.helpers
 from pudl.helpers import (
@@ -24,6 +28,7 @@ from pudl.helpers import (
     expand_timeseries,
     flatten_list,
     get_parquet_table,
+    get_parquet_table_polars,
     normalize_year_fragments,
     remove_leading_zeros_from_numeric_strings,
     retry,
@@ -32,6 +37,8 @@ from pudl.helpers import (
     standardize_phone_column,
     zero_pad_numeric_string,
 )
+from pudl.metadata.classes import Resource
+from pudl.workspace.setup import PudlPaths
 
 MONTHLY_GEN_FUEL = pd.DataFrame(
     {
@@ -1196,3 +1203,181 @@ def test_get_parquet_table_subset_applies_resource_override(mocker, tmp_path):
     result = get_parquet_table(resource_name, columns=subset)
     assert str(result["customers"].dtype) == "float64"
     assert result["customers"].tolist() == [1.5]
+
+
+# Shared by the golden-behavior dtype tests below. Covers every PUDL field-type
+# family, each with a null, as plain Python objects so the same dict works for
+# both pd.DataFrame and pl.LazyFrame.
+_MULTI_TYPE_FIELDS = [
+    {"name": "id", "type": "integer", "description": "Primary key."},
+    {"name": "value", "type": "number", "description": "A float value."},
+    {"name": "flag", "type": "boolean", "description": "A boolean flag."},
+    {"name": "name", "type": "string", "description": "A string field."},
+    {"name": "observed_on", "type": "date", "description": "A date."},
+    {"name": "recorded_at", "type": "datetime", "description": "A datetime."},
+    {
+        "name": "code",
+        "type": "string",
+        "description": "Enum-constrained code.",
+        "constraints": {"enum": ["a", "b", "c"]},
+    },
+]
+_MULTI_TYPE_DATA = {
+    "id": [1, 2, 3],
+    "value": [1.5, None, 3.5],
+    "flag": [True, False, None],
+    "name": ["x", None, "z"],
+    "observed_on": [date(2020, 1, 1), date(2020, 2, 1), None],
+    "recorded_at": [datetime(2020, 1, 1), None, datetime(2020, 3, 1, 12, 0, 0)],
+    "code": ["a", "b", None],
+}
+
+
+def _make_multi_type_resource(name: str) -> Resource:
+    """Build a synthetic Resource covering every PUDL field-type family."""
+    return Resource(
+        name=name,
+        description="Synthetic resource covering every PUDL field-type family.",
+        schema={"fields": _MULTI_TYPE_FIELDS, "primary_key": ["id"]},
+    )
+
+
+def _make_test_pudl_paths(tmp_path) -> PudlPaths:
+    """Build a :class:`PudlPaths` rooted at a pytest ``tmp_path``."""
+    return PudlPaths(pudl_input=tmp_path / "input", pudl_output=tmp_path / "output")
+
+
+def test_get_parquet_table_full_read_dtypes(mocker, tmp_path):
+    """Golden-behavior test: a full-column read must reproduce what was written."""
+    resource = _make_multi_type_resource("_test__get_parquet_table_full_read_dtypes")
+    written_df = resource.enforce_schema(pd.DataFrame(_MULTI_TYPE_DATA))
+
+    paths = _make_test_pudl_paths(tmp_path)
+    parquet_path = paths.parquet_path(resource.name)
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    written_df.to_parquet(parquet_path, index=False, schema=resource.to_pyarrow())
+
+    mocker.patch("pudl.metadata.classes.Resource.from_id", return_value=resource)
+
+    result = get_parquet_table(resource.name, paths=paths)
+    assert_frame_equal(result, written_df)
+
+
+def test_get_parquet_table_polars_full_read_dtypes(mocker, tmp_path):
+    """Golden-behavior test: same as above, for the Polars LazyFrame path."""
+    resource = _make_multi_type_resource(
+        "_test__get_parquet_table_polars_full_read_dtypes"
+    )
+    # Pre-existing pyrefly complaint, same as the identical cast() call in
+    # PudlParquetIOManager.handle_output.
+    written_lf = pl.LazyFrame(_MULTI_TYPE_DATA).cast(
+        resource.to_polars_dtypes()  # type: ignore[bad-argument-type]
+    )
+
+    paths = _make_test_pudl_paths(tmp_path)
+    parquet_path = paths.parquet_path(resource.name)
+    parquet_path.parent.mkdir(parents=True, exist_ok=True)
+    written_lf.sink_parquet(parquet_path, engine="streaming")
+
+    mocker.patch("pudl.metadata.classes.Resource.from_id", return_value=resource)
+
+    result = get_parquet_table_polars(resource.name, paths=paths)
+    assert_pl_frame_equal(result.collect(), written_lf.collect())
+
+
+# "c" is declared but never appears in any row, so these check whether an unused
+# category survives -- not just whether observed values round-trip.
+_CATEGORICAL_CATEGORIES = ["a", "b", "c"]
+_CATEGORICAL_VALUES = ["a", "b", None]
+
+
+def _write_pandas_categorical(path):
+    pd.DataFrame(
+        {
+            "code": pd.Categorical(
+                _CATEGORICAL_VALUES, categories=_CATEGORICAL_CATEGORIES
+            )
+        }
+    ).to_parquet(
+        path,
+        schema=pa.schema([pa.field("code", pa.dictionary(pa.int32(), pa.string()))]),
+    )
+
+
+def _write_polars_enum(path):
+    pl.LazyFrame({"code": _CATEGORICAL_VALUES}).cast(
+        {"code": pl.Enum(_CATEGORICAL_CATEGORIES)}
+    ).sink_parquet(path)
+
+
+@pytest.mark.parametrize(
+    ("write", "read_categories", "expected"),
+    [
+        (
+            _write_pandas_categorical,
+            lambda p: set(
+                pd.read_parquet(p)["code"].dtype.categories  # type: ignore[missing-attribute]
+            ),
+            {"a", "b", "c"},
+        ),
+        (
+            _write_polars_enum,
+            # Enum's category list is a fixed, declared dtype-level property.
+            lambda p: set(
+                pl.read_parquet(p)["code"].dtype.categories  # type: ignore[missing-attribute]
+            ),
+            {"a", "b", "c"},
+        ),
+        (
+            _write_polars_enum,
+            lambda p: set(
+                pd.read_parquet(p)["code"].dtype.categories  # type: ignore[missing-attribute]
+            ),
+            {"a", "b", "c"},
+        ),
+        (
+            _write_pandas_categorical,
+            # Categorical has no fixed list -- only whatever's actually present.
+            lambda p: set(pl.read_parquet(p)["code"].drop_nulls().unique().to_list()),
+            {"a", "b"},
+        ),
+    ],
+    ids=[
+        "pandas-write_pandas-read_preserves-unused",
+        "polars-write_polars-read_preserves-unused",
+        "polars-write_pandas-read_preserves-unused",
+        "pandas-write_polars-read_drops-unused",
+    ],
+)
+def test_constrained_categorical_cross_backend_parquet_roundtrip(
+    tmp_path, write, read_categories, expected
+):
+    """Cross-backend behavior for a constrained categorical/enum column's Parquet round trip.
+
+    Not symmetric: Polars' ``Enum`` writer stores its entire declared category
+    list in the physical dictionary page regardless of what's observed, so both
+    pandas and Polars recover it fully. Pandas' plain ``Categorical`` writer only
+    encodes what's actually referenced, and while pandas itself reads that back
+    faithfully, Polars' generic (non-Polars-authored) dictionary decoding compacts
+    away unreferenced entries -- so only that one direction loses the unused
+    category. Locked in here so a future pandas/polars/pyarrow upgrade that
+    changes this is caught rather than discovered downstream.
+    """
+    path = tmp_path / "code.parquet"
+    write(path)
+    assert read_categories(path) == expected
+
+
+def test_polars_enum_parquet_roundtrip_is_order_sensitive(tmp_path):
+    """A pl.Enum's category order is part of its identity, unlike a Categorical's.
+
+    Reading a Polars-written Enum column back with a differently-ordered (but
+    same-membership) Enum schema raises, rather than coercing -- the counterpart
+    to the "preserves order" half of the polars-write/polars-read case above.
+    """
+    path = tmp_path / "code.parquet"
+    pl.LazyFrame({"code": ["a", "b"]}).cast(
+        {"code": pl.Enum(["c", "b", "a"])}
+    ).sink_parquet(path)
+    with pytest.raises(pl.exceptions.SchemaError):
+        pl.scan_parquet(path, schema={"code": pl.Enum(["a", "b", "c"])}).collect()

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -187,6 +187,25 @@ def test_field_definitions() -> None:
         )
 
 
+def test_enum_constraint_order_is_deterministic() -> None:
+    """An enum constraint's value order must not depend on set-iteration order.
+
+    Some enum constraints (e.g. ``EPACEMS_STATES`` in ``pudl.metadata.enums``) are
+    built from a Python ``set``, whose iteration order depends on per-process hash
+    randomization rather than the values themselves -- so ``list(some_set)`` can
+    differ between two runs of the same code. ``FieldConstraints``' deterministic-
+    sort validator makes the order a pure function of the values themselves,
+    independent of the input list/set's construction order or process.
+    """
+    field = Field(
+        name="_test_field",
+        type="string",
+        description="Test field.",
+        constraints={"enum": {"z", "a", "m", "b"}},
+    )
+    assert field.constraints.enum == ["a", "b", "m", "z"]
+
+
 def test_field_unit_strings() -> None:
     """Check that all unit strings in FIELD_METADATA parse against PUDL_UNIT_REGISTRY.
 

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -15,6 +15,7 @@ import polars as pl
 import pyarrow as pa
 import pytest
 import sqlalchemy as sa
+from pandera.errors import SchemaErrors
 from shapely import Point
 
 from pudl.metadata.classes import (
@@ -346,6 +347,35 @@ def test_check_primary_key_polars_temporal_catches_duplicate() -> None:
     )
     errors = resource._check_primary_key_polars(lf)
     assert len(errors) > 0
+
+
+def test_duplicate_primary_key_error_is_schema_errors_compatible() -> None:
+    """A duplicate-PK SchemaError must survive being wrapped in a real SchemaErrors.
+
+    Regression test: pandera's polars backend unconditionally reads
+    ``err.schema.name`` and ``err.check_output`` off of every error the moment a
+    ``SchemaErrors`` containing it is constructed (see ``failure_cases_metadata``
+    in ``pandera/backends/polars/base.py``), not just when the error is later
+    displayed. The two returned-list-only tests above (checking
+    ``len(errors) > 0``) never actually construct one, so they didn't catch that
+    the manually-built duplicate-PK ``SchemaError`` used to leave both of those
+    ``None``, crashing with an opaque ``AttributeError`` -- as first surfaced by
+    a real duplicate-primary-key partition of ``core_ferceqr__quarterly_index_pub``.
+    """
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
+            "unit_id": [1, 1, 1],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    # Constructing SchemaErrors -- not just returning the list -- is what
+    # previously crashed; pandera does this eagerly in its own __init__.
+    schema_errors = SchemaErrors(
+        schema=resource.schema.to_pandera(), schema_errors=errors, data=lf
+    )
+    assert "not unique" in str(schema_errors)
 
 
 def test_check_primary_key_polars_categorical_valid() -> None:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from datetime import date
 from typing import Any
 
 import duckdb.sqltypes
@@ -17,6 +18,7 @@ import sqlalchemy as sa
 from shapely import Point
 
 from pudl.metadata.classes import (
+    _CHUNKED_PK_CHECK_TABLES,
     PUDL_PACKAGE,
     DataSource,
     Field,
@@ -204,6 +206,257 @@ def test_enum_constraint_order_is_deterministic() -> None:
         constraints={"enum": {"z", "a", "m", "b"}},
     )
     assert field.constraints.enum == ["a", "b", "m", "z"]
+
+
+def test_check_primary_key_reports_both_duplicates_and_nulls() -> None:
+    """check_primary_key should report every violation in one pass, not just the first.
+
+    Regression test: an earlier version raised on the first problem it found
+    (duplicates), so a caller fixing that would only discover the null-value
+    problem on a second run.
+    """
+    resource = Resource(
+        name="_test__check_primary_key",
+        description="Synthetic resource for check_primary_key tests.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."}
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    df = pd.DataFrame({"id": pd.array([1, 1, None], dtype="Int64")})
+    with pytest.raises(
+        ValueError, match=r"(?s)duplicate primary keys.*Null values"
+    ) as exc:
+        resource.check_primary_key(df)
+    assert "duplicate primary keys" in str(exc.value)
+    assert "Null values found" in str(exc.value)
+
+
+def test_check_primary_key_dispatches_by_type() -> None:
+    """check_primary_key routes to the pandas or polars implementation by type.
+
+    Callers shouldn't have to remember two method names for the two backends --
+    this locks in that a single ``check_primary_key`` call works for either.
+    """
+    resource = Resource(
+        name="_test__check_primary_key_dispatch",
+        description="Synthetic resource for check_primary_key dispatch tests.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."}
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    # Pandas: raises directly, returns nothing.
+    with pytest.raises(ValueError, match="duplicate primary keys"):
+        resource.check_primary_key(pd.DataFrame({"id": [1, 1]}))
+
+    # Polars: returns a list of SchemaErrors instead of raising.
+    errors = resource.check_primary_key(pl.LazyFrame({"id": [1, 1]}))
+    assert isinstance(errors, list)
+    assert len(errors) > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for chunked primary-key uniqueness checking (Resource.check_primary_key's
+# polars path, i.e. Resource._check_primary_key_polars)
+# ---------------------------------------------------------------------------
+#
+# The polars path never uses pandera's built-in composite-uniqueness check
+# (too memory-hungry, see polars-comment.md); it always uses its own
+# group-by/count-based `Resource._find_duplicate_primary_keys`, optionally run
+# once per chunk instead of once on the whole table for PUDL's few oversized
+# tables (`_CHUNKED_PK_CHECK_TABLES`). Chunking is only correct because the
+# chunking column is itself part of the primary key -- two rows with an
+# identical composite key necessarily share the same value of it, so
+# duplicates can never span chunk boundaries, whether the column is
+# date/datetime (chunked by year) or anything else (chunked by distinct
+# value). These tests exercise the machinery directly with synthetic
+# resources, independent of which real tables are currently enumerated.
+
+
+def _temporal_pk_resource() -> Resource:
+    return Resource(
+        name="_test__temporal_pk_chunking",
+        description="Synthetic resource with a temporal primary key.",
+        schema={
+            "fields": [
+                {"name": "event_date", "type": "date", "description": "Event date."},
+                {"name": "unit_id", "type": "integer", "description": "Unit ID."},
+            ],
+            "primary_key": ["event_date", "unit_id"],
+        },
+    )
+
+
+def _categorical_pk_resource() -> Resource:
+    return Resource(
+        name="_test__categorical_pk_chunking",
+        description="Synthetic resource with a string primary-key column.",
+        schema={
+            "fields": [
+                {"name": "filer_id", "type": "string", "description": "Filer ID."},
+                {
+                    "name": "record_id",
+                    "type": "integer",
+                    "description": "Record ID.",
+                },
+            ],
+            "primary_key": ["filer_id", "record_id"],
+        },
+    )
+
+
+def test_check_primary_key_polars_temporal_valid() -> None:
+    """Repeated non-key values across different years are not false positives.
+
+    ``_temporal_pk_resource`` isn't in ``_CHUNKED_PK_CHECK_TABLES``, so this
+    exercises ``check_primary_key``'s default, unchunked polars dispatch path;
+    ``test_chunk_filters_temporal_*`` below separately verify the chunking
+    mechanism itself preserves the same correctness.
+    """
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [
+                date(2020, 1, 1),
+                date(2020, 1, 2),
+                date(2021, 1, 1),
+                date(2021, 1, 2),
+            ],
+            # unit_id repeats across years -- fine, since event_date differs.
+            "unit_id": [1, 2, 1, 2],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    assert errors == []
+
+
+def test_check_primary_key_polars_temporal_catches_duplicate() -> None:
+    """A true duplicate composite key within one year is still caught."""
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
+            "unit_id": [1, 1, 1],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    assert len(errors) > 0
+
+
+def test_check_primary_key_polars_categorical_valid() -> None:
+    """Repeated non-key values across different filers are not false positives."""
+    resource = _categorical_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "filer_id": ["A", "A", "B", "B"],
+            # record_id repeats across filers -- fine, since filer_id differs.
+            "record_id": [1, 2, 1, 2],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    assert errors == []
+
+
+def test_check_primary_key_polars_categorical_catches_duplicate() -> None:
+    """A true duplicate composite key within one filer is still caught."""
+    resource = _categorical_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "filer_id": ["A", "A", "B"],
+            "record_id": [1, 1, 1],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    assert len(errors) > 0
+
+
+def test_chunk_filters_temporal_partitions_by_year() -> None:
+    """Temporal chunk filters split rows into non-overlapping, year-aligned sets."""
+    lf = pl.LazyFrame(
+        {"event_date": [date(2020, 1, 1), date(2020, 6, 1), date(2021, 3, 1)]}
+    )
+    filters = Resource._chunk_filters(lf, "event_date")
+    assert len(filters) == 2  # 2020 and 2021
+    row_counts = sorted(lf.filter(f).select(pl.len()).collect().item() for f in filters)
+    assert row_counts == [1, 2]
+
+
+def test_chunk_filters_categorical_partitions_by_value() -> None:
+    """Categorical chunk filters split rows by each distinct value, exactly."""
+    lf = pl.LazyFrame({"filer_id": ["A", "A", "B"]})
+    filters = Resource._chunk_filters(lf, "filer_id")
+    assert len(filters) == 2  # "A" and "B"
+    counts_by_value = {}
+    for f in filters:
+        chunk = lf.filter(f).collect()
+        counts_by_value[chunk["filer_id"][0]] = chunk.height
+    assert counts_by_value == {"A": 2, "B": 1}
+
+
+def test_check_primary_key_polars_no_primary_key() -> None:
+    """Resources without a primary key are trivially valid."""
+    resource = Resource(
+        name="_test__no_pk",
+        description="Synthetic resource without a primary key.",
+        schema={"fields": [{"name": "x", "type": "integer", "description": "X."}]},
+    )
+    lf = pl.LazyFrame({"x": [1, 1, 1]})
+    assert resource._check_primary_key_polars(lf) == []
+
+
+def test_check_primary_key_polars_rejects_bad_chunk_field(mocker) -> None:
+    """A chunk field that isn't part of the primary key is a config error.
+
+    Chunking is only exact (see `Resource._chunk_filters`) when the chunk
+    column is part of the primary key -- if `_CHUNKED_PK_CHECK_TABLES` is ever
+    misconfigured with a column that isn't, that has to fail loudly rather
+    than silently produce an incomplete uniqueness check.
+    """
+    resource = Resource(
+        name="_test__bad_chunk_field",
+        description="Synthetic resource for testing chunk-field misconfiguration.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."},
+                {"name": "other", "type": "integer", "description": "Not in the PK."},
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    mocker.patch.dict(_CHUNKED_PK_CHECK_TABLES, {resource.name: "other"})
+    lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
+    with pytest.raises(AssertionError, match="isn't part of"):
+        resource._check_primary_key_polars(lf)
+
+
+def test_find_duplicate_primary_keys() -> None:
+    """The underlying group-by/count reduction correctly identifies duplicates."""
+    lf = pl.LazyFrame({"a": [1, 1, 2], "b": ["x", "x", "y"]})
+    duplicates = Resource._find_duplicate_primary_keys(lf, ["a", "b"])
+    assert duplicates.height == 1
+    assert duplicates["a"][0] == 1
+    assert duplicates["b"][0] == "x"
+    assert duplicates["_pk_count"][0] == 2
+
+
+def test_chunked_pk_check_tables_are_valid() -> None:
+    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
+
+    Guards against the mapping silently going stale if a listed resource's
+    primary key changes -- the chunking column must remain part of the
+    primary key, since that's what makes chunking by it exact rather than
+    approximate.
+    """
+    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
+        resource = PUDL_PACKAGE.get_resource(resource_name)
+        assert field_name in resource.schema.primary_key, (
+            f"{field_name} is not part of {resource_name}'s primary key"
+        )
 
 
 def test_field_unit_strings() -> None:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -211,6 +211,50 @@ def test_enum_constraint_order_is_deterministic() -> None:
     assert field.constraints.enum == ["a", "b", "m", "z"]
 
 
+@pytest.mark.parametrize(
+    ("field_type", "constraints", "expected"),
+    [
+        ("integer", {}, False),
+        ("integer", {"required": True}, True),
+        ("integer", {"unique": True}, True),
+        ("integer", {"minimum": 0}, True),
+        ("integer", {"maximum": 100}, True),
+        ("string", {"min_length": 1}, True),
+        ("string", {"max_length": 10}, True),
+        ("string", {"pattern": r"^[a-z]+$"}, True),
+        ("string", {"enum": ["a", "b"]}, True),
+    ],
+    ids=[
+        "no_constraints",
+        "required",
+        "unique",
+        "minimum",
+        "maximum",
+        "min_length",
+        "max_length",
+        "pattern",
+        "enum",
+    ],
+)
+def test_field_has_content_constraints(field_type, constraints, expected) -> None:
+    """Each individual content constraint should independently flip the result.
+
+    ``has_content_constraints`` ORs together eight separate conditions; asserting
+    only on combinations that set several at once wouldn't catch a future edit
+    that accidentally drops one of them from the ``any([...])`` list, since the
+    others would still make the check pass. Each constraint is exercised alone,
+    plus the all-defaults case, so every arm of the ``any()`` is independently
+    load-bearing.
+    """
+    field = Field(
+        name="_test_field",
+        type=field_type,
+        description="Test field.",
+        constraints=constraints,
+    )
+    assert field.has_content_constraints() == expected
+
+
 def _pk_violation_resource() -> Resource:
     return Resource(
         name="_test__check_primary_key",

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -190,6 +190,25 @@ def test_field_definitions() -> None:
         )
 
 
+def test_enum_constraint_order_is_deterministic() -> None:
+    """An enum constraint's value order must not depend on set-iteration order.
+
+    Some enum constraints (e.g. ``EPACEMS_STATES`` in ``pudl.metadata.enums``) are
+    built from a Python ``set``, whose iteration order depends on per-process hash
+    randomization rather than the values themselves -- so ``list(some_set)`` can
+    differ between two runs of the same code. ``FieldConstraints``' deterministic-
+    sort validator makes the order a pure function of the values themselves,
+    independent of the input list/set's construction order or process.
+    """
+    field = Field(
+        name="_test_field",
+        type="string",
+        description="Test field.",
+        constraints={"enum": {"z", "a", "m", "b"}},
+    )
+    assert field.constraints.enum == ["a", "b", "m", "z"]
+
+
 def test_field_unit_strings() -> None:
     """Check that all unit strings in FIELD_METADATA parse against PUDL_UNIT_REGISTRY.
 

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -364,7 +364,7 @@ def test_check_primary_key_errors_are_schema_errors_compatible(make_data) -> Non
 
 # ---------------------------------------------------------------------------
 # Tests for chunked primary-key uniqueness checking (Resource.check_primary_key's
-# polars path, i.e. Resource._check_primary_key_polars)
+# polars path)
 # ---------------------------------------------------------------------------
 #
 # The polars path never uses pandera's built-in composite-uniqueness check
@@ -378,11 +378,13 @@ def test_check_primary_key_errors_are_schema_errors_compatible(make_data) -> Non
 # identical composite key necessarily share the same value of it, so
 # duplicates can never span chunk boundaries, whether the column is
 # date/datetime (chunked by year) or anything else (chunked by distinct
-# value). These tests exercise the machinery directly with synthetic
-# resources, independent of which real tables are currently enumerated.
+# value). These tests go through the public `check_primary_key` dispatcher
+# rather than the private `_check_primary_key_polars`/`_chunk_filters` helpers
+# directly, with synthetic resources, independent of which real tables are
+# currently enumerated.
 
 
-def _temporal_pk_resource() -> Resource:
+def _temporal_pk_resource(chunked: bool = False) -> Resource:
     return Resource(
         name="_test__temporal_pk_chunking",
         description="Synthetic resource with a temporal primary key.",
@@ -392,11 +394,12 @@ def _temporal_pk_resource() -> Resource:
                 {"name": "unit_id", "type": "integer", "description": "Unit ID."},
             ],
             "primary_key": ["event_date", "unit_id"],
+            "chunk_field": "event_date" if chunked else None,
         },
     )
 
 
-def _categorical_pk_resource() -> Resource:
+def _categorical_pk_resource(chunked: bool = False) -> Resource:
     return Resource(
         name="_test__categorical_pk_chunking",
         description="Synthetic resource with a string primary-key column.",
@@ -410,6 +413,7 @@ def _categorical_pk_resource() -> Resource:
                 },
             ],
             "primary_key": ["filer_id", "record_id"],
+            "chunk_field": "filer_id" if chunked else None,
         },
     )
 
@@ -464,35 +468,61 @@ def _categorical_pk_resource() -> Resource:
         "categorical_duplicate",
     ],
 )
-def test_check_primary_key_polars_unchunked(
-    resource_fn, data, expect_violation
+@pytest.mark.parametrize("chunked", [False, True], ids=["unchunked", "chunked"])
+def test_check_primary_key_polars_detects_violations(
+    resource_fn, data, expect_violation, chunked
 ) -> None:
     """Repeated non-key values are not false positives; true duplicates are caught.
 
-    No ``chunk_field`` is set on either synthetic resource, so this exercises
-    ``check_primary_key``'s default, unchunked polars dispatch path;
-    ``test_chunk_filters_*`` below separately verify the chunking mechanism
-    itself preserves the same correctness.
+    Parametrized over ``chunked`` so that every case runs both with and without
+    ``schema.chunk_field`` set on the synthetic resource, on the exact same input
+    data -- chunking must never change the answer ``check_primary_key`` gives,
+    only how it gets there. Goes through the public ``check_primary_key``
+    dispatcher, the same entry point every real caller uses, rather than the
+    private ``_check_primary_key_polars``.
     """
-    errors = resource_fn()._check_primary_key_polars(pl.LazyFrame(data))
+    errors = resource_fn(chunked=chunked).check_primary_key(pl.LazyFrame(data))
     assert bool(errors) == expect_violation
 
 
-def test_chunk_filters_temporal_partitions_by_year() -> None:
-    """Temporal chunk filters split rows into non-overlapping, year-aligned sets."""
+def test_check_primary_key_chunks_by_year_for_temporal_chunk_field(mocker) -> None:
+    """A date/datetime ``chunk_field`` is actually used to partition rows by year.
+
+    Spies on the private ``Resource._chunk_filters`` rather than calling it
+    directly, so the test still goes through the public ``check_primary_key``
+    entry point (chunking is otherwise invisible from the outside, since it's
+    only an internal performance detail -- the spy is what makes "we're
+    peeking at an implementation detail here" explicit rather than incidental).
+    """
+    spy = mocker.spy(Resource, "_chunk_filters")
     lf = pl.LazyFrame(
-        {"event_date": [date(2020, 1, 1), date(2020, 6, 1), date(2021, 3, 1)]}
+        {
+            "event_date": [date(2020, 1, 1), date(2020, 6, 1), date(2021, 3, 1)],
+            "unit_id": [1, 2, 1],
+        }
     )
-    filters = Resource._chunk_filters(lf, "event_date")
+    _temporal_pk_resource(chunked=True).check_primary_key(lf)
+
+    spy.assert_called_once_with(mocker.ANY, "event_date")
+    filters = spy.spy_return
     assert len(filters) == 2  # 2020 and 2021
     row_counts = sorted(lf.filter(f).select(pl.len()).collect().item() for f in filters)
     assert row_counts == [1, 2]
 
 
-def test_chunk_filters_categorical_partitions_by_value() -> None:
-    """Categorical chunk filters split rows by each distinct value, exactly."""
-    lf = pl.LazyFrame({"filer_id": ["A", "A", "B"]})
-    filters = Resource._chunk_filters(lf, "filer_id")
+def test_check_primary_key_chunks_by_value_for_categorical_chunk_field(mocker) -> None:
+    """A non-temporal ``chunk_field`` is actually used to partition rows by value.
+
+    See ``test_check_primary_key_chunks_by_year_for_temporal_chunk_field`` for
+    why this spies on ``Resource._chunk_filters`` rather than calling it
+    directly.
+    """
+    spy = mocker.spy(Resource, "_chunk_filters")
+    lf = pl.LazyFrame({"filer_id": ["A", "A", "B"], "record_id": [1, 2, 1]})
+    _categorical_pk_resource(chunked=True).check_primary_key(lf)
+
+    spy.assert_called_once_with(mocker.ANY, "filer_id")
+    filters = spy.spy_return
     assert len(filters) == 2  # "A" and "B"
     counts_by_value = {}
     for f in filters:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -19,7 +19,6 @@ from pandera.errors import SchemaErrors
 from shapely import Point
 
 from pudl.metadata.classes import (
-    _CHUNKED_PK_CHECK_TABLES,
     PUDL_PACKAGE,
     DataSource,
     Field,
@@ -209,14 +208,8 @@ def test_enum_constraint_order_is_deterministic() -> None:
     assert field.constraints.enum == ["a", "b", "m", "z"]
 
 
-def test_check_primary_key_reports_both_duplicates_and_nulls() -> None:
-    """check_primary_key should report every violation in one pass, not just the first.
-
-    Regression test: an earlier version raised on the first problem it found
-    (duplicates), so a caller fixing that would only discover the null-value
-    problem on a second run.
-    """
-    resource = Resource(
+def _pk_violation_resource() -> Resource:
+    return Resource(
         name="_test__check_primary_key",
         description="Synthetic resource for check_primary_key tests.",
         schema={
@@ -226,39 +219,100 @@ def test_check_primary_key_reports_both_duplicates_and_nulls() -> None:
             "primary_key": ["id"],
         },
     )
-    df = pd.DataFrame({"id": pd.array([1, 1, None], dtype="Int64")})
-    with pytest.raises(
-        ValueError, match=r"(?s)duplicate primary keys.*Null values"
-    ) as exc:
-        resource.check_primary_key(df)
-    assert "duplicate primary keys" in str(exc.value)
-    assert "Null values found" in str(exc.value)
 
 
-def test_check_primary_key_dispatches_by_type() -> None:
-    """check_primary_key routes to the pandas or polars implementation by type.
+def _pandas_pk_violation_data() -> pd.DataFrame:
+    """A single-column PK with both a duplicate (1, 1) and a null value."""
+    return pd.DataFrame({"id": pd.array([1, 1, None], dtype="Int64")})
 
-    Callers shouldn't have to remember two method names for the two backends --
-    this locks in that a single ``check_primary_key`` call works for either.
+
+def _polars_pk_violation_data() -> pl.LazyFrame:
+    """A single-column PK with both a duplicate (1, 1) and a null value."""
+    return pl.LazyFrame({"id": [1, 1, None]})
+
+
+@pytest.mark.parametrize(
+    "make_data",
+    [_pandas_pk_violation_data, _polars_pk_violation_data],
+    ids=["pandas", "polars"],
+)
+def test_check_primary_key_reports_duplicates_and_nulls(make_data) -> None:
+    """check_primary_key should report every violation type, for either backend.
+
+    Regression test: the pandas path used to raise on the first problem it
+    found (duplicates), so a caller fixing that would only discover the
+    null-value problem on a second run. The polars path separately never
+    checked for nulls at all -- a lone null primary-key value passed silently,
+    since ``_find_duplicate_primary_keys``'s group-by/count approach only ever
+    flags a null combination that happens to repeat (see
+    ``_find_null_primary_keys``). Both backends now report every violation
+    type found in one call, without raising.
     """
-    resource = Resource(
-        name="_test__check_primary_key_dispatch",
-        description="Synthetic resource for check_primary_key dispatch tests.",
-        schema={
-            "fields": [
-                {"name": "id", "type": "integer", "description": "Primary key."}
-            ],
-            "primary_key": ["id"],
-        },
-    )
-    # Pandas: raises directly, returns nothing.
-    with pytest.raises(ValueError, match="duplicate primary keys"):
-        resource.check_primary_key(pd.DataFrame({"id": [1, 1]}))
+    errors = _pk_violation_resource().check_primary_key(make_data())
+    messages = " ".join(str(error).lower() for error in errors)
+    assert "duplicate" in messages
+    assert "null" in messages
 
-    # Polars: returns a list of SchemaErrors instead of raising.
-    errors = resource.check_primary_key(pl.LazyFrame({"id": [1, 1]}))
-    assert isinstance(errors, list)
-    assert len(errors) > 0
+
+def test_check_primary_key_polars_catches_lone_null_without_duplicate() -> None:
+    """A single null primary-key value is caught even with no duplicate present.
+
+    Narrower regression test than the parametrized one above: isolates the
+    "null with no accompanying duplicate" case, which is the one
+    ``_find_duplicate_primary_keys``'s group-by/count approach can never catch
+    on its own, to make sure ``_find_null_primary_keys`` is doing real work
+    and not just piggybacking on a duplicate that happens to also be null.
+    """
+    resource = _pk_violation_resource()
+    errors = resource.check_primary_key(pl.LazyFrame({"id": [1, None, 3]}))
+    assert len(errors) == 1
+    assert "null" in str(errors[0]).lower()
+
+
+def test_enforce_schema_raises_combining_primary_key_violations() -> None:
+    """enforce_schema is the caller that wants a hard failure on any PK violation.
+
+    It combines every SchemaError ``check_primary_key`` returns into one
+    ``ValueError`` rather than raising on the first, so both duplicate and null
+    violations are visible in a single run instead of requiring a fix-and-rerun
+    cycle to discover the second one.
+    """
+    resource = _pk_violation_resource()
+    df = _pandas_pk_violation_data()
+    with pytest.raises(ValueError, match=r"(?s)duplicate primary keys.*[Nn]ull") as exc:
+        resource.enforce_schema(df)
+    assert "duplicate primary keys" in str(exc.value)
+    assert "null" in str(exc.value).lower()
+
+
+@pytest.mark.parametrize(
+    "make_data",
+    [_pandas_pk_violation_data, _polars_pk_violation_data],
+    ids=["pandas", "polars"],
+)
+def test_check_primary_key_errors_are_schema_errors_compatible(make_data) -> None:
+    """Every backend's SchemaErrors must survive being wrapped in a real SchemaErrors.
+
+    Regression test: pandera's backends unconditionally read attributes like
+    ``schema``/``check_output`` off of a SchemaError the moment it's collected
+    into a SchemaErrors, not just when displayed later (see
+    ``failure_cases_metadata`` in ``pandera/backends/{pandas,polars}/base.py``).
+    A manually-built duplicate-PK SchemaError once left both of those ``None``
+    for the polars backend, crashing with an opaque ``AttributeError`` -- as
+    first surfaced by a real duplicate-primary-key partition of
+    ``core_ferceqr__quarterly_index_pub``. Constructing a real SchemaErrors
+    here -- not just checking ``len(errors) > 0`` -- is what catches that; a
+    bare list of errors is not enough, since the crash only happens once
+    they're collected into a SchemaErrors.
+    """
+    data = make_data()
+    errors = _pk_violation_resource().check_primary_key(data)
+    schema_errors = SchemaErrors(
+        schema=errors[0].schema, schema_errors=errors, data=data
+    )
+    message = str(schema_errors).lower()
+    assert "duplicate" in message
+    assert "null" in message
 
 
 # ---------------------------------------------------------------------------
@@ -269,8 +323,10 @@ def test_check_primary_key_dispatches_by_type() -> None:
 # The polars path never uses pandera's built-in composite-uniqueness check
 # (too memory-hungry, see polars-comment.md); it always uses its own
 # group-by/count-based `Resource._find_duplicate_primary_keys`, optionally run
-# once per chunk instead of once on the whole table for PUDL's few oversized
-# tables (`_CHUNKED_PK_CHECK_TABLES`). Chunking is only correct because the
+# once per chunk instead of once on the whole table via a caller-supplied
+# `chunk_field` (which tables need this, if any, is an orchestration decision
+# made by the caller -- see `pudl.dagster.asset_checks._CHUNKED_PK_CHECK_TABLES`
+# for PUDL's few oversized tables). Chunking is only correct because the
 # chunking column is itself part of the primary key -- two rows with an
 # identical composite key necessarily share the same value of it, so
 # duplicates can never span chunk boundaries, whether the column is
@@ -314,8 +370,8 @@ def _categorical_pk_resource() -> Resource:
 def test_check_primary_key_polars_temporal_valid() -> None:
     """Repeated non-key values across different years are not false positives.
 
-    ``_temporal_pk_resource`` isn't in ``_CHUNKED_PK_CHECK_TABLES``, so this
-    exercises ``check_primary_key``'s default, unchunked polars dispatch path;
+    No ``chunk_field`` is passed here, so this exercises
+    ``check_primary_key``'s default, unchunked polars dispatch path;
     ``test_chunk_filters_temporal_*`` below separately verify the chunking
     mechanism itself preserves the same correctness.
     """
@@ -347,35 +403,6 @@ def test_check_primary_key_polars_temporal_catches_duplicate() -> None:
     )
     errors = resource._check_primary_key_polars(lf)
     assert len(errors) > 0
-
-
-def test_duplicate_primary_key_error_is_schema_errors_compatible() -> None:
-    """A duplicate-PK SchemaError must survive being wrapped in a real SchemaErrors.
-
-    Regression test: pandera's polars backend unconditionally reads
-    ``err.schema.name`` and ``err.check_output`` off of every error the moment a
-    ``SchemaErrors`` containing it is constructed (see ``failure_cases_metadata``
-    in ``pandera/backends/polars/base.py``), not just when the error is later
-    displayed. The two returned-list-only tests above (checking
-    ``len(errors) > 0``) never actually construct one, so they didn't catch that
-    the manually-built duplicate-PK ``SchemaError`` used to leave both of those
-    ``None``, crashing with an opaque ``AttributeError`` -- as first surfaced by
-    a real duplicate-primary-key partition of ``core_ferceqr__quarterly_index_pub``.
-    """
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
-            "unit_id": [1, 1, 1],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    # Constructing SchemaErrors -- not just returning the list -- is what
-    # previously crashed; pandera does this eagerly in its own __init__.
-    schema_errors = SchemaErrors(
-        schema=resource.schema.to_pandera(), schema_errors=errors, data=lf
-    )
-    assert "not unique" in str(schema_errors)
 
 
 def test_check_primary_key_polars_categorical_valid() -> None:
@@ -429,23 +456,30 @@ def test_chunk_filters_categorical_partitions_by_value() -> None:
 
 
 def test_check_primary_key_polars_no_primary_key() -> None:
-    """Resources without a primary key are trivially valid."""
+    """Resources without a primary key are trivially valid.
+
+    Goes through the public ``check_primary_key`` dispatcher rather than
+    ``_check_primary_key_polars`` directly: the "no primary key" guard lives
+    only in the dispatcher (``_check_primary_key_polars`` assumes a non-empty
+    ``primary_key`` -- an empty one breaks ``pl.any_horizontal`` in the null
+    check), so calling the private method directly here would test a
+    combination that never happens in practice.
+    """
     resource = Resource(
         name="_test__no_pk",
         description="Synthetic resource without a primary key.",
         schema={"fields": [{"name": "x", "type": "integer", "description": "X."}]},
     )
     lf = pl.LazyFrame({"x": [1, 1, 1]})
-    assert resource._check_primary_key_polars(lf) == []
+    assert resource.check_primary_key(lf) == []
 
 
-def test_check_primary_key_polars_rejects_bad_chunk_field(mocker) -> None:
-    """A chunk field that isn't part of the primary key is a config error.
+def test_check_primary_key_polars_rejects_bad_chunk_field() -> None:
+    """A chunk field that isn't part of the primary key is a caller error.
 
     Chunking is only exact (see `Resource._chunk_filters`) when the chunk
-    column is part of the primary key -- if `_CHUNKED_PK_CHECK_TABLES` is ever
-    misconfigured with a column that isn't, that has to fail loudly rather
-    than silently produce an incomplete uniqueness check.
+    column is part of the primary key -- a caller passing one that isn't has
+    to fail loudly rather than silently produce an incomplete uniqueness check.
     """
     resource = Resource(
         name="_test__bad_chunk_field",
@@ -458,10 +492,9 @@ def test_check_primary_key_polars_rejects_bad_chunk_field(mocker) -> None:
             "primary_key": ["id"],
         },
     )
-    mocker.patch.dict(_CHUNKED_PK_CHECK_TABLES, {resource.name: "other"})
     lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
-    with pytest.raises(AssertionError, match="isn't part of"):
-        resource._check_primary_key_polars(lf)
+    with pytest.raises(ValueError, match="isn't part of"):
+        resource._check_primary_key_polars(lf, chunk_field="other")
 
 
 def test_find_duplicate_primary_keys() -> None:
@@ -472,21 +505,6 @@ def test_find_duplicate_primary_keys() -> None:
     assert duplicates["a"][0] == 1
     assert duplicates["b"][0] == "x"
     assert duplicates["_pk_count"][0] == 2
-
-
-def test_chunked_pk_check_tables_are_valid() -> None:
-    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
-
-    Guards against the mapping silently going stale if a listed resource's
-    primary key changes -- the chunking column must remain part of the
-    primary key, since that's what makes chunking by it exact rather than
-    approximate.
-    """
-    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
-        resource = PUDL_PACKAGE.get_resource(resource_name)
-        assert field_name in resource.schema.primary_key, (
-            f"{field_name} is not part of {resource_name}'s primary key"
-        )
 
 
 def test_field_unit_strings() -> None:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -13,7 +13,6 @@ import pandera.pandas as pr_pandas
 import pandera.polars as pr_polars
 import polars as pl
 import pyarrow as pa
-import pydantic
 import pytest
 import sqlalchemy as sa
 from pandera.errors import SchemaErrors
@@ -245,32 +244,12 @@ def test_check_primary_key_reports_duplicates_and_nulls(make_data) -> None:
 
     Regression test: the pandas path used to raise on the first problem it
     found (duplicates), so a caller fixing that would only discover the
-    null-value problem on a second run. The polars path separately never
-    checked for nulls at all -- a lone null primary-key value passed silently,
-    since ``_find_duplicate_primary_keys``'s group-by/count approach only ever
-    flags a null combination that happens to repeat (see
-    ``_find_null_primary_keys``). Both backends now report every violation
-    type found in one call, without raising.
+    null-value problem on a second run.
     """
     errors = _pk_violation_resource().check_primary_key(make_data())
     messages = " ".join(str(error).lower() for error in errors)
     assert "duplicate" in messages
     assert "null" in messages
-
-
-def test_check_primary_key_polars_catches_lone_null_without_duplicate() -> None:
-    """A single null primary-key value is caught even with no duplicate present.
-
-    Narrower regression test than the parametrized one above: isolates the
-    "null with no accompanying duplicate" case, which is the one
-    ``_find_duplicate_primary_keys``'s group-by/count approach can never catch
-    on its own, to make sure ``_find_null_primary_keys`` is doing real work
-    and not just piggybacking on a duplicate that happens to also be null.
-    """
-    resource = _pk_violation_resource()
-    errors = resource.check_primary_key(pl.LazyFrame({"id": [1, None, 3]}))
-    assert len(errors) == 1
-    assert "null" in str(errors[0]).lower()
 
 
 def test_enforce_schema_raises_combining_primary_key_violations() -> None:
@@ -371,69 +350,68 @@ def _categorical_pk_resource() -> Resource:
     )
 
 
-def test_check_primary_key_polars_temporal_valid() -> None:
-    """Repeated non-key values across different years are not false positives.
+@pytest.mark.parametrize(
+    ("resource_fn", "data", "expect_violation"),
+    [
+        (
+            _temporal_pk_resource,
+            {
+                "event_date": [
+                    date(2020, 1, 1),
+                    date(2020, 1, 2),
+                    date(2021, 1, 1),
+                    date(2021, 1, 2),
+                ],
+                # unit_id repeats across years -- fine, since event_date differs.
+                "unit_id": [1, 2, 1, 2],
+            },
+            False,
+        ),
+        (
+            _temporal_pk_resource,
+            {
+                "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
+                "unit_id": [1, 1, 1],
+            },
+            True,
+        ),
+        (
+            _categorical_pk_resource,
+            {
+                "filer_id": ["A", "A", "B", "B"],
+                # record_id repeats across filers -- fine, since filer_id differs.
+                "record_id": [1, 2, 1, 2],
+            },
+            False,
+        ),
+        (
+            _categorical_pk_resource,
+            {
+                "filer_id": ["A", "A", "B"],
+                "record_id": [1, 1, 1],
+            },
+            True,
+        ),
+    ],
+    ids=[
+        "temporal_valid",
+        "temporal_duplicate",
+        "categorical_valid",
+        "categorical_duplicate",
+    ],
+)
+def test_check_primary_key_polars_unchunked(
+    resource_fn, data, expect_violation
+) -> None:
+    """Repeated non-key values are not false positives; true duplicates are caught.
 
-    No ``chunk_field`` is passed here, so this exercises
+    No ``chunk_field`` is set on either synthetic resource, so this exercises
     ``check_primary_key``'s default, unchunked polars dispatch path;
-    ``test_chunk_filters_temporal_*`` below separately verify the chunking
-    mechanism itself preserves the same correctness.
+    ``test_chunk_filters_*`` below separately verify the chunking mechanism
+    itself preserves the same correctness.
     """
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [
-                date(2020, 1, 1),
-                date(2020, 1, 2),
-                date(2021, 1, 1),
-                date(2021, 1, 2),
-            ],
-            # unit_id repeats across years -- fine, since event_date differs.
-            "unit_id": [1, 2, 1, 2],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    assert errors == []
-
-
-def test_check_primary_key_polars_temporal_catches_duplicate() -> None:
-    """A true duplicate composite key within one year is still caught."""
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
-            "unit_id": [1, 1, 1],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    assert len(errors) > 0
-
-
-def test_check_primary_key_polars_categorical_valid() -> None:
-    """Repeated non-key values across different filers are not false positives."""
-    resource = _categorical_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "filer_id": ["A", "A", "B", "B"],
-            # record_id repeats across filers -- fine, since filer_id differs.
-            "record_id": [1, 2, 1, 2],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    assert errors == []
-
-
-def test_check_primary_key_polars_categorical_catches_duplicate() -> None:
-    """A true duplicate composite key within one filer is still caught."""
-    resource = _categorical_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "filer_id": ["A", "A", "B"],
-            "record_id": [1, 1, 1],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    assert len(errors) > 0
+    errors = resource_fn()._check_primary_key_polars(pl.LazyFrame(data))
+    assert bool(errors) == expect_violation
 
 
 def test_chunk_filters_temporal_partitions_by_year() -> None:
@@ -476,33 +454,6 @@ def test_check_primary_key_polars_no_primary_key() -> None:
     )
     lf = pl.LazyFrame({"x": [1, 1, 1]})
     assert resource.check_primary_key(lf) == []
-
-
-def test_schema_rejects_chunk_field_not_in_primary_key() -> None:
-    """A chunk field that isn't part of the primary key is a metadata error.
-
-    Chunking is only exact (see `Resource._chunk_filters`) when the chunk
-    column is part of the primary key, so ``Schema`` itself rejects the
-    combination at construction time rather than letting it silently produce
-    an incomplete uniqueness check later in ``Resource._check_primary_key_polars``.
-    """
-    with pytest.raises(pydantic.ValidationError, match="isn't part of"):
-        Resource(
-            name="_test__bad_chunk_field",
-            description="Synthetic resource for testing chunk-field misconfiguration.",
-            schema={
-                "fields": [
-                    {"name": "id", "type": "integer", "description": "Primary key."},
-                    {
-                        "name": "other",
-                        "type": "integer",
-                        "description": "Not in the PK.",
-                    },
-                ],
-                "primary_key": ["id"],
-                "chunk_field": "other",
-            },
-        )
 
 
 def test_find_duplicate_primary_keys() -> None:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -213,17 +213,17 @@ def test_enum_constraint_order_is_deterministic() -> None:
 
 
 @pytest.mark.parametrize(
-    ("field_type", "constraints", "expected"),
+    ("constraints", "expected"),
     [
-        ("integer", {}, False),
-        ("integer", {"required": True}, True),
-        ("integer", {"unique": True}, True),
-        ("integer", {"minimum": 0}, True),
-        ("integer", {"maximum": 100}, True),
-        ("string", {"min_length": 1}, True),
-        ("string", {"max_length": 10}, True),
-        ("string", {"pattern": r"^[a-z]+$"}, True),
-        ("string", {"enum": ["a", "b"]}, True),
+        ({}, False),
+        ({"required": True}, True),
+        ({"unique": True}, True),
+        ({"minimum": 0}, True),
+        ({"maximum": 100}, True),
+        ({"min_length": 1}, True),
+        ({"max_length": 10}, True),
+        ({"pattern": r"^[a-z]+$"}, True),
+        ({"enum": ["a", "b"]}, True),
     ],
     ids=[
         "no_constraints",
@@ -237,28 +237,23 @@ def test_enum_constraint_order_is_deterministic() -> None:
         "enum",
     ],
 )
-def test_field_has_content_constraints(field_type, constraints, expected) -> None:
+def test_field_constraints_requires_content_validation(constraints, expected) -> None:
     """Each individual content constraint should independently flip the result.
 
-    ``has_content_constraints`` compares each constraint field against its default;
-    asserting only on combinations that set several at once wouldn't catch a future
-    edit that broke the comparison for one particular field, since the others would
-    still make the check pass. Each constraint is exercised alone, plus the
-    all-defaults case, so every field is independently load-bearing.
+    ``requires_content_validation`` compares each constraint field against its
+    default; asserting only on combinations that set several at once wouldn't
+    catch a future edit that broke the comparison for one particular field,
+    since the others would still make the check pass. Each constraint is
+    exercised alone, plus the all-defaults case, so every field is
+    independently load-bearing.
     """
-    field = Field(
-        name="_test_field",
-        type=field_type,
-        description="Test field.",
-        constraints=constraints,
-    )
-    assert field.has_content_constraints() == expected
+    assert FieldConstraints(**constraints).requires_content_validation() == expected
 
 
-def test_field_has_content_constraints_covers_new_constraint_fields() -> None:
+def test_field_constraints_requires_content_validation_covers_new_fields() -> None:
     """A newly added constraint field is automatically treated as content-requiring.
 
-    ``has_content_constraints`` derives the set of fields it checks from
+    ``requires_content_validation`` derives the set of fields it checks from
     ``FieldConstraints.model_fields`` rather than a hand-maintained list, so a
     constraint type added to ``FieldConstraints`` is picked up automatically
     instead of being silently ignored. This subclass stands in for that future
@@ -269,10 +264,10 @@ def test_field_has_content_constraints_covers_new_constraint_fields() -> None:
         new_constraint: str | None = None
 
     defaults = _FieldConstraintsWithNewField()
-    assert defaults.has_content_constraints() is False
+    assert defaults.requires_content_validation() is False
 
     with_new_field_set = _FieldConstraintsWithNewField(new_constraint="x")
-    assert with_new_field_set.has_content_constraints() is True
+    assert with_new_field_set.requires_content_validation() is True
 
 
 def _pk_violation_resource() -> Resource:
@@ -371,17 +366,17 @@ def test_check_primary_key_errors_are_schema_errors_compatible(make_data) -> Non
 # (too memory-hungry, see polars-comment.md); it always uses its own
 # group-by/count-based `Resource._find_duplicate_primary_keys`, optionally run
 # once per chunk instead of once on the whole table via the resource's declared
-# `schema.chunk_field` (which tables need this, if any, is decided per-resource --
-# see `pudl.metadata.resources.epacems`/`vcerare` for PUDL's few oversized tables
-# that set it). Chunking is only correct because the
-# chunking column is itself part of the primary key -- two rows with an
-# identical composite key necessarily share the same value of it, so
-# duplicates can never span chunk boundaries, whether the column is
-# date/datetime (chunked by year) or anything else (chunked by distinct
-# value). These tests go through the public `check_primary_key` dispatcher
-# rather than the private `_check_primary_key_polars`/`_chunk_filters` helpers
-# directly, with synthetic resources, independent of which real tables are
-# currently enumerated.
+# `schema.pk_check_chunk_field` (which tables need this, if any, is decided
+# per-resource -- see `pudl.metadata.resources.epacems`/`vcerare` for PUDL's few
+# oversized tables that set it). Chunking is only correct because the chunking
+# column is itself part of the primary key -- two rows with an identical
+# composite key necessarily share the same value of it, so duplicates can never
+# span chunk boundaries, whether the column is date/datetime (chunked by
+# calendar year -- always annual, no other granularity is supported) or
+# anything else (chunked by exact distinct value). These tests go through the
+# public `check_primary_key` dispatcher rather than the private
+# `_check_primary_key_polars`/`_chunk_filters` helpers directly, with synthetic
+# resources, independent of which real tables are currently enumerated.
 
 
 def _temporal_pk_resource(chunked: bool = False) -> Resource:
@@ -394,7 +389,7 @@ def _temporal_pk_resource(chunked: bool = False) -> Resource:
                 {"name": "unit_id", "type": "integer", "description": "Unit ID."},
             ],
             "primary_key": ["event_date", "unit_id"],
-            "chunk_field": "event_date" if chunked else None,
+            "pk_check_chunk_field": "event_date" if chunked else None,
         },
     )
 
@@ -413,7 +408,7 @@ def _categorical_pk_resource(chunked: bool = False) -> Resource:
                 },
             ],
             "primary_key": ["filer_id", "record_id"],
-            "chunk_field": "filer_id" if chunked else None,
+            "pk_check_chunk_field": "filer_id" if chunked else None,
         },
     )
 
@@ -475,24 +470,26 @@ def test_check_primary_key_polars_detects_violations(
     """Repeated non-key values are not false positives; true duplicates are caught.
 
     Parametrized over ``chunked`` so that every case runs both with and without
-    ``schema.chunk_field`` set on the synthetic resource, on the exact same input
-    data -- chunking must never change the answer ``check_primary_key`` gives,
-    only how it gets there. Goes through the public ``check_primary_key``
-    dispatcher, the same entry point every real caller uses, rather than the
-    private ``_check_primary_key_polars``.
+    ``schema.pk_check_chunk_field`` set on the synthetic resource, on the exact
+    same input data -- chunking must never change the answer
+    ``check_primary_key`` gives, only how it gets there. Goes through the
+    public ``check_primary_key`` dispatcher, the same entry point every real
+    caller uses, rather than the private ``_check_primary_key_polars``.
     """
     errors = resource_fn(chunked=chunked).check_primary_key(pl.LazyFrame(data))
     assert bool(errors) == expect_violation
 
 
-def test_check_primary_key_chunks_by_year_for_temporal_chunk_field(mocker) -> None:
-    """A date/datetime ``chunk_field`` is actually used to partition rows by year.
+def test_check_primary_key_chunks_temporal_field_by_calendar_year(mocker) -> None:
+    """A date/datetime ``pk_check_chunk_field`` partitions rows by calendar year.
 
-    Spies on the private ``Resource._chunk_filters`` rather than calling it
-    directly, so the test still goes through the public ``check_primary_key``
-    entry point (chunking is otherwise invisible from the outside, since it's
-    only an internal performance detail -- the spy is what makes "we're
-    peeking at an implementation detail here" explicit rather than incidental).
+    Chunking a temporal field is always annual -- no other granularity is
+    supported (see ``Resource._chunk_filters``). Spies on the private
+    ``Resource._chunk_filters`` rather than calling it directly, so the test
+    still goes through the public ``check_primary_key`` entry point (chunking
+    is otherwise invisible from the outside, since it's only an internal
+    performance detail -- the spy is what makes "we're peeking at an
+    implementation detail here" explicit rather than incidental).
     """
     spy = mocker.spy(Resource, "_chunk_filters")
     lf = pl.LazyFrame(
@@ -510,10 +507,10 @@ def test_check_primary_key_chunks_by_year_for_temporal_chunk_field(mocker) -> No
     assert row_counts == [1, 2]
 
 
-def test_check_primary_key_chunks_by_value_for_categorical_chunk_field(mocker) -> None:
-    """A non-temporal ``chunk_field`` is actually used to partition rows by value.
+def test_check_primary_key_chunks_categorical_field_by_value(mocker) -> None:
+    """A non-temporal ``pk_check_chunk_field`` partitions rows by exact value.
 
-    See ``test_check_primary_key_chunks_by_year_for_temporal_chunk_field`` for
+    See ``test_check_primary_key_chunks_temporal_field_by_calendar_year`` for
     why this spies on ``Resource._chunk_filters`` rather than calling it
     directly.
     """

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -13,7 +13,6 @@ import pandera.pandas as pr_pandas
 import pandera.polars as pr_polars
 import polars as pl
 import pyarrow as pa
-import pydantic
 import pytest
 import sqlalchemy as sa
 from pandera.errors import SchemaErrors
@@ -242,32 +241,12 @@ def test_check_primary_key_reports_duplicates_and_nulls(make_data) -> None:
 
     Regression test: the pandas path used to raise on the first problem it
     found (duplicates), so a caller fixing that would only discover the
-    null-value problem on a second run. The polars path separately never
-    checked for nulls at all -- a lone null primary-key value passed silently,
-    since ``_find_duplicate_primary_keys``'s group-by/count approach only ever
-    flags a null combination that happens to repeat (see
-    ``_find_null_primary_keys``). Both backends now report every violation
-    type found in one call, without raising.
+    null-value problem on a second run.
     """
     errors = _pk_violation_resource().check_primary_key(make_data())
     messages = " ".join(str(error).lower() for error in errors)
     assert "duplicate" in messages
     assert "null" in messages
-
-
-def test_check_primary_key_polars_catches_lone_null_without_duplicate() -> None:
-    """A single null primary-key value is caught even with no duplicate present.
-
-    Narrower regression test than the parametrized one above: isolates the
-    "null with no accompanying duplicate" case, which is the one
-    ``_find_duplicate_primary_keys``'s group-by/count approach can never catch
-    on its own, to make sure ``_find_null_primary_keys`` is doing real work
-    and not just piggybacking on a duplicate that happens to also be null.
-    """
-    resource = _pk_violation_resource()
-    errors = resource.check_primary_key(pl.LazyFrame({"id": [1, None, 3]}))
-    assert len(errors) == 1
-    assert "null" in str(errors[0]).lower()
 
 
 def test_enforce_schema_raises_combining_primary_key_violations() -> None:
@@ -368,69 +347,68 @@ def _categorical_pk_resource() -> Resource:
     )
 
 
-def test_check_primary_key_polars_temporal_valid() -> None:
-    """Repeated non-key values across different years are not false positives.
+@pytest.mark.parametrize(
+    ("resource_fn", "data", "expect_violation"),
+    [
+        (
+            _temporal_pk_resource,
+            {
+                "event_date": [
+                    date(2020, 1, 1),
+                    date(2020, 1, 2),
+                    date(2021, 1, 1),
+                    date(2021, 1, 2),
+                ],
+                # unit_id repeats across years -- fine, since event_date differs.
+                "unit_id": [1, 2, 1, 2],
+            },
+            False,
+        ),
+        (
+            _temporal_pk_resource,
+            {
+                "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
+                "unit_id": [1, 1, 1],
+            },
+            True,
+        ),
+        (
+            _categorical_pk_resource,
+            {
+                "filer_id": ["A", "A", "B", "B"],
+                # record_id repeats across filers -- fine, since filer_id differs.
+                "record_id": [1, 2, 1, 2],
+            },
+            False,
+        ),
+        (
+            _categorical_pk_resource,
+            {
+                "filer_id": ["A", "A", "B"],
+                "record_id": [1, 1, 1],
+            },
+            True,
+        ),
+    ],
+    ids=[
+        "temporal_valid",
+        "temporal_duplicate",
+        "categorical_valid",
+        "categorical_duplicate",
+    ],
+)
+def test_check_primary_key_polars_unchunked(
+    resource_fn, data, expect_violation
+) -> None:
+    """Repeated non-key values are not false positives; true duplicates are caught.
 
-    No ``chunk_field`` is passed here, so this exercises
+    No ``chunk_field`` is set on either synthetic resource, so this exercises
     ``check_primary_key``'s default, unchunked polars dispatch path;
-    ``test_chunk_filters_temporal_*`` below separately verify the chunking
-    mechanism itself preserves the same correctness.
+    ``test_chunk_filters_*`` below separately verify the chunking mechanism
+    itself preserves the same correctness.
     """
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [
-                date(2020, 1, 1),
-                date(2020, 1, 2),
-                date(2021, 1, 1),
-                date(2021, 1, 2),
-            ],
-            # unit_id repeats across years -- fine, since event_date differs.
-            "unit_id": [1, 2, 1, 2],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    assert errors == []
-
-
-def test_check_primary_key_polars_temporal_catches_duplicate() -> None:
-    """A true duplicate composite key within one year is still caught."""
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
-            "unit_id": [1, 1, 1],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    assert len(errors) > 0
-
-
-def test_check_primary_key_polars_categorical_valid() -> None:
-    """Repeated non-key values across different filers are not false positives."""
-    resource = _categorical_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "filer_id": ["A", "A", "B", "B"],
-            # record_id repeats across filers -- fine, since filer_id differs.
-            "record_id": [1, 2, 1, 2],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    assert errors == []
-
-
-def test_check_primary_key_polars_categorical_catches_duplicate() -> None:
-    """A true duplicate composite key within one filer is still caught."""
-    resource = _categorical_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "filer_id": ["A", "A", "B"],
-            "record_id": [1, 1, 1],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    assert len(errors) > 0
+    errors = resource_fn()._check_primary_key_polars(pl.LazyFrame(data))
+    assert bool(errors) == expect_violation
 
 
 def test_chunk_filters_temporal_partitions_by_year() -> None:
@@ -473,33 +451,6 @@ def test_check_primary_key_polars_no_primary_key() -> None:
     )
     lf = pl.LazyFrame({"x": [1, 1, 1]})
     assert resource.check_primary_key(lf) == []
-
-
-def test_schema_rejects_chunk_field_not_in_primary_key() -> None:
-    """A chunk field that isn't part of the primary key is a metadata error.
-
-    Chunking is only exact (see `Resource._chunk_filters`) when the chunk
-    column is part of the primary key, so ``Schema`` itself rejects the
-    combination at construction time rather than letting it silently produce
-    an incomplete uniqueness check later in ``Resource._check_primary_key_polars``.
-    """
-    with pytest.raises(pydantic.ValidationError, match="isn't part of"):
-        Resource(
-            name="_test__bad_chunk_field",
-            description="Synthetic resource for testing chunk-field misconfiguration.",
-            schema={
-                "fields": [
-                    {"name": "id", "type": "integer", "description": "Primary key."},
-                    {
-                        "name": "other",
-                        "type": "integer",
-                        "description": "Not in the PK.",
-                    },
-                ],
-                "primary_key": ["id"],
-                "chunk_field": "other",
-            },
-        )
 
 
 def test_find_duplicate_primary_keys() -> None:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -15,6 +15,7 @@ import polars as pl
 import pyarrow as pa
 import pytest
 import sqlalchemy as sa
+from pandera.errors import SchemaErrors
 from shapely import Point
 
 from pudl.metadata.classes import (
@@ -349,6 +350,35 @@ def test_check_primary_key_polars_temporal_catches_duplicate() -> None:
     )
     errors = resource._check_primary_key_polars(lf)
     assert len(errors) > 0
+
+
+def test_duplicate_primary_key_error_is_schema_errors_compatible() -> None:
+    """A duplicate-PK SchemaError must survive being wrapped in a real SchemaErrors.
+
+    Regression test: pandera's polars backend unconditionally reads
+    ``err.schema.name`` and ``err.check_output`` off of every error the moment a
+    ``SchemaErrors`` containing it is constructed (see ``failure_cases_metadata``
+    in ``pandera/backends/polars/base.py``), not just when the error is later
+    displayed. The two returned-list-only tests above (checking
+    ``len(errors) > 0``) never actually construct one, so they didn't catch that
+    the manually-built duplicate-PK ``SchemaError`` used to leave both of those
+    ``None``, crashing with an opaque ``AttributeError`` -- as first surfaced by
+    a real duplicate-primary-key partition of ``core_ferceqr__quarterly_index_pub``.
+    """
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
+            "unit_id": [1, 1, 1],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    # Constructing SchemaErrors -- not just returning the list -- is what
+    # previously crashed; pandera does this eagerly in its own __init__.
+    schema_errors = SchemaErrors(
+        schema=resource.schema.to_pandera(), schema_errors=errors, data=lf
+    )
+    assert "not unique" in str(schema_errors)
 
 
 def test_check_primary_key_polars_categorical_valid() -> None:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -22,6 +22,7 @@ from pudl.metadata.classes import (
     PUDL_PACKAGE,
     DataSource,
     Field,
+    FieldConstraints,
     Package,
     PudlResourceDescriptor,
     Resource,
@@ -239,12 +240,11 @@ def test_enum_constraint_order_is_deterministic() -> None:
 def test_field_has_content_constraints(field_type, constraints, expected) -> None:
     """Each individual content constraint should independently flip the result.
 
-    ``has_content_constraints`` ORs together eight separate conditions; asserting
-    only on combinations that set several at once wouldn't catch a future edit
-    that accidentally drops one of them from the ``any([...])`` list, since the
-    others would still make the check pass. Each constraint is exercised alone,
-    plus the all-defaults case, so every arm of the ``any()`` is independently
-    load-bearing.
+    ``has_content_constraints`` compares each constraint field against its default;
+    asserting only on combinations that set several at once wouldn't catch a future
+    edit that broke the comparison for one particular field, since the others would
+    still make the check pass. Each constraint is exercised alone, plus the
+    all-defaults case, so every field is independently load-bearing.
     """
     field = Field(
         name="_test_field",
@@ -253,6 +253,26 @@ def test_field_has_content_constraints(field_type, constraints, expected) -> Non
         constraints=constraints,
     )
     assert field.has_content_constraints() == expected
+
+
+def test_field_has_content_constraints_covers_new_constraint_fields() -> None:
+    """A newly added constraint field is automatically treated as content-requiring.
+
+    ``has_content_constraints`` derives the set of fields it checks from
+    ``FieldConstraints.model_fields`` rather than a hand-maintained list, so a
+    constraint type added to ``FieldConstraints`` is picked up automatically
+    instead of being silently ignored. This subclass stands in for that future
+    field.
+    """
+
+    class _FieldConstraintsWithNewField(FieldConstraints):
+        new_constraint: str | None = None
+
+    defaults = _FieldConstraintsWithNewField()
+    assert defaults.has_content_constraints() is False
+
+    with_new_field_set = _FieldConstraintsWithNewField(new_constraint="x")
+    assert with_new_field_set.has_content_constraints() is True
 
 
 def _pk_violation_resource() -> Resource:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from datetime import date
 from typing import Any
 
 import duckdb.sqltypes
@@ -17,6 +18,7 @@ import sqlalchemy as sa
 from shapely import Point
 
 from pudl.metadata.classes import (
+    _CHUNKED_PK_CHECK_TABLES,
     PUDL_PACKAGE,
     DataSource,
     Field,
@@ -207,6 +209,257 @@ def test_enum_constraint_order_is_deterministic() -> None:
         constraints={"enum": {"z", "a", "m", "b"}},
     )
     assert field.constraints.enum == ["a", "b", "m", "z"]
+
+
+def test_check_primary_key_reports_both_duplicates_and_nulls() -> None:
+    """check_primary_key should report every violation in one pass, not just the first.
+
+    Regression test: an earlier version raised on the first problem it found
+    (duplicates), so a caller fixing that would only discover the null-value
+    problem on a second run.
+    """
+    resource = Resource(
+        name="_test__check_primary_key",
+        description="Synthetic resource for check_primary_key tests.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."}
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    df = pd.DataFrame({"id": pd.array([1, 1, None], dtype="Int64")})
+    with pytest.raises(
+        ValueError, match=r"(?s)duplicate primary keys.*Null values"
+    ) as exc:
+        resource.check_primary_key(df)
+    assert "duplicate primary keys" in str(exc.value)
+    assert "Null values found" in str(exc.value)
+
+
+def test_check_primary_key_dispatches_by_type() -> None:
+    """check_primary_key routes to the pandas or polars implementation by type.
+
+    Callers shouldn't have to remember two method names for the two backends --
+    this locks in that a single ``check_primary_key`` call works for either.
+    """
+    resource = Resource(
+        name="_test__check_primary_key_dispatch",
+        description="Synthetic resource for check_primary_key dispatch tests.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."}
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    # Pandas: raises directly, returns nothing.
+    with pytest.raises(ValueError, match="duplicate primary keys"):
+        resource.check_primary_key(pd.DataFrame({"id": [1, 1]}))
+
+    # Polars: returns a list of SchemaErrors instead of raising.
+    errors = resource.check_primary_key(pl.LazyFrame({"id": [1, 1]}))
+    assert isinstance(errors, list)
+    assert len(errors) > 0
+
+
+# ---------------------------------------------------------------------------
+# Tests for chunked primary-key uniqueness checking (Resource.check_primary_key's
+# polars path, i.e. Resource._check_primary_key_polars)
+# ---------------------------------------------------------------------------
+#
+# The polars path never uses pandera's built-in composite-uniqueness check
+# (too memory-hungry, see polars-comment.md); it always uses its own
+# group-by/count-based `Resource._find_duplicate_primary_keys`, optionally run
+# once per chunk instead of once on the whole table for PUDL's few oversized
+# tables (`_CHUNKED_PK_CHECK_TABLES`). Chunking is only correct because the
+# chunking column is itself part of the primary key -- two rows with an
+# identical composite key necessarily share the same value of it, so
+# duplicates can never span chunk boundaries, whether the column is
+# date/datetime (chunked by year) or anything else (chunked by distinct
+# value). These tests exercise the machinery directly with synthetic
+# resources, independent of which real tables are currently enumerated.
+
+
+def _temporal_pk_resource() -> Resource:
+    return Resource(
+        name="_test__temporal_pk_chunking",
+        description="Synthetic resource with a temporal primary key.",
+        schema={
+            "fields": [
+                {"name": "event_date", "type": "date", "description": "Event date."},
+                {"name": "unit_id", "type": "integer", "description": "Unit ID."},
+            ],
+            "primary_key": ["event_date", "unit_id"],
+        },
+    )
+
+
+def _categorical_pk_resource() -> Resource:
+    return Resource(
+        name="_test__categorical_pk_chunking",
+        description="Synthetic resource with a string primary-key column.",
+        schema={
+            "fields": [
+                {"name": "filer_id", "type": "string", "description": "Filer ID."},
+                {
+                    "name": "record_id",
+                    "type": "integer",
+                    "description": "Record ID.",
+                },
+            ],
+            "primary_key": ["filer_id", "record_id"],
+        },
+    )
+
+
+def test_check_primary_key_polars_temporal_valid() -> None:
+    """Repeated non-key values across different years are not false positives.
+
+    ``_temporal_pk_resource`` isn't in ``_CHUNKED_PK_CHECK_TABLES``, so this
+    exercises ``check_primary_key``'s default, unchunked polars dispatch path;
+    ``test_chunk_filters_temporal_*`` below separately verify the chunking
+    mechanism itself preserves the same correctness.
+    """
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [
+                date(2020, 1, 1),
+                date(2020, 1, 2),
+                date(2021, 1, 1),
+                date(2021, 1, 2),
+            ],
+            # unit_id repeats across years -- fine, since event_date differs.
+            "unit_id": [1, 2, 1, 2],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    assert errors == []
+
+
+def test_check_primary_key_polars_temporal_catches_duplicate() -> None:
+    """A true duplicate composite key within one year is still caught."""
+    resource = _temporal_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
+            "unit_id": [1, 1, 1],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    assert len(errors) > 0
+
+
+def test_check_primary_key_polars_categorical_valid() -> None:
+    """Repeated non-key values across different filers are not false positives."""
+    resource = _categorical_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "filer_id": ["A", "A", "B", "B"],
+            # record_id repeats across filers -- fine, since filer_id differs.
+            "record_id": [1, 2, 1, 2],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    assert errors == []
+
+
+def test_check_primary_key_polars_categorical_catches_duplicate() -> None:
+    """A true duplicate composite key within one filer is still caught."""
+    resource = _categorical_pk_resource()
+    lf = pl.LazyFrame(
+        {
+            "filer_id": ["A", "A", "B"],
+            "record_id": [1, 1, 1],
+        }
+    )
+    errors = resource._check_primary_key_polars(lf)
+    assert len(errors) > 0
+
+
+def test_chunk_filters_temporal_partitions_by_year() -> None:
+    """Temporal chunk filters split rows into non-overlapping, year-aligned sets."""
+    lf = pl.LazyFrame(
+        {"event_date": [date(2020, 1, 1), date(2020, 6, 1), date(2021, 3, 1)]}
+    )
+    filters = Resource._chunk_filters(lf, "event_date")
+    assert len(filters) == 2  # 2020 and 2021
+    row_counts = sorted(lf.filter(f).select(pl.len()).collect().item() for f in filters)
+    assert row_counts == [1, 2]
+
+
+def test_chunk_filters_categorical_partitions_by_value() -> None:
+    """Categorical chunk filters split rows by each distinct value, exactly."""
+    lf = pl.LazyFrame({"filer_id": ["A", "A", "B"]})
+    filters = Resource._chunk_filters(lf, "filer_id")
+    assert len(filters) == 2  # "A" and "B"
+    counts_by_value = {}
+    for f in filters:
+        chunk = lf.filter(f).collect()
+        counts_by_value[chunk["filer_id"][0]] = chunk.height
+    assert counts_by_value == {"A": 2, "B": 1}
+
+
+def test_check_primary_key_polars_no_primary_key() -> None:
+    """Resources without a primary key are trivially valid."""
+    resource = Resource(
+        name="_test__no_pk",
+        description="Synthetic resource without a primary key.",
+        schema={"fields": [{"name": "x", "type": "integer", "description": "X."}]},
+    )
+    lf = pl.LazyFrame({"x": [1, 1, 1]})
+    assert resource._check_primary_key_polars(lf) == []
+
+
+def test_check_primary_key_polars_rejects_bad_chunk_field(mocker) -> None:
+    """A chunk field that isn't part of the primary key is a config error.
+
+    Chunking is only exact (see `Resource._chunk_filters`) when the chunk
+    column is part of the primary key -- if `_CHUNKED_PK_CHECK_TABLES` is ever
+    misconfigured with a column that isn't, that has to fail loudly rather
+    than silently produce an incomplete uniqueness check.
+    """
+    resource = Resource(
+        name="_test__bad_chunk_field",
+        description="Synthetic resource for testing chunk-field misconfiguration.",
+        schema={
+            "fields": [
+                {"name": "id", "type": "integer", "description": "Primary key."},
+                {"name": "other", "type": "integer", "description": "Not in the PK."},
+            ],
+            "primary_key": ["id"],
+        },
+    )
+    mocker.patch.dict(_CHUNKED_PK_CHECK_TABLES, {resource.name: "other"})
+    lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
+    with pytest.raises(AssertionError, match="isn't part of"):
+        resource._check_primary_key_polars(lf)
+
+
+def test_find_duplicate_primary_keys() -> None:
+    """The underlying group-by/count reduction correctly identifies duplicates."""
+    lf = pl.LazyFrame({"a": [1, 1, 2], "b": ["x", "x", "y"]})
+    duplicates = Resource._find_duplicate_primary_keys(lf, ["a", "b"])
+    assert duplicates.height == 1
+    assert duplicates["a"][0] == 1
+    assert duplicates["b"][0] == "x"
+    assert duplicates["_pk_count"][0] == 2
+
+
+def test_chunked_pk_check_tables_are_valid() -> None:
+    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
+
+    Guards against the mapping silently going stale if a listed resource's
+    primary key changes -- the chunking column must remain part of the
+    primary key, since that's what makes chunking by it exact rather than
+    approximate.
+    """
+    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
+        resource = PUDL_PACKAGE.get_resource(resource_name)
+        assert field_name in resource.schema.primary_key, (
+            f"{field_name} is not part of {resource_name}'s primary key"
+        )
 
 
 def test_field_unit_strings() -> None:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -19,7 +19,6 @@ from pandera.errors import SchemaErrors
 from shapely import Point
 
 from pudl.metadata.classes import (
-    _CHUNKED_PK_CHECK_TABLES,
     PUDL_PACKAGE,
     DataSource,
     Field,
@@ -212,14 +211,8 @@ def test_enum_constraint_order_is_deterministic() -> None:
     assert field.constraints.enum == ["a", "b", "m", "z"]
 
 
-def test_check_primary_key_reports_both_duplicates_and_nulls() -> None:
-    """check_primary_key should report every violation in one pass, not just the first.
-
-    Regression test: an earlier version raised on the first problem it found
-    (duplicates), so a caller fixing that would only discover the null-value
-    problem on a second run.
-    """
-    resource = Resource(
+def _pk_violation_resource() -> Resource:
+    return Resource(
         name="_test__check_primary_key",
         description="Synthetic resource for check_primary_key tests.",
         schema={
@@ -229,39 +222,100 @@ def test_check_primary_key_reports_both_duplicates_and_nulls() -> None:
             "primary_key": ["id"],
         },
     )
-    df = pd.DataFrame({"id": pd.array([1, 1, None], dtype="Int64")})
-    with pytest.raises(
-        ValueError, match=r"(?s)duplicate primary keys.*Null values"
-    ) as exc:
-        resource.check_primary_key(df)
-    assert "duplicate primary keys" in str(exc.value)
-    assert "Null values found" in str(exc.value)
 
 
-def test_check_primary_key_dispatches_by_type() -> None:
-    """check_primary_key routes to the pandas or polars implementation by type.
+def _pandas_pk_violation_data() -> pd.DataFrame:
+    """A single-column PK with both a duplicate (1, 1) and a null value."""
+    return pd.DataFrame({"id": pd.array([1, 1, None], dtype="Int64")})
 
-    Callers shouldn't have to remember two method names for the two backends --
-    this locks in that a single ``check_primary_key`` call works for either.
+
+def _polars_pk_violation_data() -> pl.LazyFrame:
+    """A single-column PK with both a duplicate (1, 1) and a null value."""
+    return pl.LazyFrame({"id": [1, 1, None]})
+
+
+@pytest.mark.parametrize(
+    "make_data",
+    [_pandas_pk_violation_data, _polars_pk_violation_data],
+    ids=["pandas", "polars"],
+)
+def test_check_primary_key_reports_duplicates_and_nulls(make_data) -> None:
+    """check_primary_key should report every violation type, for either backend.
+
+    Regression test: the pandas path used to raise on the first problem it
+    found (duplicates), so a caller fixing that would only discover the
+    null-value problem on a second run. The polars path separately never
+    checked for nulls at all -- a lone null primary-key value passed silently,
+    since ``_find_duplicate_primary_keys``'s group-by/count approach only ever
+    flags a null combination that happens to repeat (see
+    ``_find_null_primary_keys``). Both backends now report every violation
+    type found in one call, without raising.
     """
-    resource = Resource(
-        name="_test__check_primary_key_dispatch",
-        description="Synthetic resource for check_primary_key dispatch tests.",
-        schema={
-            "fields": [
-                {"name": "id", "type": "integer", "description": "Primary key."}
-            ],
-            "primary_key": ["id"],
-        },
-    )
-    # Pandas: raises directly, returns nothing.
-    with pytest.raises(ValueError, match="duplicate primary keys"):
-        resource.check_primary_key(pd.DataFrame({"id": [1, 1]}))
+    errors = _pk_violation_resource().check_primary_key(make_data())
+    messages = " ".join(str(error).lower() for error in errors)
+    assert "duplicate" in messages
+    assert "null" in messages
 
-    # Polars: returns a list of SchemaErrors instead of raising.
-    errors = resource.check_primary_key(pl.LazyFrame({"id": [1, 1]}))
-    assert isinstance(errors, list)
-    assert len(errors) > 0
+
+def test_check_primary_key_polars_catches_lone_null_without_duplicate() -> None:
+    """A single null primary-key value is caught even with no duplicate present.
+
+    Narrower regression test than the parametrized one above: isolates the
+    "null with no accompanying duplicate" case, which is the one
+    ``_find_duplicate_primary_keys``'s group-by/count approach can never catch
+    on its own, to make sure ``_find_null_primary_keys`` is doing real work
+    and not just piggybacking on a duplicate that happens to also be null.
+    """
+    resource = _pk_violation_resource()
+    errors = resource.check_primary_key(pl.LazyFrame({"id": [1, None, 3]}))
+    assert len(errors) == 1
+    assert "null" in str(errors[0]).lower()
+
+
+def test_enforce_schema_raises_combining_primary_key_violations() -> None:
+    """enforce_schema is the caller that wants a hard failure on any PK violation.
+
+    It combines every SchemaError ``check_primary_key`` returns into one
+    ``ValueError`` rather than raising on the first, so both duplicate and null
+    violations are visible in a single run instead of requiring a fix-and-rerun
+    cycle to discover the second one.
+    """
+    resource = _pk_violation_resource()
+    df = _pandas_pk_violation_data()
+    with pytest.raises(ValueError, match=r"(?s)duplicate primary keys.*[Nn]ull") as exc:
+        resource.enforce_schema(df)
+    assert "duplicate primary keys" in str(exc.value)
+    assert "null" in str(exc.value).lower()
+
+
+@pytest.mark.parametrize(
+    "make_data",
+    [_pandas_pk_violation_data, _polars_pk_violation_data],
+    ids=["pandas", "polars"],
+)
+def test_check_primary_key_errors_are_schema_errors_compatible(make_data) -> None:
+    """Every backend's SchemaErrors must survive being wrapped in a real SchemaErrors.
+
+    Regression test: pandera's backends unconditionally read attributes like
+    ``schema``/``check_output`` off of a SchemaError the moment it's collected
+    into a SchemaErrors, not just when displayed later (see
+    ``failure_cases_metadata`` in ``pandera/backends/{pandas,polars}/base.py``).
+    A manually-built duplicate-PK SchemaError once left both of those ``None``
+    for the polars backend, crashing with an opaque ``AttributeError`` -- as
+    first surfaced by a real duplicate-primary-key partition of
+    ``core_ferceqr__quarterly_index_pub``. Constructing a real SchemaErrors
+    here -- not just checking ``len(errors) > 0`` -- is what catches that; a
+    bare list of errors is not enough, since the crash only happens once
+    they're collected into a SchemaErrors.
+    """
+    data = make_data()
+    errors = _pk_violation_resource().check_primary_key(data)
+    schema_errors = SchemaErrors(
+        schema=errors[0].schema, schema_errors=errors, data=data
+    )
+    message = str(schema_errors).lower()
+    assert "duplicate" in message
+    assert "null" in message
 
 
 # ---------------------------------------------------------------------------
@@ -272,8 +326,10 @@ def test_check_primary_key_dispatches_by_type() -> None:
 # The polars path never uses pandera's built-in composite-uniqueness check
 # (too memory-hungry, see polars-comment.md); it always uses its own
 # group-by/count-based `Resource._find_duplicate_primary_keys`, optionally run
-# once per chunk instead of once on the whole table for PUDL's few oversized
-# tables (`_CHUNKED_PK_CHECK_TABLES`). Chunking is only correct because the
+# once per chunk instead of once on the whole table via a caller-supplied
+# `chunk_field` (which tables need this, if any, is an orchestration decision
+# made by the caller -- see `pudl.dagster.asset_checks._CHUNKED_PK_CHECK_TABLES`
+# for PUDL's few oversized tables). Chunking is only correct because the
 # chunking column is itself part of the primary key -- two rows with an
 # identical composite key necessarily share the same value of it, so
 # duplicates can never span chunk boundaries, whether the column is
@@ -317,8 +373,8 @@ def _categorical_pk_resource() -> Resource:
 def test_check_primary_key_polars_temporal_valid() -> None:
     """Repeated non-key values across different years are not false positives.
 
-    ``_temporal_pk_resource`` isn't in ``_CHUNKED_PK_CHECK_TABLES``, so this
-    exercises ``check_primary_key``'s default, unchunked polars dispatch path;
+    No ``chunk_field`` is passed here, so this exercises
+    ``check_primary_key``'s default, unchunked polars dispatch path;
     ``test_chunk_filters_temporal_*`` below separately verify the chunking
     mechanism itself preserves the same correctness.
     """
@@ -350,35 +406,6 @@ def test_check_primary_key_polars_temporal_catches_duplicate() -> None:
     )
     errors = resource._check_primary_key_polars(lf)
     assert len(errors) > 0
-
-
-def test_duplicate_primary_key_error_is_schema_errors_compatible() -> None:
-    """A duplicate-PK SchemaError must survive being wrapped in a real SchemaErrors.
-
-    Regression test: pandera's polars backend unconditionally reads
-    ``err.schema.name`` and ``err.check_output`` off of every error the moment a
-    ``SchemaErrors`` containing it is constructed (see ``failure_cases_metadata``
-    in ``pandera/backends/polars/base.py``), not just when the error is later
-    displayed. The two returned-list-only tests above (checking
-    ``len(errors) > 0``) never actually construct one, so they didn't catch that
-    the manually-built duplicate-PK ``SchemaError`` used to leave both of those
-    ``None``, crashing with an opaque ``AttributeError`` -- as first surfaced by
-    a real duplicate-primary-key partition of ``core_ferceqr__quarterly_index_pub``.
-    """
-    resource = _temporal_pk_resource()
-    lf = pl.LazyFrame(
-        {
-            "event_date": [date(2020, 1, 1), date(2020, 1, 1), date(2021, 1, 1)],
-            "unit_id": [1, 1, 1],
-        }
-    )
-    errors = resource._check_primary_key_polars(lf)
-    # Constructing SchemaErrors -- not just returning the list -- is what
-    # previously crashed; pandera does this eagerly in its own __init__.
-    schema_errors = SchemaErrors(
-        schema=resource.schema.to_pandera(), schema_errors=errors, data=lf
-    )
-    assert "not unique" in str(schema_errors)
 
 
 def test_check_primary_key_polars_categorical_valid() -> None:
@@ -432,23 +459,30 @@ def test_chunk_filters_categorical_partitions_by_value() -> None:
 
 
 def test_check_primary_key_polars_no_primary_key() -> None:
-    """Resources without a primary key are trivially valid."""
+    """Resources without a primary key are trivially valid.
+
+    Goes through the public ``check_primary_key`` dispatcher rather than
+    ``_check_primary_key_polars`` directly: the "no primary key" guard lives
+    only in the dispatcher (``_check_primary_key_polars`` assumes a non-empty
+    ``primary_key`` -- an empty one breaks ``pl.any_horizontal`` in the null
+    check), so calling the private method directly here would test a
+    combination that never happens in practice.
+    """
     resource = Resource(
         name="_test__no_pk",
         description="Synthetic resource without a primary key.",
         schema={"fields": [{"name": "x", "type": "integer", "description": "X."}]},
     )
     lf = pl.LazyFrame({"x": [1, 1, 1]})
-    assert resource._check_primary_key_polars(lf) == []
+    assert resource.check_primary_key(lf) == []
 
 
-def test_check_primary_key_polars_rejects_bad_chunk_field(mocker) -> None:
-    """A chunk field that isn't part of the primary key is a config error.
+def test_check_primary_key_polars_rejects_bad_chunk_field() -> None:
+    """A chunk field that isn't part of the primary key is a caller error.
 
     Chunking is only exact (see `Resource._chunk_filters`) when the chunk
-    column is part of the primary key -- if `_CHUNKED_PK_CHECK_TABLES` is ever
-    misconfigured with a column that isn't, that has to fail loudly rather
-    than silently produce an incomplete uniqueness check.
+    column is part of the primary key -- a caller passing one that isn't has
+    to fail loudly rather than silently produce an incomplete uniqueness check.
     """
     resource = Resource(
         name="_test__bad_chunk_field",
@@ -461,10 +495,9 @@ def test_check_primary_key_polars_rejects_bad_chunk_field(mocker) -> None:
             "primary_key": ["id"],
         },
     )
-    mocker.patch.dict(_CHUNKED_PK_CHECK_TABLES, {resource.name: "other"})
     lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
-    with pytest.raises(AssertionError, match="isn't part of"):
-        resource._check_primary_key_polars(lf)
+    with pytest.raises(ValueError, match="isn't part of"):
+        resource._check_primary_key_polars(lf, chunk_field="other")
 
 
 def test_find_duplicate_primary_keys() -> None:
@@ -475,21 +508,6 @@ def test_find_duplicate_primary_keys() -> None:
     assert duplicates["a"][0] == 1
     assert duplicates["b"][0] == "x"
     assert duplicates["_pk_count"][0] == 2
-
-
-def test_chunked_pk_check_tables_are_valid() -> None:
-    """Every entry in _CHUNKED_PK_CHECK_TABLES must name a real, matching field.
-
-    Guards against the mapping silently going stale if a listed resource's
-    primary key changes -- the chunking column must remain part of the
-    primary key, since that's what makes chunking by it exact rather than
-    approximate.
-    """
-    for resource_name, field_name in _CHUNKED_PK_CHECK_TABLES.items():
-        resource = PUDL_PACKAGE.get_resource(resource_name)
-        assert field_name in resource.schema.primary_key, (
-            f"{field_name} is not part of {resource_name}'s primary key"
-        )
 
 
 def test_field_unit_strings() -> None:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -13,6 +13,7 @@ import pandera.pandas as pr_pandas
 import pandera.polars as pr_polars
 import polars as pl
 import pyarrow as pa
+import pydantic
 import pytest
 import sqlalchemy as sa
 from pandera.errors import SchemaErrors
@@ -326,10 +327,10 @@ def test_check_primary_key_errors_are_schema_errors_compatible(make_data) -> Non
 # The polars path never uses pandera's built-in composite-uniqueness check
 # (too memory-hungry, see polars-comment.md); it always uses its own
 # group-by/count-based `Resource._find_duplicate_primary_keys`, optionally run
-# once per chunk instead of once on the whole table via a caller-supplied
-# `chunk_field` (which tables need this, if any, is an orchestration decision
-# made by the caller -- see `pudl.dagster.asset_checks._CHUNKED_PK_CHECK_TABLES`
-# for PUDL's few oversized tables). Chunking is only correct because the
+# once per chunk instead of once on the whole table via the resource's declared
+# `schema.chunk_field` (which tables need this, if any, is decided per-resource --
+# see `pudl.metadata.resources.epacems`/`vcerare` for PUDL's few oversized tables
+# that set it). Chunking is only correct because the
 # chunking column is itself part of the primary key -- two rows with an
 # identical composite key necessarily share the same value of it, so
 # duplicates can never span chunk boundaries, whether the column is
@@ -477,27 +478,31 @@ def test_check_primary_key_polars_no_primary_key() -> None:
     assert resource.check_primary_key(lf) == []
 
 
-def test_check_primary_key_polars_rejects_bad_chunk_field() -> None:
-    """A chunk field that isn't part of the primary key is a caller error.
+def test_schema_rejects_chunk_field_not_in_primary_key() -> None:
+    """A chunk field that isn't part of the primary key is a metadata error.
 
     Chunking is only exact (see `Resource._chunk_filters`) when the chunk
-    column is part of the primary key -- a caller passing one that isn't has
-    to fail loudly rather than silently produce an incomplete uniqueness check.
+    column is part of the primary key, so ``Schema`` itself rejects the
+    combination at construction time rather than letting it silently produce
+    an incomplete uniqueness check later in ``Resource._check_primary_key_polars``.
     """
-    resource = Resource(
-        name="_test__bad_chunk_field",
-        description="Synthetic resource for testing chunk-field misconfiguration.",
-        schema={
-            "fields": [
-                {"name": "id", "type": "integer", "description": "Primary key."},
-                {"name": "other", "type": "integer", "description": "Not in the PK."},
-            ],
-            "primary_key": ["id"],
-        },
-    )
-    lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
-    with pytest.raises(ValueError, match="isn't part of"):
-        resource._check_primary_key_polars(lf, chunk_field="other")
+    with pytest.raises(pydantic.ValidationError, match="isn't part of"):
+        Resource(
+            name="_test__bad_chunk_field",
+            description="Synthetic resource for testing chunk-field misconfiguration.",
+            schema={
+                "fields": [
+                    {"name": "id", "type": "integer", "description": "Primary key."},
+                    {
+                        "name": "other",
+                        "type": "integer",
+                        "description": "Not in the PK.",
+                    },
+                ],
+                "primary_key": ["id"],
+                "chunk_field": "other",
+            },
+        )
 
 
 def test_find_duplicate_primary_keys() -> None:

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -208,6 +208,50 @@ def test_enum_constraint_order_is_deterministic() -> None:
     assert field.constraints.enum == ["a", "b", "m", "z"]
 
 
+@pytest.mark.parametrize(
+    ("field_type", "constraints", "expected"),
+    [
+        ("integer", {}, False),
+        ("integer", {"required": True}, True),
+        ("integer", {"unique": True}, True),
+        ("integer", {"minimum": 0}, True),
+        ("integer", {"maximum": 100}, True),
+        ("string", {"min_length": 1}, True),
+        ("string", {"max_length": 10}, True),
+        ("string", {"pattern": r"^[a-z]+$"}, True),
+        ("string", {"enum": ["a", "b"]}, True),
+    ],
+    ids=[
+        "no_constraints",
+        "required",
+        "unique",
+        "minimum",
+        "maximum",
+        "min_length",
+        "max_length",
+        "pattern",
+        "enum",
+    ],
+)
+def test_field_has_content_constraints(field_type, constraints, expected) -> None:
+    """Each individual content constraint should independently flip the result.
+
+    ``has_content_constraints`` ORs together eight separate conditions; asserting
+    only on combinations that set several at once wouldn't catch a future edit
+    that accidentally drops one of them from the ``any([...])`` list, since the
+    others would still make the check pass. Each constraint is exercised alone,
+    plus the all-defaults case, so every arm of the ``any()`` is independently
+    load-bearing.
+    """
+    field = Field(
+        name="_test_field",
+        type=field_type,
+        description="Test field.",
+        constraints=constraints,
+    )
+    assert field.has_content_constraints() == expected
+
+
 def _pk_violation_resource() -> Resource:
     return Resource(
         name="_test__check_primary_key",

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -520,16 +520,6 @@ def test_check_primary_key_polars_no_primary_key() -> None:
     assert resource.check_primary_key(lf) == []
 
 
-def test_find_duplicate_primary_keys() -> None:
-    """The underlying group-by/count reduction correctly identifies duplicates."""
-    lf = pl.LazyFrame({"a": [1, 1, 2], "b": ["x", "x", "y"]})
-    duplicates = Resource._find_duplicate_primary_keys(lf, ["a", "b"])
-    assert duplicates.height == 1
-    assert duplicates["a"][0] == 1
-    assert duplicates["b"][0] == "x"
-    assert duplicates["_pk_count"][0] == 2
-
-
 def test_field_unit_strings() -> None:
     """Check that all unit strings in FIELD_METADATA parse against PUDL_UNIT_REGISTRY.
 

--- a/tests/unit/metadata/metadata_test.py
+++ b/tests/unit/metadata/metadata_test.py
@@ -13,6 +13,7 @@ import pandera.pandas as pr_pandas
 import pandera.polars as pr_polars
 import polars as pl
 import pyarrow as pa
+import pydantic
 import pytest
 import sqlalchemy as sa
 from pandera.errors import SchemaErrors
@@ -323,10 +324,10 @@ def test_check_primary_key_errors_are_schema_errors_compatible(make_data) -> Non
 # The polars path never uses pandera's built-in composite-uniqueness check
 # (too memory-hungry, see polars-comment.md); it always uses its own
 # group-by/count-based `Resource._find_duplicate_primary_keys`, optionally run
-# once per chunk instead of once on the whole table via a caller-supplied
-# `chunk_field` (which tables need this, if any, is an orchestration decision
-# made by the caller -- see `pudl.dagster.asset_checks._CHUNKED_PK_CHECK_TABLES`
-# for PUDL's few oversized tables). Chunking is only correct because the
+# once per chunk instead of once on the whole table via the resource's declared
+# `schema.chunk_field` (which tables need this, if any, is decided per-resource --
+# see `pudl.metadata.resources.epacems`/`vcerare` for PUDL's few oversized tables
+# that set it). Chunking is only correct because the
 # chunking column is itself part of the primary key -- two rows with an
 # identical composite key necessarily share the same value of it, so
 # duplicates can never span chunk boundaries, whether the column is
@@ -474,27 +475,31 @@ def test_check_primary_key_polars_no_primary_key() -> None:
     assert resource.check_primary_key(lf) == []
 
 
-def test_check_primary_key_polars_rejects_bad_chunk_field() -> None:
-    """A chunk field that isn't part of the primary key is a caller error.
+def test_schema_rejects_chunk_field_not_in_primary_key() -> None:
+    """A chunk field that isn't part of the primary key is a metadata error.
 
     Chunking is only exact (see `Resource._chunk_filters`) when the chunk
-    column is part of the primary key -- a caller passing one that isn't has
-    to fail loudly rather than silently produce an incomplete uniqueness check.
+    column is part of the primary key, so ``Schema`` itself rejects the
+    combination at construction time rather than letting it silently produce
+    an incomplete uniqueness check later in ``Resource._check_primary_key_polars``.
     """
-    resource = Resource(
-        name="_test__bad_chunk_field",
-        description="Synthetic resource for testing chunk-field misconfiguration.",
-        schema={
-            "fields": [
-                {"name": "id", "type": "integer", "description": "Primary key."},
-                {"name": "other", "type": "integer", "description": "Not in the PK."},
-            ],
-            "primary_key": ["id"],
-        },
-    )
-    lf = pl.LazyFrame({"id": [1, 2], "other": [1, 2]})
-    with pytest.raises(ValueError, match="isn't part of"):
-        resource._check_primary_key_polars(lf, chunk_field="other")
+    with pytest.raises(pydantic.ValidationError, match="isn't part of"):
+        Resource(
+            name="_test__bad_chunk_field",
+            description="Synthetic resource for testing chunk-field misconfiguration.",
+            schema={
+                "fields": [
+                    {"name": "id", "type": "integer", "description": "Primary key."},
+                    {
+                        "name": "other",
+                        "type": "integer",
+                        "description": "Not in the PK.",
+                    },
+                ],
+                "primary_key": ["id"],
+                "chunk_field": "other",
+            },
+        )
 
 
 def test_find_duplicate_primary_keys() -> None:


### PR DESCRIPTION
# Overview

## Pandera LazyFrame validation was... very lazy

- Pandera's Polars backend silently validates only column presence and dtype for `pl.LazyFrame` inputs unless validation depth is explicitly forced to `SCHEMA_AND_DATA`.
- PUDL has never done this, so every Check, range, enum, nullable, and uniqueness constraint declared in our metadata has gone unenforced for every Polars-backed asset check (~99% of PUDL's tables).
- Only the the handful of geopandas backed assets (used for geometry-bearing geospatial tables), was actually enforcing them.
- The `format_df` method called on most outputs did check Enum validity, as well as PK uniqueness & non-nullness.
- Enabling deep validation blows up memory usage and makes big tables slow.

## Per-column asset checks

- Parquet makes it very fast and easy to read individual columns and row groups.
- With the exception of composite primary key uniqueness validation, all of our checks apply to single columns.
- This means we can quickly iterate over each individual column that has checks defined on it, run those checks, and move on.
- Most columns have no checks defined and so never ever need to be read.
- This is so fast and memory efficient that we can run all the checks on all the tables no matter how big. Even for the billion-row EPA CEMS peak memory usage is only about 1.2 GB.

## Composite primary key checks

- Composite primary-key uniqueness needed its own fix.
- Pandera's built-in check collects the entire LazyFrame up to three times and calls the eager (non-streaming) `.is_duplicated()`, which I clocked using ~165 GB of memory on EPA CEMS. So that's not going to work.
- I replaced it with a single streaming group-by/count reduction, with optional per-table chunking (temporal or categorical) for the handful of tables still too large to check in one pass.
- The chunking is strictly corrct, so long as the chunking column is part of the primary key.
- It uses literal (rather than derived) filters against the chunking column's own stored values so Parquet row-group pruning (based on min/max metadata) can be used to avoid reading the vast majority of the data in any individual chunk query.
- Running this check on `core_ferceqr__transactions` ran just fine (it's partitioned by quarter) but highlighted that actually, what we had listed as the PK is very much non-unique (up to tens of millions of duplicate groups in the largest quarter).
- Documented the intended primary key and the open question in `additional_primary_key_text`.

## How should we manage Enums and Categoricals?

After conferring with @krivard and @cmgosnell we decided to go with just validating the ENUM values in our Pandera schema checks, and not trying to manage all of the different library complexities. We're going with least-common-denominator (Parquet) which has a Categorical type that lists all allowed values, but doesn't enforce them. Se https://github.com/catalyst-cooperative/pudl/pull/5442 for a way to make the DuckDB Parquet outputs also do this (rather than just writing Strings). See notes in the comments for more details.

## Other small wins

- Ensured that all Enum constraints use a sorted list of values to minimize future conflicts and make them more readable.
- Narrowed the Enum constraint type to only allow lists of strings (since that's all we use, and I think all we want to use)
- Centralized primary key validation in the `Resource.check_primary_key()` method so it's just done in one place.
- Populated richer Dagster metadata for the pandera schema asset checks to make debugging failures easier.
- Added a raft of tests related to these changes.
- Reduced (or at least re-organized...) unnecessary type enforcement.
 
## Documentation

Make sure to update relevant aspects of the documentation:

- [ ] Update the [release notes](https://docs.catalyst.coop/pudl/en/nightly/release_notes.html): reference the PR and related issues.
- [ ] Update relevant Data Source jinja templates (see `docs/data_sources/templates`).
- [ ] Update relevant table or source description metadata (see `src/metadata`).
- [ ] Review and update any other aspects of the documentation that might be affected by this PR.

# Testing

How did you make sure this worked? How can a reviewer verify this?

## To-do list

- [ ] If updating analyses or data processing functions: make sure to update row count expectations in `dbt` tests.
- [ ] Run `pixi run prek-run` to run linters and static code analysis checks.
- [ ] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [ ] Review the PR yourself and call out any questions or issues you have.
- [ ] For PRs that change the PUDL outputs significantly, run the full ETL locally and then [run the data validations](https://docs.catalyst.coop/pudl/en/nightly/dev/data_validation.html) using dbt. If you can't run the ETL locally then run the `build-deploy-pudl` GitHub Action manually and ensure that it succeeds.
