### PR TITLE
Close out release notes for PUDL v2026.8.0

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,8 +3,11 @@ changelog:
   exclude:
     authors:
       - catalyst-workflow-triggerer
+      - catalyst-workflow-triggerer[bot]
       - dependabot
+      - dependabot[bot]
       - pre-commit-ci
+      - pre-commit-ci[bot]
       - pudlbot
     labels:
       - conda-lock

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,6 @@ authors:
     given-names: Austen
   - family-names: Schira
     given-names: Zachary
-  - family-names: Lamb
-    given-names: Katherine
   - family-names: Belfer
     given-names: Ella
     orcid: https://orcid.org/0000-0001-9784-8531
@@ -23,6 +21,6 @@ authors:
     orcid: https://orcid.org/0009-0009-9063-080X
 
 title: "The Public Utility Data Liberation (PUDL) Project"
-version: 2026.7.2
+version: 2026.8.0
 doi: 10.5281/zenodo.3404014
-date-released: 2026-07-14
+date-released: 2026-08-07

--- a/dbt/models/sec10k/core_sec10k__assn_exhibit_21_subsidiaries_and_eia_utilities/schema.yml
+++ b/dbt/models/sec10k/core_sec10k__assn_exhibit_21_subsidiaries_and_eia_utilities/schema.yml
@@ -10,7 +10,7 @@ sources:
               config:
                 enabled: "{{ target.name == 'etl-full'}}"
               arguments:
-                min_value: 5724
+                min_value: 5720
                 max_value: 5730
         columns:
           - name: subsidiary_company_id_sec10k

--- a/dbt/schema_inputs/sec10k/core_sec10k__assn_exhibit_21_subsidiaries_and_eia_utilities/schema.human.yml
+++ b/dbt/schema_inputs/sec10k/core_sec10k__assn_exhibit_21_subsidiaries_and_eia_utilities/schema.human.yml
@@ -9,9 +9,9 @@ sources:
               config:
                 enabled: "{{ target.name == 'etl-full'}}"
               arguments:
-                # remote builds 2026-07-19:
-                min_value: 5724
-                # local builds 2026-07-19:
+                # remote builds 2026-08-07:
+                min_value: 5720
+                # local builds 2026-08-07:
                 max_value: 5730
         columns:
           - name: subsidiary_company_id_sec10k

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,13 +1,17 @@
 =======================================================================================
 PUDL Release Notes
 =======================================================================================
-.. _release-v2026.8.x:
+.. _release-v2026.8.0:
 
 ---------------------------------------------------------------------------------------
-v2026.8.x (2026-08-xx)
+v2026.8.0 (2026-08-07)
 ---------------------------------------------------------------------------------------
 
-This is the upcoming quarterly PUDL release.
+This is a regular quarterly PUDL release with a bunch of dataset updates. We've also
+added a new raw EPA MATS dataset, and Puerto Rico is now included in our EIA-860/860M
+data thanks to first-time contributor :user:`bsousa22`. We also tracked down and fixed a
+longstanding bug that had FERC Form 714 balancing authority data crossed between the
+Desert Southwest and Upper Great Plains West regions. See below for all the details.
 
 New Data
 ^^^^^^^^
@@ -19,6 +23,13 @@ EIA-860M
   issue :issue:`4352` and PR :pr:`5360`. Shoutout to :user:`bsousa22` for making his
   first PUDL contribution!
 
+EPA MATS
+~~~~~~~~
+
+* Added the EPA Mercury and Air Toxics Standards (MATS) dataset, extracted into a raw
+  table with additional records through end of June 2026. This data is not yet deeply
+  integrated into PUDL. See issue :issue:`5358` and PRs :pr:`5389`, :pr:`5464`. Also
+  a contribution from :user:`bsousa22`.
 
 Expanded Data Coverage
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -36,37 +47,33 @@ EIA-860M
 
 EIA-923
 ~~~~~~~
-* Added :doc:`EIA-923M <data_sources/eia923>` data through May 2026. See
-  issue :issue:`5460` and PR :pr:`5468`.
+
+* Added early release data for EIA-923 2025. See issue :issue:`5372` and PR :pr:`5391`.
+* Added :doc:`EIA-923M <data_sources/eia923>` data for April and May 2026. See issue
+  :issue:`5460` and PRs :pr:`5391,5468`.
 
 EIA-930
 ~~~~~~~
 
-* Updated :doc:`EIA-930 <data_sources/eia930>` data. See PRs :pr:`5445` and :pr:`5464`.
+* Updated :doc:`EIA-930 <data_sources/eia930>` data. See PRs :pr:`5445,5464`.
 
 FERC-714
 ~~~~~~~~
 
-* Added 2025 XBRL data for :doc:`FERC-714 <data_sources/ferc714>`. See
-  :issue:`5424` and PRs :pr:`5436`, :pr:`5464`.
+* Added 2025 XBRL data for :doc:`FERC-714 <data_sources/ferc714>`. See :issue:`5424` and
+  PRs :pr:`5436,5464`.
 
 EIA Electricity API
 ~~~~~~~~~~~~~~~~~~~
 
-* Updated the :doc:`bulk EIA Electricity API <data_sources/eiaapi>`
-  data used to fill in redacted fuel prices. See PRs :pr:`5441` and :pr:`5464`.
+* Updated the :doc:`bulk EIA Electricity API <data_sources/eiaapi>` data used to fill in
+  redacted fuel prices. See PRs :pr:`5441,5464`.
 
 EPA CEMS
 ~~~~~~~~
 
-* Updated the :doc:`EPA CEMS <data_sources/epacems>` data with
-  additional records through end of June 2026. See PR :pr:`5441` and :pr:`5464`.
-
-EPA MATS
-~~~~~~~~
-
-* Updated the EPA MATS data with additional records through end of June 2026. See PR
-  :pr:`5464`.
+* Updated the :doc:`EPA CEMS <data_sources/epacems>` data with additional records
+  through end of June 2026. See PRs :pr:`5441,5464`.
 
 PHMSA Natural Gas data
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -76,16 +83,15 @@ PHMSA Natural Gas data
 FERC Form 6
 ~~~~~~~~~~~
 
-* Updated the raw FERC Form 6 archives to include additional
-  2025 data. This data is converted to SQLite, but not deeply
-  integrated into PUDL. See PR :pr:`5441`.
+* Updated the raw FERC Form 6 archives to include additional 2025 data. This data is
+  converted to SQLite, but not deeply integrated into PUDL. See PR :pr:`5441`.
 
 Documentation
 ^^^^^^^^^^^^^
 
 * Added LLM use guidelines and best practices to the
   :doc:`contributor guide <CONTRIBUTING>` and :doc:`dev guide <dev/llm_best_practices>`.
-
+  See PR :pr:`5395`.
 * Set up the `sphinx_llm <https://github.com/NVIDIA/sphinx-llm>`__ Sphinx extension to
   generate a Markdown version of the PUDL documentation, suitable for consumption by
   LLMs, based on the `llms.txt <https://llmstxt.org/>`__ convention. Each page now
@@ -111,6 +117,11 @@ Bug Fixes & Data Cleaning
   due to the limited precision of 32-bit floats, on top of the brittleness of of merging
   on floating point numbers. These are now being captured deterministically by merging
   on values within a fixed tolerance of $5. See PR :pr:`5350`.
+* Fixed the Dagster asset graph for :doc:`EIA-860 <data_sources/eia860>` to correctly
+  depend on :doc:`EIA-860M <data_sources/eia860>`, so selecting the ``raw_eia860m``
+  asset group and its downstream assets now also captures the EIA-860 assets that
+  rely on it, instead of silently leaving them stale. See :issue:`4327` and
+  PR :pr:`5409`.
 
 Performance Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -142,6 +153,9 @@ Developer Experience
   microsecond resolution in :mod:`pudl.metadata.dtypes`. The unused ``compact`` argument
   to :meth:`~pudl.metadata.classes.Field.to_pandas_dtype` was retired. See PR
   :pr:`5350`.
+* Sanitized the batch job IDs used by the deploy and build workflows so they always
+  meet Google Batch's naming requirements, fixing failures we had previously worked
+  around by making the IDs more generic. See :issue:`5411` and PR :pr:`5429`.
 
 .. _release-v2026.7.2:
 
@@ -189,12 +203,6 @@ EIA-176
 
 Expanded Data Coverage
 ^^^^^^^^^^^^^^^^^^^^^^
-
-EIA-923
-~~~~~~~
-
-* Added early release data for EIA-923 2025. See issue :issue:`5372` and PR :pr:`5391`.
-* Added 2026 data through April for EIA-923. See :pr:`5391`.
 
 EIA-191
 ~~~~~~~


### PR DESCRIPTION
# Overview

- Close out the release notes for PUDL data release v2026.8.0
- Fix a row-count issue in the SEC 10-K tables
- Update citation file
- Try to keep bot PRs from showing up in autogenerated release notes on GitHub

Part of #5473 