### PR TITLE
Fix git repo test isolation

### DIFF
--- a/tests/integration/analysis/record_linkage_test.py
+++ b/tests/integration/analysis/record_linkage_test.py
@@ -48,14 +48,19 @@ def _randomly_modify_string(input_str: str, k: int = 5) -> str:
     num_edits = min(random.randrange(k) for i in range(10))
     for _ in range(num_edits):
         edit = edit_types[random.randrange(3)]
-        position = random.randrange(len(input_str) - 1)
-
+        # Positions must be computed against the current list length, which
+        # changes as "add"/"delete" edits accumulate.
         if edit == "add":
-            input_list.insert(position, random.choice(characters))
+            input_list.insert(
+                random.randrange(len(input_list) + 1), random.choice(characters)
+            )
+        elif not input_list:
+            # Nothing left to delete or substitute.
+            continue
         elif edit == "delete":
-            input_list.pop(position)
+            input_list.pop(random.randrange(len(input_list)))
         else:
-            input_list[position] = random.choice(characters)
+            input_list[random.randrange(len(input_list))] = random.choice(characters)
 
     return "".join(input_list)
 

--- a/tests/integration/deploy/zenodo_metadata_test.py
+++ b/tests/integration/deploy/zenodo_metadata_test.py
@@ -21,12 +21,13 @@ def git_repo(tmp_path, monkeypatch) -> Path:
     Real ``git`` commands (via ``run_git``), not mocks, so these tests actually
     exercise git's own tag resolution (``rev-parse <tag>^{commit}``) rather than
     just the string-comparison logic downstream of it. ``tmp_path`` living outside
-    this repo's own working tree isn't enough to isolate these commands on its own:
-    ``GIT_DIR``/``GIT_WORK_TREE``/``GIT_INDEX_FILE`` env vars, if set in the calling
-    process (as pre-commit/git hooks do), override git's normal cwd-based repo
-    discovery and would silently redirect ``run_git`` here into the real PUDL repo's
-    index instead of this throwaway one. Clearing them for the test process ensures
-    ``run_git``'s ``cwd=repo_root`` is what actually determines the repo.
+    this repo's own working tree isn't enough to isolate these commands on its own.
+
+    We need to unset some git env vars and redirect git's global/system config to empty
+    files so that the throwaway repo's local config is the only config in effect.
+    Leaving the global / system env vars unset results in git falling back to the
+    default locations for those configs (``~/.gitconfig`` and ``/etc/gitconfig``) which
+    may well exist.
     """
     for var in (
         "GIT_DIR",
@@ -38,14 +39,16 @@ def git_repo(tmp_path, monkeypatch) -> Path:
     ):
         monkeypatch.delenv(var, raising=False)
 
+    empty_config = tmp_path / "empty_gitconfig"
+    empty_config.write_text("")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(empty_config))
+    monkeypatch.setenv("GIT_CONFIG_SYSTEM", str(empty_config))
+
     repo_root = tmp_path / "repo"
     repo_root.mkdir()
     run_git(["init"], cwd=repo_root)
     run_git(["config", "user.email", "test@example.com"], cwd=repo_root)
     run_git(["config", "user.name", "Test"], cwd=repo_root)
-    # Override any ambient global gpg-signing config, which would otherwise make
-    # `git tag` fail here asking for a signing key/message it doesn't have.
-    run_git(["config", "tag.gpgSign", "false"], cwd=repo_root)
     (repo_root / "README.md").write_text("test\n")
     run_git(["add", "README.md"], cwd=repo_root)
     run_git(["commit", "-m", "Initial commit"], cwd=repo_root)


### PR DESCRIPTION
# Overview

Hardens the `git_repo` fixture in `tests/integration/deploy/zenodo_metadata_test.py`. This was split out from the `goodbye-alembic` branch so it can get into `main` ASAP.

- I discovered that one of the newer integration tests was falling back onto global / system git configurations because when I ran the integration tests locally it kept prompting me to sign a commit with GPG.
- Redirect `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` to an empty config file so the throwaway repo's local config is the only config in effect. Just unsetting the git env vars isn't enough — git falls back to `~/.gitconfig` and `/etc/gitconfig`, which may exist and carry things like ambient gpg-signing config.
- With global/system config neutralized, the explicit `tag.gpgSign=false` workaround is no longer needed and is removed.

## Incidental change

- While running the integration tests for this, also found a flaky non-deterministic failure in another test and fixed it.