### PR TITLE
Switch from Enum to Categorical in dataframe schemas

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -44,21 +44,12 @@ Bug Fixes & Data Cleaning
 Performance Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-* Stopped using ``pl.Enum`` for enum-constrained string fields in favor of
-  unconstrained ``pl.Categorical``/pandas ``"category"``. Polars embeds an ``Enum``
-  column's fixed category list directly in Parquet field metadata, which permanently
-  pins the physical dtype: any later attempt to scan that file with a different
-  schema fails at collection time instead of being coerced. ``Categorical``
-  round-trips through Parquet cleanly, and the enum value constraint itself is still
-  enforced via Pandera's ``Check.isin``. Switched
-  :func:`~pudl.helpers.get_parquet_table_polars` to using a single
-  ``pl.scan_parquet(..., schema=...)`` call, since the ``.cast()`` was only necessary
-  due to the presence of ``pl.Enum`` columns, and forced materialization. This
-  allowed us to remove a gated ``.collect(engine="streaming")`` call on high-memory
-  assets, and surfaced that Pandera's Polars backend had never enforced content
-  checks (value ranges, uniqueness, etc.) on any ``LazyFrame``-backed asset,
-  regardless of that gate. Enabling real content validation for ``LazyFrame`` assets
-  is left to PR :pr:`5432`.
+* Switched from using ``pl.Enum`` to unconstrained ``pl.Categorical`` types to preserve
+  lazy execution in :func:`~pudl.helpers.get_parquet_table_polars`. This allows running
+  schema checks on large tables, and Pandera's Polars backend never actually enforced
+  data content checks on ``pl.LazyFrame`` assets (99% of assets in PUDL). See PR
+  :pr:`5434`. Implementing efficient content validation for ``pl.LazyFrame`` assets is
+  left to PR :pr:`5432`.
 * The fast ETL now processes only two representative
   :doc:`EIA-861 <data_sources/eia861>` years instead of the entire time series, bringing
   it in line with how every other dataset is already handled and speeding up both local

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -44,6 +44,21 @@ Bug Fixes & Data Cleaning
 Performance Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
+* Stopped using ``pl.Enum`` for enum-constrained string fields in favor of
+  unconstrained ``pl.Categorical``/pandas ``"category"``. Polars embeds an ``Enum``
+  column's fixed category list directly in Parquet field metadata, which permanently
+  pins the physical dtype: any later attempt to scan that file with a different
+  schema fails at collection time instead of being coerced. ``Categorical``
+  round-trips through Parquet cleanly, and the enum value constraint itself is still
+  enforced via Pandera's ``Check.isin``. Switched
+  :func:`~pudl.helpers.get_parquet_table_polars` to using a single
+  ``pl.scan_parquet(..., schema=...)`` call, since the ``.cast()`` was only necessary
+  due to the presence of ``pl.Enum`` columns, and forced materialization. This
+  allowed us to remove a gated ``.collect(engine="streaming")`` call on high-memory
+  assets, and surfaced that Pandera's Polars backend had never enforced content
+  checks (value ranges, uniqueness, etc.) on any ``LazyFrame``-backed asset,
+  regardless of that gate. Enabling real content validation for ``LazyFrame`` assets
+  is left as follow-up work.
 * The fast ETL now processes only two representative
   :doc:`EIA-861 <data_sources/eia861>` years instead of the entire time series, bringing
   it in line with how every other dataset is already handled and speeding up both local

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -58,7 +58,7 @@ Performance Improvements
   assets, and surfaced that Pandera's Polars backend had never enforced content
   checks (value ranges, uniqueness, etc.) on any ``LazyFrame``-backed asset,
   regardless of that gate. Enabling real content validation for ``LazyFrame`` assets
-  is left as follow-up work.
+  is left to PR :pr:`5432`.
 * The fast ETL now processes only two representative
   :doc:`EIA-861 <data_sources/eia861>` years instead of the entire time series, bringing
   it in line with how every other dataset is already handled and speeding up both local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -568,6 +568,7 @@ filterwarnings = [
     "once:Valid config keys have changed in V2:UserWarning",
     "once:AssetExecutionContext.op_config is deprecated:DeprecationWarning",
     "ignore:unclosed database:ResourceWarning",
+    "ignore:Exception ignored in:pytest.PytestUnraisableExceptionWarning",
     "ignore:Specifying a partitions_def on an AssetCheckSpec is currently in preview",
     "ignore:No path_separator found in configuration:DeprecationWarning:alembic",
     "ignore:Extension type 'geoarrow.wkb' is not registered:UserWarning",

--- a/src/pudl/dagster/asset_checks.py
+++ b/src/pudl/dagster/asset_checks.py
@@ -265,7 +265,6 @@ def asset_check_from_schema(  # noqa: C901
     asset_key: dg.AssetKey,
     package: Package,
     duckdb_asset: bool,
-    high_memory_asset: bool,
 ) -> dg.AssetChecksDefinition | None:
     """Create a Dagster asset check based on the resource schema, if defined.
 
@@ -320,11 +319,18 @@ def asset_check_from_schema(  # noqa: C901
 
         try:
             if isinstance(asset_value, pl.LazyFrame):
-                validated_schema = asset_value.pipe(pandera_schema.validate, lazy=True)
-                # Only validate data contents if asset is not marked as high memory
-                if not high_memory_asset:
-                    validated_schema.collect(engine="streaming")
+                # NOTE: Pandera's polars backend only performs schema-level
+                # validation (column presence + dtype) for a `pl.LazyFrame`,
+                # via `collect_schema()` -- it does not run Check/unique/
+                # non-nullable content validation unless the validation depth
+                # is explicitly forced to `SCHEMA_AND_DATA`, which we do not
+                # currently do here. Content constraints declared in PUDL's
+                # metadata (enum values, ranges, uniqueness, etc.) are
+                # therefore NOT enforced for Polars LazyFrame assets today.
+                assert isinstance(pandera_schema, pr_polars.DataFrameSchema)
+                pandera_schema.validate(asset_value, lazy=True)
             else:
+                assert isinstance(pandera_schema, pr_pandas.DataFrameSchema)
                 pandera_schema.validate(asset_value, lazy=True)
             return dg.AssetCheckResult(passed=True, metadata=metadata)
 
@@ -414,12 +420,6 @@ duckdb_assets = [
     "core_ferceqr__transactions",
 ]
 
-high_memory_assets = [
-    "out_vcerare__hourly_available_capacity_factor",
-    "core_epacems__hourly_emissions",
-    "core_ferceqr__transactions",
-]
-
 default_asset_checks += [
     check
     for check in (
@@ -427,7 +427,6 @@ default_asset_checks += [
             asset_key,
             PUDL_PACKAGE,
             duckdb_asset=asset_key.to_user_string() in duckdb_assets,
-            high_memory_asset=asset_key.to_user_string() in high_memory_assets,
         )
         for asset_key in asset_keys
     )
@@ -546,5 +545,4 @@ __all__ = [
     "group_mean_continuity_check",
     "default_asset_checks",
     "duckdb_assets",
-    "high_memory_assets",
 ]

--- a/src/pudl/helpers.py
+++ b/src/pudl/helpers.py
@@ -2221,16 +2221,12 @@ def get_parquet_table_polars(
         table_name: Name of the table to read.
         partitions: Optional dictionary of partitions to filter the data. See
             :class:`ParquetData` definition for details.
+        paths: optional :class:`PudlPaths`. By default, the default
+            :class:`PudlPaths` will be used.
 
     Returns:
         A polars LazyFrame representing the table.
     """
-    # Import here to avoid circular imports
-    from pudl.metadata.classes import Resource
-
-    resource = Resource.from_id(table_name)
-    schema = resource.to_polars_dtypes()
-
     # Get the Parquet file path
     if partitions is None:
         resolved_paths = PudlPaths() if paths is None else paths
@@ -2240,7 +2236,22 @@ def get_parquet_table_polars(
         # Points to a directory of parquet files when there partitions is non None
         parquet_path = parquet_data.parquet_path
 
-    return pl.scan_parquet(parquet_path).cast(schema, strict=False)
+    # Import here to avoid circular imports
+    from pudl.metadata.classes import Resource
+
+    resource = Resource.from_id(table_name)
+    # Pass the expected schema in directly rather than scanning then casting: casting
+    # a LazyFrame containing Enum-typed columns forces materialization, which is very
+    # slow for our largest hourly tables. Enum-constrained fields are stored as plain
+    # Categorical (see Field.to_polars_dtype), so no such cast is needed here anyway.
+    # Parquet files still store integer/float columns as 32-bit (FIELD_DTYPES_PYARROW),
+    # narrower than the 64-bit Polars schema we're requesting here, so allow scan-time
+    # upcasting rather than the strict match scan_parquet defaults to.
+    return pl.scan_parquet(
+        parquet_path,
+        schema=resource.to_polars_dtypes(),
+        cast_options=pl.ScanCastOptions(integer_cast="upcast", float_cast="upcast"),
+    )
 
 
 def get_parquet_table(

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -725,9 +725,17 @@ class Field(PudlMeta):
         return FIELD_DTYPES_DUCKDB[self.type]
 
     def to_polars_dtype(self) -> pl.DataType:
-        """Return polars data type."""
-        if self.constraints.enum:
-            return pl.Enum(self.constraints.enum)
+        """Return polars data type.
+
+        Enum-constrained string fields are stored as unconstrained
+        :class:`pl.Categorical` rather than :class:`pl.Enum`. Polars embeds a fixed,
+        ordered category list from an ``Enum`` column directly in the Parquet field
+        metadata, which permanently pins the physical dtype: any later attempt to scan
+        that file with a different schema or even slightly different ``Enum`` fails
+        instead of being coerced. ``Categorical`` round-trips through Parquet fine.
+        """
+        if self.constraints.enum and self.type == "string":
+            return pl.Categorical
         return FIELD_DTYPES_POLARS[self.type]
 
     def to_pandas_dtype(self, compact: bool = False) -> str | pd.CategoricalDtype:
@@ -736,7 +744,7 @@ class Field(PudlMeta):
         Args:
             compact: Whether to return a low-memory data type (32-bit integer or float).
         """
-        if self.constraints.enum:
+        if self.constraints.enum and self.type == "string":
             return pd.CategoricalDtype(self.constraints.enum)
         if compact:
             if self.type == "integer":
@@ -891,9 +899,11 @@ class Field(PudlMeta):
         constraints = self.constraints
         checks = constraints.to_pandera_checks(use_pandas_backend)
         if constraints.enum:
-            column_type = (
-                "category" if use_pandas_backend else pl.Enum(constraints.enum)
-            )
+            # The physical dtype is unconstrained Categorical/"category" (see
+            # Field.to_polars_dtype / Field.to_pandas_dtype); the enum value
+            # constraint itself is enforced by the `checks` (Check.isin) above,
+            # not by the declared column dtype.
+            column_type = "category" if use_pandas_backend else pl.Categorical
         elif self.type == "geometry":
             column_type = gpd.array.GeometryDtype()
         else:
@@ -1019,7 +1029,7 @@ class Schema(PudlMeta):
                     )
         return self
 
-    def to_pandera(self: Self) -> pr_polars.DataFrameSchema:
+    def to_pandera(self: Self) -> pr_polars.DataFrameSchema | pr_pandas.DataFrameSchema:
         """Turn PUDL Schema into Pandera schema, so dagster can understand it."""
         # 2024-02-09: pr.Check doesn't have interop with Pydantic type system
         # yet, so we encode as Callable, then cast.
@@ -2044,17 +2054,16 @@ class Resource(PudlMeta):
                 and pd.api.types.is_integer_dtype(df[field.name])
             ):
                 df[field.name] = pd.to_datetime(df[field.name], format="%Y")
-            if isinstance(dtypes[field.name], pd.CategoricalDtype):
+            if field.constraints.enum and field.type == "string" and field.name in df:
                 uncategorized = [
                     value
                     for value in df[field.name].dropna().unique()
-                    if value not in dtypes[field.name].categories
+                    if value not in field.constraints.enum
                 ]
                 if uncategorized:
                     raise ValueError(
                         f"Values in {field.name} column are not included in "
-                        "categorical values in field enum constraint "
-                        f"and will be converted to nulls ({uncategorized})."
+                        f"the field's enum constraint: {uncategorized}."
                     )
         df = (
             # Reorder columns and insert missing columns

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -65,7 +65,6 @@ def test_asset_checks_preserve_runtime_input_types(
         dg.AssetKey([asset_name]),
         PUDL_PACKAGE,
         duckdb_asset=duckdb_asset,
-        high_memory_asset=False,
     )
 
     assert check is not None


### PR DESCRIPTION
# Overview

While working on #5190 @cmgosnell discovered that Polars Enum types were forcing the materialization of LazyFrames during schema validation, leading to memory issues and general slowness of large table loading/writing/validation, and making it difficult to enforce our specified schemas on the Parquet outputs.

I spent some time debugging this and discovered two confusing issues that were interacting:

- First, **Pandera silently ignores all content checks** when you tell it to validate a Polars LazyFrame. Our schema validation was not actually checking any of the value constraints we had defined.
- Second, **Polars quietly embeds its own metadata in Parquet outputs** for `pl.Enum` columns, and uses that metadata to reconstitute the `Enum` type when reading the Parquet file back in. This embedded `Enum` type cannot be overridden by a schema passed to `pl.scan_parquet()`. This means that if we write a Parquet file with an `Enum` column, and then later try to read it back in with a different schema (e.g., using `pl.Categorical` instead of `pl.Enum`), Polars will refuse to read the file and throw an error. Even if we use a `pl.Enum` type in the schema, if it has a different set of values, or the values are in a different order, it will be considered incompatible. Only a `cast()` can change the type, which forces materialization of the LazyFrame and defeats the purpose of using LazyFrames in the first place.

Given that we weren't even checking the `Enum` constraints due to the issue with Pandera and `LazyFrames above`, I switched all of our constrained Enum types to unconstrained `Categorical` types for our dataframe backends (pandas, polars, and pyarrow). We also (re-)discovered that PyArrow has no constrained `Enum` type at all, so we can't distribute this kind of constraint directly in the Parquet outputs -- it needs to be checked and enforced in our pipeline, and then documented in the metadata we publish alongside the data.

Obviously not checking our column constraints is a major issue! I've deferred fixing it to #5432 (which hangs off of this PR) to keep this focused on fixing the immediate memory blowup issue for #5190. This PR doesn't make anything worse.

## Documentation

- [x] Update release notes
- [x] Review and update any other aspects of the documentation that might be affected by this PR (I didn't see any)

## To-do list

- [x] Run `pixi run prek-run` to run linters and static code analysis checks.
- [x] Run `pixi run pytest-ci` locally to ensure that the merge queue will accept your PR.
- [x] Run the full ETL locally + `dbt_helper validate`
- [x] Review the PR yourself and call out any questions or issues you have.