### PR TITLE
Add per-year dbt tests for operational characteristics

### DIFF
--- a/dbt/models/epacems/out_epacems__yearly_operational_characteristics/schema.yml
+++ b/dbt/models/epacems/out_epacems__yearly_operational_characteristics/schema.yml
@@ -56,31 +56,475 @@ sources:
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: heat_rate_at_max_load_factor_mmbtu_per_mwh
             data_tests:
-              - dbt_expectations.expect_column_values_to_be_between:
-                  description: |-
-                    This is a per-unit median heat rate computed only from the hours in that unit's single
-                    highest load-factor bin. Under etl-fast's single quarter of data that bin can contain
-                    very few hours, making the median far more volatile than in production (12 trailing
-                    quarters), so this check is disabled for etl-fast.
+              - expect_column_fraction_outside_range:
                   arguments:
                     min_value: 5.4
                     max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.065
+                    row_condition: report_year = 2000
                   config:
-                    error_if: ">50"
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.06
+                    row_condition: report_year = 2001
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.06
+                    row_condition: report_year = 2002
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.045
+                    row_condition: report_year = 2003
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.045
+                    row_condition: report_year = 2004
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.05
+                    row_condition: report_year = 2005
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.055
+                    row_condition: report_year = 2006
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.055
+                    row_condition: report_year = 2007
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.05
+                    row_condition: report_year = 2008
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.04
+                    row_condition: report_year = 2009
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.035
+                    row_condition: report_year = 2010
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.0275
+                    row_condition: report_year = 2011
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.0225
+                    row_condition: report_year = 2012
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.025
+                    row_condition: report_year = 2013
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.0225
+                    row_condition: report_year = 2014
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.02
+                    row_condition: report_year = 2015
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.0225
+                    row_condition: report_year = 2016
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.025
+                    row_condition: report_year = 2017
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.025
+                    row_condition: report_year = 2018
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.0175
+                    row_condition: report_year = 2019
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.0175
+                    row_condition: report_year = 2020
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.015
+                    row_condition: report_year = 2021
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.015
+                    row_condition: report_year = 2022
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.015
+                    row_condition: report_year = 2023
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.0175
+                    row_condition: report_year = 2024
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 25.0
+                    max_fraction_above: 0.015
+                    max_fraction_below: 0.0175
+                    row_condition: report_year = 2025
+                  config:
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: heat_rate_at_min_stable_load_factor_mmbtu_per_mwh
             data_tests:
-              - dbt_expectations.expect_column_values_to_be_between:
-                  description: |-
-                    This is a per-unit median heat rate computed only from the hours in that unit's single
-                    highest load-factor bin. Under etl-fast's single quarter of data that bin can contain
-                    very few hours, making the median far more volatile than in production (12 trailing
-                    quarters), so this check is disabled for etl-fast.
+              - expect_column_fraction_outside_range:
                   arguments:
                     min_value: 5.4
-                    max_value: 25.0
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.03
+                    row_condition: report_year = 2000
                   config:
-                    error_if: ">60"
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.025
+                    row_condition: report_year = 2001
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.03
+                    row_condition: report_year = 2002
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.0225
+                    row_condition: report_year = 2003
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.0225
+                    row_condition: report_year = 2004
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.015
+                    row_condition: report_year = 2005
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.02
+                    row_condition: report_year = 2006
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.02
+                    row_condition: report_year = 2007
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.0125
+                    row_condition: report_year = 2008
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.01
+                    row_condition: report_year = 2009
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.01
+                    row_condition: report_year = 2010
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.0075
+                    row_condition: report_year = 2011
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.0075
+                    row_condition: report_year = 2012
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.0075
+                    row_condition: report_year = 2013
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.01
+                    row_condition: report_year = 2014
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.01
+                    row_condition: report_year = 2015
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.0075
+                    row_condition: report_year = 2016
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.0075
+                    row_condition: report_year = 2017
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.0125
+                    row_condition: report_year = 2018
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.005
+                    row_condition: report_year = 2019
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.005
+                    row_condition: report_year = 2020
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.005
+                    row_condition: report_year = 2021
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.005
+                    row_condition: report_year = 2022
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.006
+                    row_condition: report_year = 2023
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.006
+                    row_condition: report_year = 2024
+                  config:
+                    enabled: "{{ target.name == 'etl-full' }}"
+              - expect_column_fraction_outside_range:
+                  arguments:
+                    min_value: 5.4
+                    max_value: 30.0
+                    max_fraction_above: 0.03
+                    max_fraction_below: 0.005
+                    row_condition: report_year = 2025
+                  config:
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: ramp_up_rate_per_min
             data_tests:

--- a/dbt/schema_inputs/epacems/out_epacems__yearly_operational_characteristics/schema.human.yml
+++ b/dbt/schema_inputs/epacems/out_epacems__yearly_operational_characteristics/schema.human.yml
@@ -47,34 +47,491 @@ sources:
                     enabled: "{{ target.name == 'etl-full' }}"
           - name: heat_rate_at_max_load_factor_mmbtu_per_mwh
             data_tests:
-              - dbt_expectations.expect_column_values_to_be_between:
-                  description: |-
-                    This is a per-unit median heat rate computed only from the hours in that unit's single
-                    highest load-factor bin. Under etl-fast's single quarter of data that bin can contain
-                    very few hours, making the median far more volatile than in production (12 trailing
-                    quarters), so this check is disabled for etl-fast.
-                  arguments:
-                    # World record for most efficient CCGT is 5.5
-                    min_value: 5.4
-                    max_value: 25.0
-                  config:
-                    error_if: ">50"
-                    enabled: "{{ target.name == 'etl-full' }}"
+              # Per-unit median heat rate over each unit's single highest load-factor bin.
+              # min_value is the thermodynamic-ish floor: the world's most efficient CCGT
+              # runs ~5.5 MMBtu/MWh, so anything materially below 5.4 is a bad estimate.
+              # max_value is 25.0 here because units are most efficient at max output.
+              # The fraction of unphysically low values shrinks over time as EPA CEMS unit
+              # coverage and hourly heat-input quality improve, so max_fraction_below is
+              # set per report_year (~1.5x the observed rate); years not listed are
+              # unchecked. High-side outliers show no trend, so max_fraction_above is a
+              # single flat bound. etl-full only: under etl-fast's single quarter each
+              # load-factor bin holds too few hours for the median to be stable.
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.065,
+                      row_condition: "report_year = 2000",
+                    } # observed 4.67%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.060,
+                      row_condition: "report_year = 2001",
+                    } # observed 4.19%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.060,
+                      row_condition: "report_year = 2002",
+                    } # observed 4.36%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.045,
+                      row_condition: "report_year = 2003",
+                    } # observed 3.23%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.045,
+                      row_condition: "report_year = 2004",
+                    } # observed 3.08%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.050,
+                      row_condition: "report_year = 2005",
+                    } # observed 3.66%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.055,
+                      row_condition: "report_year = 2006",
+                    } # observed 3.88%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.055,
+                      row_condition: "report_year = 2007",
+                    } # observed 3.89%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.050,
+                      row_condition: "report_year = 2008",
+                    } # observed 3.61%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.040,
+                      row_condition: "report_year = 2009",
+                    } # observed 2.93%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.035,
+                      row_condition: "report_year = 2010",
+                    } # observed 2.32%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.0275,
+                      row_condition: "report_year = 2011",
+                    } # observed 1.82%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.0225,
+                      row_condition: "report_year = 2012",
+                    } # observed 1.41%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.025,
+                      row_condition: "report_year = 2013",
+                    } # observed 1.67%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.0225,
+                      row_condition: "report_year = 2014",
+                    } # observed 1.39%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.020,
+                      row_condition: "report_year = 2015",
+                    } # observed 1.13%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.0225,
+                      row_condition: "report_year = 2016",
+                    } # observed 1.43%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.025,
+                      row_condition: "report_year = 2017",
+                    } # observed 1.64%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.025,
+                      row_condition: "report_year = 2018",
+                    } # observed 1.67%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.0175,
+                      row_condition: "report_year = 2019",
+                    } # observed 0.98%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.0175,
+                      row_condition: "report_year = 2020",
+                    } # observed 0.97%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.015,
+                      row_condition: "report_year = 2021",
+                    } # observed 0.89%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.015,
+                      row_condition: "report_year = 2022",
+                    } # observed 0.90%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.015,
+                      row_condition: "report_year = 2023",
+                    } # observed 0.77%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.0175,
+                      row_condition: "report_year = 2024",
+                    } # observed 0.99%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 25.0,
+                      max_fraction_above: 0.015,
+                      max_fraction_below: 0.0175,
+                      row_condition: "report_year = 2025",
+                    } # observed 0.95%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
           - name: heat_rate_at_min_stable_load_factor_mmbtu_per_mwh
             data_tests:
-              - dbt_expectations.expect_column_values_to_be_between:
-                  description: |-
-                    This is a per-unit median heat rate computed only from the hours in that unit's single
-                    highest load-factor bin. Under etl-fast's single quarter of data that bin can contain
-                    very few hours, making the median far more volatile than in production (12 trailing
-                    quarters), so this check is disabled for etl-fast.
-                  arguments:
-                    # World record for most efficient CCGT is 5.5
-                    min_value: 5.4
-                    max_value: 25.0
-                  config:
-                    error_if: ">60"
-                    enabled: "{{ target.name == 'etl-full' }}"
+              # Same metric and floor reasoning as heat_rate_at_max_load_factor above, but
+              # evaluated in each unit's lowest load-factor bin, where thermal plants run
+              # less efficiently -- hence a looser max_value of 30.0. Per-year
+              # max_fraction_below again tracks improving EPA CEMS data quality; flat
+              # max_fraction_above; etl-full only.
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.030,
+                      row_condition: "report_year = 2000",
+                    } # observed 1.96%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.025,
+                      row_condition: "report_year = 2001",
+                    } # observed 1.54%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.030,
+                      row_condition: "report_year = 2002",
+                    } # observed 1.95%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.0225,
+                      row_condition: "report_year = 2003",
+                    } # observed 1.45%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.0225,
+                      row_condition: "report_year = 2004",
+                    } # observed 1.36%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.015,
+                      row_condition: "report_year = 2005",
+                    } # observed 0.89%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.020,
+                      row_condition: "report_year = 2006",
+                    } # observed 1.16%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.020,
+                      row_condition: "report_year = 2007",
+                    } # observed 1.16%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.0125,
+                      row_condition: "report_year = 2008",
+                    } # observed 0.68%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.010,
+                      row_condition: "report_year = 2009",
+                    } # observed 0.54%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.010,
+                      row_condition: "report_year = 2010",
+                    } # observed 0.53%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.0075,
+                      row_condition: "report_year = 2011",
+                    } # observed 0.28%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.0075,
+                      row_condition: "report_year = 2012",
+                    } # observed 0.23%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.0075,
+                      row_condition: "report_year = 2013",
+                    } # observed 0.28%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.010,
+                      row_condition: "report_year = 2014",
+                    } # observed 0.41%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.010,
+                      row_condition: "report_year = 2015",
+                    } # observed 0.47%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.0075,
+                      row_condition: "report_year = 2016",
+                    } # observed 0.24%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.0075,
+                      row_condition: "report_year = 2017",
+                    } # observed 0.27%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.0125,
+                      row_condition: "report_year = 2018",
+                    } # observed 0.75%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.005,
+                      row_condition: "report_year = 2019",
+                    } # observed 0.11%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.005,
+                      row_condition: "report_year = 2020",
+                    } # observed 0.17%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.005,
+                      row_condition: "report_year = 2021",
+                    } # observed 0.20%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.005,
+                      row_condition: "report_year = 2022",
+                    } # observed 0.19%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.006,
+                      row_condition: "report_year = 2023",
+                    } # observed 0.22%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.006,
+                      row_condition: "report_year = 2024",
+                    } # observed 0.23%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
+              - expect_column_fraction_outside_range:
+                  arguments: {
+                      min_value: 5.4,
+                      max_value: 30.0,
+                      max_fraction_above: 0.030,
+                      max_fraction_below: 0.005,
+                      row_condition: "report_year = 2025",
+                    } # observed 0.20%
+                  config: { enabled: "{{ target.name == 'etl-full' }}" }
           - name: ramp_up_rate_per_min
             data_tests:
               - dbt_expectations.expect_column_values_to_be_between:

--- a/dbt/tests/data_tests/generic_tests/expect_column_fraction_outside_range.sql
+++ b/dbt/tests/data_tests/generic_tests/expect_column_fraction_outside_range.sql
@@ -1,0 +1,49 @@
+{% test expect_column_fraction_outside_range(
+    model,
+    column_name,
+    min_value,
+    max_value,
+    max_fraction_below=0.0,
+    max_fraction_above=0.0,
+    row_condition=None
+) %}
+
+{# Check that the fraction of non-null values falling below min_value and the fraction
+falling above max_value each stay within an acceptable bound. Unlike
+dbt_expectations.expect_column_values_to_be_between with error_if, which counts absolute
+rows and therefore drifts as a table gains partitions, this expresses tolerance as a
+share of the (optionally row_condition-filtered) population. When row_condition selects
+no rows the test passes, so per-year invocations for years absent from the data do not
+register as failures. #}
+
+{% if max_fraction_below < 0.0 or max_fraction_below > 1.0 %}
+    {{ exceptions.raise_compiler_error("max_fraction_below must be between 0.0 and 1.0, got: " ~ max_fraction_below) }}
+{% endif %}
+{% if max_fraction_above < 0.0 or max_fraction_above > 1.0 %}
+    {{ exceptions.raise_compiler_error("max_fraction_above must be between 0.0 and 1.0, got: " ~ max_fraction_above) }}
+{% endif %}
+
+WITH counts AS (
+    SELECT
+        COUNT({{ column_name }}) AS n_total,
+        COUNT(*) FILTER (WHERE {{ column_name }} < {{ min_value }}) AS n_below,
+        COUNT(*) FILTER (WHERE {{ column_name }} > {{ max_value }}) AS n_above
+    FROM {{ model }}
+    {%- if row_condition %}
+    WHERE {{ row_condition }}
+    {%- endif %}
+)
+SELECT
+    n_total,
+    n_below,
+    n_above,
+    n_below::FLOAT / NULLIF(n_total, 0) AS fraction_below,
+    n_above::FLOAT / NULLIF(n_total, 0) AS fraction_above
+FROM counts
+WHERE n_total > 0
+    AND (
+        n_below::FLOAT / n_total > {{ max_fraction_below }}
+        OR n_above::FLOAT / n_total > {{ max_fraction_above }}
+    )
+
+{% endtest %}

--- a/dbt/tests/data_tests/generic_tests/schema.yml
+++ b/dbt/tests/data_tests/generic_tests/schema.yml
@@ -64,6 +64,37 @@ macros:
         type: float
         description: Maximum acceptable fraction (between 0 and 1).
 
+  - name: test_expect_column_fraction_outside_range
+    description: >
+      Check that the fraction of non-null values below min_value and the fraction above
+      max_value each stay within an acceptable bound. Unlike
+      dbt_expectations.expect_column_values_to_be_between with error_if, which counts
+      absolute rows and therefore drifts as a table gains partitions, this expresses
+      tolerance as a share of the population. Combine with a per-year row_condition to
+      set expectations that tighten as data quality improves over time; a row_condition
+      that selects no rows passes, so years absent from the data do not fail.
+    arguments:
+      - name: column_name
+        type: string
+        description: The name of the column whose values are checked.
+      - name: min_value
+        type: float
+        description: Lower bound; values strictly below this count toward fraction_below.
+      - name: max_value
+        type: float
+        description: Upper bound; values strictly above this count toward fraction_above.
+      - name: max_fraction_below
+        type: float
+        description: Maximum acceptable fraction of values below min_value (0 to 1, default 0).
+      - name: max_fraction_above
+        type: float
+        description: Maximum acceptable fraction of values above max_value (0 to 1, default 0).
+      - name: row_condition
+        type: string
+        description: >
+          Optional SQL condition restricting the population the fractions are computed
+          over (e.g., "report_year = 2020").
+
   - name: test_expect_includes_all_value_combinations_from
     description: >
       Check that all values in a column or set of columns are the same as the same set


### PR DESCRIPTION
# Overview

The multi-year EPA CEMS derived operational characteristics table got merged in without an update to the dbt data test expectations to accommodate multiple years of data. This caused the fixed "error if" expectations to fail in the nightly builds.

This PR adds calibrated per-year expectations for what fraction of records we expect to show up below a minimum heat rate (5.4). The per-year threshold changes because the quality of the data has improved dramatically over time. Low heat rate outliers are now 10-20x less common than they were in 2000.

The rate of high heat rate outliers has remained comparatively stable over time, so use a fixed fractional expectation on those.