### PR TITLE
Fix intermittent docs build failures from sphinx_llm.txt race condition

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -150,6 +150,12 @@ autoapi_ignore = [
 ]
 autoapi_add_toctree_entry = False
 
+# sphinx_llm.txt normally builds its markdown twin of the docs in a background
+# subprocess that overlaps with the main HTML build. However, because of our
+# dynamic file generation and cleanup, this results in a race condition and
+# conflicts between the two builds, so we disable the parallel build.
+llms_txt_build_parallel = False
+
 # GitHub repo
 issues_github_path = "catalyst-cooperative/pudl"
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -100,6 +100,10 @@ Bug Fixes & Data Cleaning
   With the fix, 788 records in ``out_pudl__yearly_assn_eia_ferc1_plant_parts`` which
   used to have a NULL ``report_date`` now appear with correct date information. See
   issue :issue:`4130` and PR :pr:`5503`
+* Fixed a race condition that intermittently failed the docs build due to the HTML and
+  Markdown builds attempting to clean up the same dynamically generated output files at
+  the end of their build. Fixed by setting ``llms_txt_build_parallel = False``. See
+  issue :issue:`5502`.
 
 Performance Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -103,7 +103,7 @@ Bug Fixes & Data Cleaning
 * Fixed a race condition that intermittently failed the docs build due to the HTML and
   Markdown builds attempting to clean up the same dynamically generated output files at
   the end of their build. Fixed by setting ``llms_txt_build_parallel = False``. See
-  issue :issue:`5502`.
+  issue :issue:`5502` and PR :pr:`5516`.
 
 Performance Improvements
 ^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

- The `sphinx_llm.txt` extension spawns a second, independent `sphinx-build` subprocess to generate a markdown twin of the docs for `llms.txt`, and by default runs it *concurrently* with the primary HTML build.
- Both processes point at the same `docs/` source directory, so each runs its own copy of the `sphinx-autoapi` lifecycle — regenerating and then deleting the shared `docs/autoapi/` directory. Whichever build finished first could delete the `.rst` files while the other was still reading them during its parallel writing-output phase, raising a `FileNotFoundError` and failing the build.
- This explains the intermittent failure rate on `main`/`nightly` reported in the issue — the specific `autoapi/.../index.rst` path that "didn't exist" differed randomly across failed runs.
- I set `llms_txt_build_parallel = False` in `docs/conf.py` so the markdown subprocess only starts after the primary build fully finishes, eliminating the shared-file race.
- This results in a modest increase in total `docs-build` time since the two builds no longer overlap.
- I'm still not clear to me why I've never seen this particular failure happen when building the docs locally though.

Closes #5502