### PR TITLE
Fix op chars dbt

### DIFF
--- a/dbt/models/epacems/out_epacems__yearly_operational_characteristics/schema.yml
+++ b/dbt/models/epacems/out_epacems__yearly_operational_characteristics/schema.yml
@@ -58,6 +58,7 @@ sources:
                     max_value: 25.0
                   config:
                     error_if: ">60"
+                    enabled: "{{ target.name == 'etl-full' }}"
           - name: ramp_up_rate_per_min
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/models/epacems/out_epacems__yearly_operational_characteristics/schema.yml
+++ b/dbt/models/epacems/out_epacems__yearly_operational_characteristics/schema.yml
@@ -27,39 +27,37 @@ sources:
               - dbt_expectations.expect_column_values_to_be_between:
                   description: min_up_time_hours is the minimum observed run length for a unit. Under etl-fast (a single EPA CEMS quarter instead of the 12 trailing quarters used in production), that minimum is drawn from a much smaller sample of up/down events, so it's a far noisier statistic and routinely falls outside this range. Disabled for etl-fast rather than loosened, since there's no principled single-quarter outlier count to pick.
                   arguments:
-                    min_value: 0.0
-                    max_value: 24.0
+                    min_value: 1.0
+                    max_value: 12000
                   config:
-                    error_if: ">58"
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: min_down_time_hours
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   description: "Same reasoning as min_up_time_hours above: this is a minimum-of-a-small-sample statistic that's too noisy to check meaningfully against etl-fast's single quarter of EPA CEMS data."
                   arguments:
-                    min_value: 0.0
-                    max_value: 24.0
+                    min_value: 1.0
+                    max_value: 26304
                   config:
-                    error_if: ">52"
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: heat_rate_at_max_load_factor_mmbtu_per_mwh
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   description: This is a per-unit median heat rate computed only from the hours in that unit's single highest load-factor bin. Under etl-fast's single quarter of data that bin can contain very few hours, making the median far more volatile than in production (12 trailing quarters), so this check is disabled for etl-fast.
                   arguments:
-                    min_value: 3.0
-                    max_value: 18.0
+                    min_value: 5.4
+                    max_value: 25.0
                   config:
-                    error_if: ">49"
+                    error_if: ">50"
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: heat_rate_at_min_stable_load_factor_mmbtu_per_mwh
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
-                    min_value: 3.0
+                    min_value: 5.4
                     max_value: 25.0
                   config:
-                    error_if: ">57"
+                    error_if: ">60"
           - name: ramp_up_rate_per_min
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/schema_inputs/epacems/out_epacems__yearly_operational_characteristics/schema.human.yml
+++ b/dbt/schema_inputs/epacems/out_epacems__yearly_operational_characteristics/schema.human.yml
@@ -73,6 +73,7 @@ sources:
                     max_value: 25.0
                   config:
                     error_if: ">60"
+                    enabled: "{{ target.name == 'etl-full' }}"
           - name: ramp_up_rate_per_min
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/schema_inputs/epacems/out_epacems__yearly_operational_characteristics/schema.human.yml
+++ b/dbt/schema_inputs/epacems/out_epacems__yearly_operational_characteristics/schema.human.yml
@@ -28,10 +28,11 @@ sources:
                     etl-fast rather than loosened, since there's no principled
                     single-quarter outlier count to pick.
                   arguments:
-                    min_value: 0.0
-                    max_value: 24.0
+                    # A min of 0.0 would not count as up time. 1.0 is lowest possible.
+                    min_value: 1.0
+                    # Baseload CCGTs have mandatory inspections every 8-12k hours.
+                    max_value: 12000
                   config:
-                    error_if: ">58"
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: min_down_time_hours
             data_tests:
@@ -41,10 +42,11 @@ sources:
                     minimum-of-a-small-sample statistic that's too noisy to check
                     meaningfully against etl-fast's single quarter of EPA CEMS data.
                   arguments:
-                    min_value: 0.0
-                    max_value: 24.0
+                    # A min of 0.0 would not count as down time. 1.0 is lowest possible.
+                    min_value: 1.0
+                    # Number of hours in 3 years. Some units never fire.
+                    max_value: 26304
                   config:
-                    error_if: ">52"
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: heat_rate_at_max_load_factor_mmbtu_per_mwh
             data_tests:
@@ -56,19 +58,21 @@ sources:
                     the median far more volatile than in production (12 trailing
                     quarters), so this check is disabled for etl-fast.
                   arguments:
-                    min_value: 3.0
-                    max_value: 18.0
+                    # World record for most efficient CCGT is 5.5
+                    min_value: 5.4
+                    max_value: 25.0
                   config:
-                    error_if: ">49"
+                    error_if: ">50"
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: heat_rate_at_min_stable_load_factor_mmbtu_per_mwh
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:
                   arguments:
-                    min_value: 3.0
+                    # World record for most efficient CCGT is 5.5
+                    min_value: 5.4
                     max_value: 25.0
                   config:
-                    error_if: ">57"
+                    error_if: ">60"
           - name: ramp_up_rate_per_min
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/seeds/etl_full_row_counts.csv
+++ b/dbt/seeds/etl_full_row_counts.csv
@@ -4116,7 +4116,7 @@ out_eia__yearly_utilities,2023,7806
 out_eia__yearly_utilities,2024,8285
 out_eia__yearly_utilities,2025,8525
 out_eia__yearly_utilities,2026,7668
-out_epacems__yearly_operational_characteristics,2025,4223
+out_epacems__yearly_operational_characteristics,2025,4173
 out_ferc1__yearly_all_plants,1994,2439
 out_ferc1__yearly_all_plants,1995,2451
 out_ferc1__yearly_all_plants,1996,2417


### PR DESCRIPTION
# Overview

- Update heat rate and min up/down time dbt tests to be physically informed.
- Exclude running another test in the etl-fast / CI due to sampling noise.
- These guys failed the nightly builds last night, so trying to get them fixed.
- Update row counts for the `out_epacems__yearly_operational_characteristics` as well
- Data validation passes locally with these params.