### PR TITLE
Pin pyrefly to 1.2.0, fix pre-existing errors, refresh baseline

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,8 @@ eia861-transform.ipynb merge=ours
 pixi.lock merge=ours linguist-generated=true
 schema.machine.yml merge=ours linguist-generated=true
 schema.yml merge=ours linguist-generated=true
+.pyrefly-baseline.json merge=ours linguist-generated=true
+.secrets.baseline merge=ours linguist-generated=true
 *.csv text
 *.py text
 *.json text

--- a/.pyrefly-baseline.json
+++ b/.pyrefly-baseline.json
@@ -596,7 +596,7 @@
       "path": "src/pudl/analysis/record_linkage/link_cross_year.py",
       "code": -2,
       "name": "bad-index",
-      "description": "Cannot index into `tuple[ndarray, ndarray]`\n  No matching overload found for function `tuple.__getitem__` called with arguments: (tuple[slice[Any, Unknown, Unknown], slice[Any, Unknown, Unknown]])\n  Possible overloads:\n    (key: SupportsIndex, /) -> ndarray [closest match]\n    (key: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | Unknown | None], /) -> tuple[ndarray, ...]\n  Argument `tuple[slice[Any, Unknown, Unknown], slice[Any, Unknown, Unknown]]` is not assignable to parameter `key` with type `SupportsIndex` in function `tuple.__getitem__`",
+      "description": "Cannot index into `tuple[ndarray, ndarray]`\n  No matching overload found for function `tuple.__getitem__` called with arguments: (tuple[slice[None, None, None], slice[None, None, None]])\n  Possible overloads:\n    (key: SupportsIndex, /) -> ndarray [closest match]\n    (key: slice[SupportsIndex | None, SupportsIndex | None, SupportsIndex | Unknown | None], /) -> tuple[ndarray, ...]\n  Argument `tuple[slice[None, None, None], slice[None, None, None]]` is not assignable to parameter `key` with type `SupportsIndex` in function `tuple.__getitem__`",
       "concise_description": "Cannot index into `tuple[ndarray, ndarray]`",
       "severity": "error"
     },
@@ -997,15 +997,39 @@
       "severity": "error"
     },
     {
-      "line": 29,
-      "column": 32,
-      "stop_line": 37,
-      "stop_column": 2,
+      "line": 31,
+      "column": 17,
+      "stop_line": 31,
+      "stop_column": 35,
       "path": "src/pudl/analysis/state_demand.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`list[dict[str, Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64]]` is not assignable to `list[dict[str, str]]`",
-      "concise_description": "`list[dict[str, Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64]]` is not assignable to `list[dict[str, str]]`",
+      "description": "`Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` is not assignable to dict value type `str`",
+      "concise_description": "`Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` is not assignable to dict value type `str`",
+      "severity": "error"
+    },
+    {
+      "line": 32,
+      "column": 17,
+      "stop_line": 32,
+      "stop_column": 35,
+      "path": "src/pudl/analysis/state_demand.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` is not assignable to dict value type `str`",
+      "concise_description": "`Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` is not assignable to dict value type `str`",
+      "severity": "error"
+    },
+    {
+      "line": 33,
+      "column": 17,
+      "stop_line": 33,
+      "stop_column": 32,
+      "path": "src/pudl/analysis/state_demand.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` is not assignable to dict value type `str`",
+      "concise_description": "`Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` is not assignable to dict value type `str`",
       "severity": "error"
     },
     {
@@ -1045,15 +1069,99 @@
       "severity": "error"
     },
     {
-      "line": 64,
-      "column": 40,
-      "stop_line": 73,
-      "stop_column": 2,
+      "line": 65,
+      "column": 25,
+      "stop_line": 65,
+      "stop_column": 28,
       "path": "src/pudl/analysis/timeseries_cleaning.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`dict[str, int]` is not assignable to `dict[str, str]`",
-      "concise_description": "`dict[str, int]` is not assignable to `dict[str, str]`",
+      "description": "`Literal[-10]` is not assignable to dict value type `str`",
+      "concise_description": "`Literal[-10]` is not assignable to dict value type `str`",
+      "severity": "error"
+    },
+    {
+      "line": 66,
+      "column": 26,
+      "stop_line": 66,
+      "stop_column": 28,
+      "path": "src/pudl/analysis/timeseries_cleaning.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Literal[-9]` is not assignable to dict value type `str`",
+      "concise_description": "`Literal[-9]` is not assignable to dict value type `str`",
+      "severity": "error"
+    },
+    {
+      "line": 67,
+      "column": 28,
+      "stop_line": 67,
+      "stop_column": 30,
+      "path": "src/pudl/analysis/timeseries_cleaning.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Literal[-8]` is not assignable to dict value type `str`",
+      "concise_description": "`Literal[-8]` is not assignable to dict value type `str`",
+      "severity": "error"
+    },
+    {
+      "line": 68,
+      "column": 23,
+      "stop_line": 68,
+      "stop_column": 25,
+      "path": "src/pudl/analysis/timeseries_cleaning.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Literal[-7]` is not assignable to dict value type `str`",
+      "concise_description": "`Literal[-7]` is not assignable to dict value type `str`",
+      "severity": "error"
+    },
+    {
+      "line": 69,
+      "column": 24,
+      "stop_line": 69,
+      "stop_column": 26,
+      "path": "src/pudl/analysis/timeseries_cleaning.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Literal[-7]` is not assignable to dict value type `str`",
+      "concise_description": "`Literal[-7]` is not assignable to dict value type `str`",
+      "severity": "error"
+    },
+    {
+      "line": 70,
+      "column": 24,
+      "stop_line": 70,
+      "stop_column": 26,
+      "path": "src/pudl/analysis/timeseries_cleaning.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Literal[-6]` is not assignable to dict value type `str`",
+      "concise_description": "`Literal[-6]` is not assignable to dict value type `str`",
+      "severity": "error"
+    },
+    {
+      "line": 71,
+      "column": 25,
+      "stop_line": 71,
+      "stop_column": 27,
+      "path": "src/pudl/analysis/timeseries_cleaning.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Literal[-5]` is not assignable to dict value type `str`",
+      "concise_description": "`Literal[-5]` is not assignable to dict value type `str`",
+      "severity": "error"
+    },
+    {
+      "line": 72,
+      "column": 24,
+      "stop_line": 72,
+      "stop_column": 26,
+      "path": "src/pudl/analysis/timeseries_cleaning.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`Literal[-4]` is not assignable to dict value type `str`",
+      "concise_description": "`Literal[-4]` is not assignable to dict value type `str`",
       "severity": "error"
     },
     {
@@ -1789,18 +1897,6 @@
       "severity": "error"
     },
     {
-      "line": 328,
-      "column": 40,
-      "stop_line": 328,
-      "stop_column": 64,
-      "path": "src/pudl/dagster/asset_checks.py",
-      "code": -2,
-      "name": "bad-specialization",
-      "description": "`GeoDataFrame` is not assignable to any of constraints `LazyFrame`, `DataFrame` of type variable `PolarsFrame`",
-      "concise_description": "`GeoDataFrame` is not assignable to any of constraints `LazyFrame`, `DataFrame` of type variable `PolarsFrame`",
-      "severity": "error"
-    },
-    {
       "line": 355,
       "column": 15,
       "stop_line": 355,
@@ -2425,6 +2521,18 @@
       "severity": "error"
     },
     {
+      "line": 141,
+      "column": 43,
+      "stop_line": 141,
+      "stop_column": 51,
+      "path": "src/pudl/extract/dbf.py",
+      "code": -2,
+      "name": "unsupported-operation",
+      "description": "Cannot set item in `dict[Any, str]`\n  Argument `bytes | Unknown | None` is not assignable to parameter `value` with type `str` in function `dict.__setitem__`\n  The declared type does not allow `None`. Consider narrowing the value with an `is not None` check.",
+      "concise_description": "Cannot set item in `dict[Any, str]`",
+      "severity": "error"
+    },
+    {
       "line": 182,
       "column": 42,
       "stop_line": 182,
@@ -2557,9 +2665,9 @@
       "severity": "error"
     },
     {
-      "line": 22,
+      "line": 33,
       "column": 9,
-      "stop_line": 22,
+      "stop_line": 33,
       "stop_column": 22,
       "path": "src/pudl/extract/eia191.py",
       "code": -2,
@@ -2569,9 +2677,9 @@
       "severity": "error"
     },
     {
-      "line": 28,
+      "line": 39,
       "column": 16,
-      "stop_line": 28,
+      "stop_line": 39,
       "stop_column": 55,
       "path": "src/pudl/extract/eia191.py",
       "code": -2,
@@ -3013,54 +3121,6 @@
       "severity": "error"
     },
     {
-      "line": 22,
-      "column": 1,
-      "stop_line": 22,
-      "stop_column": 16,
-      "path": "src/pudl/extract/ferceqr.py",
-      "code": -2,
-      "name": "no-matching-overload",
-      "description": "No matching overload found for function `contextlib.contextmanager` called with arguments: ((base_path: UPath, year_quarter: str) -> ZipFile)\n  Possible overloads:\n    (func: (ParamSpec(_P)) -> Generator[_T_co, None, object]) -> (ParamSpec(_P)) -> _GeneratorContextManager[_T_co] [closest match]\n    (func: (ParamSpec(_P)) -> Iterator[_T_co]) -> (ParamSpec(_P)) -> _GeneratorContextManager[_T_co]\n  Argument `(base_path: UPath, year_quarter: str) -> ZipFile` is not assignable to parameter `func` with type `(base_path: UPath, year_quarter: str) -> Generator[@_, None, object]` in function `contextlib.contextmanager`",
-      "concise_description": "No matching overload found for function `contextlib.contextmanager` called with arguments: ((base_path: UPath, year_quarter: str) -> ZipFile)",
-      "severity": "error"
-    },
-    {
-      "line": 23,
-      "column": 54,
-      "stop_line": 23,
-      "stop_column": 69,
-      "path": "src/pudl/extract/ferceqr.py",
-      "code": -2,
-      "name": "bad-return",
-      "description": "Generator function should return `Generator`",
-      "concise_description": "Generator function should return `Generator`",
-      "severity": "error"
-    },
-    {
-      "line": 71,
-      "column": 5,
-      "stop_line": 71,
-      "stop_column": 11,
-      "path": "src/pudl/extract/ferceqr.py",
-      "code": -2,
-      "name": "not-iterable",
-      "description": "Type `None` is not iterable",
-      "concise_description": "Type `None` is not iterable",
-      "severity": "error"
-    },
-    {
-      "line": 144,
-      "column": 22,
-      "stop_line": 144,
-      "stop_column": 26,
-      "path": "src/pudl/extract/ferceqr.py",
-      "code": -2,
-      "name": "bad-argument-type",
-      "description": "Argument `Path` is not assignable to parameter `csv_path` with type `str` in function `_extract_other_table`",
-      "concise_description": "Argument `Path` is not assignable to parameter `csv_path` with type `str` in function `_extract_other_table`",
-      "severity": "error"
-    },
-    {
       "line": 69,
       "column": 35,
       "stop_line": 69,
@@ -3152,8 +3212,8 @@
       "path": "src/pudl/extract/vcerare.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `str` has no attribute `select`\nObject of class `tuple` has no attribute `select`",
-      "concise_description": "Object of class `str` has no attribute `select`\nObject of class `tuple` has no attribute `select`",
+      "description": "Object of type `str | tuple[str, Any]` has no attribute `select`\n  Object of class `str` has no attribute `select`\n  Object of class `tuple` has no attribute `select`",
+      "concise_description": "Object of type `str | tuple[str, Any]` has no attribute `select`",
       "severity": "error"
     },
     {
@@ -3368,14 +3428,14 @@
       "path": "src/pudl/glue/ferc714.py",
       "code": -2,
       "name": "not-a-type",
-      "description": "Expected a type form, got instance of `slice[type[str], type[DataFrame], type[DataFrame] | type[str]]`",
-      "concise_description": "Expected a type form, got instance of `slice[type[str], type[DataFrame], type[DataFrame] | type[str]]`",
+      "description": "Expected a type form, got instance of `slice[type[str], type[DataFrame], None]`",
+      "concise_description": "Expected a type form, got instance of `slice[type[str], type[DataFrame], None]`",
       "severity": "error"
     },
     {
-      "line": 619,
+      "line": 623,
       "column": 26,
-      "stop_line": 619,
+      "stop_line": 623,
       "stop_column": 30,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3385,9 +3445,9 @@
       "severity": "error"
     },
     {
-      "line": 769,
+      "line": 773,
       "column": 25,
-      "stop_line": 769,
+      "stop_line": 773,
       "stop_column": 52,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3397,9 +3457,9 @@
       "severity": "error"
     },
     {
-      "line": 780,
+      "line": 784,
       "column": 25,
-      "stop_line": 780,
+      "stop_line": 784,
       "stop_column": 52,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3409,9 +3469,9 @@
       "severity": "error"
     },
     {
-      "line": 781,
+      "line": 785,
       "column": 26,
-      "stop_line": 781,
+      "stop_line": 785,
       "stop_column": 54,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3421,9 +3481,9 @@
       "severity": "error"
     },
     {
-      "line": 912,
+      "line": 916,
       "column": 31,
-      "stop_line": 912,
+      "stop_line": 916,
       "stop_column": 41,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3433,9 +3493,9 @@
       "severity": "error"
     },
     {
-      "line": 1474,
+      "line": 1478,
       "column": 12,
-      "stop_line": 1474,
+      "stop_line": 1478,
       "stop_column": 18,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3445,9 +3505,9 @@
       "severity": "error"
     },
     {
-      "line": 1700,
+      "line": 1704,
       "column": 22,
-      "stop_line": 1700,
+      "stop_line": 1704,
       "stop_column": 49,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3457,9 +3517,9 @@
       "severity": "error"
     },
     {
-      "line": 1701,
+      "line": 1705,
       "column": 17,
-      "stop_line": 1701,
+      "stop_line": 1705,
       "stop_column": 44,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3469,9 +3529,9 @@
       "severity": "error"
     },
     {
-      "line": 1703,
+      "line": 1707,
       "column": 21,
-      "stop_line": 1703,
+      "stop_line": 1707,
       "stop_column": 26,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3481,9 +3541,9 @@
       "severity": "error"
     },
     {
-      "line": 1848,
+      "line": 1852,
       "column": 9,
-      "stop_line": 1849,
+      "stop_line": 1853,
       "stop_column": 41,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3493,9 +3553,9 @@
       "severity": "error"
     },
     {
-      "line": 1906,
+      "line": 1910,
       "column": 47,
-      "stop_line": 1906,
+      "stop_line": 1910,
       "stop_column": 56,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3505,9 +3565,9 @@
       "severity": "error"
     },
     {
-      "line": 2074,
+      "line": 2078,
       "column": 22,
-      "stop_line": 2074,
+      "stop_line": 2078,
       "stop_column": 30,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3517,9 +3577,9 @@
       "severity": "error"
     },
     {
-      "line": 2119,
+      "line": 2123,
       "column": 10,
-      "stop_line": 2123,
+      "stop_line": 2127,
       "stop_column": 17,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3529,69 +3589,57 @@
       "severity": "error"
     },
     {
-      "line": 2155,
-      "column": 35,
-      "stop_line": 2155,
-      "stop_column": 46,
-      "path": "src/pudl/helpers.py",
-      "code": -2,
-      "name": "bad-argument-type",
-      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "severity": "error"
-    },
-    {
-      "line": 2156,
-      "column": 9,
-      "stop_line": 2156,
-      "stop_column": 32,
-      "path": "src/pudl/helpers.py",
-      "code": -2,
-      "name": "unsupported-operation",
-      "description": "`+` is not supported between `Iterable[str]` and `list[str]`\n  Cannot find `__add__` or `__radd__`",
-      "concise_description": "`+` is not supported between `Iterable[str]` and `list[str]`",
-      "severity": "error"
-    },
-    {
-      "line": 2158,
-      "column": 35,
-      "stop_line": 2158,
-      "stop_column": 46,
-      "path": "src/pudl/helpers.py",
-      "code": -2,
-      "name": "bad-argument-type",
-      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "severity": "error"
-    },
-    {
       "line": 2159,
-      "column": 9,
+      "column": 35,
       "stop_line": 2159,
+      "stop_column": 46,
+      "path": "src/pudl/helpers.py",
+      "code": -2,
+      "name": "bad-argument-type",
+      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
+      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
+      "severity": "error"
+    },
+    {
+      "line": 2160,
+      "column": 9,
+      "stop_line": 2160,
       "stop_column": 32,
       "path": "src/pudl/helpers.py",
       "code": -2,
       "name": "unsupported-operation",
-      "description": "`+` is not supported between `Iterable[str]` and `list[str]`\n  Cannot find `__add__` or `__radd__`",
+      "description": "`+` is not supported between `Iterable[str]` and `list[str]`\n  Cannot find `__radd__` or `__add__`",
       "concise_description": "`+` is not supported between `Iterable[str]` and `list[str]`",
       "severity": "error"
     },
     {
-      "line": 2243,
-      "column": 47,
-      "stop_line": 2243,
-      "stop_column": 53,
+      "line": 2162,
+      "column": 35,
+      "stop_line": 2162,
+      "stop_column": 46,
       "path": "src/pudl/helpers.py",
       "code": -2,
       "name": "bad-argument-type",
-      "description": "Argument `dict[str, DataType]` is not assignable to parameter `dtypes` with type `DataType | DataTypeClass | DataTypeExpr | Mapping[DataType | DataTypeClass | Selector | str, DataType | DataTypeClass | type[Decimal | bool | bytes | date | datetime | float | int | list[Any] | object | str | time | timedelta | tuple[Any, ...] | None]] | Schema` in function `polars.lazyframe.frame.LazyFrame.cast`",
-      "concise_description": "Argument `dict[str, DataType]` is not assignable to parameter `dtypes` with type `DataType | DataTypeClass | DataTypeExpr | Mapping[DataType | DataTypeClass | Selector | str, DataType | DataTypeClass | type[Decimal | bool | bytes | date | datetime | float | int | list[Any] | object | str | time | timedelta | tuple[Any, ...] | None]] | Schema` in function `polars.lazyframe.frame.LazyFrame.cast`",
+      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
+      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
       "severity": "error"
     },
     {
-      "line": 2360,
+      "line": 2163,
+      "column": 9,
+      "stop_line": 2163,
+      "stop_column": 32,
+      "path": "src/pudl/helpers.py",
+      "code": -2,
+      "name": "unsupported-operation",
+      "description": "`+` is not supported between `Iterable[str]` and `list[str]`\n  Cannot find `__radd__` or `__add__`",
+      "concise_description": "`+` is not supported between `Iterable[str]` and `list[str]`",
+      "severity": "error"
+    },
+    {
+      "line": 2407,
       "column": 57,
-      "stop_line": 2360,
+      "stop_line": 2407,
       "stop_column": 73,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3601,9 +3649,9 @@
       "severity": "error"
     },
     {
-      "line": 2481,
+      "line": 2549,
       "column": 1,
-      "stop_line": 2481,
+      "stop_line": 2549,
       "stop_column": 16,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3613,9 +3661,9 @@
       "severity": "error"
     },
     {
-      "line": 2484,
+      "line": 2552,
       "column": 6,
-      "stop_line": 2484,
+      "stop_line": 2552,
       "stop_column": 63,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3625,9 +3673,9 @@
       "severity": "error"
     },
     {
-      "line": 2510,
+      "line": 2578,
       "column": 6,
-      "stop_line": 2510,
+      "stop_line": 2578,
       "stop_column": 29,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3637,9 +3685,9 @@
       "severity": "error"
     },
     {
-      "line": 2658,
+      "line": 2726,
       "column": 27,
-      "stop_line": 2658,
+      "stop_line": 2726,
       "stop_column": 55,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3649,9 +3697,9 @@
       "severity": "error"
     },
     {
-      "line": 2686,
+      "line": 2754,
       "column": 12,
-      "stop_line": 2686,
+      "stop_line": 2754,
       "stop_column": 40,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3661,9 +3709,9 @@
       "severity": "error"
     },
     {
-      "line": 173,
+      "line": 175,
       "column": 58,
-      "stop_line": 173,
+      "stop_line": 175,
       "stop_column": 62,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3673,21 +3721,9 @@
       "severity": "error"
     },
     {
-      "line": 288,
-      "column": 33,
-      "stop_line": 288,
-      "stop_column": 37,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "bad-function-definition",
-      "description": "Default `None` is not assignable to parameter `value` with type `list[Unknown]`\n  The declared type does not allow `None`. Consider changing the declared type to `list[Unknown] | None`.",
-      "concise_description": "Default `None` is not assignable to parameter `value` with type `list[Unknown]`",
-      "severity": "error"
-    },
-    {
-      "line": 610,
+      "line": 619,
       "column": 51,
-      "stop_line": 610,
+      "stop_line": 619,
       "stop_column": 60,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3697,21 +3733,9 @@
       "severity": "error"
     },
     {
-      "line": 730,
-      "column": 28,
-      "stop_line": 730,
-      "stop_column": 49,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "bad-argument-type",
-      "description": "Argument `list[bool | date | datetime | float | int | str]` is not assignable to parameter `categories` with type `Iterable[str] | Series | type[Enum]` in function `polars.datatypes.classes.Enum.__init__`",
-      "concise_description": "Argument `list[bool | date | datetime | float | int | str]` is not assignable to parameter `categories` with type `Iterable[str] | Series | type[Enum]` in function `polars.datatypes.classes.Enum.__init__`",
-      "severity": "error"
-    },
-    {
-      "line": 731,
+      "line": 748,
       "column": 16,
-      "stop_line": 731,
+      "stop_line": 748,
       "stop_column": 46,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3721,9 +3745,9 @@
       "severity": "error"
     },
     {
-      "line": 751,
+      "line": 759,
       "column": 20,
-      "stop_line": 751,
+      "stop_line": 759,
       "stop_column": 51,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3733,21 +3757,9 @@
       "severity": "error"
     },
     {
-      "line": 751,
-      "column": 27,
-      "stop_line": 751,
-      "stop_column": 51,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "no-matching-overload",
-      "description": "No matching overload found for function `sqlalchemy.sql.sqltypes.Enum.__init__` called with arguments: (*list[bool | date | datetime | float | int | str])\n  Possible overloads:\n    (enums: type[Enum], **kw: Any) -> None [closest match]\n    (*enums: str, **kw: Any) -> None\n  Argument `bool | date | datetime | float | int | str` is not assignable to parameter `enums` with type `type[Enum]` in function `sqlalchemy.sql.sqltypes.Enum.__init__`",
-      "concise_description": "No matching overload found for function `sqlalchemy.sql.sqltypes.Enum.__init__` called with arguments: (*list[bool | date | datetime | float | int | str])",
-      "severity": "error"
-    },
-    {
-      "line": 752,
+      "line": 760,
       "column": 16,
-      "stop_line": 752,
+      "stop_line": 760,
       "stop_column": 46,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3757,69 +3769,33 @@
       "severity": "error"
     },
     {
-      "line": 895,
-      "column": 63,
-      "stop_line": 895,
-      "stop_column": 79,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "bad-argument-type",
-      "description": "Argument `list[bool | date | datetime | float | int | str]` is not assignable to parameter `categories` with type `Iterable[str] | Series | type[Enum]` in function `polars.datatypes.classes.Enum.__init__`",
-      "concise_description": "Argument `list[bool | date | datetime | float | int | str]` is not assignable to parameter `categories` with type `Iterable[str] | Series | type[Enum]` in function `polars.datatypes.classes.Enum.__init__`",
-      "severity": "error"
-    },
-    {
-      "line": 907,
-      "column": 16,
-      "stop_line": 912,
-      "stop_column": 10,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "bad-return",
-      "description": "Returned type `pandera.api.pandas.components.Column | pandera.api.polars.components.Column` is not assignable to declared return type `pandera.api.polars.components.Column`",
-      "concise_description": "Returned type `pandera.api.pandas.components.Column | pandera.api.polars.components.Column` is not assignable to declared return type `pandera.api.polars.components.Column`",
-      "severity": "error"
-    },
-    {
-      "line": 908,
+      "line": 941,
       "column": 13,
-      "stop_line": 908,
+      "stop_line": 941,
       "stop_column": 24,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
       "name": "bad-argument-type",
-      "description": "Argument `polars.datatypes.classes.DataType | Enum | GeometryDtype | str | type[polars.datatypes.classes.DataType]` is not assignable to parameter `dtype` with type `pandera.dtypes.DataType | ExtensionDtype | dtype | str | type[Any] | None` in function `pandera.api.pandas.components.Column.__init__`",
-      "concise_description": "Argument `polars.datatypes.classes.DataType | Enum | GeometryDtype | str | type[polars.datatypes.classes.DataType]` is not assignable to parameter `dtype` with type `pandera.dtypes.DataType | ExtensionDtype | dtype | str | type[Any] | None` in function `pandera.api.pandas.components.Column.__init__`",
+      "description": "Argument `Categorical | polars.datatypes.classes.DataType | GeometryDtype | str | type[polars.datatypes.classes.DataType]` is not assignable to parameter `dtype` with type `pandera.dtypes.DataType | ExtensionDtype | dtype | str | type[Any] | None` in function `pandera.api.pandas.components.Column.__init__`",
+      "concise_description": "Argument `Categorical | polars.datatypes.classes.DataType | GeometryDtype | str | type[polars.datatypes.classes.DataType]` is not assignable to parameter `dtype` with type `pandera.dtypes.DataType | ExtensionDtype | dtype | str | type[Any] | None` in function `pandera.api.pandas.components.Column.__init__`",
       "severity": "error"
     },
     {
-      "line": 908,
+      "line": 941,
       "column": 13,
-      "stop_line": 908,
+      "stop_line": 941,
       "stop_column": 24,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
       "name": "bad-argument-type",
-      "description": "Argument `DataType | Enum | GeometryDtype | str | type[DataType]` is not assignable to parameter `dtype` with type `DataType | DataTypeClass | str | type[Any] | None` in function `pandera.api.polars.components.Column.__init__`",
-      "concise_description": "Argument `DataType | Enum | GeometryDtype | str | type[DataType]` is not assignable to parameter `dtype` with type `DataType | DataTypeClass | str | type[Any] | None` in function `pandera.api.polars.components.Column.__init__`",
+      "description": "Argument `Categorical | DataType | GeometryDtype | str | type[DataType]` is not assignable to parameter `dtype` with type `DataType | DataTypeClass | str | type[Any] | None` in function `pandera.api.polars.components.Column.__init__`",
+      "concise_description": "Argument `Categorical | DataType | GeometryDtype | str | type[DataType]` is not assignable to parameter `dtype` with type `DataType | DataTypeClass | str | type[Any] | None` in function `pandera.api.polars.components.Column.__init__`",
       "severity": "error"
     },
     {
-      "line": 1029,
-      "column": 16,
-      "stop_line": 1035,
-      "stop_column": 10,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "bad-return",
-      "description": "Returned type `pandera.api.pandas.container.DataFrameSchema | pandera.api.polars.container.DataFrameSchema` is not assignable to declared return type `pandera.api.polars.container.DataFrameSchema`",
-      "concise_description": "Returned type `pandera.api.pandas.container.DataFrameSchema | pandera.api.polars.container.DataFrameSchema` is not assignable to declared return type `pandera.api.polars.container.DataFrameSchema`",
-      "severity": "error"
-    },
-    {
-      "line": 1161,
+      "line": 1225,
       "column": 56,
-      "stop_line": 1161,
+      "stop_line": 1225,
       "stop_column": 60,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3829,9 +3805,9 @@
       "severity": "error"
     },
     {
-      "line": 1190,
+      "line": 1254,
       "column": 40,
-      "stop_line": 1190,
+      "stop_line": 1254,
       "stop_column": 69,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3841,9 +3817,9 @@
       "severity": "error"
     },
     {
-      "line": 1660,
+      "line": 1725,
       "column": 5,
-      "stop_line": 1660,
+      "stop_line": 1725,
       "stop_column": 11,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3853,9 +3829,9 @@
       "severity": "error"
     },
     {
-      "line": 1744,
+      "line": 1809,
       "column": 59,
-      "stop_line": 1744,
+      "stop_line": 1809,
       "stop_column": 74,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3865,9 +3841,9 @@
       "severity": "error"
     },
     {
-      "line": 1745,
+      "line": 1810,
       "column": 69,
-      "stop_line": 1745,
+      "stop_line": 1810,
       "stop_column": 78,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3877,9 +3853,9 @@
       "severity": "error"
     },
     {
-      "line": 1859,
+      "line": 1924,
       "column": 33,
-      "stop_line": 1859,
+      "stop_line": 1924,
       "stop_column": 37,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3889,9 +3865,9 @@
       "severity": "error"
     },
     {
-      "line": 1877,
+      "line": 1942,
       "column": 32,
-      "stop_line": 1877,
+      "stop_line": 1942,
       "stop_column": 44,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3901,9 +3877,21 @@
       "severity": "error"
     },
     {
-      "line": 1979,
+      "line": 1965,
+      "column": 24,
+      "stop_line": 1965,
+      "stop_column": 39,
+      "path": "src/pudl/metadata/classes.py",
+      "code": -2,
+      "name": "bad-argument-type",
+      "description": "Argument `list[str] | None` is not assignable to parameter `extrapaths` with type `list[str]` in function `frictionless.resource.resource.Resource.__init__`\n  The declared type does not allow `None`. Consider narrowing the value with an `is not None` check.",
+      "concise_description": "Argument `list[str] | None` is not assignable to parameter `extrapaths` with type `list[str]` in function `frictionless.resource.resource.Resource.__init__`",
+      "severity": "error"
+    },
+    {
+      "line": 2042,
       "column": 16,
-      "stop_line": 1979,
+      "stop_line": 2042,
       "stop_column": 21,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3913,21 +3901,9 @@
       "severity": "error"
     },
     {
-      "line": 2051,
-      "column": 37,
-      "stop_line": 2051,
-      "stop_column": 66,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "missing-attribute",
-      "description": "Object of class `str` has no attribute `categories`",
-      "concise_description": "Object of class `str` has no attribute `categories`",
-      "severity": "error"
-    },
-    {
-      "line": 2061,
+      "line": 2122,
       "column": 32,
-      "stop_line": 2061,
+      "stop_line": 2122,
       "stop_column": 45,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3937,21 +3913,9 @@
       "severity": "error"
     },
     {
-      "line": 2114,
-      "column": 73,
-      "stop_line": 2114,
-      "stop_column": 77,
-      "path": "src/pudl/metadata/classes.py",
-      "code": -2,
-      "name": "bad-function-definition",
-      "description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`\n  The declared type does not allow `None`. Consider changing the declared type to `(...) -> Unknown | None`.",
-      "concise_description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`",
-      "severity": "error"
-    },
-    {
-      "line": 2221,
+      "line": 2528,
       "column": 27,
-      "stop_line": 2221,
+      "stop_line": 2528,
       "stop_column": 31,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3961,9 +3925,9 @@
       "severity": "error"
     },
     {
-      "line": 2287,
+      "line": 2594,
       "column": 47,
-      "stop_line": 2287,
+      "stop_line": 2594,
       "stop_column": 70,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3973,9 +3937,9 @@
       "severity": "error"
     },
     {
-      "line": 2393,
+      "line": 2700,
       "column": 36,
-      "stop_line": 2393,
+      "stop_line": 2700,
       "stop_column": 68,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3985,9 +3949,9 @@
       "severity": "error"
     },
     {
-      "line": 2395,
+      "line": 2702,
       "column": 43,
-      "stop_line": 2395,
+      "stop_line": 2702,
       "stop_column": 45,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3997,9 +3961,9 @@
       "severity": "error"
     },
     {
-      "line": 2471,
+      "line": 2778,
       "column": 16,
-      "stop_line": 2471,
+      "stop_line": 2778,
       "stop_column": 28,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4009,9 +3973,9 @@
       "severity": "error"
     },
     {
-      "line": 2557,
+      "line": 2864,
       "column": 40,
-      "stop_line": 2557,
+      "stop_line": 2864,
       "stop_column": 53,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4021,9 +3985,9 @@
       "severity": "error"
     },
     {
-      "line": 2561,
+      "line": 2868,
       "column": 72,
-      "stop_line": 2561,
+      "stop_line": 2868,
       "stop_column": 88,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4033,9 +3997,9 @@
       "severity": "error"
     },
     {
-      "line": 2562,
+      "line": 2869,
       "column": 59,
-      "stop_line": 2562,
+      "stop_line": 2869,
       "stop_column": 83,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4045,9 +4009,9 @@
       "severity": "error"
     },
     {
-      "line": 2563,
+      "line": 2870,
       "column": 62,
-      "stop_line": 2563,
+      "stop_line": 2870,
       "stop_column": 89,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4057,9 +4021,9 @@
       "severity": "error"
     },
     {
-      "line": 2584,
+      "line": 2891,
       "column": 44,
-      "stop_line": 2584,
+      "stop_line": 2891,
       "stop_column": 80,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4309,18 +4273,6 @@
       "severity": "error"
     },
     {
-      "line": 348,
-      "column": 29,
-      "stop_line": 348,
-      "stop_column": 33,
-      "path": "src/pudl/metadata/helpers.py",
-      "code": -2,
-      "name": "bad-function-definition",
-      "description": "Default `None` is not assignable to parameter `error` with type `((...) -> Unknown) | str`\n  The declared type does not allow `None`. Consider changing the declared type to `((...) -> Unknown) | str | None`.",
-      "concise_description": "Default `None` is not assignable to parameter `error` with type `((...) -> Unknown) | str`",
-      "severity": "error"
-    },
-    {
       "line": 391,
       "column": 27,
       "stop_line": 391,
@@ -4345,18 +4297,6 @@
       "severity": "error"
     },
     {
-      "line": 422,
-      "column": 23,
-      "stop_line": 422,
-      "stop_column": 27,
-      "path": "src/pudl/metadata/helpers.py",
-      "code": -2,
-      "name": "bad-function-definition",
-      "description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`\n  The declared type does not allow `None`. Consider changing the declared type to `(...) -> Unknown | None`.",
-      "concise_description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`",
-      "severity": "error"
-    },
-    {
       "line": 466,
       "column": 25,
       "stop_line": 466,
@@ -4366,18 +4306,6 @@
       "name": "no-matching-overload",
       "description": "No matching overload found for function `pandas.core.frame.DataFrame.groupby` called with arguments: (Iterable[Unknown])\n  Possible overloads:\n    (by: Scalar, ...) -> DataFrameGroupBy[Scalar, Literal[True]] [closest match]\n    (by: Scalar, ...) -> DataFrameGroupBy[Scalar, Literal[False]]\n    (by: DatetimeIndex, ...) -> DataFrameGroupBy[Timestamp, Literal[True]]\n    (by: DatetimeIndex, ...) -> DataFrameGroupBy[Timestamp, Literal[False]]\n    (by: TimedeltaIndex, ...) -> DataFrameGroupBy[Timedelta, Literal[True]]\n    (by: TimedeltaIndex, ...) -> DataFrameGroupBy[Timedelta, Literal[False]]\n    (by: PeriodIndex, ...) -> DataFrameGroupBy[Period, Literal[True]]\n    (by: PeriodIndex, ...) -> DataFrameGroupBy[Period, Literal[False]]\n    (by: IntervalIndex[IntervalT], ...) -> DataFrameGroupBy[IntervalT, Literal[True]]\n    (by: IntervalIndex[IntervalT], ...) -> DataFrameGroupBy[IntervalT, Literal[False]]\n    (by: ((...) -> Any) | Grouper | Mapping[Hashable | None, Any] | MultiIndex | list[((...) -> Any) | ufunc] | list[Grouper] | list[Index] | list[Mapping[Hashable | None, Any]] | list[Series] | list[ndarray] | list[Unknown] | ndarray | ufunc | tuple[Unknown, ...] | None = ..., ...) -> DataFrameGroupBy[tuple[Unknown, ...], Literal[True]]\n    (by: ((...) -> Any) | Grouper | Mapping[Hashable | None, Any] | MultiIndex | list[((...) -> Any) | ufunc] | list[Grouper] | list[Index] | list[Mapping[Hashable | None, Any]] | list[Series] | list[ndarray] | list[Unknown] | ndarray | ufunc | tuple[Unknown, ...] | None = ..., ...) -> DataFrameGroupBy[tuple[Unknown, ...], Literal[False]]\n    (by: Series[SeriesByT], ...) -> DataFrameGroupBy[SeriesByT, Literal[True]]\n    (by: Series[SeriesByT], ...) -> DataFrameGroupBy[SeriesByT, Literal[False]]\n    (by: CategoricalIndex | Index | Series, ...) -> DataFrameGroupBy[Any, Literal[True]]\n    (by: CategoricalIndex | Index | Series, ...) -> DataFrameGroupBy[Any, Literal[False]]\n  Argument `Iterable[Unknown]` is not assignable to parameter `by` with type `Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` in function `pandas.core.frame.DataFrame.groupby`",
       "concise_description": "No matching overload found for function `pandas.core.frame.DataFrame.groupby` called with arguments: (Iterable[Unknown])",
-      "severity": "error"
-    },
-    {
-      "line": 508,
-      "column": 23,
-      "stop_line": 508,
-      "stop_column": 27,
-      "path": "src/pudl/metadata/helpers.py",
-      "code": -2,
-      "name": "bad-function-definition",
-      "description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`\n  The declared type does not allow `None`. Consider changing the declared type to `(...) -> Unknown | None`.",
-      "concise_description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`",
       "severity": "error"
     },
     {
@@ -4393,15 +4321,39 @@
       "severity": "error"
     },
     {
-      "line": 20,
-      "column": 62,
-      "stop_line": 336,
-      "stop_column": 2,
+      "line": 74,
+      "column": 27,
+      "stop_line": 79,
+      "stop_column": 10,
       "path": "src/pudl/metadata/resources/__init__.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`dict[str, dict[str, list[dict[str, str]] | list[str]] | dict[str, list[str] | list[@_]] | dict[str, list[str]]]` is not assignable to `dict[str, dict[str, dict[str, str] | list[str]]]`",
-      "concise_description": "`dict[str, dict[str, list[dict[str, str]] | list[str]] | dict[str, list[str] | list[@_]] | dict[str, list[str]]]` is not assignable to `dict[str, dict[str, dict[str, str] | list[str]]]`",
+      "description": "`list[dict[str, str]]` is not assignable to dict value type `dict[str, str] | list[str]`",
+      "concise_description": "`list[dict[str, str]]` is not assignable to dict value type `dict[str, str] | list[str]`",
+      "severity": "error"
+    },
+    {
+      "line": 171,
+      "column": 27,
+      "stop_line": 185,
+      "stop_column": 10,
+      "path": "src/pudl/metadata/resources/__init__.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`list[dict[str, str]]` is not assignable to dict value type `dict[str, str] | list[str]`",
+      "concise_description": "`list[dict[str, str]]` is not assignable to dict value type `dict[str, str] | list[str]`",
+      "severity": "error"
+    },
+    {
+      "line": 312,
+      "column": 27,
+      "stop_line": 327,
+      "stop_column": 10,
+      "path": "src/pudl/metadata/resources/__init__.py",
+      "code": -2,
+      "name": "bad-assignment",
+      "description": "`list[dict[str, str]]` is not assignable to dict value type `dict[str, str] | list[str]`",
+      "concise_description": "`list[dict[str, str]]` is not assignable to dict value type `dict[str, str] | list[str]`",
       "severity": "error"
     },
     {
@@ -4777,9 +4729,9 @@
       "severity": "error"
     },
     {
-      "line": 1968,
+      "line": 1993,
       "column": 21,
-      "stop_line": 1968,
+      "stop_line": 1993,
       "stop_column": 43,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4789,9 +4741,9 @@
       "severity": "error"
     },
     {
-      "line": 1975,
+      "line": 2000,
       "column": 44,
-      "stop_line": 1975,
+      "stop_line": 2000,
       "stop_column": 77,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4801,9 +4753,9 @@
       "severity": "error"
     },
     {
-      "line": 1977,
+      "line": 2002,
       "column": 16,
-      "stop_line": 1977,
+      "stop_line": 2002,
       "stop_column": 76,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4813,9 +4765,9 @@
       "severity": "error"
     },
     {
-      "line": 2043,
+      "line": 2068,
       "column": 65,
-      "stop_line": 2043,
+      "stop_line": 2068,
       "stop_column": 68,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4825,9 +4777,9 @@
       "severity": "error"
     },
     {
-      "line": 2045,
+      "line": 2070,
       "column": 65,
-      "stop_line": 2045,
+      "stop_line": 2070,
       "stop_column": 68,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4837,9 +4789,9 @@
       "severity": "error"
     },
     {
-      "line": 2127,
+      "line": 2152,
       "column": 17,
-      "stop_line": 2127,
+      "stop_line": 2152,
       "stop_column": 35,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4849,9 +4801,9 @@
       "severity": "error"
     },
     {
-      "line": 2132,
+      "line": 2157,
       "column": 37,
-      "stop_line": 2132,
+      "stop_line": 2157,
       "stop_column": 69,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4861,9 +4813,9 @@
       "severity": "error"
     },
     {
-      "line": 2375,
+      "line": 2400,
       "column": 39,
-      "stop_line": 2375,
+      "stop_line": 2400,
       "stop_column": 43,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4873,9 +4825,9 @@
       "severity": "error"
     },
     {
-      "line": 2436,
+      "line": 2461,
       "column": 36,
-      "stop_line": 2436,
+      "stop_line": 2461,
       "stop_column": 41,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4885,9 +4837,9 @@
       "severity": "error"
     },
     {
-      "line": 2530,
+      "line": 2555,
       "column": 20,
-      "stop_line": 2530,
+      "stop_line": 2555,
       "stop_column": 44,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4897,9 +4849,9 @@
       "severity": "error"
     },
     {
-      "line": 2545,
+      "line": 2570,
       "column": 53,
-      "stop_line": 2545,
+      "stop_line": 2570,
       "stop_column": 70,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4909,9 +4861,9 @@
       "severity": "error"
     },
     {
-      "line": 2580,
+      "line": 2605,
       "column": 34,
-      "stop_line": 2580,
+      "stop_line": 2605,
       "stop_column": 43,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4921,9 +4873,9 @@
       "severity": "error"
     },
     {
-      "line": 2632,
+      "line": 2657,
       "column": 44,
-      "stop_line": 2632,
+      "stop_line": 2657,
       "stop_column": 61,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4933,9 +4885,9 @@
       "severity": "error"
     },
     {
-      "line": 2879,
+      "line": 2904,
       "column": 13,
-      "stop_line": 2888,
+      "stop_line": 2913,
       "stop_column": 10,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4945,9 +4897,9 @@
       "severity": "error"
     },
     {
-      "line": 2893,
+      "line": 2918,
       "column": 13,
-      "stop_line": 2900,
+      "stop_line": 2925,
       "stop_column": 10,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4957,9 +4909,9 @@
       "severity": "error"
     },
     {
-      "line": 2905,
+      "line": 2930,
       "column": 13,
-      "stop_line": 2905,
+      "stop_line": 2930,
       "stop_column": 80,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -4969,9 +4921,9 @@
       "severity": "error"
     },
     {
-      "line": 2910,
+      "line": 2935,
       "column": 13,
-      "stop_line": 2916,
+      "stop_line": 2941,
       "stop_column": 10,
       "path": "src/pudl/output/ferc1.py",
       "code": -2,
@@ -5317,9 +5269,9 @@
       "severity": "error"
     },
     {
-      "line": 307,
+      "line": 324,
       "column": 21,
-      "stop_line": 307,
+      "stop_line": 324,
       "stop_column": 69,
       "path": "src/pudl/settings.py",
       "code": -2,
@@ -6452,8 +6404,8 @@
       "path": "src/pudl/transform/eia860.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `Timedelta` has no attribute `index`\nObject of class `Timestamp` has no attribute `index`\nObject of class `bool` has no attribute `index`\nObject of class `complex` has no attribute `index`\nObject of class `complexfloating` has no attribute `index`\nObject of class `date` has no attribute `index`\nObject of class `datetime64` has no attribute `index`\nObject of class `datetime` has no attribute `index`\nObject of class `float` has no attribute `index`\nObject of class `floating` has no attribute `index`\nObject of class `int` has no attribute `index`\nObject of class `integer` has no attribute `index`\nObject of class `timedelta64` has no attribute `index`\nObject of class `timedelta` has no attribute `index`",
-      "concise_description": "Object of class `Timedelta` has no attribute `index`\nObject of class `Timestamp` has no attribute `index`\nObject of class `bool` has no attribute `index`\nObject of class `complex` has no attribute `index`\nObject of class `complexfloating` has no attribute `index`\nObject of class `date` has no attribute `index`\nObject of class `datetime64` has no attribute `index`\nObject of class `datetime` has no attribute `index`\nObject of class `float` has no attribute `index`\nObject of class `floating` has no attribute `index`\nObject of class `int` has no attribute `index`\nObject of class `integer` has no attribute `index`\nObject of class `timedelta64` has no attribute `index`\nObject of class `timedelta` has no attribute `index`",
+      "description": "Object of type `Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` has no attribute `index`\n  Object of class `Timedelta` has no attribute `index`\n  Object of class `Timestamp` has no attribute `index`\n  Object of class `bool` has no attribute `index`\n  Object of class `complex` has no attribute `index`\n  Object of class `complexfloating` has no attribute `index`\n  Object of class `date` has no attribute `index`\n  Object of class `datetime64` has no attribute `index`\n  Object of class `datetime` has no attribute `index`\n  Object of class `float` has no attribute `index`\n  Object of class `floating` has no attribute `index`\n  Object of class `int` has no attribute `index`\n  Object of class `integer` has no attribute `index`\n  Object of class `timedelta64` has no attribute `index`\n  Object of class `timedelta` has no attribute `index`",
+      "concise_description": "Object of type `Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` has no attribute `index`",
       "severity": "error"
     },
     {
@@ -6464,8 +6416,8 @@
       "path": "src/pudl/transform/eia860.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `Timedelta` has no attribute `reset_index`\nObject of class `Timestamp` has no attribute `reset_index`\nObject of class `bool` has no attribute `reset_index`\nObject of class `bytes` has no attribute `reset_index`\nObject of class `complex` has no attribute `reset_index`\nObject of class `complexfloating` has no attribute `reset_index`\nObject of class `date` has no attribute `reset_index`\nObject of class `datetime64` has no attribute `reset_index`\nObject of class `datetime` has no attribute `reset_index`\nObject of class `float` has no attribute `reset_index`\nObject of class `floating` has no attribute `reset_index`\nObject of class `int` has no attribute `reset_index`\nObject of class `integer` has no attribute `reset_index`\nObject of class `str` has no attribute `reset_index`\nObject of class `timedelta64` has no attribute `reset_index`\nObject of class `timedelta` has no attribute `reset_index`",
-      "concise_description": "Object of class `Timedelta` has no attribute `reset_index`\nObject of class `Timestamp` has no attribute `reset_index`\nObject of class `bool` has no attribute `reset_index`\nObject of class `bytes` has no attribute `reset_index`\nObject of class `complex` has no attribute `reset_index`\nObject of class `complexfloating` has no attribute `reset_index`\nObject of class `date` has no attribute `reset_index`\nObject of class `datetime64` has no attribute `reset_index`\nObject of class `datetime` has no attribute `reset_index`\nObject of class `float` has no attribute `reset_index`\nObject of class `floating` has no attribute `reset_index`\nObject of class `int` has no attribute `reset_index`\nObject of class `integer` has no attribute `reset_index`\nObject of class `str` has no attribute `reset_index`\nObject of class `timedelta64` has no attribute `reset_index`\nObject of class `timedelta` has no attribute `reset_index`",
+      "description": "Object of type `Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` has no attribute `reset_index`\n  Object of class `Timedelta` has no attribute `reset_index`\n  Object of class `Timestamp` has no attribute `reset_index`\n  Object of class `bool` has no attribute `reset_index`\n  Object of class `bytes` has no attribute `reset_index`\n  Object of class `complex` has no attribute `reset_index`\n  Object of class `complexfloating` has no attribute `reset_index`\n  Object of class `date` has no attribute `reset_index`\n  Object of class `datetime64` has no attribute `reset_index`\n  Object of class `datetime` has no attribute `reset_index`\n  Object of class `float` has no attribute `reset_index`\n  Object of class `floating` has no attribute `reset_index`\n  Object of class `int` has no attribute `reset_index`\n  Object of class `integer` has no attribute `reset_index`\n  Object of class `str` has no attribute `reset_index`\n  Object of class `timedelta64` has no attribute `reset_index`\n  Object of class `timedelta` has no attribute `reset_index`",
+      "concise_description": "Object of type `Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64` has no attribute `reset_index`",
       "severity": "error"
     },
     {
@@ -6625,15 +6577,15 @@
       "severity": "error"
     },
     {
-      "line": 515,
-      "column": 35,
-      "stop_line": 533,
-      "stop_column": 2,
+      "line": 527,
+      "column": 5,
+      "stop_line": 527,
+      "stop_column": 10,
       "path": "src/pudl/transform/eia861.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`dict[int | str, str]` is not assignable to `dict[str, str]`",
-      "concise_description": "`dict[int | str, str]` is not assignable to `dict[str, str]`",
+      "description": "`Literal[25470]` is not assignable to dict key type `str`",
+      "concise_description": "`Literal[25470]` is not assignable to dict key type `str`",
       "severity": "error"
     },
     {
@@ -7400,8 +7352,8 @@
       "path": "src/pudl/transform/ferc1.py",
       "code": -2,
       "name": "not-a-type",
-      "description": "Expected a type form, got instance of `slice[type[str], type[list[str]], type[str] | type[list[str]]]`",
-      "concise_description": "Expected a type form, got instance of `slice[type[str], type[list[str]], type[str] | type[list[str]]]`",
+      "description": "Expected a type form, got instance of `slice[type[str], type[list[str]], None]`",
+      "concise_description": "Expected a type form, got instance of `slice[type[str], type[list[str]], None]`",
       "severity": "error"
     },
     {
@@ -7448,7 +7400,7 @@
       "path": "src/pudl/transform/ferc1.py",
       "code": -2,
       "name": "bad-index",
-      "description": "Cannot index into `_LocIndexerSeries`\n  No matching overload found for function `pandas.core.series._LocIndexerSeries.__getitem__` called with arguments: (tuple[slice[Any, Unknown, Unknown], list[str] | None])\n  Possible overloads:\n    (key: Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64 | tuple[Scalar, ...]) -> Any [closest match]\n    (idx: ((...) -> Unknown) | Index | Sequence[tuple[IndexOpsMixin | Sequence[Scalar] | Series[builtins.bool] | Timedelta | Timestamp | builtins.bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | list[builtins.bool] | ndarray[tuple[Any, ...], dtype[numpy.bool]] | slice[Any, Any, Any] | str | timedelta | timedelta64, ...]] | SequenceNotStr[Timestamp | float | str] | Series[builtins.bool] | Series | list[builtins.bool] | ndarray[tuple[Any, ...], dtype[numpy.bool]] | slice[Any, Any, Any] | tuple[IndexOpsMixin | Sequence[Scalar] | Series[builtins.bool] | Timedelta | Timestamp | builtins.bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | list[builtins.bool] | ndarray[tuple[Any, ...], dtype[numpy.bool]] | slice[Any, Any, Any] | str | timedelta | timedelta64, ...]) -> Series\n  Argument `tuple[slice[Any, Unknown, Unknown], list[str] | None]` is not assignable to parameter `key` with type `Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64 | tuple[Scalar, ...]` in function `pandas.core.series._LocIndexerSeries.__getitem__`",
+      "description": "Cannot index into `_LocIndexerSeries`\n  No matching overload found for function `pandas.core.series._LocIndexerSeries.__getitem__` called with arguments: (tuple[slice[None, None, None], list[str] | None])\n  Possible overloads:\n    (key: Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64 | tuple[Scalar, ...]) -> Any [closest match]\n    (idx: ((...) -> Unknown) | Index | Sequence[tuple[IndexOpsMixin | Sequence[Scalar] | Series[builtins.bool] | Timedelta | Timestamp | builtins.bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | list[builtins.bool] | ndarray[tuple[Any, ...], dtype[numpy.bool]] | slice[Any, Any, Any] | str | timedelta | timedelta64, ...]] | SequenceNotStr[Timestamp | float | str] | Series[builtins.bool] | Series | list[builtins.bool] | ndarray[tuple[Any, ...], dtype[numpy.bool]] | slice[Any, Any, Any] | tuple[IndexOpsMixin | Sequence[Scalar] | Series[builtins.bool] | Timedelta | Timestamp | builtins.bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | list[builtins.bool] | ndarray[tuple[Any, ...], dtype[numpy.bool]] | slice[Any, Any, Any] | str | timedelta | timedelta64, ...]) -> Series\n  Argument `tuple[slice[None, None, None], list[str] | None]` is not assignable to parameter `key` with type `Timedelta | Timestamp | bool | bytes | complex | complexfloating | date | datetime | datetime64 | float | floating | int | integer | str | timedelta | timedelta64 | tuple[Scalar, ...]` in function `pandas.core.series._LocIndexerSeries.__getitem__`",
       "concise_description": "Cannot index into `_LocIndexerSeries`",
       "severity": "error"
     },
@@ -8761,9 +8713,9 @@
       "severity": "error"
     },
     {
-      "line": 395,
+      "line": 400,
       "column": 9,
-      "stop_line": 396,
+      "stop_line": 401,
       "stop_column": 38,
       "path": "src/pudl/transform/ferc714.py",
       "code": -2,
@@ -8773,9 +8725,9 @@
       "severity": "error"
     },
     {
-      "line": 426,
+      "line": 434,
       "column": 77,
-      "stop_line": 426,
+      "stop_line": 434,
       "stop_column": 87,
       "path": "src/pudl/transform/ferc714.py",
       "code": -2,
@@ -8785,9 +8737,9 @@
       "severity": "error"
     },
     {
-      "line": 446,
+      "line": 454,
       "column": 9,
-      "stop_line": 447,
+      "stop_line": 455,
       "stop_column": 38,
       "path": "src/pudl/transform/ferc714.py",
       "code": -2,
@@ -8797,9 +8749,9 @@
       "severity": "error"
     },
     {
-      "line": 977,
+      "line": 985,
       "column": 28,
-      "stop_line": 977,
+      "stop_line": 985,
       "stop_column": 54,
       "path": "src/pudl/transform/ferc714.py",
       "code": -2,
@@ -8809,9 +8761,9 @@
       "severity": "error"
     },
     {
-      "line": 982,
+      "line": 990,
       "column": 21,
-      "stop_line": 982,
+      "stop_line": 990,
       "stop_column": 47,
       "path": "src/pudl/transform/ferc714.py",
       "code": -2,
@@ -8821,9 +8773,9 @@
       "severity": "error"
     },
     {
-      "line": 989,
+      "line": 997,
       "column": 13,
-      "stop_line": 989,
+      "stop_line": 997,
       "stop_column": 37,
       "path": "src/pudl/transform/ferc714.py",
       "code": -2,
@@ -8833,9 +8785,9 @@
       "severity": "error"
     },
     {
-      "line": 990,
+      "line": 998,
       "column": 14,
-      "stop_line": 990,
+      "stop_line": 998,
       "stop_column": 38,
       "path": "src/pudl/transform/ferc714.py",
       "code": -2,
@@ -8845,9 +8797,9 @@
       "severity": "error"
     },
     {
-      "line": 1066,
+      "line": 1074,
       "column": 16,
-      "stop_line": 1066,
+      "stop_line": 1074,
       "stop_column": 21,
       "path": "src/pudl/transform/ferc714.py",
       "code": -2,
@@ -8869,63 +8821,63 @@
       "severity": "error"
     },
     {
-      "line": 335,
-      "column": 40,
-      "stop_line": 338,
-      "stop_column": 2,
+      "line": 336,
+      "column": 19,
+      "stop_line": 337,
+      "stop_column": 29,
       "path": "src/pudl/transform/params/ferc1.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`dict[str, Traversable]` is not assignable to `dict[str, set[str]]`",
-      "concise_description": "`dict[str, Traversable]` is not assignable to `dict[str, set[str]]`",
+      "description": "`Traversable` is not assignable to dict value type `set[str]`",
+      "concise_description": "`Traversable` is not assignable to dict value type `set[str]`",
       "severity": "error"
     },
     {
-      "line": 345,
-      "column": 45,
-      "stop_line": 348,
-      "stop_column": 2,
+      "line": 346,
+      "column": 19,
+      "stop_line": 347,
+      "stop_column": 34,
       "path": "src/pudl/transform/params/ferc1.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`dict[str, Traversable]` is not assignable to `dict[str, set[str]]`",
-      "concise_description": "`dict[str, Traversable]` is not assignable to `dict[str, set[str]]`",
+      "description": "`Traversable` is not assignable to dict value type `set[str]`",
+      "concise_description": "`Traversable` is not assignable to dict value type `set[str]`",
       "severity": "error"
     },
     {
-      "line": 352,
-      "column": 46,
-      "stop_line": 355,
-      "stop_column": 2,
+      "line": 353,
+      "column": 19,
+      "stop_line": 354,
+      "stop_column": 35,
       "path": "src/pudl/transform/params/ferc1.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`dict[str, Traversable]` is not assignable to `dict[str, set[str]]`",
-      "concise_description": "`dict[str, Traversable]` is not assignable to `dict[str, set[str]]`",
+      "description": "`Traversable` is not assignable to dict value type `set[str]`",
+      "concise_description": "`Traversable` is not assignable to dict value type `set[str]`",
       "severity": "error"
     },
     {
-      "line": 366,
-      "column": 52,
-      "stop_line": 463,
-      "stop_column": 2,
+      "line": 367,
+      "column": 19,
+      "stop_line": 462,
+      "stop_column": 6,
       "path": "src/pudl/transform/params/ferc1.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`dict[str, dict[str, set[str]]]` is not assignable to `dict[str, set[str]]`",
-      "concise_description": "`dict[str, dict[str, set[str]]]` is not assignable to `dict[str, set[str]]`",
+      "description": "`dict[str, set[str]]` is not assignable to dict value type `set[str]`",
+      "concise_description": "`dict[str, set[str]]` is not assignable to dict value type `set[str]`",
       "severity": "error"
     },
     {
-      "line": 474,
-      "column": 53,
-      "stop_line": 477,
-      "stop_column": 2,
+      "line": 475,
+      "column": 19,
+      "stop_line": 476,
+      "stop_column": 42,
       "path": "src/pudl/transform/params/ferc1.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`dict[str, Traversable]` is not assignable to `dict[str, set[str]]`",
-      "concise_description": "`dict[str, Traversable]` is not assignable to `dict[str, set[str]]`",
+      "description": "`Traversable` is not assignable to dict value type `set[str]`",
+      "concise_description": "`Traversable` is not assignable to dict value type `set[str]`",
       "severity": "error"
     },
     {
@@ -9337,9 +9289,9 @@
       "severity": "error"
     },
     {
-      "line": 322,
+      "line": 323,
       "column": 16,
-      "stop_line": 322,
+      "stop_line": 323,
       "stop_column": 55,
       "path": "src/pudl/workspace/datastore.py",
       "code": -2,
@@ -9349,9 +9301,9 @@
       "severity": "error"
     },
     {
-      "line": 359,
+      "line": 360,
       "column": 42,
-      "stop_line": 359,
+      "stop_line": 360,
       "stop_column": 49,
       "path": "src/pudl/workspace/datastore.py",
       "code": -2,
@@ -9361,9 +9313,9 @@
       "severity": "error"
     },
     {
-      "line": 555,
+      "line": 556,
       "column": 43,
-      "stop_line": 555,
+      "stop_line": 556,
       "stop_column": 61,
       "path": "src/pudl/workspace/datastore.py",
       "code": -2,
@@ -9373,9 +9325,9 @@
       "severity": "error"
     },
     {
-      "line": 564,
+      "line": 565,
       "column": 50,
-      "stop_line": 564,
+      "stop_line": 565,
       "stop_column": 68,
       "path": "src/pudl/workspace/datastore.py",
       "code": -2,
@@ -9385,9 +9337,9 @@
       "severity": "error"
     },
     {
-      "line": 584,
+      "line": 585,
       "column": 42,
-      "stop_line": 584,
+      "stop_line": 585,
       "stop_column": 53,
       "path": "src/pudl/workspace/datastore.py",
       "code": -2,
@@ -9397,9 +9349,9 @@
       "severity": "error"
     },
     {
-      "line": 588,
+      "line": 589,
       "column": 56,
-      "stop_line": 588,
+      "stop_line": 589,
       "stop_column": 63,
       "path": "src/pudl/workspace/datastore.py",
       "code": -2,
@@ -9409,9 +9361,9 @@
       "severity": "error"
     },
     {
-      "line": 610,
+      "line": 611,
       "column": 52,
-      "stop_line": 610,
+      "stop_line": 611,
       "stop_column": 63,
       "path": "src/pudl/workspace/datastore.py",
       "code": -2,
@@ -9985,9 +9937,9 @@
       "severity": "error"
     },
     {
-      "line": 73,
+      "line": 76,
       "column": 9,
-      "stop_line": 73,
+      "stop_line": 76,
       "stop_column": 34,
       "path": "tests/unit/dagster/asset_checks_test.py",
       "code": -2,
@@ -9997,9 +9949,9 @@
       "severity": "error"
     },
     {
-      "line": 138,
+      "line": 141,
       "column": 27,
-      "stop_line": 138,
+      "stop_line": 141,
       "stop_column": 55,
       "path": "tests/unit/dagster/asset_checks_test.py",
       "code": -2,
@@ -10033,6 +9985,18 @@
       "severity": "error"
     },
     {
+      "line": 134,
+      "column": 12,
+      "stop_line": 134,
+      "stop_column": 44,
+      "path": "tests/unit/dagster/ferceqr_deployment_test.py",
+      "code": -2,
+      "name": "not-iterable",
+      "description": "`in` is not supported between `Unknown` and `None`",
+      "concise_description": "`in` is not supported between `Unknown` and `None`",
+      "severity": "error"
+    },
+    {
       "line": 208,
       "column": 12,
       "stop_line": 208,
@@ -10040,8 +10004,8 @@
       "path": "tests/unit/dagster/ferceqr_deployment_test.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `DagsterRunReaction` has no attribute `run_key`\nObject of class `Iterator` has no attribute `run_key`\nObject of class `NoneType` has no attribute `run_key`\nObject of class `SensorResult` has no attribute `run_key`\nObject of class `Sequence` has no attribute `run_key`\nObject of class `SkipReason` has no attribute `run_key`",
-      "concise_description": "Object of class `DagsterRunReaction` has no attribute `run_key`\nObject of class `Iterator` has no attribute `run_key`\nObject of class `NoneType` has no attribute `run_key`\nObject of class `SensorResult` has no attribute `run_key`\nObject of class `Sequence` has no attribute `run_key`\nObject of class `SkipReason` has no attribute `run_key`",
+      "description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `run_key`\n  Object of class `DagsterRunReaction` has no attribute `run_key`\n  Object of class `Iterator` has no attribute `run_key`\n  Object of class `NoneType` has no attribute `run_key`\n  Object of class `SensorResult` has no attribute `run_key`\n  Object of class `Sequence` has no attribute `run_key`\n  Object of class `SkipReason` has no attribute `run_key`",
+      "concise_description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `run_key`",
       "severity": "error"
     },
     {
@@ -10052,8 +10016,8 @@
       "path": "tests/unit/dagster/ferceqr_deployment_test.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `DagsterRunReaction` has no attribute `asset_selection`\nObject of class `Iterator` has no attribute `asset_selection`\nObject of class `NoneType` has no attribute `asset_selection`\nObject of class `SensorResult` has no attribute `asset_selection`\nObject of class `Sequence` has no attribute `asset_selection`\nObject of class `SkipReason` has no attribute `asset_selection`",
-      "concise_description": "Object of class `DagsterRunReaction` has no attribute `asset_selection`\nObject of class `Iterator` has no attribute `asset_selection`\nObject of class `NoneType` has no attribute `asset_selection`\nObject of class `SensorResult` has no attribute `asset_selection`\nObject of class `Sequence` has no attribute `asset_selection`\nObject of class `SkipReason` has no attribute `asset_selection`",
+      "description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `asset_selection`\n  Object of class `DagsterRunReaction` has no attribute `asset_selection`\n  Object of class `Iterator` has no attribute `asset_selection`\n  Object of class `NoneType` has no attribute `asset_selection`\n  Object of class `SensorResult` has no attribute `asset_selection`\n  Object of class `Sequence` has no attribute `asset_selection`\n  Object of class `SkipReason` has no attribute `asset_selection`",
+      "concise_description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `asset_selection`",
       "severity": "error"
     },
     {
@@ -10064,8 +10028,8 @@
       "path": "tests/unit/dagster/ferceqr_deployment_test.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `DagsterRunReaction` has no attribute `tags`\nObject of class `Iterator` has no attribute `tags`\nObject of class `NoneType` has no attribute `tags`\nObject of class `SensorResult` has no attribute `tags`\nObject of class `Sequence` has no attribute `tags`\nObject of class `SkipReason` has no attribute `tags`",
-      "concise_description": "Object of class `DagsterRunReaction` has no attribute `tags`\nObject of class `Iterator` has no attribute `tags`\nObject of class `NoneType` has no attribute `tags`\nObject of class `SensorResult` has no attribute `tags`\nObject of class `Sequence` has no attribute `tags`\nObject of class `SkipReason` has no attribute `tags`",
+      "description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `tags`\n  Object of class `DagsterRunReaction` has no attribute `tags`\n  Object of class `Iterator` has no attribute `tags`\n  Object of class `NoneType` has no attribute `tags`\n  Object of class `SensorResult` has no attribute `tags`\n  Object of class `Sequence` has no attribute `tags`\n  Object of class `SkipReason` has no attribute `tags`",
+      "concise_description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `tags`",
       "severity": "error"
     },
     {
@@ -10076,8 +10040,8 @@
       "path": "tests/unit/dagster/ferceqr_deployment_test.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `DagsterRunReaction` has no attribute `run_key`\nObject of class `Iterator` has no attribute `run_key`\nObject of class `NoneType` has no attribute `run_key`\nObject of class `SensorResult` has no attribute `run_key`\nObject of class `Sequence` has no attribute `run_key`\nObject of class `SkipReason` has no attribute `run_key`",
-      "concise_description": "Object of class `DagsterRunReaction` has no attribute `run_key`\nObject of class `Iterator` has no attribute `run_key`\nObject of class `NoneType` has no attribute `run_key`\nObject of class `SensorResult` has no attribute `run_key`\nObject of class `Sequence` has no attribute `run_key`\nObject of class `SkipReason` has no attribute `run_key`",
+      "description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `run_key`\n  Object of class `DagsterRunReaction` has no attribute `run_key`\n  Object of class `Iterator` has no attribute `run_key`\n  Object of class `NoneType` has no attribute `run_key`\n  Object of class `SensorResult` has no attribute `run_key`\n  Object of class `Sequence` has no attribute `run_key`\n  Object of class `SkipReason` has no attribute `run_key`",
+      "concise_description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `run_key`",
       "severity": "error"
     },
     {
@@ -10088,8 +10052,8 @@
       "path": "tests/unit/dagster/ferceqr_deployment_test.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `DagsterRunReaction` has no attribute `asset_selection`\nObject of class `Iterator` has no attribute `asset_selection`\nObject of class `NoneType` has no attribute `asset_selection`\nObject of class `SensorResult` has no attribute `asset_selection`\nObject of class `Sequence` has no attribute `asset_selection`\nObject of class `SkipReason` has no attribute `asset_selection`",
-      "concise_description": "Object of class `DagsterRunReaction` has no attribute `asset_selection`\nObject of class `Iterator` has no attribute `asset_selection`\nObject of class `NoneType` has no attribute `asset_selection`\nObject of class `SensorResult` has no attribute `asset_selection`\nObject of class `Sequence` has no attribute `asset_selection`\nObject of class `SkipReason` has no attribute `asset_selection`",
+      "description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `asset_selection`\n  Object of class `DagsterRunReaction` has no attribute `asset_selection`\n  Object of class `Iterator` has no attribute `asset_selection`\n  Object of class `NoneType` has no attribute `asset_selection`\n  Object of class `SensorResult` has no attribute `asset_selection`\n  Object of class `Sequence` has no attribute `asset_selection`\n  Object of class `SkipReason` has no attribute `asset_selection`",
+      "concise_description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `asset_selection`",
       "severity": "error"
     },
     {
@@ -10100,8 +10064,8 @@
       "path": "tests/unit/dagster/ferceqr_deployment_test.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `DagsterRunReaction` has no attribute `tags`\nObject of class `Iterator` has no attribute `tags`\nObject of class `NoneType` has no attribute `tags`\nObject of class `SensorResult` has no attribute `tags`\nObject of class `Sequence` has no attribute `tags`\nObject of class `SkipReason` has no attribute `tags`",
-      "concise_description": "Object of class `DagsterRunReaction` has no attribute `tags`\nObject of class `Iterator` has no attribute `tags`\nObject of class `NoneType` has no attribute `tags`\nObject of class `SensorResult` has no attribute `tags`\nObject of class `Sequence` has no attribute `tags`\nObject of class `SkipReason` has no attribute `tags`",
+      "description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `tags`\n  Object of class `DagsterRunReaction` has no attribute `tags`\n  Object of class `Iterator` has no attribute `tags`\n  Object of class `NoneType` has no attribute `tags`\n  Object of class `SensorResult` has no attribute `tags`\n  Object of class `Sequence` has no attribute `tags`\n  Object of class `SkipReason` has no attribute `tags`",
+      "concise_description": "Object of type `DagsterRunReaction | Iterator[DagsterRunReaction | RunRequest | SensorResult | SkipReason] | RunRequest | SensorResult | Sequence[RunRequest] | SkipReason | None` has no attribute `tags`",
       "severity": "error"
     },
     {
@@ -10141,15 +10105,15 @@
       "severity": "error"
     },
     {
-      "line": 385,
-      "column": 27,
-      "stop_line": 385,
-      "stop_column": 78,
+      "line": 378,
+      "column": 5,
+      "stop_line": 378,
+      "stop_column": 59,
       "path": "tests/unit/dagster/io_managers_test.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `NoneType` has no attribute `get_dataset_years`",
-      "concise_description": "Object of class `NoneType` has no attribute `get_dataset_years`",
+      "description": "Object of class `FunctionType` has no attribute `return_value`",
+      "concise_description": "Object of class `FunctionType` has no attribute `return_value`",
       "severity": "error"
     },
     {
@@ -10189,15 +10153,15 @@
       "severity": "error"
     },
     {
-      "line": 444,
-      "column": 27,
-      "stop_line": 444,
-      "stop_column": 78,
+      "line": 437,
+      "column": 5,
+      "stop_line": 437,
+      "stop_column": 59,
       "path": "tests/unit/dagster/io_managers_test.py",
       "code": -2,
       "name": "missing-attribute",
-      "description": "Object of class `NoneType` has no attribute `get_dataset_years`",
-      "concise_description": "Object of class `NoneType` has no attribute `get_dataset_years`",
+      "description": "Object of class `FunctionType` has no attribute `return_value`",
+      "concise_description": "Object of class `FunctionType` has no attribute `return_value`",
       "severity": "error"
     },
     {
@@ -10249,6 +10213,18 @@
       "severity": "error"
     },
     {
+      "line": 503,
+      "column": 5,
+      "stop_line": 503,
+      "stop_column": 59,
+      "path": "tests/unit/dagster/io_managers_test.py",
+      "code": -2,
+      "name": "missing-attribute",
+      "description": "Object of class `FunctionType` has no attribute `return_value`",
+      "concise_description": "Object of class `FunctionType` has no attribute `return_value`",
+      "severity": "error"
+    },
+    {
       "line": 530,
       "column": 61,
       "stop_line": 534,
@@ -10270,6 +10246,18 @@
       "name": "read-only",
       "description": "Attribute `is_ephemeral` of class `DagsterInstance` is a read-only property and cannot be set",
       "concise_description": "Attribute `is_ephemeral` of class `DagsterInstance` is a read-only property and cannot be set",
+      "severity": "error"
+    },
+    {
+      "line": 541,
+      "column": 5,
+      "stop_line": 541,
+      "stop_column": 59,
+      "path": "tests/unit/dagster/io_managers_test.py",
+      "code": -2,
+      "name": "missing-attribute",
+      "description": "Object of class `FunctionType` has no attribute `return_value`",
+      "concise_description": "Object of class `FunctionType` has no attribute `return_value`",
       "severity": "error"
     },
     {
@@ -10297,9 +10285,9 @@
       "severity": "error"
     },
     {
-      "line": 618,
+      "line": 627,
       "column": 55,
-      "stop_line": 618,
+      "stop_line": 627,
       "stop_column": 68,
       "path": "tests/unit/deploy/deploy_pudl_test.py",
       "code": -2,
@@ -10621,9 +10609,9 @@
       "severity": "error"
     },
     {
-      "line": 400,
+      "line": 772,
       "column": 13,
-      "stop_line": 400,
+      "stop_line": 772,
       "stop_column": 38,
       "path": "tests/unit/metadata/metadata_test.py",
       "code": -2,
@@ -11305,15 +11293,15 @@
       "severity": "error"
     },
     {
-      "line": 155,
-      "column": 36,
-      "stop_line": 185,
-      "stop_column": 2,
+      "line": 156,
+      "column": 19,
+      "stop_line": 184,
+      "stop_column": 6,
       "path": "tests/unit/transform/classes_test.py",
       "code": -2,
       "name": "bad-assignment",
-      "description": "`dict[str, dict[str, set[str]]]` is not assignable to `dict[str, set[str]]`",
-      "concise_description": "`dict[str, dict[str, set[str]]]` is not assignable to `dict[str, set[str]]`",
+      "description": "`dict[str, set[str]]` is not assignable to dict value type `set[str]`",
+      "concise_description": "`dict[str, set[str]]` is not assignable to dict value type `set[str]`",
       "severity": "error"
     },
     {

--- a/.pyrefly-baseline.json
+++ b/.pyrefly-baseline.json
@@ -2197,9 +2197,9 @@
       "severity": "error"
     },
     {
-      "line": 87,
+      "line": 99,
       "column": 12,
-      "stop_line": 87,
+      "stop_line": 99,
       "stop_column": 36,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2209,9 +2209,9 @@
       "severity": "error"
     },
     {
-      "line": 289,
+      "line": 301,
       "column": 23,
-      "stop_line": 289,
+      "stop_line": 301,
       "stop_column": 65,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2221,9 +2221,9 @@
       "severity": "error"
     },
     {
-      "line": 381,
+      "line": 393,
       "column": 24,
-      "stop_line": 381,
+      "stop_line": 393,
       "stop_column": 52,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2233,9 +2233,9 @@
       "severity": "error"
     },
     {
-      "line": 396,
+      "line": 408,
       "column": 22,
-      "stop_line": 396,
+      "stop_line": 408,
       "stop_column": 44,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2245,9 +2245,9 @@
       "severity": "error"
     },
     {
-      "line": 414,
+      "line": 426,
       "column": 61,
-      "stop_line": 414,
+      "stop_line": 426,
       "stop_column": 76,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2257,9 +2257,9 @@
       "severity": "error"
     },
     {
-      "line": 416,
+      "line": 428,
       "column": 54,
-      "stop_line": 416,
+      "stop_line": 428,
       "stop_column": 69,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2269,9 +2269,9 @@
       "severity": "error"
     },
     {
-      "line": 501,
+      "line": 516,
       "column": 23,
-      "stop_line": 501,
+      "stop_line": 516,
       "stop_column": 65,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2281,9 +2281,9 @@
       "severity": "error"
     },
     {
-      "line": 585,
+      "line": 600,
       "column": 16,
-      "stop_line": 585,
+      "stop_line": 600,
       "stop_column": 46,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2293,9 +2293,9 @@
       "severity": "error"
     },
     {
-      "line": 591,
+      "line": 606,
       "column": 13,
-      "stop_line": 591,
+      "stop_line": 606,
       "stop_column": 25,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2305,9 +2305,9 @@
       "severity": "error"
     },
     {
-      "line": 592,
+      "line": 607,
       "column": 16,
-      "stop_line": 592,
+      "stop_line": 607,
       "stop_column": 28,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2317,9 +2317,9 @@
       "severity": "error"
     },
     {
-      "line": 610,
+      "line": 625,
       "column": 13,
-      "stop_line": 610,
+      "stop_line": 625,
       "stop_column": 27,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2329,9 +2329,9 @@
       "severity": "error"
     },
     {
-      "line": 612,
+      "line": 627,
       "column": 16,
-      "stop_line": 612,
+      "stop_line": 627,
       "stop_column": 30,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2341,9 +2341,9 @@
       "severity": "error"
     },
     {
-      "line": 632,
+      "line": 647,
       "column": 22,
-      "stop_line": 632,
+      "stop_line": 647,
       "stop_column": 46,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2353,9 +2353,9 @@
       "severity": "error"
     },
     {
-      "line": 638,
+      "line": 653,
       "column": 19,
-      "stop_line": 638,
+      "stop_line": 653,
       "stop_column": 57,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2365,9 +2365,9 @@
       "severity": "error"
     },
     {
-      "line": 669,
+      "line": 684,
       "column": 13,
-      "stop_line": 669,
+      "stop_line": 684,
       "stop_column": 41,
       "path": "src/pudl/dagster/io_managers.py",
       "code": -2,
@@ -2485,9 +2485,9 @@
       "severity": "error"
     },
     {
-      "line": 399,
+      "line": 404,
       "column": 13,
-      "stop_line": 399,
+      "stop_line": 404,
       "stop_column": 71,
       "path": "src/pudl/deploy/pudl.py",
       "code": -2,
@@ -2497,9 +2497,9 @@
       "severity": "error"
     },
     {
-      "line": 601,
+      "line": 650,
       "column": 19,
-      "stop_line": 601,
+      "stop_line": 650,
       "stop_column": 79,
       "path": "src/pudl/deploy/pudl.py",
       "code": -2,
@@ -3121,6 +3121,54 @@
       "severity": "error"
     },
     {
+      "line": 22,
+      "column": 1,
+      "stop_line": 22,
+      "stop_column": 16,
+      "path": "src/pudl/extract/ferceqr.py",
+      "code": -2,
+      "name": "no-matching-overload",
+      "description": "No matching overload found for function `contextlib.contextmanager` called with arguments: ((base_path: UPath, year_quarter: str) -> ZipFile)\n  Possible overloads:\n    (func: (ParamSpec(_P)) -> Generator[_T_co, None, object]) -> (ParamSpec(_P)) -> _GeneratorContextManager[_T_co] [closest match]\n    (func: (ParamSpec(_P)) -> Iterator[_T_co]) -> (ParamSpec(_P)) -> _GeneratorContextManager[_T_co]\n  Argument `(base_path: UPath, year_quarter: str) -> ZipFile` is not assignable to parameter `func` with type `(base_path: UPath, year_quarter: str) -> Generator[@_, None, object]` in function `contextlib.contextmanager`",
+      "concise_description": "No matching overload found for function `contextlib.contextmanager` called with arguments: ((base_path: UPath, year_quarter: str) -> ZipFile)",
+      "severity": "error"
+    },
+    {
+      "line": 23,
+      "column": 54,
+      "stop_line": 23,
+      "stop_column": 69,
+      "path": "src/pudl/extract/ferceqr.py",
+      "code": -2,
+      "name": "bad-return",
+      "description": "Generator function should return `Generator`",
+      "concise_description": "Generator function should return `Generator`",
+      "severity": "error"
+    },
+    {
+      "line": 71,
+      "column": 5,
+      "stop_line": 71,
+      "stop_column": 11,
+      "path": "src/pudl/extract/ferceqr.py",
+      "code": -2,
+      "name": "not-iterable",
+      "description": "Type `None` is not iterable",
+      "concise_description": "Type `None` is not iterable",
+      "severity": "error"
+    },
+    {
+      "line": 144,
+      "column": 22,
+      "stop_line": 144,
+      "stop_column": 26,
+      "path": "src/pudl/extract/ferceqr.py",
+      "code": -2,
+      "name": "bad-argument-type",
+      "description": "Argument `Path` is not assignable to parameter `csv_path` with type `str` in function `_extract_other_table`",
+      "concise_description": "Argument `Path` is not assignable to parameter `csv_path` with type `str` in function `_extract_other_table`",
+      "severity": "error"
+    },
+    {
       "line": 69,
       "column": 35,
       "stop_line": 69,
@@ -3433,9 +3481,9 @@
       "severity": "error"
     },
     {
-      "line": 623,
+      "line": 619,
       "column": 26,
-      "stop_line": 623,
+      "stop_line": 619,
       "stop_column": 30,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3445,9 +3493,9 @@
       "severity": "error"
     },
     {
-      "line": 773,
+      "line": 769,
       "column": 25,
-      "stop_line": 773,
+      "stop_line": 769,
       "stop_column": 52,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3457,9 +3505,9 @@
       "severity": "error"
     },
     {
-      "line": 784,
+      "line": 780,
       "column": 25,
-      "stop_line": 784,
+      "stop_line": 780,
       "stop_column": 52,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3469,9 +3517,9 @@
       "severity": "error"
     },
     {
-      "line": 785,
+      "line": 781,
       "column": 26,
-      "stop_line": 785,
+      "stop_line": 781,
       "stop_column": 54,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3481,9 +3529,9 @@
       "severity": "error"
     },
     {
-      "line": 916,
+      "line": 912,
       "column": 31,
-      "stop_line": 916,
+      "stop_line": 912,
       "stop_column": 41,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3493,9 +3541,9 @@
       "severity": "error"
     },
     {
-      "line": 1478,
+      "line": 1474,
       "column": 12,
-      "stop_line": 1478,
+      "stop_line": 1474,
       "stop_column": 18,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3505,9 +3553,9 @@
       "severity": "error"
     },
     {
-      "line": 1704,
+      "line": 1700,
       "column": 22,
-      "stop_line": 1704,
+      "stop_line": 1700,
       "stop_column": 49,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3517,9 +3565,9 @@
       "severity": "error"
     },
     {
-      "line": 1705,
+      "line": 1701,
       "column": 17,
-      "stop_line": 1705,
+      "stop_line": 1701,
       "stop_column": 44,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3529,9 +3577,9 @@
       "severity": "error"
     },
     {
-      "line": 1707,
+      "line": 1703,
       "column": 21,
-      "stop_line": 1707,
+      "stop_line": 1703,
       "stop_column": 26,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3541,9 +3589,9 @@
       "severity": "error"
     },
     {
-      "line": 1852,
+      "line": 1848,
       "column": 9,
-      "stop_line": 1853,
+      "stop_line": 1849,
       "stop_column": 41,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3553,9 +3601,9 @@
       "severity": "error"
     },
     {
-      "line": 1910,
+      "line": 1906,
       "column": 47,
-      "stop_line": 1910,
+      "stop_line": 1906,
       "stop_column": 56,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3565,9 +3613,9 @@
       "severity": "error"
     },
     {
-      "line": 2078,
+      "line": 2074,
       "column": 22,
-      "stop_line": 2078,
+      "stop_line": 2074,
       "stop_column": 30,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3577,9 +3625,9 @@
       "severity": "error"
     },
     {
-      "line": 2123,
+      "line": 2119,
       "column": 10,
-      "stop_line": 2127,
+      "stop_line": 2123,
       "stop_column": 17,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3589,21 +3637,45 @@
       "severity": "error"
     },
     {
+      "line": 2155,
+      "column": 35,
+      "stop_line": 2155,
+      "stop_column": 46,
+      "path": "src/pudl/helpers.py",
+      "code": -2,
+      "name": "bad-argument-type",
+      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
+      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
+      "severity": "error"
+    },
+    {
+      "line": 2156,
+      "column": 9,
+      "stop_line": 2156,
+      "stop_column": 32,
+      "path": "src/pudl/helpers.py",
+      "code": -2,
+      "name": "unsupported-operation",
+      "description": "`+` is not supported between `Iterable[str]` and `list[str]`\n  Cannot find `__radd__` or `__add__`",
+      "concise_description": "`+` is not supported between `Iterable[str]` and `list[str]`",
+      "severity": "error"
+    },
+    {
+      "line": 2158,
+      "column": 35,
+      "stop_line": 2158,
+      "stop_column": 46,
+      "path": "src/pudl/helpers.py",
+      "code": -2,
+      "name": "bad-argument-type",
+      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
+      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
+      "severity": "error"
+    },
+    {
       "line": 2159,
-      "column": 35,
+      "column": 9,
       "stop_line": 2159,
-      "stop_column": 46,
-      "path": "src/pudl/helpers.py",
-      "code": -2,
-      "name": "bad-argument-type",
-      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "severity": "error"
-    },
-    {
-      "line": 2160,
-      "column": 9,
-      "stop_line": 2160,
       "stop_column": 32,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3613,33 +3685,9 @@
       "severity": "error"
     },
     {
-      "line": 2162,
-      "column": 35,
-      "stop_line": 2162,
-      "stop_column": 46,
-      "path": "src/pudl/helpers.py",
-      "code": -2,
-      "name": "bad-argument-type",
-      "description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "concise_description": "Argument `Iterable[str]` is not assignable to parameter `id_vars` with type `Sequence[Unknown] | ndarray | tuple[Unknown, ...] | None` in function `pandas.core.frame.DataFrame.melt`",
-      "severity": "error"
-    },
-    {
-      "line": 2163,
-      "column": 9,
-      "stop_line": 2163,
-      "stop_column": 32,
-      "path": "src/pudl/helpers.py",
-      "code": -2,
-      "name": "unsupported-operation",
-      "description": "`+` is not supported between `Iterable[str]` and `list[str]`\n  Cannot find `__radd__` or `__add__`",
-      "concise_description": "`+` is not supported between `Iterable[str]` and `list[str]`",
-      "severity": "error"
-    },
-    {
-      "line": 2407,
+      "line": 2371,
       "column": 57,
-      "stop_line": 2407,
+      "stop_line": 2371,
       "stop_column": 73,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3649,9 +3697,9 @@
       "severity": "error"
     },
     {
-      "line": 2549,
+      "line": 2492,
       "column": 1,
-      "stop_line": 2549,
+      "stop_line": 2492,
       "stop_column": 16,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3661,9 +3709,9 @@
       "severity": "error"
     },
     {
-      "line": 2552,
+      "line": 2495,
       "column": 6,
-      "stop_line": 2552,
+      "stop_line": 2495,
       "stop_column": 63,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3673,9 +3721,9 @@
       "severity": "error"
     },
     {
-      "line": 2578,
+      "line": 2521,
       "column": 6,
-      "stop_line": 2578,
+      "stop_line": 2521,
       "stop_column": 29,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3685,9 +3733,9 @@
       "severity": "error"
     },
     {
-      "line": 2726,
+      "line": 2669,
       "column": 27,
-      "stop_line": 2726,
+      "stop_line": 2669,
       "stop_column": 55,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3697,9 +3745,9 @@
       "severity": "error"
     },
     {
-      "line": 2754,
+      "line": 2697,
       "column": 12,
-      "stop_line": 2754,
+      "stop_line": 2697,
       "stop_column": 40,
       "path": "src/pudl/helpers.py",
       "code": -2,
@@ -3709,9 +3757,9 @@
       "severity": "error"
     },
     {
-      "line": 175,
+      "line": 173,
       "column": 58,
-      "stop_line": 175,
+      "stop_line": 173,
       "stop_column": 62,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3721,9 +3769,21 @@
       "severity": "error"
     },
     {
-      "line": 619,
+      "line": 288,
+      "column": 33,
+      "stop_line": 288,
+      "stop_column": 37,
+      "path": "src/pudl/metadata/classes.py",
+      "code": -2,
+      "name": "bad-function-definition",
+      "description": "Default `None` is not assignable to parameter `value` with type `list[Unknown]`\n  The declared type does not allow `None`. Consider changing the declared type to `list[Unknown] | None`.",
+      "concise_description": "Default `None` is not assignable to parameter `value` with type `list[Unknown]`",
+      "severity": "error"
+    },
+    {
+      "line": 610,
       "column": 51,
-      "stop_line": 619,
+      "stop_line": 610,
       "stop_column": 60,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3733,9 +3793,9 @@
       "severity": "error"
     },
     {
-      "line": 748,
+      "line": 739,
       "column": 16,
-      "stop_line": 748,
+      "stop_line": 739,
       "stop_column": 46,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3745,9 +3805,9 @@
       "severity": "error"
     },
     {
-      "line": 759,
+      "line": 750,
       "column": 20,
-      "stop_line": 759,
+      "stop_line": 750,
       "stop_column": 51,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3757,9 +3817,21 @@
       "severity": "error"
     },
     {
-      "line": 760,
+      "line": 750,
+      "column": 27,
+      "stop_line": 750,
+      "stop_column": 51,
+      "path": "src/pudl/metadata/classes.py",
+      "code": -2,
+      "name": "no-matching-overload",
+      "description": "No matching overload found for function `sqlalchemy.sql.sqltypes.Enum.__init__` called with arguments: (*list[bool | date | datetime | float | int | str])\n  Possible overloads:\n    (enums: type[Enum], **kw: Any) -> None [closest match]\n    (*enums: str, **kw: Any) -> None\n  Argument `bool | date | datetime | float | int | str` is not assignable to parameter `enums` with type `type[Enum]` in function `sqlalchemy.sql.sqltypes.Enum.__init__`",
+      "concise_description": "No matching overload found for function `sqlalchemy.sql.sqltypes.Enum.__init__` called with arguments: (*list[bool | date | datetime | float | int | str])",
+      "severity": "error"
+    },
+    {
+      "line": 751,
       "column": 16,
-      "stop_line": 760,
+      "stop_line": 751,
       "stop_column": 46,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3769,9 +3841,21 @@
       "severity": "error"
     },
     {
-      "line": 941,
+      "line": 929,
+      "column": 16,
+      "stop_line": 934,
+      "stop_column": 10,
+      "path": "src/pudl/metadata/classes.py",
+      "code": -2,
+      "name": "bad-return",
+      "description": "Returned type `pandera.api.pandas.components.Column | pandera.api.polars.components.Column` is not assignable to declared return type `pandera.api.polars.components.Column`",
+      "concise_description": "Returned type `pandera.api.pandas.components.Column | pandera.api.polars.components.Column` is not assignable to declared return type `pandera.api.polars.components.Column`",
+      "severity": "error"
+    },
+    {
+      "line": 930,
       "column": 13,
-      "stop_line": 941,
+      "stop_line": 930,
       "stop_column": 24,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3781,9 +3865,9 @@
       "severity": "error"
     },
     {
-      "line": 941,
+      "line": 930,
       "column": 13,
-      "stop_line": 941,
+      "stop_line": 930,
       "stop_column": 24,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3793,9 +3877,9 @@
       "severity": "error"
     },
     {
-      "line": 1225,
+      "line": 1183,
       "column": 56,
-      "stop_line": 1225,
+      "stop_line": 1183,
       "stop_column": 60,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3805,9 +3889,9 @@
       "severity": "error"
     },
     {
-      "line": 1254,
+      "line": 1212,
       "column": 40,
-      "stop_line": 1254,
+      "stop_line": 1212,
       "stop_column": 69,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3817,9 +3901,9 @@
       "severity": "error"
     },
     {
-      "line": 1725,
+      "line": 1682,
       "column": 5,
-      "stop_line": 1725,
+      "stop_line": 1682,
       "stop_column": 11,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3829,9 +3913,9 @@
       "severity": "error"
     },
     {
-      "line": 1809,
+      "line": 1766,
       "column": 59,
-      "stop_line": 1809,
+      "stop_line": 1766,
       "stop_column": 74,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3841,9 +3925,9 @@
       "severity": "error"
     },
     {
-      "line": 1810,
+      "line": 1767,
       "column": 69,
-      "stop_line": 1810,
+      "stop_line": 1767,
       "stop_column": 78,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3853,9 +3937,9 @@
       "severity": "error"
     },
     {
-      "line": 1924,
+      "line": 1881,
       "column": 33,
-      "stop_line": 1924,
+      "stop_line": 1881,
       "stop_column": 37,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3865,9 +3949,9 @@
       "severity": "error"
     },
     {
-      "line": 1942,
+      "line": 1899,
       "column": 32,
-      "stop_line": 1942,
+      "stop_line": 1899,
       "stop_column": 44,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3877,9 +3961,9 @@
       "severity": "error"
     },
     {
-      "line": 1965,
+      "line": 1920,
       "column": 24,
-      "stop_line": 1965,
+      "stop_line": 1920,
       "stop_column": 39,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3889,9 +3973,9 @@
       "severity": "error"
     },
     {
-      "line": 2042,
+      "line": 1997,
       "column": 16,
-      "stop_line": 2042,
+      "stop_line": 1997,
       "stop_column": 21,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3901,9 +3985,9 @@
       "severity": "error"
     },
     {
-      "line": 2122,
+      "line": 2077,
       "column": 32,
-      "stop_line": 2122,
+      "stop_line": 2077,
       "stop_column": 45,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3913,9 +3997,21 @@
       "severity": "error"
     },
     {
-      "line": 2528,
+      "line": 2130,
+      "column": 73,
+      "stop_line": 2130,
+      "stop_column": 77,
+      "path": "src/pudl/metadata/classes.py",
+      "code": -2,
+      "name": "bad-function-definition",
+      "description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`\n  The declared type does not allow `None`. Consider changing the declared type to `(...) -> Unknown | None`.",
+      "concise_description": "Default `None` is not assignable to parameter `error` with type `(...) -> Unknown`",
+      "severity": "error"
+    },
+    {
+      "line": 2237,
       "column": 27,
-      "stop_line": 2528,
+      "stop_line": 2237,
       "stop_column": 31,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3925,9 +4021,9 @@
       "severity": "error"
     },
     {
-      "line": 2594,
+      "line": 2303,
       "column": 47,
-      "stop_line": 2594,
+      "stop_line": 2303,
       "stop_column": 70,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3937,9 +4033,9 @@
       "severity": "error"
     },
     {
-      "line": 2700,
+      "line": 2409,
       "column": 36,
-      "stop_line": 2700,
+      "stop_line": 2409,
       "stop_column": 68,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3949,9 +4045,9 @@
       "severity": "error"
     },
     {
-      "line": 2702,
+      "line": 2411,
       "column": 43,
-      "stop_line": 2702,
+      "stop_line": 2411,
       "stop_column": 45,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3961,9 +4057,9 @@
       "severity": "error"
     },
     {
-      "line": 2778,
+      "line": 2487,
       "column": 16,
-      "stop_line": 2778,
+      "stop_line": 2487,
       "stop_column": 28,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3973,9 +4069,9 @@
       "severity": "error"
     },
     {
-      "line": 2864,
+      "line": 2573,
       "column": 40,
-      "stop_line": 2864,
+      "stop_line": 2573,
       "stop_column": 53,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3985,9 +4081,9 @@
       "severity": "error"
     },
     {
-      "line": 2868,
+      "line": 2577,
       "column": 72,
-      "stop_line": 2868,
+      "stop_line": 2577,
       "stop_column": 88,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -3997,9 +4093,9 @@
       "severity": "error"
     },
     {
-      "line": 2869,
+      "line": 2578,
       "column": 59,
-      "stop_line": 2869,
+      "stop_line": 2578,
       "stop_column": 83,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4009,9 +4105,9 @@
       "severity": "error"
     },
     {
-      "line": 2870,
+      "line": 2579,
       "column": 62,
-      "stop_line": 2870,
+      "stop_line": 2579,
       "stop_column": 89,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -4021,9 +4117,9 @@
       "severity": "error"
     },
     {
-      "line": 2891,
+      "line": 2600,
       "column": 44,
-      "stop_line": 2891,
+      "stop_line": 2600,
       "stop_column": 80,
       "path": "src/pudl/metadata/classes.py",
       "code": -2,
@@ -7129,9 +7225,9 @@
       "severity": "error"
     },
     {
-      "line": 728,
+      "line": 744,
       "column": 16,
-      "stop_line": 728,
+      "stop_line": 744,
       "stop_column": 44,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -7141,9 +7237,9 @@
       "severity": "error"
     },
     {
-      "line": 731,
+      "line": 747,
       "column": 16,
-      "stop_line": 731,
+      "stop_line": 747,
       "stop_column": 47,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -7153,9 +7249,9 @@
       "severity": "error"
     },
     {
-      "line": 1067,
+      "line": 1083,
       "column": 17,
-      "stop_line": 1067,
+      "stop_line": 1083,
       "stop_column": 43,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -7165,9 +7261,9 @@
       "severity": "error"
     },
     {
-      "line": 1101,
+      "line": 1117,
       "column": 12,
-      "stop_line": 1101,
+      "stop_line": 1117,
       "stop_column": 38,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -7177,9 +7273,9 @@
       "severity": "error"
     },
     {
-      "line": 1105,
+      "line": 1121,
       "column": 20,
-      "stop_line": 1105,
+      "stop_line": 1121,
       "stop_column": 51,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -7189,9 +7285,9 @@
       "severity": "error"
     },
     {
-      "line": 1107,
+      "line": 1123,
       "column": 14,
-      "stop_line": 1107,
+      "stop_line": 1123,
       "stop_column": 40,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -7201,9 +7297,9 @@
       "severity": "error"
     },
     {
-      "line": 1109,
+      "line": 1125,
       "column": 20,
-      "stop_line": 1109,
+      "stop_line": 1125,
       "stop_column": 51,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -7213,9 +7309,9 @@
       "severity": "error"
     },
     {
-      "line": 1377,
+      "line": 1393,
       "column": 22,
-      "stop_line": 1377,
+      "stop_line": 1393,
       "stop_column": 51,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -7225,9 +7321,9 @@
       "severity": "error"
     },
     {
-      "line": 1741,
+      "line": 1757,
       "column": 28,
-      "stop_line": 1741,
+      "stop_line": 1757,
       "stop_column": 57,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -7237,9 +7333,9 @@
       "severity": "error"
     },
     {
-      "line": 1998,
+      "line": 2014,
       "column": 28,
-      "stop_line": 1998,
+      "stop_line": 2014,
       "stop_column": 53,
       "path": "src/pudl/transform/eia923.py",
       "code": -2,
@@ -9937,21 +10033,9 @@
       "severity": "error"
     },
     {
-      "line": 76,
-      "column": 9,
-      "stop_line": 76,
-      "stop_column": 34,
-      "path": "tests/unit/dagster/asset_checks_test.py",
-      "code": -2,
-      "name": "missing-attribute",
-      "description": "Object of class `NodeDefinition` has no attribute `compute_fn`",
-      "concise_description": "Object of class `NodeDefinition` has no attribute `compute_fn`",
-      "severity": "error"
-    },
-    {
-      "line": 141,
+      "line": 139,
       "column": 27,
-      "stop_line": 141,
+      "stop_line": 139,
       "stop_column": 55,
       "path": "tests/unit/dagster/asset_checks_test.py",
       "code": -2,
@@ -10609,9 +10693,9 @@
       "severity": "error"
     },
     {
-      "line": 772,
+      "line": 452,
       "column": 13,
-      "stop_line": 772,
+      "stop_line": 452,
       "stop_column": 38,
       "path": "tests/unit/metadata/metadata_test.py",
       "code": -2,
@@ -11221,9 +11305,9 @@
       "severity": "error"
     },
     {
-      "line": 342,
+      "line": 384,
       "column": 13,
-      "stop_line": 342,
+      "stop_line": 384,
       "stop_column": 28,
       "path": "tests/unit/settings_test.py",
       "code": -2,
@@ -11233,9 +11317,9 @@
       "severity": "error"
     },
     {
-      "line": 346,
+      "line": 388,
       "column": 13,
-      "stop_line": 346,
+      "stop_line": 388,
       "stop_column": 31,
       "path": "tests/unit/settings_test.py",
       "code": -2,
@@ -11245,9 +11329,9 @@
       "severity": "error"
     },
     {
-      "line": 374,
+      "line": 416,
       "column": 16,
-      "stop_line": 374,
+      "stop_line": 416,
       "stop_column": 45,
       "path": "tests/unit/settings_test.py",
       "code": -2,
@@ -11257,9 +11341,9 @@
       "severity": "error"
     },
     {
-      "line": 543,
+      "line": 585,
       "column": 16,
-      "stop_line": 543,
+      "stop_line": 585,
       "stop_column": 52,
       "path": "tests/unit/settings_test.py",
       "code": -2,
@@ -11269,9 +11353,9 @@
       "severity": "error"
     },
     {
-      "line": 565,
+      "line": 607,
       "column": 18,
-      "stop_line": 565,
+      "stop_line": 607,
       "stop_column": 64,
       "path": "tests/unit/settings_test.py",
       "code": -2,
@@ -11281,9 +11365,9 @@
       "severity": "error"
     },
     {
-      "line": 566,
+      "line": 608,
       "column": 16,
-      "stop_line": 566,
+      "stop_line": 608,
       "stop_column": 52,
       "path": "tests/unit/settings_test.py",
       "code": -2,

--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,30 @@
+{
+  "lsp": {
+    "pyrefly": {
+      "binary": {
+        "path": "pixi",
+        "arguments": [
+          "run",
+          "--frozen",
+          "-e",
+          "dev",
+          "--executable",
+          "pyrefly",
+          "lsp"
+        ]
+      }
+    },
+    "ruff": {
+      "binary": {
+        "path": "pixi",
+        "arguments": [
+          "run",
+          "--frozen",
+          "--executable",
+          "ruff",
+          "server"
+        ]
+      }
+    }
+  }
+}

--- a/docs/dev/dev_setup.rst
+++ b/docs/dev/dev_setup.rst
@@ -310,6 +310,74 @@ Linting and Formatting
   that corrects a typos), add ``# spellchecker:ignore`` as a comment to the end of the
   line.
 
+Type Checking with pyrefly
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+We use `pyrefly <https://pyrefly.org/>`__, a fast Rust-based Python type checker, to
+catch type errors before they reach CI. It isn't yet part of the standard pre-commit
+hooks or CI pipeline -- PUDL's codebase predates comprehensive type annotations, so for
+now pyrefly runs as a voluntary check for anyone gradually cleaning up typing issues in
+the code they touch.
+
+**Running the checks**
+
+pyrefly is a dev-only dependency, so always run it through the ``dev`` pixi environment:
+
+.. code-block:: console
+
+    $ pixi run pyrefly-check                                  # whole project, against the baseline
+    $ pixi run -e dev pyrefly check src/pudl/path/to/file.py   # quick check of one file
+
+``pyrefly-check`` lives in the ``dev`` feature's task table specifically so that plain
+``pixi run pyrefly-check`` always resolves to the project-pinned ``pyrefly`` binary,
+rather than silently falling back to a different version found on ``$PATH`` (e.g. one
+installed globally for editor or language-server integration).
+
+**The baseline**
+
+PUDL isn't enforcing full type-checking project-wide yet, so ``.pyrefly-baseline.json``
+records every pre-existing type error as of when it was last regenerated, and
+``pixi run pyrefly-check`` only fails on errors *not already in the baseline*. This
+makes it possible to catch newly introduced type errors in code you're touching without
+requiring the whole codebase to be error-free first.
+
+Regenerate the baseline when:
+
+* You've fixed one or more pre-existing errors, to shrink the baseline and prevent them
+  from regressing.
+* pyrefly's own version has been bumped, since a newer version's stricter (or simply
+  different) checks can surface errors in files you never touched.
+
+.. code-block:: console
+
+    $ pixi run -e dev pyrefly check --baseline .pyrefly-baseline.json --update-baseline
+
+Never hand-edit ``.pyrefly-baseline.json``, and never regenerate it just to make a
+*newly introduced* error in your own change disappear -- that defeats its purpose as a
+ratchet against regressions. Fix the error instead, or check with the team if you think
+it should legitimately be deferred.
+
+**Reviewing a baseline regeneration**
+
+A raw ``git diff .pyrefly-baseline.json`` after regenerating is nearly unreadable:
+fixing even one error, or bumping pyrefly's version, can shift line/column numbers on
+hundreds of unrelated entries without any error actually appearing or disappearing.
+
+Use ``pixi run pyrefly-baseline-diff`` (``src/pudl/scripts/pyrefly_baseline_diff.py``)
+instead. It diffs the baseline against ``HEAD`` by ``(file, error code, description)``
+rather than by line number, so the output only shows errors that were genuinely fixed or
+newly added:
+
+.. code-block:: console
+
+    $ pixi run -e dev pyrefly check --baseline .pyrefly-baseline.json --update-baseline
+    $ pixi run pyrefly-baseline-diff
+
+Run this every time you regenerate the baseline, before committing it. Confirm the
+"fixed" list matches what you intended to fix, and scrutinize the "newly baselined"
+list carefully -- it should only ever contain pre-existing issues you're knowingly
+deferring (e.g. ones surfaced by a version bump), never something your own change
+introduced.
+
 Linting Within Your Editor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 If you are using an editor designed for Python development many of these code linting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,14 @@ marimo = ">=0.13"
 cmd = "pyrefly check --baseline .pyrefly-baseline.json"
 description = "Type-check with pyrefly against the tracked baseline"
 
+[tool.pixi.feature.dev.tasks.pyrefly-baseline-diff]
+cmd = "pyrefly_baseline_diff"
+description = """
+Diff .pyrefly-baseline.json against git HEAD by (file, code, description), ignoring \
+line/column churn. Run after `pyrefly check --baseline .pyrefly-baseline.json \
+--update-baseline` to sanity-check the regenerated baseline before committing it.
+"""
+
 [tool.pixi.environments]
 dev = { features = ["dev"], solve-group = "default" }
 
@@ -444,6 +452,7 @@ resource_description = "pudl.scripts.resource_description:main"
 update_zenodo_dois = "pudl.scripts.update_zenodo_dois:main"
 zenodo_data_release = "pudl.scripts.zenodo_data_release:main"
 generate_ferc_provenance = "pudl.scripts.generate_ferc_provenance:main"
+pyrefly_baseline_diff = "pudl.scripts.pyrefly_baseline_diff:main"
 
 [tool.ruff]
 # Configurations that apply to both the `format` and `lint` subcommands.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,12 +185,21 @@ marimo = ">=0.23.15"
 matplotx = ">=0.3.10"
 plotly = ">=6.6"
 ripgrep = ">=15" # Primarily for agent skills use
-pyrefly = ">=1.1.1" # Experimental, also for agent skills use
+pyrefly = ">=1.2.0" # Experimental, also for agent skills use
 
 # linux-aarch64 (e.g. Docker via OrbStack on Apple Silicon) only has marimo <=0.13
 # available on conda-forge, so relax the version requirement for that platform only.
 [tool.pixi.feature.dev.target.linux-aarch64.dependencies]
 marimo = ">=0.13"
+
+# pyrefly is a dev-only dependency (see above), so this task is scoped to the dev
+# feature rather than the default task table. That makes it uniquely defined in the
+# dev environment, so `pixi run pyrefly-check` resolves there automatically -- no
+# `-e dev` needed, and no risk of silently falling back to a `pyrefly` found on $PATH
+# outside the pixi environment (e.g. one installed globally for editor/LSP use).
+[tool.pixi.feature.dev.tasks.pyrefly-check]
+cmd = "pyrefly check --baseline .pyrefly-baseline.json"
+description = "Type-check with pyrefly against the tracked baseline"
 
 [tool.pixi.environments]
 dev = { features = ["dev"], solve-group = "default" }
@@ -408,10 +417,6 @@ cmd = """
 npx -y @devcontainers/cli build --workspace-folder . --log-level info
 """
 description = "Rebuild devcontainer image metadata (workspace .pixi and caches are now separate volumes)"
-
-[tool.pixi.tasks.pyrefly-check]
-cmd = "pyrefly check --baseline .pyrefly-baseline.json"
-description = "Type-check with pyrefly against the tracked baseline"
 
 # Coding agent environment
 # NOTE (2026-03-17): We're using the `experimental_install` command

--- a/src/pudl/extract/epamats.py
+++ b/src/pudl/extract/epamats.py
@@ -149,7 +149,11 @@ class EpaMatsDatastore:
             lf = pl.scan_csv(csv_file, low_memory=True, schema_overrides=DTYPE_DICT)
             lf = (
                 lf.select(list(RENAME_DICT))
-                .cast(DTYPE_DICT, strict=False)
+                # dict[str, ...] can't satisfy Mapping's invariant key type
+                # against the union `.cast()` declares, even though `str` is
+                # one of the union members -- a typeshed limitation, not a
+                # real type mismatch.
+                .cast(DTYPE_DICT, strict=False)  # type: ignore[bad-argument-type]
                 .rename(RENAME_DICT, strict=False)
             )
 

--- a/src/pudl/metadata/classes.py
+++ b/src/pudl/metadata/classes.py
@@ -735,7 +735,7 @@ class Field(PudlMeta):
         instead of being coerced. ``Categorical`` round-trips through Parquet fine.
         """
         if self.constraints.enum and self.type == "string":
-            return pl.Categorical
+            return pl.Categorical()
         return FIELD_DTYPES_POLARS[self.type]
 
     def to_pandas_dtype(self) -> str | pd.CategoricalDtype:
@@ -915,7 +915,7 @@ class Field(PudlMeta):
             # Field.to_polars_dtype / Field.to_pandas_dtype); the enum value
             # constraint itself is enforced by the `checks` (Check.isin) above,
             # not by the declared column dtype.
-            column_type = "category" if use_pandas_backend else pl.Categorical
+            column_type = "category" if use_pandas_backend else pl.Categorical()
         elif self.type == "geometry":
             column_type = gpd.array.GeometryDtype()
         else:

--- a/src/pudl/metadata/helpers.py
+++ b/src/pudl/metadata/helpers.py
@@ -345,7 +345,7 @@ def as_dict(x: pd.Series) -> dict[Any, list]:
 def try_aggfunc(
     func: Callable,
     raised: bool = True,
-    error: str | Callable = None,
+    error: str | Callable | None = None,
 ) -> Callable:
     """Wrap aggregate function in a try-except for error handling.
 
@@ -419,7 +419,7 @@ def groupby_apply(
     by: Iterable,
     aggfuncs: dict[Any, Callable],
     raised: bool = True,
-    error: Callable = None,
+    error: Callable | None = None,
 ) -> tuple[pd.DataFrame, dict[Any, pd.Series]]:
     """Aggregate dataframe and capture errors (using apply).
 
@@ -505,7 +505,7 @@ def groupby_aggregate(
     by: Iterable,
     aggfuncs: dict[Any, Callable],
     raised: bool = True,
-    error: Callable = None,
+    error: Callable | None = None,
 ) -> tuple[pd.DataFrame, dict[Any, pd.Series]]:
     """Aggregate dataframe and capture errors (using aggregate).
 

--- a/src/pudl/scripts/pyrefly_baseline_diff.py
+++ b/src/pudl/scripts/pyrefly_baseline_diff.py
@@ -1,0 +1,85 @@
+"""Diff the pyrefly baseline against a git ref by content, not by line number.
+
+Raw JSON diffs of ``.pyrefly-baseline.json`` are dominated by line/column churn from
+ordinary code changes and pyrefly version bumps -- a single ``--update-baseline`` run
+can touch hundreds of lines without any error actually appearing or disappearing. This
+diffs baseline entries by ``(file, error code, description)`` instead, so the output
+only shows errors that were genuinely fixed or newly introduced.
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import click
+
+
+def _load_baseline_entries(
+    ref: str | None, baseline_path: Path
+) -> set[tuple[str, str, str]]:
+    """Load baseline error entries from a git ref, or the working tree if ``ref`` is None."""
+    if ref is None:
+        text = baseline_path.read_text()
+    else:
+        result = subprocess.run(  # noqa: S603
+            ["git", "show", f"{ref}:{baseline_path}"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        text = result.stdout
+    errors = json.loads(text)["errors"]
+    return {(e["path"], e["name"], e["description"]) for e in errors}
+
+
+@click.command(
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+@click.option(
+    "--ref",
+    default="HEAD",
+    show_default=True,
+    help="Git ref to diff the working-tree baseline against.",
+)
+@click.option(
+    "--baseline-path",
+    default=".pyrefly-baseline.json",
+    show_default=True,
+    type=click.Path(path_type=Path),
+    help="Path to the pyrefly baseline file, relative to the repo root.",
+)
+def main(ref: str, baseline_path: Path) -> None:
+    """Diff a pyrefly baseline against a git ref by (file, code, description).
+
+    Run this after ``pyrefly check --baseline .pyrefly-baseline.json --update-baseline``
+    to sanity-check the regenerated baseline before committing it: the "fixed" list
+    should match what you intentionally fixed, and the "newly baselined" list should
+    only contain pre-existing issues you're deliberately deferring -- not something
+    your own change introduced.
+    """
+    old = _load_baseline_entries(ref, baseline_path)
+    new = _load_baseline_entries(None, baseline_path)
+
+    removed = sorted(old - new)
+    added = sorted(new - old)
+
+    click.echo(f"{len(old)} entries at {ref!r} -> {len(new)} entries in working tree")
+
+    click.echo(f"\n{len(removed)} fixed (present at {ref!r}, gone now):")
+    for path, name, description in removed:
+        click.echo(f"  - {path} [{name}] {description[:100]}")
+
+    click.echo(f"\n{len(added)} newly baselined (absent at {ref!r}, present now):")
+    for path, name, description in added:
+        click.echo(f"  + {path} [{name}] {description[:100]}")
+
+    if added:
+        click.echo(
+            "\nReview the 'newly baselined' entries above carefully -- confirm "
+            "they're pre-existing issues you're deliberately deferring, not "
+            "something your own change introduced."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/dagster/asset_checks_test.py
+++ b/tests/unit/dagster/asset_checks_test.py
@@ -38,6 +38,7 @@ import pytest
 from dagster._core.definitions.asset_checks.asset_checks_definition import (
     AssetChecksDefinition,
 )
+from dagster._core.definitions.decorators.op_decorator import DecoratedOpFunction
 
 from pudl.dagster.asset_checks import (
     _build_registry_from_descriptor,
@@ -68,10 +69,11 @@ def test_asset_checks_preserve_runtime_input_types(
     )
 
     assert check is not None
-    assert (
-        check.node_def.compute_fn.decorated_fn.__annotations__["asset_value"]
-        is expected_type
-    )
+    node_def = check.node_def
+    assert isinstance(node_def, dg.OpDefinition)
+    compute_fn = node_def.compute_fn
+    assert isinstance(compute_fn, DecoratedOpFunction)
+    assert compute_fn.decorated_fn.__annotations__["asset_value"] is expected_type
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Fix a handful pre-existing type issues identified by pyrefly (unrelated to FERC EQR).
- Scope the `pyrefly-check` pixi task to the `dev` environment so it always resolves the project-pinned pyrefly rather than whatever happens to be on `$PATH`, and bump the pin to match what's actually resolved (>=1.2.0).
- Regenerate `.pyrefly-baseline.json` against the fixed tree, and mark it (plus `.secrets.baseline`) `linguist-generated` so GitHub doesn't auto-expand them in PR diffs.
- Add dev docs covering pyrefly usage and baseline regeneration.

Split out of #5442 — this is pure pyrefly tooling/config with no FERC EQR content, so it can be reviewed and merged independently.

## Testing

- [x] `pixi run pytest-unit`
- [x] `pixi run pyrefly-check`
- [x] `pixi run prek-run`